### PR TITLE
nimble/controller: Remove not working restrictions

### DIFF
--- a/net/nimble/controller/syscfg.yml
+++ b/net/nimble/controller/syscfg.yml
@@ -241,9 +241,6 @@ syscfg.defs:
             Advertising Feature. That means extended scanner, advertiser
             and connect.
         value: MYNEWT_VAL_BLE_EXT_ADV
-        restrictions:
-            - 'BLE_EXT_ADV if 1'
-            - '!BLE_EXT_ADV if 0'
 
     BLE_PUBLIC_DEV_ADDR:
         description: >


### PR DESCRIPTION
When BLE_EXT_ADV is set to 0 then we got:

Error: Syscfg restriction violations detected:
    BLE_LL_CFG_FEAT_LL_EXT_ADV=MYNEWT_VAL_BLE_EXT_ADV requires
BLE_EXT_ADV be set, but BLE_EXT_ADV=0

Setting history (newest -> oldest):
    BLE_EXT_ADV: [net/nimble:0]
    BLE_LL_CFG_FEAT_LL_EXT_ADV:
[net/nimble/controller:MYNEWT_VAL_BLE_EXT_ADV]

This is because BLE_LL_CFG_FEAT_LL_EXT_ADV value is other flag which is
not resolved yet.

This patch remove restrictions. It should still work fine until user use
BLE_EXT_ADV to configure extended advertising - will put it in
documentation