### PR TITLE
Shell improvements before 1.1

### DIFF
--- a/sys/shell/include/shell/shell.h
+++ b/sys/shell/include/shell/shell.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+struct os_eventq;
+
 /** @brief Callback called when command is entered.
  *
  *  @param argc Number of parameters passed.
@@ -90,6 +92,12 @@ void shell_register_prompt_handler(shell_prompt_function_t handler);
  *  @param name Module name.
  */
 void shell_register_default_module(const char *name);
+
+/** @brief Optionally set event queue to process shell command events
+ *
+ *  @param evq Event queue to be used in shell
+ */
+void shell_evq_set(struct os_eventq *evq);
 
 #if MYNEWT_VAL(SHELL_NEWTMGR)
 struct os_mbuf;

--- a/sys/shell/include/shell/shell.h
+++ b/sys/shell/include/shell/shell.h
@@ -55,16 +55,6 @@ struct shell_module {
     const struct shell_cmd *commands;
 };
 
-/** @brief Callback called when registering module
- *
- *  @param module_name Name of the module
- *  @param commands Array of shell_cmd structs
- *
- * @return 0 in case of success or negative value in case of error.
- */
-typedef int (*shell_register_function_t)(const char *name,
-                                         const struct shell_cmd *commands);
-
 /** @brief Register a shell_module object
  *
  *  @param shell_name Module name to be entered in shell console.

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -335,7 +335,6 @@ get_cb(int argc, char *argv[])
     }
 
     shell_module = &shell_modules[module];
-    console_printf("module: %d, command: %s\n", module, command);
     for (i = 0; shell_module->commands[i].sc_cmd; i++) {
         if (!strcmp(command, shell_module->commands[i].sc_cmd)) {
             return shell_module->commands[i].sc_cmd_func;

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -934,9 +934,9 @@ shell_init(void)
 #endif
 
 #if MYNEWT_VAL(SHELL_OS_MODULE)
-    shell_os_register(shell_register);
+    shell_os_register();
 #endif
 #if MYNEWT_VAL(SHELL_PROMPT_MODULE)
-    shell_prompt_register(shell_register);
+    shell_prompt_register();
 #endif
 }

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -193,16 +193,17 @@ show_cmd_help(char *argv[])
             console_printf("%s:\n", shell_module->commands[i].sc_cmd);
 
             if (!shell_module->commands[i].help) {
-                console_printf("\n");
+                console_printf("(no help available)\n");
                 return 0;
             }
             if (shell_module->commands[i].help->usage) {
+                console_printf("%s:\n", shell_module->commands[i].sc_cmd);
                 console_printf("%s\n", shell_module->commands[i].help->usage);
             } else if (shell_module->commands[i].help->summary) {
-                console_printf("%s\n",
-                               shell_module->commands[i].help->summary);
+                console_printf("%s:\n", shell_module->commands[i].sc_cmd);
+                console_printf("%s\n", shell_module->commands[i].help->summary);
             } else {
-                console_printf("\n");
+                console_printf("(no help available)\n");
             }
 
             return 0;

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -51,6 +51,15 @@ static struct console_input buf[MYNEWT_VAL(SHELL_MAX_CMD_QUEUED)];
 static struct os_eventq avail_queue;
 static struct os_event shell_console_ev[MYNEWT_VAL(SHELL_MAX_CMD_QUEUED)];
 
+/* Shared queue that the shell uses for work items. */
+static struct os_eventq *shell_evq;
+
+void
+shell_evq_set(struct os_eventq *evq)
+{
+    os_eventq_designate(&shell_evq, evq, NULL);
+}
+
 static const char *
 get_prompt(void)
 {
@@ -920,10 +929,12 @@ shell_init(void)
     return;
 #endif
 
+    shell_evq_set(os_eventq_dflt_get());
     os_eventq_init(&avail_queue);
     line_queue_init();
+    console_set_queues(&avail_queue, shell_evq);
+
     prompt = SHELL_PROMPT;
-    console_set_queues(&avail_queue, os_eventq_dflt_get());
 
 #if MYNEWT_VAL(SHELL_NEWTMGR)
     shell_nlip_init();

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -882,7 +882,8 @@ int
 shell_register(const char *module_name, const struct shell_cmd *commands)
 {
     if (num_of_shell_entities >= MYNEWT_VAL(SHELL_MAX_MODULES)) {
-        return -1;
+        console_printf("Max number of modules reached\n");
+        assert(0);
     }
 
     shell_modules[num_of_shell_entities].name = module_name;

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -219,8 +219,8 @@ static const struct shell_cmd os_commands[] = {
 };
 
 void
-shell_os_register(shell_register_function_t register_func)
+shell_os_register(void)
 {
-    register_func(SHELL_OS, os_commands);
+    shell_register(SHELL_OS, os_commands);
 }
 

--- a/sys/shell/src/shell_priv.h
+++ b/sys/shell/src/shell_priv.h
@@ -37,8 +37,8 @@ void shell_nlip_init(void);
 void shell_nlip_clear_pkt(void);
 #endif
 
-void shell_os_register(shell_register_function_t register_func);
-void shell_prompt_register(shell_register_function_t register_func);
+void shell_os_register(void);
+void shell_prompt_register(void);
 
 #ifdef __cplusplus
 }

--- a/sys/shell/src/shell_prompt.c
+++ b/sys/shell/src/shell_prompt.c
@@ -87,7 +87,7 @@ static const struct shell_cmd prompt_commands[] = {
 
 
 void
-shell_prompt_register(shell_register_function_t register_func)
+shell_prompt_register(void)
 {
-    register_func(SHELL_PROMPT, prompt_commands);
+    shell_register(SHELL_PROMPT, prompt_commands);
 }

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -29,6 +29,9 @@ syscfg.defs:
     SHELL_CMD_HELP:
         description: 'Include help information for shell commands'
         value: 1
+    SHELL_PROMPT_SUFFIX:
+        description: 'Prompt suffix'
+        value: '"> "'
     SHELL_MAX_MODULES:
         description: 'Max number of modules'
         value: 3


### PR DESCRIPTION
This patch introduces simplifications and improvements suggested by @cwanda.

Changes include:
* bringing back shell_evq_set
* directly using shell_register api in internal shell modules
* asserting when max number of modules exceeded 
* removing module name length limit
* adding prompt suffix option to syscfg
* some whitespace fixes