### PR TITLE
testutil - Remove init boilerplate

### DIFF
--- a/apps/test/src/test.c
+++ b/apps/test/src/test.c
@@ -30,8 +30,7 @@ extern int util_test_all(void);
 int
 main(void)
 {
-    tu_config.tc_print_results = 1;
-    tu_init();
+    sysinit();
 
     os_test_all();
     nffs_test_all();

--- a/boot/boot_serial/test/src/boot_test.c
+++ b/boot/boot_serial/test/src/boot_test.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "sysflash/sysflash.h"
 #include "os/endian.h"
@@ -65,8 +66,7 @@ boot_serial_test(void)
 int
 main(void)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     boot_serial_test();
 

--- a/boot/bootutil/test/src/boot_test.c
+++ b/boot/bootutil/test/src/boot_test.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "sysflash/sysflash.h"
 #include "testutil/testutil.h"
@@ -89,10 +90,7 @@ boot_test_all(void)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_parse_args(argc, argv);
-
-    tu_init();
+    sysinit();
 
     boot_test_all();
 

--- a/crypto/mbedtls/test/src/mbedtls_test.c
+++ b/crypto/mbedtls/test/src/mbedtls_test.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 
@@ -88,8 +89,7 @@ TEST_SUITE(mbedtls_test_all)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     mbedtls_test_all();
 

--- a/encoding/base64/test/src/encoding_test.c
+++ b/encoding/base64/test/src/encoding_test.c
@@ -18,6 +18,7 @@
  */
 #include <assert.h>
 #include <stddef.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "encoding_test_priv.h"
@@ -43,8 +44,7 @@ TEST_SUITE(hex_fmt_test_suite)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     hex_fmt_test_all();
     return tu_any_failed;

--- a/encoding/cborattr/test/src/test_cborattr.c
+++ b/encoding/cborattr/test/src/test_cborattr.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "test_cborattr.h"
@@ -39,8 +40,7 @@ TEST_SUITE(test_cborattr_suite)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     test_cborattr_suite();
 

--- a/encoding/json/test/src/test_json.c
+++ b/encoding/json/test/src/test_json.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "test_json.h"
@@ -33,8 +34,7 @@ TEST_SUITE(test_json_suite) {
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     test_json_suite();
 

--- a/fs/fcb/test/src/fcb_test.c
+++ b/fs/fcb/test/src/fcb_test.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "os/os.h"
 #include "testutil/testutil.h"
@@ -197,8 +198,7 @@ TEST_SUITE(fcb_test_all)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     tu_suite_set_init_cb(fcb_ts_init, NULL);
     fcb_test_all();

--- a/fs/nffs/test/src/nffs_test.c
+++ b/fs/nffs/test/src/nffs_test.c
@@ -39,6 +39,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "hal/hal_flash.h"
 #include "testutil/testutil.h"
@@ -203,13 +204,11 @@ nffs_test_suite_cache_init(void)
 int
 main(void)
 {
-    ts_config.ts_print_results = 1;
-    ts_config.ts_system_assert = 0; /* handle asserts */
     nffs_config.nc_num_inodes = 1024 * 8;
     nffs_config.nc_num_blocks = 1024 * 20;
     nffs_current_area_descs = nffs_selftest_area_descs;
 
-    tu_init();
+    sysinit();
 
     tu_suite_set_init_cb((void*)nffs_test_suite_gen_1_1_init, NULL);
     nffs_test_suite();

--- a/kernel/os/test/src/os_test.c
+++ b/kernel/os/test/src/os_test.c
@@ -18,6 +18,7 @@
  */
 #include <assert.h>
 #include <stddef.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "os/os_test.h"
@@ -112,9 +113,7 @@ os_test_all(void)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_parse_args(argc, argv);
-    tu_init();
+    sysinit();
 
     os_test_all();
 

--- a/net/ip/mn_socket/test/src/mn_sock_test.c
+++ b/net/ip/mn_socket/test/src/mn_sock_test.c
@@ -80,8 +80,7 @@ mn_socket_test_init()
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     tu_suite_set_init_cb((void*)mn_socket_test_init, NULL);
     mn_socket_test_all();

--- a/net/nimble/host/test/src/ble_hs_test.c
+++ b/net/nimble/host/test/src/ble_hs_test.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "os/os.h"
 #include "nimble/hci_common.h"
@@ -29,10 +30,7 @@
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_parse_args(argc, argv);
-
-    tu_init();
+    sysinit();
 
     ble_att_clt_test_all();
     ble_att_svr_test_all();

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include "sysinit/sysinit.h"
 #include "stats/stats.h"
 #include "testutil/testutil.h"
 #include "nimble/ble.h"
@@ -2362,7 +2363,7 @@ ble_hs_test_util_store_delete(int obj_type, const union ble_store_key *key)
 void
 ble_hs_test_util_init_no_start(void)
 {
-    tu_init();
+    sysinit();
 
     os_eventq_init(&ble_hs_test_util_evq);
     STAILQ_INIT(&ble_hs_test_util_prev_tx_queue);

--- a/net/oic/test/src/test_oic.c
+++ b/net/oic/test/src/test_oic.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "test_oic.h"
@@ -35,8 +36,7 @@ oic_test_init(void)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     tu_suite_set_init_cb((void *)oic_test_init, NULL);
     oic_test_all();

--- a/sys/config/test-fcb/src/conf_test_fcb.c
+++ b/sys/config/test-fcb/src/conf_test_fcb.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "sysinit/sysinit.h"
 #include <os/os.h>
 #include <flash_map/flash_map.h>
 #include <testutil/testutil.h>
@@ -351,8 +352,7 @@ TEST_SUITE(config_test_all)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     conf_init();
     config_test_all();

--- a/sys/config/test-nffs/src/conf_test_nffs.c
+++ b/sys/config/test-nffs/src/conf_test_nffs.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "sysinit/sysinit.h"
 #include <os/os.h>
 #include <testutil/testutil.h>
 #include <nffs/nffs.h>
@@ -355,8 +356,7 @@ TEST_SUITE(config_test_all)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     conf_init();
     config_test_all();

--- a/sys/flash_map/test/src/flash_map_test.c
+++ b/sys/flash_map/test/src/flash_map_test.c
@@ -51,8 +51,7 @@ TEST_SUITE(flash_map_test_suite)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     fa_sectors = (struct flash_area *)
                 malloc(sizeof(struct flash_area*) * SELFTEST_FA_SECTOR_COUNT);

--- a/sys/log/full/test/src/log_test.c
+++ b/sys/log/full/test/src/log_test.c
@@ -18,6 +18,7 @@
  */
 #include <string.h>
 
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "os/os.h"
 #include "testutil/testutil.h"
@@ -100,8 +101,7 @@ TEST_SUITE(log_test_all)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     log_test_all();
 

--- a/test/testutil/include/testutil/testutil.h
+++ b/test/testutil/include/testutil/testutil.h
@@ -132,8 +132,6 @@ struct ts_config {
     void *ts_restart_arg;
 };
 
-int tu_parse_args(int argc, char **argv);
-int tu_init(void);
 void tu_restart(void);
 
 /*

--- a/test/testutil/pkg.yml
+++ b/test/testutil/pkg.yml
@@ -29,3 +29,6 @@ pkg.deps:
     - hw/hal
     - kernel/os
     - sys/sysinit
+
+pkg.init:
+    tu_init: 1

--- a/test/testutil/src/testutil.c
+++ b/test/testutil/src/testutil.c
@@ -37,15 +37,16 @@ int tu_any_failed;
 
 struct ts_testsuite_list *ts_suites;
 
-int
+void
 tu_init(void)
 {
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
 #if MYNEWT_VAL(SELFTEST)
     os_init(NULL);
-    sysinit();
+    ts_config.ts_print_results = 1;
 #endif
-
-    return 0;
 }
 
 void
@@ -57,25 +58,6 @@ tu_arch_restart(void)
 #else
     hal_system_reset();
 #endif
-}
-
-int
-tu_parse_args(int argc, char **argv)
-{
-    int ch;
-
-    while ((ch = getopt(argc, argv, "s")) != -1) {
-        switch (ch) {
-        case 's':
-            ts_config.ts_system_assert = 1;
-            break;
-
-        default:
-            return EINVAL;
-        }
-    }
-
-    return 0;
 }
 
 void

--- a/util/cbmem/test/src/cbmem_test.c
+++ b/util/cbmem/test/src/cbmem_test.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stddef.h>
+#include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
@@ -96,8 +97,7 @@ TEST_SUITE(cbmem_test_suite)
 int
 main(int argc, char **argv)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     tu_suite_set_init_cb(setup_cbmem1, NULL);
     cbmem_test_suite();


### PR DESCRIPTION
All selftest main() functions had the same initialization sequence for the testutil package:

1. `ts_config.ts_print_results = 1;`
2. `tu_init();`
3. (sometimes) `tu_parse_args(argc, argv);`

The issues with this are:

* Since (1) is always present, it could be performed by the `tu_init()` function call automatically.
* (2) is inconsistent with regular apps.  An app calls `sysinit()` from main, but selftest programs call `tu_init()`, which in turn calls `sysinit()`.
* (3) is obsolete; `newt run <test-pkg>` takes care of argument parsing now.

This commit addresses these issues as follows:

1. Move `ts_config.ts_print_results = 1;` into `tu_init()`.
2. Turn `tu_init()` into a sysinit function.  That is, have it get called automatically by sysinit.
3. Remove `tu_parse_args()` entirely.
4. In selftest `main()` functions, call `sysinit()` instead of `tu_init()` like a regular app.

The motivation for this commit is to make unit test documentation easier to understand.