### PR TITLE
nmgr_ble - don't crash if peer disconnected during MTU query

### DIFF
--- a/mgmt/newtmgr/include/newtmgr/newtmgr.h
+++ b/mgmt/newtmgr/include/newtmgr/newtmgr.h
@@ -43,6 +43,9 @@ typedef int (*nmgr_transport_out_func_t)(struct nmgr_transport *nt,
  * from the peer whose MTU is being queried.  This function takes an mbuf
  * parameter because some transports store connection-specific information in
  * the mbuf user header (e.g., the BLE transport stores the connection handle).
+ *
+ * @return                      The transport's MTU;
+ *                              0 if transmission is currently not possible.
  */
 typedef uint16_t (*nmgr_transport_get_mtu_func_t)(struct os_mbuf *m);
 

--- a/mgmt/newtmgr/src/newtmgr.c
+++ b/mgmt/newtmgr/src/newtmgr.c
@@ -210,6 +210,10 @@ nmgr_handle_req(struct nmgr_transport *nt, struct os_mbuf *req)
     }
 
     mtu = nt->nt_get_mtu(req);
+    if (mtu == 0) {
+        /* The transport cannot support a transmission right now. */
+        goto err_norsp;
+    }
 
     /* Copy the request user header into the response. */
     memcpy(OS_MBUF_USRHDR(rsp), OS_MBUF_USRHDR(req), OS_MBUF_USRHDR_LEN(req));

--- a/mgmt/newtmgr/transport/ble/src/newtmgr_ble.c
+++ b/mgmt/newtmgr/transport/ble/src/newtmgr_ble.c
@@ -152,7 +152,8 @@ nmgr_ble_get_mtu(struct os_mbuf *req) {
     memcpy(&conn_handle, OS_MBUF_USRHDR(req), sizeof (conn_handle));
     mtu = ble_att_mtu(conn_handle);
     if (!mtu) {
-        assert(0);
+        /* No longer connected. */
+        return 0;
     }
 
     /* 3 is the number of bytes for ATT notification base */


### PR DESCRIPTION
When queried for the connection's ATT MTU, the BLE newtmgr transport assumes the peer is connected.  If the peer is no longer connected when the query occurs, a failed assert is triggered.

The assumption that the peer is still connected is not always vaild.  A well-timed control-c during a newtmgr image upgrade can trigger this crash:

```
Program received signal SIGTRAP, Trace/breakpoint trap.
__assert_func (file=<optimized out>, line=<optimized out>, func=<optimized out>, e=<optimized out>) at kernel/os/src/arch/cortex_m4/os_fault.c:137
137            asm("bkpt");
(gdb) whe
#0  __assert_func (file=<optimized out>, line=<optimized out>, func=<optimized out>, e=<optimized out>) at kernel/os/src/arch/cortex_m4/os_fault.c:137
#1  0x00025c8e in nmgr_ble_get_mtu (req=<optimized out>) at mgmt/newtmgr/transport/ble/src/newtmgr_ble.c:155
#2  0x000254aa in nmgr_handle_req (req=0x200016cc <os_msys_init_1_data+336>, nt=0x25c8f <nmgr_ble_get_mtu+30>) at mgmt/newtmgr/src/newtmgr.c:212
#3  nmgr_process (nt=0x25c8f <nmgr_ble_get_mtu+30>) at mgmt/newtmgr/src/newtmgr.c:334
#4  nmgr_event_data_in (ev=<optimized out>) at mgmt/newtmgr/src/newtmgr.c:341#5  0x000091b8 in os_eventq_run (evq=<optimized out>) at kernel/os/src/os_eventq.c:172  #6  0x0000886e in main () at apps/bleprph/src/main.c:318
```

The fix is to give the transport MTU function a way to indicate failure.  The function does this by returning 0.  When the MTU function indicates failure, the implication is that no sends are possible, so the newtmgr command handler aborts without sending a response.