### PR TITLE
microbit bsp: add JLINK_DEBUG option to switch to jlink

### DIFF
--- a/hw/bsp/bbc_microbit/microbit_debug.sh
+++ b/hw/bsp/bbc_microbit/microbit_debug.sh
@@ -27,11 +27,29 @@
 #  - RESET set if target should be reset when attaching
 #  - NO_GDB set if we should not start gdb to debug
 #
-. $CORE_PATH/hw/scripts/openocd.sh
 
+USE_OPENOCD=1
 FILE_NAME=$BIN_BASENAME.elf
-CFG="-f interface/cmsis-dap.cfg -f target/nrf51.cfg"
-# Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf51.cpu configure -event gdb-detach {if {[nrf51.cpu curstate] eq \"halted\"} resume;shutdown}"
 
-openocd_debug
+# Look for 'JLINK_DEBUG' in FEATURES
+for feature in $FEATURES; do
+    if [ $feature = "JLINK_DEBUG" ]; then
+        USE_OPENOCD=0
+    fi
+done
+
+if [ $USE_OPENOCD -eq 1 ]; then
+    . $CORE_PATH/hw/scripts/openocd.sh
+
+    CFG="-f interface/cmsis-dap.cfg -f target/nrf51.cfg"
+    # Exit openocd when gdb detaches.
+    EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf51.cpu configure -event gdb-detach {if {[nrf51.cpu curstate] eq \"halted\"} resume;shutdown}"
+
+    openocd_debug
+else
+    . $CORE_PATH/hw/scripts/jlink.sh
+
+    JLINK_DEV="nRF51422_xxAC"
+
+    jlink_debug
+fi

--- a/hw/bsp/bbc_microbit/microbit_download.sh
+++ b/hw/bsp/bbc_microbit/microbit_download.sh
@@ -29,14 +29,32 @@
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
 
-. $CORE_PATH/hw/scripts/openocd.sh
+USE_OPENOCD=1
 
-CFG="-f interface/cmsis-dap.cfg -f target/nrf51.cfg"
+# Look for 'openocd_debug' in FEATURES
+for feature in $FEATURES; do
+    if [ $feature = "JLINK_DEBUG" ]; then
+        USE_OPENOCD=0
+    fi
+done
 
 if [ "$MFG_IMAGE" ]; then
-    FLASH_OFFSET=0
+    FLASH_OFFSET=0x0
 fi
 
-common_file_to_load
-openocd_load
-openocd_reset_run
+if [ $USE_OPENOCD -eq 1 ]; then
+    . $CORE_PATH/hw/scripts/openocd.sh
+
+    CFG="-f interface/cmsis-dap.cfg -f target/nrf51.cfg"
+
+    common_file_to_load
+    openocd_load
+    openocd_reset_run
+else
+    . $CORE_PATH/hw/scripts/jlink.sh
+
+    JLINK_DEV="nRF51422_xxAC"
+
+    common_file_to_load
+    jlink_load
+fi

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -67,6 +67,10 @@ syscfg.defs:
         description: 'NRF51 RTC0'
         value:  0
 
+    JLINK_DEBUG:
+        description: 'Use Segger JLINK OBE firmware'
+        value: 0
+
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG


### PR DESCRIPTION
Helpful as a 'free' Segger RTT device via JLINK OB firmware from Segger

Youll need to change the uploader firmware on your board to the new jlink firmware using the following guide from Segger
https://www.segger.com/products/debug-probes/j-link/models/other-j-links/bbc-microbit-j-link-upgrade/?L=0

(NOTE if you ever want to go back to the original daplink (cmsisdap) firwmare for you microbit, follow those instructions:
https://www.mbed.com/en/platform/hardware/prototyping-production/daplink/daplink-on-kl26z/)
