### PR TITLE
nimble: add monitor protocol/interface

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -61,6 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * PRINTF_SUPPORT_LONG because int == long.
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -337,6 +338,7 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 break;
             case '%':
                 written += putf(putp, ch);
+                break;
             default:
                 break;
             }

--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -375,9 +375,15 @@ int printf(const char *fmt, ...)
 int vsnprintf(char *str, size_t size, const char *fmt, va_list va)
 {
     struct MemFile state;
-    FILE *f = fmemopen_w(&state, str, size - 1);
+    FILE *f = fmemopen_w(&state, str, size);
     tfp_format(f, fmt, va);
-    *(state.buffer) = '\0';
+    if (size > 0) {
+        if (state.bytes_written < size) {
+            *(state.buffer) = '\0';
+        } else {
+            str[size - 1] = '\0';
+        }
+    }
     return state.bytes_written;
 }
 

--- a/net/nimble/host/include/host/ble_monitor.h
+++ b/net/nimble/host/include/host/ble_monitor.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-// TODO: API goes here...
+int ble_monitor_log(int level, const char *fmt, ...);
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/include/host/ble_monitor.h
+++ b/net/nimble/host/include/host/ble_monitor.h
@@ -23,7 +23,7 @@
 #include <syscfg/syscfg.h>
 
 #undef BLE_MONITOR
-#define BLE_MONITOR (MYNEWT_VAL(BLE_MONITOR_UART))
+#define BLE_MONITOR (MYNEWT_VAL(BLE_MONITOR_UART) || MYNEWT_VAL(BLE_MONITOR_RTT))
 
 #ifdef __cplusplus
 extern "C" {

--- a/net/nimble/host/include/host/ble_monitor.h
+++ b/net/nimble/host/include/host/ble_monitor.h
@@ -31,6 +31,8 @@ extern "C" {
 
 int ble_monitor_log(int level, const char *fmt, ...);
 
+int ble_monitor_out(int c);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/host/include/host/ble_monitor.h
+++ b/net/nimble/host/include/host/ble_monitor.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_MONITOR_
+#define H_BLE_MONITOR_
+
+#include <syscfg/syscfg.h>
+
+#undef BLE_MONITOR
+#define BLE_MONITOR (MYNEWT_VAL(BLE_MONITOR_UART))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// TODO: API goes here...
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/net/nimble/host/pkg.yml
+++ b/net/nimble/host/pkg.yml
@@ -36,6 +36,9 @@ pkg.deps.BLE_SM_LEGACY:
 pkg.deps.BLE_SM_SC:
     - crypto/tinycrypt
 
+pkg.deps.BLE_MONITOR_RTT:
+    - hw/drivers/rtt
+
 pkg.req_apis:
     - ble_transport
     - console

--- a/net/nimble/host/src/ble_hs_dbg.c
+++ b/net/nimble/host/src/ble_hs_dbg.c
@@ -24,6 +24,7 @@
 #include "console/console.h"
 #include "nimble/hci_common.h"
 #include "nimble/ble_hci_trans.h"
+#include "host/ble_monitor.h"
 #include "ble_hs_priv.h"
 
 static void
@@ -452,7 +453,7 @@ ble_hs_dbg_cmd_status_disp(uint8_t *evdata, uint8_t len)
 void
 ble_hs_dbg_event_disp(uint8_t *evbuf)
 {
-#if MYNEWT_VAL(LOG_LEVEL) > LOG_LEVEL_DEBUG
+#if MYNEWT_VAL(LOG_LEVEL) > LOG_LEVEL_DEBUG || BLE_MONITOR
     return;
 #endif
 

--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -23,6 +23,7 @@
 #include "os/os.h"
 #include "mem/mem.h"
 #include "nimble/ble_hci_trans.h"
+#include "host/ble_monitor.h"
 #include "ble_hs_priv.h"
 #include "ble_hs_dbg_priv.h"
 #include "ble_monitor_priv.h"
@@ -403,8 +404,10 @@ ble_hs_hci_acl_hdr_prepend(struct os_mbuf *om, uint16_t handle,
 
     memcpy(om->om_data, &hci_hdr, sizeof hci_hdr);
 
+#if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "host tx hci data; handle=%d length=%d\n", handle,
                get_le16(&hci_hdr.hdh_len));
+#endif
 
     return om;
 }
@@ -441,9 +444,11 @@ ble_hs_hci_acl_tx(struct ble_hs_conn *connection, struct os_mbuf *txom)
         }
         pb = BLE_HCI_PB_MIDDLE;
 
+#if !BLE_MONITOR
         BLE_HS_LOG(DEBUG, "ble_hs_hci_acl_tx(): ");
         ble_hs_log_mbuf(frag);
         BLE_HS_LOG(DEBUG, "\n");
+#endif
 
         rc = ble_hs_tx_data(frag);
         if (rc != 0) {

--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -25,6 +25,7 @@
 #include "nimble/ble_hci_trans.h"
 #include "ble_hs_priv.h"
 #include "ble_hs_dbg_priv.h"
+#include "ble_monitor_priv.h"
 
 #define BLE_HCI_CMD_TIMEOUT     (OS_TICKS_PER_SEC)
 
@@ -233,6 +234,12 @@ ble_hs_hci_wait_for_ack(void)
     switch (rc) {
     case 0:
         BLE_HS_DBG_ASSERT(ble_hs_hci_ack != NULL);
+
+#if BLE_MONITOR
+        ble_monitor_send(BLE_MONITOR_OPCODE_EVENT_PKT, ble_hs_hci_ack,
+                         ble_hs_hci_ack[1] + BLE_HCI_EVENT_HDR_LEN);
+#endif
+
         break;
     case OS_TIMEOUT:
         rc = BLE_HS_ETIMEOUT_HCI;

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -27,11 +27,17 @@
 #include "nimble/ble_hci_trans.h"
 #include "ble_hs_dbg_priv.h"
 #include "ble_hs_priv.h"
+#include "ble_monitor_priv.h"
 
 static int
 ble_hs_hci_cmd_transport(uint8_t *cmdbuf)
 {
     int rc;
+
+#if BLE_MONITOR
+    ble_monitor_send(BLE_MONITOR_OPCODE_COMMAND_PKT, cmdbuf,
+                     cmdbuf[2] + BLE_HCI_CMD_HDR_LEN);
+#endif
 
     rc = ble_hci_trans_hs_cmd_tx(cmdbuf);
     switch (rc) {

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -25,6 +25,7 @@
 #include "console/console.h"
 #include "nimble/hci_common.h"
 #include "nimble/ble_hci_trans.h"
+#include "host/ble_monitor.h"
 #include "ble_hs_dbg_priv.h"
 #include "ble_hs_priv.h"
 #include "ble_monitor_priv.h"
@@ -80,10 +81,13 @@ ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len, const void *cmddata)
         memcpy(buf + BLE_HCI_CMD_HDR_LEN, cmddata, len);
     }
 
+#if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "ble_hs_hci_cmd_send: ogf=0x%02x ocf=0x%04x len=%d\n",
                ogf, ocf, len);
     ble_hs_log_flat_buf(buf, len + BLE_HCI_CMD_HDR_LEN);
     BLE_HS_LOG(DEBUG, "\n");
+#endif
+
     rc = ble_hs_hci_cmd_transport(buf);
 
     if (rc == 0) {

--- a/net/nimble/host/src/ble_hs_hci_evt.c
+++ b/net/nimble/host/src/ble_hs_hci_evt.c
@@ -25,6 +25,7 @@
 #include "nimble/hci_common.h"
 #include "nimble/ble_hci_trans.h"
 #include "host/ble_gap.h"
+#include "host/ble_monitor.h"
 #include "ble_hs_priv.h"
 #include "ble_hs_dbg_priv.h"
 
@@ -605,6 +606,7 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
     }
 
 #if (BLETEST_THROUGHPUT_TEST == 0)
+#if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "ble_hs_hci_evt_acl_process(): conn_handle=%u pb=%x "
                       "len=%u data=",
                BLE_HCI_DATA_HANDLE(hci_hdr.hdh_handle_pb_bc),
@@ -612,6 +614,7 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
                hci_hdr.hdh_len);
     ble_hs_log_mbuf(om);
     BLE_HS_LOG(DEBUG, "\n");
+#endif
 #endif
 
     if (hci_hdr.hdh_len != OS_MBUF_PKTHDR(om)->omp_len) {

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -43,6 +43,7 @@
 #include "ble_hs_id_priv.h"
 #include "ble_uuid_priv.h"
 #include "host/ble_hs.h"
+#include "host/ble_monitor.h"
 #include "nimble/nimble_opt.h"
 #include "stats/stats.h"
 #ifdef __cplusplus
@@ -119,7 +120,7 @@ void ble_hs_hw_error(uint8_t hw_code);
 void ble_hs_timer_resched(void);
 void ble_hs_notifications_sched(void);
 
-#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_DEBUG
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_DEBUG && !BLE_MONITOR
 
 #define BLE_HS_LOG_CMD(is_tx, cmd_type, cmd_name, conn_handle,                \
                        log_cb, cmd) do                                        \

--- a/net/nimble/host/src/ble_l2cap_sig.c
+++ b/net/nimble/host/src/ble_l2cap_sig.c
@@ -46,6 +46,7 @@
 #include <errno.h>
 #include "console/console.h"
 #include "nimble/ble.h"
+#include "host/ble_monitor.h"
 #include "ble_hs_priv.h"
 
 /*****************************************************************************
@@ -740,7 +741,9 @@ ble_l2cap_sig_coc_rsp_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
     struct ble_hs_conn *conn;
     int rc;
 
+#if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "L2CAP LE COC connection response received\n");
+#endif
 
     proc = ble_l2cap_sig_proc_extract(conn_handle,
                                       BLE_L2CAP_SIG_PROC_OP_CONNECT,
@@ -1109,9 +1112,12 @@ ble_l2cap_sig_rx(struct ble_l2cap_chan *chan)
     om = &chan->rx_buf;
 
     STATS_INC(ble_l2cap_stats, sig_rx);
+
+#if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "L2CAP - rxed signalling msg: ");
     ble_hs_log_mbuf(*om);
     BLE_HS_LOG(DEBUG, "\n");
+#endif
 
     rc = ble_hs_mbuf_pullup_base(om, BLE_L2CAP_SIG_HDR_SZ);
     if (rc != 0) {

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -307,7 +307,7 @@ ble_monitor_log(int level, const char *fmt, ...)
     int len;
 
     va_start(va, fmt);
-    len = vsprintf(NULL, fmt, va);
+    len = vsnprintf(NULL, 0, fmt, va);
     va_end(va);
 
     switch (level) {

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -94,6 +94,9 @@ monitor_uart_queue_char(uint8_t ch)
             tx_ringbuf_tail) {
         uart_start_tx(uart);
         OS_EXIT_CRITICAL(sr);
+        if (os_started()) {
+            os_time_delay(1);
+        }
         OS_ENTER_CRITICAL(sr);
     }
 

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -207,8 +207,8 @@ ble_monitor_init(void)
         .uc_cb_arg = NULL,
     };
 
-    uart = (struct uart_dev *)os_dev_open("uart0", OS_TIMEOUT_NEVER,
-                                             &uc);
+    uart = (struct uart_dev *)os_dev_open(MYNEWT_VAL(BLE_MONITOR_UART_DEV),
+                                          OS_TIMEOUT_NEVER, &uc);
     if (!uart) {
         return -1;
     }

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -311,4 +311,23 @@ ble_monitor_log(int level, const char *fmt, ...)
     return 0;
 }
 
+int
+ble_monitor_out(int c)
+{
+    static char buf[128];
+    static size_t len;
+
+    if (c != '\n' && len < sizeof(buf) - 1) {
+        buf[len++] = c;
+        return c;
+    }
+
+    buf[len++] = '\0';
+
+    ble_monitor_send(BLE_MONITOR_OPCODE_SYSTEM_NOTE, buf, len);
+    len = 0;
+
+    return c;
+}
+
 #endif

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -300,9 +300,9 @@ ble_monitor_new_index(uint8_t bus, uint8_t *addr, const char *name)
 int
 ble_monitor_log(int level, const char *fmt, ...)
 {
+    static const char id[] = "nimble";
     struct ble_monitor_hdr hdr;
     struct ble_monitor_user_logging ulog;
-    const char id[] = "nimble";
     va_list va;
     int len;
 

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -151,7 +151,8 @@ monitor_write(const void *buf, size_t len)
 }
 #endif
 
-static size_t btmon_write(FILE *instance, const char *bp, size_t n)
+static size_t
+btmon_write(FILE *instance, const char *bp, size_t n)
 {
     monitor_write(bp, n);
 

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -216,10 +216,12 @@ ble_monitor_init(void)
 
 #if MYNEWT_VAL(BLE_MONITOR_RTT)
 #if MYNEWT_VAL(BLE_MONITOR_RTT_BUFFERED)
-    rtt_index = SEGGER_RTT_AllocUpBuffer("monitor", rtt_buf, sizeof(rtt_buf),
+    rtt_index = SEGGER_RTT_AllocUpBuffer(MYNEWT_VAL(BLE_MONITOR_RTT_BUFFER_NAME),
+                                         rtt_buf, sizeof(rtt_buf),
                                          SEGGER_RTT_MODE_NO_BLOCK_SKIP);
 #else
-    rtt_index = SEGGER_RTT_AllocUpBuffer("monitor", rtt_buf, sizeof(rtt_buf),
+    rtt_index = SEGGER_RTT_AllocUpBuffer(MYNEWT_VAL(BLE_MONITOR_RTT_BUFFER_NAME),
+                                         rtt_buf, sizeof(rtt_buf),
                                          SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL);
 #endif
 

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "host/ble_monitor.h"
+
+#if BLE_MONITOR
+
+#include <stdio.h>
+#include <inttypes.h>
+#include "os/os.h"
+#include "uart/uart.h"
+#include "ble_monitor_priv.h"
+
+/* UTC Timestamp for Jan 2016 00:00:00 */
+#define UTC01_01_2016    1451606400
+
+struct os_mutex lock;
+
+struct uart_dev *uart;
+
+static uint8_t tx_ringbuf[64];
+static uint8_t tx_ringbuf_head;
+static uint8_t tx_ringbuf_tail;
+
+static inline int
+inc_and_wrap(int i, int max)
+{
+    return (i + 1) & (max - 1);
+}
+
+static int
+monitor_uart_tx_char(void *arg)
+{
+    uint8_t ch;
+
+    /* No more data */
+    if (tx_ringbuf_head == tx_ringbuf_tail) {
+        return -1;
+    }
+
+    ch = tx_ringbuf[tx_ringbuf_tail];
+    tx_ringbuf_tail = inc_and_wrap(tx_ringbuf_tail, sizeof(tx_ringbuf));
+
+    return ch;
+}
+
+static void
+monitor_uart_queue_char(uint8_t ch)
+{
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+
+    /* We need to try flush some data from ringbuffer if full */
+    while (inc_and_wrap(tx_ringbuf_head, sizeof(tx_ringbuf)) ==
+            tx_ringbuf_tail) {
+        uart_start_tx(uart);
+        OS_EXIT_CRITICAL(sr);
+        OS_ENTER_CRITICAL(sr);
+    }
+
+    tx_ringbuf[tx_ringbuf_head] = ch;
+    tx_ringbuf_head = inc_and_wrap(tx_ringbuf_head, sizeof(tx_ringbuf));
+
+    OS_EXIT_CRITICAL(sr);
+}
+
+static void
+monitor_write(const void *buf, size_t len)
+{
+    const uint8_t *ch = buf;
+
+    while (len--) {
+        monitor_uart_queue_char(*ch++);
+    }
+
+    uart_start_tx(uart);
+}
+
+static void
+encode_monitor_hdr(struct ble_monitor_hdr *hdr, int64_t ts, uint16_t opcode,
+                   uint16_t len)
+{
+    int rc;
+    struct os_timeval tv;
+
+    hdr->hdr_len  = sizeof(hdr->type) + sizeof(hdr->ts32);
+    hdr->data_len = htole16(4 + hdr->hdr_len + len);
+    hdr->opcode   = htole16(opcode);
+    hdr->flags    = 0;
+
+    /* Calculate timestamp if not present (same way as used in log module) */
+    if (ts < 0) {
+        rc = os_gettimeofday(&tv, NULL);
+        if (rc || tv.tv_sec < UTC01_01_2016) {
+            ts = os_get_uptime_usec();
+        } else {
+            ts = tv.tv_sec * 1000000 + tv.tv_usec;
+        }
+    }
+
+    /* Extended header */
+    hdr->type = BLE_MONITOR_EXTHDR_TS32;
+    hdr->ts32 = htole32(ts / 100);
+}
+
+int
+ble_monitor_init(void)
+{
+    struct uart_conf uc = {
+        .uc_speed = MYNEWT_VAL(BLE_MONITOR_UART_BAUDRATE),
+        .uc_databits = 8,
+        .uc_stopbits = 1,
+        .uc_parity = UART_PARITY_NONE,
+        .uc_flow_ctl = UART_FLOW_CTL_NONE,
+        .uc_tx_char = monitor_uart_tx_char,
+        .uc_rx_char = NULL,
+        .uc_cb_arg = NULL,
+    };
+
+    uart = (struct uart_dev *)os_dev_open("uart0", OS_TIMEOUT_NEVER,
+                                             &uc);
+    if (!uart) {
+        return -1;
+    }
+
+    os_mutex_init(&lock);
+
+    return 0;
+}
+
+int
+ble_monitor_send(uint16_t opcode, const void *data, size_t len)
+{
+    struct ble_monitor_hdr hdr;
+
+    encode_monitor_hdr(&hdr, -1, opcode, len);
+
+    os_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+
+    monitor_write(&hdr, sizeof(hdr));
+    monitor_write(data, len);
+
+    os_mutex_release(&lock);
+
+    return 0;
+}
+
+int
+ble_monitor_send_om(uint16_t opcode, const struct os_mbuf *om)
+{
+    const struct os_mbuf *om_tmp;
+    struct ble_monitor_hdr hdr;
+    uint16_t length = 0;
+
+    om_tmp = om;
+    while (om_tmp) {
+        length += om_tmp->om_len;
+        om_tmp = SLIST_NEXT(om_tmp, om_next);
+    }
+
+    encode_monitor_hdr(&hdr, -1, opcode, length);
+
+    os_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+
+    monitor_write(&hdr, sizeof(hdr));
+
+    while (om) {
+        monitor_write(om->om_data, om->om_len);
+        om = SLIST_NEXT(om, om_next);
+    }
+
+    os_mutex_release(&lock);
+
+    return 0;
+}
+
+int
+ble_monitor_new_index(uint8_t bus, uint8_t *addr, const char *name)
+{
+    struct ble_monitor_new_index pkt;
+
+    pkt.type = 0; /* Primary controller, we don't support other */
+    pkt.bus = bus;
+    memcpy(pkt.bdaddr, addr, 6);
+    strncpy(pkt.name, name, sizeof(pkt.name) - 1);
+    pkt.name[sizeof(pkt.name) - 1] = '\0';
+
+    ble_monitor_send(BLE_MONITOR_OPCODE_NEW_INDEX, &pkt, sizeof(pkt));
+
+    return 0;
+}
+
+#endif

--- a/net/nimble/host/src/ble_monitor_priv.h
+++ b/net/nimble/host/src/ble_monitor_priv.h
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_MONITOR_PRIV_
+#define H_BLE_MONITOR_PRIV_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLE_MONITOR_OPCODE_NEW_INDEX    0
+#define BLE_MONITOR_OPCODE_DEL_INDEX    1
+#define BLE_MONITOR_OPCODE_COMMAND_PKT  2
+#define BLE_MONITOR_OPCODE_EVENT_PKT    3
+#define BLE_MONITOR_OPCODE_ACL_TX_PKT   4
+#define BLE_MONITOR_OPCODE_ACL_RX_PKT   5
+#define BLE_MONITOR_OPCODE_SCO_TX_PKT   6
+#define BLE_MONITOR_OPCODE_SCO_RX_PKT   7
+#define BLE_MONITOR_OPCODE_OPEN_INDEX   8
+#define BLE_MONITOR_OPCODE_CLOSE_INDEX  9
+#define BLE_MONITOR_OPCODE_INDEX_INFO   10
+#define BLE_MONITOR_OPCODE_VENDOR_DIAG  11
+#define BLE_MONITOR_OPCODE_SYSTEM_NOTE  12
+#define BLE_MONITOR_OPCODE_USER_LOGGING 13
+#define BLE_MONITOR_OPCODE_NOP          255
+
+#define BLE_MONITOR_EXTHDR_COMMAND_DROPS    1
+#define BLE_MONITOR_EXTHDR_EVENT_DROPS      2
+#define BLE_MONITOR_EXTHDR_ACL_RX_DROPS     3
+#define BLE_MONITOR_EXTHDR_ACL_TX_DROPS     4
+#define BLE_MONITOR_EXTHDR_SCO_RX_DROPS     5
+#define BLE_MONITOR_EXTHDR_SCO_TX_DROPS     6
+#define BLE_MONITOR_EXTHDR_OTHER_DROPS      7
+#define BLE_MONITOR_EXTHDR_TS32             8
+
+struct ble_monitor_hdr {
+    uint16_t  data_len;
+    uint16_t  opcode;
+    uint8_t   flags;
+    uint8_t   hdr_len;
+
+    /* Extended header (timestamp always present) */
+    uint8_t   type;
+    uint32_t  ts32;
+} __attribute__((packed));
+
+struct ble_monitor_new_index {
+    uint8_t  type;
+    uint8_t  bus;
+    uint8_t  bdaddr[6];
+    char     name[8];
+} __attribute__((packed));
+
+struct ble_monitor_user_logging {
+    uint8_t  priority;
+    uint8_t  ident_len;
+} __attribute__((packed));
+
+int ble_monitor_init(void);
+
+int ble_monitor_send(uint16_t opcode, const void *data, size_t len);
+
+int ble_monitor_send_om(uint16_t opcode, const struct os_mbuf *om);
+
+int ble_monitor_new_index(uint8_t bus, uint8_t *addr, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -47,6 +47,9 @@ syscfg.defs:
     BLE_MONITOR_UART_BAUDRATE:
         description: Baudrate for monitor interface UART
         value: 1000000
+    BLE_MONITOR_RTT:
+        description: Enables monitor interface over RTT
+        value: 0
 
     # L2CAP settings.
     BLE_L2CAP_MAX_CHANS:

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -44,6 +44,9 @@ syscfg.defs:
     BLE_MONITOR_UART:
         description: Enables monitor interface over UART
         value: 0
+    BLE_MONITOR_UART_DEV:
+        description: Monitor interface UART device
+        value: '"uart0"'
     BLE_MONITOR_UART_BAUDRATE:
         description: Baudrate for monitor interface UART
         value: 1000000

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -53,6 +53,9 @@ syscfg.defs:
     BLE_MONITOR_RTT:
         description: Enables monitor interface over RTT
         value: 0
+    BLE_MONITOR_RTT_BUFFER_NAME:
+        description: Monitor interface upstream buffer name
+        value: '"monitor"'
     BLE_MONITOR_RTT_BUFFERED:
         description: >
             Enables buffering when using monitor interface over RTT. The data

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -50,6 +50,14 @@ syscfg.defs:
     BLE_MONITOR_RTT:
         description: Enables monitor interface over RTT
         value: 0
+    BLE_MONITOR_RTT_BUFFERED:
+        description: >
+            Enables buffering when using monitor interface over RTT. The data
+            are written to RTT once complete packet is created in intermediate
+            buffer. This allows to skip complete packet if there is not enough
+            space in RTT buffer (e.g. there is no reader connected). If disabled,
+            monitor will simply block waiting for RTT to free space in buffer.
+        value: 1
 
     # L2CAP settings.
     BLE_L2CAP_MAX_CHANS:

--- a/net/nimble/host/syscfg.yml
+++ b/net/nimble/host/syscfg.yml
@@ -40,6 +40,14 @@ syscfg.defs:
             simulator.
         value: 1
 
+    # Monitor interface settings
+    BLE_MONITOR_UART:
+        description: Enables monitor interface over UART
+        value: 0
+    BLE_MONITOR_UART_BAUDRATE:
+        description: Baudrate for monitor interface UART
+        value: 1000000
+
     # L2CAP settings.
     BLE_L2CAP_MAX_CHANS:
         description: >

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -17,23 +17,25 @@
  * under the License.
  */
 
-#ifndef __CONSOLE_PRIV_H__
-#define __CONSOLE_PRIV_H__
+#include <syscfg/syscfg.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#if MYNEWT_VAL(CONSOLE_BLE_MONITOR)
 
-int uart_console_is_init(void);
-int uart_console_init(void);
-void uart_console_blocking_mode(void);
-void uart_console_non_blocking_mode(void);
-int rtt_console_is_init(void);
-int rtt_console_init(void);
-int ble_monitor_console_is_init(void);
+#include "host/ble_monitor.h"
+#include "console/console.h"
 
-#ifdef __cplusplus
+int
+console_out(int c)
+{
+    console_is_midline = (c != '\n');
+
+    return ble_monitor_out(c);
 }
-#endif
 
-#endif /* __CONSOLE_PRIV_H__ */
+int
+ble_monitor_console_is_init(void)
+{
+    return 1;
+}
+
+#endif /* MYNEWT_VAL(CONSOLE_BLE_MONITOR) */

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -511,6 +511,9 @@ console_is_init(void)
 #if MYNEWT_VAL(CONSOLE_RTT)
     return rtt_console_is_init();
 #endif
+#if MYNEWT_VAL(CONSOLE_BLE_MONITOR)
+    return ble_monitor_console_is_init();
+#endif
     return 0;
 }
 

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -25,6 +25,9 @@ syscfg.defs:
     CONSOLE_RTT:
         description: 'Set console output to RTT'
         value: 0
+    CONSOLE_BLE_MONITOR:
+        description: 'Set console output to BLE Monitor'
+        value: 0
     CONSOLE_INPUT:
         description: 'Enable console input'
         value: 1


### PR DESCRIPTION
See here for details: http://mail-archives.apache.org/mod_mbox/incubator-mynewt-dev/201706.mbox/%3CCADAkoF4LQOdqH%3DLh%3D5GgBPC9nEaXV95TV_uQPXXWuhrpCXfbtQ%40mail.gmail.com%3E

This is core monitor protocol functionality extracted from https://github.com/apache/mynewt-core/pull/362 so logging stuff does not block it.