### PR TITLE
Add support for the VBLUno52 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It currently supports the following hardware platforms:
 * RuuviTag Sensor beacon platform (Nordic nRF52832 based)
 * nRF51 DK from Nordic Semiconductor (Cortex-M0)
 * VBLUno51 from VNG IoT Lab (Nordic nRF51822 SoC based)
+* VBLUno52 from VNG IoT Lab (Nordic nRF52832 SoC based, Cortex-M4)
 * BLE Nano from RedBear (Nordic nRF51822 SoC based)
 * BLE Nano2 and Blend2 from RedBear (Nordic nRF52832 SoC based)
 * BMD-300-EVAL-ES from Rigado (Cortex-M4)

--- a/hw/bsp/vbluno52/boot-nrf52xxaa.ld
+++ b/hw/bsp/vbluno52/boot-nrf52xxaa.ld
@@ -1,0 +1,25 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x4000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x10000
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/vbluno52/bsp.yml
+++ b/hw/bsp/vbluno52/bsp.yml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.arch: cortex_m4
+bsp.compiler: compiler/arm-none-eabi-m4
+bsp.linkerscript:
+    - "hw/bsp/vbluno52/nrf52xxaa.ld"
+    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/vbluno52/boot-nrf52xxaa.ld"
+    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+bsp.part2linkerscript: "hw/bsp/vbluno52/split-vbluno52.ld"
+bsp.downloadscript: "hw/bsp/vbluno52/vbluno52_download.sh"
+bsp.debugscript: "hw/bsp/vbluno52/vbluno52_debug.sh"
+bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/vbluno52/vbluno52_download.cmd"
+bsp.debugscript.WINDOWS.OVERWRITE: "hw/bsp/vbluno52/vbluno52_debug.cmd"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x00000000
+            size: 16kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x00008000
+            size: 232kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x00042000
+            size: 232kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x0007c000
+            size: 4kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x00004000
+            size: 16kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x0007d000
+            size: 12kB

--- a/hw/bsp/vbluno52/include/bsp/bsp.h
+++ b/hw/bsp/vbluno52/include/bsp/bsp.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+
+#include <syscfg/syscfg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stackos sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+#define sec_bss_nz_core __attribute__((section(".bss.core.nz")))
+
+/* More convenient section placement macros. */
+#define bssnz_t         sec_bss_nz_core
+
+extern uint8_t _ram_start;
+#define RAM_SIZE        0x10000
+
+/* LED pin */
+#define LED 			(12)
+#define LED_BLINK_PIN   LED
+#define LED_2           LED
+
+/* BUTTON pin */
+#define BUT 			(17)
+#define SW 				BUT
+
+
+#define NFFS_AREA_MAX   (8)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/vbluno52/include/bsp/cmsis_nvic.h
+++ b/hw/bsp/vbluno52/include/bsp/cmsis_nvic.h
@@ -1,0 +1,29 @@
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include <stdint.h>
+
+#define NVIC_NUM_VECTORS      (16 + 38)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
+#include "nrf52.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_Relocate(void);
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/bsp/vbluno52/nrf52xxaa.ld
+++ b/hw/bsp/vbluno52/nrf52xxaa.ld
@@ -1,0 +1,25 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00008000, LENGTH = 0x3a000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x10000
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/vbluno52/pkg.yml
+++ b/hw/bsp/vbluno52/pkg.yml
@@ -1,0 +1,95 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bsp/vbluno52
+pkg.type: bsp
+pkg.description: BSP definition for the VNG VBLUno52 board (Nordic nRF52832 Cortex-M4 SoC based).
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - nrf52
+    - vbluno52
+
+pkg.cflags:
+    # Nordic SDK files require these defines.
+    - '-DADC_ENABLED=0'
+    - '-DCLOCK_ENABLED=1'
+    - '-DCOMP_ENABLED=1'
+    - '-DEGU_ENABLED=0'
+    - '-DGPIOTE_ENABLED=1'
+    - '-DI2S_ENABLED=1'
+    - '-DLPCOMP_ENABLED=1'
+    - '-DNRF52'
+    - '-DPDM_ENABLED=0'
+    - '-DPERIPHERAL_RESOURCE_SHARING_ENABLED=1'
+    - '-DPWM0_ENABLED=1'
+    - '-DPWM1_ENABLED=0'
+    - '-DPWM2_ENABLED=0'
+    - '-DQDEC_ENABLED=1'
+    - '-DRNG_ENABLED=1'
+    - '-DRTC0_ENABLED=0'
+    - '-DRTC1_ENABLED=0'
+    - '-DRTC2_ENABLED=0'
+    - '-DSAADC_ENABLED=1'
+    - '-DSPI_MASTER_0_ENABLE=1'
+    - '-DSPI0_CONFIG_MISO_PIN=14'
+    - '-DSPI0_CONFIG_MOSI_PIN=13'
+    - '-DSPI0_CONFIG_SCK_PIN=15'
+    - '-DSPI0_ENABLED=1'
+    - '-DSPI0_USE_EASY_DMA=1'
+    - '-DSPI1_ENABLED=0'
+    - '-DSPI2_ENABLED=0'
+    - '-DSPIS0_CONFIG_MISO_PIN=14'
+    - '-DSPIS0_CONFIG_MOSI_PIN=13'
+    - '-DSPIS0_CONFIG_SCK_PIN=15'
+    - '-DSPIS0_ENABLED=1'
+    - '-DSPIS1_CONFIG_MISO_PIN=4'
+    - '-DSPIS1_CONFIG_MOSI_PIN=3'
+    - '-DSPIS1_CONFIG_SCK_PIN=2'
+    - '-DSPIS1_ENABLED=0'
+    - '-DSPIS2_ENABLED=0'
+    - '-DTIMER0_ENABLED=1'
+    - '-DTIMER1_ENABLED=0'
+    - '-DTIMER2_ENABLED=0'
+    - '-DTIMER3_ENABLED=0'
+    - '-DTIMER4_ENABLED=0'
+    - '-DTWI0_CONFIG_SCL=27'
+    - '-DTWI0_CONFIG_SDA=26'
+    - '-DTWI0_ENABLED=1'
+    - '-DTWI1_ENABLED=1'
+    - '-DTWIS0_ENABLED=1'
+    - '-DTWIS1_ENABLED=0'
+    - '-DUART0_ENABLED=1'
+    - '-DWDT_ENABLED=1'
+
+pkg.cflags.HARDFLOAT:
+    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+pkg.deps:
+    - hw/mcu/nordic/nrf52xxx
+    - libc/baselibc
+
+pkg.deps.BLE_DEVICE:
+    - hw/drivers/nimble/nrf52
+
+pkg.deps.UART_0:
+    - hw/drivers/uart/uart_hal
+
+pkg.deps.UART_1:
+    - hw/drivers/uart/uart_bitbang

--- a/hw/bsp/vbluno52/split-vbluno52.ld
+++ b/hw/bsp/vbluno52/split-vbluno52.ld
@@ -1,0 +1,208 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN =  0x00042000, LENGTH = 0x3a000
+  RAM  (rwx) : ORIGIN =  0x20000000, LENGTH = 0x10000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __bssnz_start__
+ *   __bssnz_end__
+ */
+ENTRY(Reset_Handler_split)
+
+SECTIONS
+{
+    .imghdr (NOLOAD):
+    {
+        . = . + 0x20;
+    } > FLASH
+
+    .text :
+    {
+        __split_isr_vector_start = .;
+        KEEP(*(.isr_vector_split))
+        __split_isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+
+    .ARM.extab : ALIGN(4)
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    /* save RAM used by the split image. This assumes that 
+     * the loader uses all the RAM up to its HeapBase  */
+    .loader_ram_contents :
+    {
+        _loader_ram_start = .;
+
+ 	/* this symbol comes from the loader linker */
+	. = . + (ABSOLUTE(__HeapBase_loader) - _loader_ram_start);
+        _loader_ram_end = .;
+    } > RAM
+
+    .data :
+    {
+        __data_start__ = .;
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        *(.preinit_array)
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        *(SORT(.init_array.*))
+        *(.init_array)
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM AT > FLASH
+
+    /* Non-zeroed BSS.  This section is similar to BSS, with the following two
+     * caveats:
+     *    1. It does not get zeroed at init-time.
+     *    2. You cannot use it as source memory for EasyDMA.
+     *
+     * This section exists because of a hardware defect; see errata 33 and 34
+     * in nrf52 errata sheet.
+     */
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/hw/bsp/vbluno52/src/arch/cortex_m4/gcc_startup_nrf52.s
+++ b/hw/bsp/vbluno52/src/arch/cortex_m4/gcc_startup_nrf52.s
@@ -1,0 +1,301 @@
+/*
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+NOTE: Template files (including this one) are application specific and therefore
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv7-m
+
+    .section .stack
+    .align 3
+    .equ    Stack_Size, 432
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long   Reset_Handler               /* Reset Handler */
+    .long   NMI_Handler                 /* NMI Handler */
+    .long   HardFault_Handler           /* Hard Fault Handler */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   SVC_Handler                 /* SVCall Handler */
+    .long   0                           /* Reserved */
+    .long   0                           /* Reserved */
+    .long   PendSV_Handler              /* PendSV Handler */
+    .long   SysTick_Handler             /* SysTick Handler */
+
+  /* External Interrupts */
+    .long   POWER_CLOCK_IRQHandler
+    .long   RADIO_IRQHandler
+    .long   UARTE0_UART0_IRQHandler
+    .long   SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    .long   SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    .long   NFCT_IRQHandler
+    .long   GPIOTE_IRQHandler
+    .long   SAADC_IRQHandler
+    .long   TIMER0_IRQHandler
+    .long   TIMER1_IRQHandler
+    .long   TIMER2_IRQHandler
+    .long   RTC0_IRQHandler
+    .long   TEMP_IRQHandler
+    .long   RNG_IRQHandler
+    .long   ECB_IRQHandler
+    .long   CCM_AAR_IRQHandler
+    .long   WDT_IRQHandler
+    .long   RTC1_IRQHandler
+    .long   QDEC_IRQHandler
+    .long   COMP_LPCOMP_IRQHandler
+    .long   SWI0_EGU0_IRQHandler
+    .long   SWI1_EGU1_IRQHandler
+    .long   SWI2_EGU2_IRQHandler
+    .long   SWI3_EGU3_IRQHandler
+    .long   SWI4_EGU4_IRQHandler
+    .long   SWI5_EGU5_IRQHandler
+    .long   TIMER3_IRQHandler
+    .long   TIMER4_IRQHandler
+    .long   PWM0_IRQHandler
+    .long   PDM_IRQHandler
+    .long   0                         /*Reserved */
+    .long   0                         /*Reserved */
+    .long   MWU_IRQHandler
+    .long   PWM1_IRQHandler
+    .long   PWM2_IRQHandler
+    .long   SPIM2_SPIS2_SPI2_IRQHandler
+    .long   RTC2_IRQHandler
+    .long   I2S_IRQHandler
+
+    .size    __isr_vector, . - __isr_vector
+
+/* Reset Handler */
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    .fnstart
+
+    /* Clear BSS */
+    mov     r0, #0
+    ldr     r2, =__bss_start__
+    ldr     r3, =__bss_end__
+.bss_zero_loop:
+    cmp     r2, r3
+    itt     lt
+    strlt   r0, [r2], #4
+    blt    .bss_zero_loop
+
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+
+.LC0:
+
+    LDR     R0, =__HeapBase
+    LDR     R1, =__HeapLimit
+    BL      _sbrkInit
+
+    LDR     R0, =SystemInit
+    BLX     R0
+
+    BL      hal_system_init
+
+    LDR     R0, =_start
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler,.-Reset_Handler
+
+    .section ".text"
+
+
+/* Dummy Exception Handlers (infinite loops which can be modified) */
+
+    .weak   NMI_Handler
+    .type   NMI_Handler, %function
+NMI_Handler:
+    B       .
+    .size   NMI_Handler, . - NMI_Handler
+
+
+    .weak   HardFault_Handler
+    .type   HardFault_Handler, %function
+HardFault_Handler:
+    B       .
+    .size   HardFault_Handler, . - HardFault_Handler
+
+
+    .weak   MemoryManagement_Handler
+    .type   MemoryManagement_Handler, %function
+MemoryManagement_Handler:
+    B       .
+    .size   MemoryManagement_Handler, . - MemoryManagement_Handler
+
+
+    .weak   BusFault_Handler
+    .type   BusFault_Handler, %function
+BusFault_Handler:
+    B       .
+    .size   BusFault_Handler, . - BusFault_Handler
+
+
+    .weak   UsageFault_Handler
+    .type   UsageFault_Handler, %function
+UsageFault_Handler:
+    B       .
+    .size   UsageFault_Handler, . - UsageFault_Handler
+
+
+    .weak   SVC_Handler
+    .type   SVC_Handler, %function
+SVC_Handler:
+    B       .
+    .size   SVC_Handler, . - SVC_Handler
+
+
+    .weak   PendSV_Handler
+    .type   PendSV_Handler, %function
+PendSV_Handler:
+    B       .
+    .size   PendSV_Handler, . - PendSV_Handler
+
+
+    .weak   SysTick_Handler
+    .type   SysTick_Handler, %function
+SysTick_Handler:
+    B       .
+    .size   SysTick_Handler, . - SysTick_Handler
+
+
+/* IRQ Handlers */
+
+    .globl  Default_Handler
+    .type   Default_Handler, %function
+Default_Handler:
+    B       .
+    .size   Default_Handler, . - Default_Handler
+
+    .macro  IRQ handler
+    .weak   \handler
+    .set    \handler, Default_Handler
+    .endm
+
+    IRQ  POWER_CLOCK_IRQHandler
+    IRQ  RADIO_IRQHandler
+    IRQ  UARTE0_UART0_IRQHandler
+    IRQ  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    IRQ  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    IRQ  NFCT_IRQHandler
+    IRQ  GPIOTE_IRQHandler
+    IRQ  SAADC_IRQHandler
+    IRQ  TIMER0_IRQHandler
+    IRQ  TIMER1_IRQHandler
+    IRQ  TIMER2_IRQHandler
+    IRQ  RTC0_IRQHandler
+    IRQ  TEMP_IRQHandler
+    IRQ  RNG_IRQHandler
+    IRQ  ECB_IRQHandler
+    IRQ  CCM_AAR_IRQHandler
+    IRQ  WDT_IRQHandler
+    IRQ  RTC1_IRQHandler
+    IRQ  QDEC_IRQHandler
+    IRQ  COMP_LPCOMP_IRQHandler
+    IRQ  SWI0_EGU0_IRQHandler
+    IRQ  SWI1_EGU1_IRQHandler
+    IRQ  SWI2_EGU2_IRQHandler
+    IRQ  SWI3_EGU3_IRQHandler
+    IRQ  SWI4_EGU4_IRQHandler
+    IRQ  SWI5_EGU5_IRQHandler
+    IRQ  TIMER3_IRQHandler
+    IRQ  TIMER4_IRQHandler
+    IRQ  PWM0_IRQHandler
+    IRQ  PDM_IRQHandler
+    IRQ  MWU_IRQHandler
+    IRQ  PWM1_IRQHandler
+    IRQ  PWM2_IRQHandler
+    IRQ  SPIM2_SPIS2_SPI2_IRQHandler
+    IRQ  RTC2_IRQHandler
+    IRQ  I2S_IRQHandler
+
+  .end

--- a/hw/bsp/vbluno52/src/arch/cortex_m4/gcc_startup_nrf52_split.s
+++ b/hw/bsp/vbluno52/src/arch/cortex_m4/gcc_startup_nrf52_split.s
@@ -1,0 +1,166 @@
+/*
+Copyright (c) 2015, Nordic Semiconductor ASA
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Nordic Semiconductor ASA nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+NOTE: Template files (including this one) are application specific and therefore
+expected to be copied into the application project folder prior to its use!
+*/
+
+    .syntax unified
+    .arch armv7-m
+    .section .stack
+    .align 3
+    .equ    Stack_Size, 432
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector_split
+    .align 2
+    .globl __isr_vector_split
+__isr_vector_split:
+    .long    __StackTop            /* Top of Stack */
+    .long   Reset_Handler_split               /* Reset Handler */
+
+    .size    __isr_vector_split, . - __isr_vector_split
+
+/* Reset Handler */
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl    Reset_Handler_split
+    .type    Reset_Handler_split, %function
+Reset_Handler_split:
+    .fnstart
+
+    /* Clear CPU state before proceeding */
+    mov     r0, #0
+    msr     control, r0
+    msr     primask, r0
+    /* Clear BSS */
+    ldr     r2, =__bss_start__
+    ldr     r3, =__bss_end__
+.bss_zero_loop:
+    cmp     r2, r3
+    itt     lt
+    strlt   r0, [r2], #4
+    blt    .bss_zero_loop
+
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble     .LC0
+
+.LC1:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC1
+
+.LC0:
+    ldr    r1, =__etext_loader
+    ldr    r2, =__data_start___loader
+    ldr    r3, =__data_end___loader
+
+    subs    r3, r2
+    ble     .LC2
+
+.LC3:
+    subs    r3, 4
+    ldr    r0, [r1,r3]
+    str    r0, [r2,r3]
+    bgt    .LC3
+.LC2:
+
+    subs    r0, r0
+    ldr    r2, =__bss_start___loader
+    ldr    r3, =__bss_end___loader
+
+    subs    r3, r2
+    ble     .LC4
+
+.LC5:
+    subs    r3, 4
+    str    r0, [r2,r3]
+    bgt    .LC5
+.LC4:
+
+    LDR     R0, =__HeapBase
+    LDR     R1, =__HeapLimit
+    BL      _sbrkInit
+
+    LDR     R0, =SystemInit
+    BLX     R0
+
+    BL      hal_system_init
+
+    LDR     R0, =_start_split
+    BX      R0
+
+    .pool
+    .cantunwind
+    .fnend
+    .size   Reset_Handler_split,.-Reset_Handler_split
+
+    .section ".text"
+  .end

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <assert.h>
+#include <nrf52.h>
+#include "os/os_cputime.h"
+#include "syscfg/syscfg.h"
+#include "sysflash/sysflash.h"
+#include "flash_map/flash_map.h"
+#include "hal/hal_bsp.h"
+#include "hal/hal_flash.h"
+#include "hal/hal_spi.h"
+#include "hal/hal_watchdog.h"
+#include "hal/hal_i2c.h"
+#include "mcu/nrf52_hal.h"
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
+#include "uart/uart.h"
+#endif
+#if MYNEWT_VAL(UART_0)
+#include "uart_hal/uart_hal.h"
+#endif
+#if MYNEWT_VAL(UART_1)
+#include "uart_bitbang/uart_bitbang.h"
+#endif
+#include "os/os_dev.h"
+#include "bsp.h"
+
+#if MYNEWT_VAL(UART_0)
+static struct uart_dev os_bsp_uart0;
+static const struct nrf52_uart_cfg os_bsp_uart0_cfg = {
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+};
+#endif
+
+#if MYNEWT_VAL(UART_1)
+static struct uart_dev os_bsp_bitbang_uart1;
+static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
+    .ubc_txpin = MYNEWT_VAL(UART_1_PIN_TX),
+    .ubc_rxpin = MYNEWT_VAL(UART_1_PIN_RX),
+    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
+};
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+/*
+ * NOTE: Our HAL expects that the SS pin, if used, is treated as a gpio line
+ * and is handled outside the SPI routines.
+ */
+static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
+    .sck_pin      = 15,
+    .mosi_pin     = 13,
+    .miso_pin     = 14,
+};
+#endif
+
+#if MYNEWT_VAL(SPI_0_SLAVE)
+static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
+    .sck_pin      = 15,
+    .mosi_pin     = 13,
+    .miso_pin     = 14,
+    .ss_pin       = 11,
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static const struct nrf52_hal_i2c_cfg hal_i2c0_cfg = {
+    .scl_pin = 27,
+    .sda_pin = 26,
+    .i2c_frequency = 100    /* 100 kHz */
+};
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf52_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = 31,
+    .sda_pin = 30,
+    .i2c_frequency = 100    /* 100 kHz */
+};
+#endif
+
+/*
+ * What memory to include in coredump.
+ */
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE
+    }
+};
+
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    /*
+     * Internal flash mapped to id 0.
+     */
+    if (id != 0) {
+        return NULL;
+    }
+    return &nrf52k_flash_dev;
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+int
+hal_bsp_power_state(int state)
+{
+    return (0);
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    uint32_t cfg_pri;
+
+    switch (irq_num) {
+    /* Radio gets highest priority */
+    case RADIO_IRQn:
+        cfg_pri = 0;
+        break;
+    default:
+        cfg_pri = pri;
+    }
+    return cfg_pri;
+}
+
+void
+hal_bsp_init(void)
+{
+    int rc;
+
+    (void)rc;
+#if MYNEWT_VAL(TIMER_0)
+    rc = hal_timer_init(0, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    rc = hal_timer_init(1, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    rc = hal_timer_init(2, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_3)
+    rc = hal_timer_init(3, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_4)
+    rc = hal_timer_init(4, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_5)
+    rc = hal_timer_init(5, NULL);
+    assert(rc == 0);
+#endif
+
+#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, (void *)&hal_i2c0_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = hal_spi_init(0, (void *)&os_bsp_spi0m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_SLAVE)
+    rc = hal_spi_init(0, (void *)&os_bsp_spi0s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(UART_0)
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&os_bsp_uart0_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(UART_1)
+    rc = os_dev_create((struct os_dev *) &os_bsp_bitbang_uart1, "uart1",
+      OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init, (void *)&os_bsp_uart1_cfg);
+    assert(rc == 0);
+#endif
+
+}

--- a/hw/bsp/vbluno52/src/sbrk.c
+++ b/hw/bsp/vbluno52/src/sbrk.c
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <hal/hal_bsp.h>
+
+/* put these in the data section so they are not cleared by _start */
+static char *sbrkBase __attribute__ ((section (".data")));
+static char *sbrkLimit __attribute__ ((section (".data")));
+static char *brk __attribute__ ((section (".data")));
+
+void
+_sbrkInit(char *base, char *limit) {
+    sbrkBase = base;
+    sbrkLimit = limit;
+    brk = base;
+}
+
+void *
+_sbrk(int incr)
+{
+    void *prev_brk;
+
+    if (incr < 0) {
+        /* Returning memory to the heap. */
+        incr = -incr;
+        if (brk - incr < sbrkBase) {
+            prev_brk = (void *)-1;
+        } else {
+            prev_brk = brk;
+            brk -= incr;
+        }
+    } else {
+        /* Allocating memory from the heap. */
+        if (sbrkLimit - brk >= incr) {
+            prev_brk = brk;
+            brk += incr;
+        } else {
+            prev_brk = (void *)-1;
+        }
+    }
+
+    return prev_brk;
+}

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: hw/bsp/vbluno52
+
+syscfg.defs:
+    BSP_NRF52:
+        description: 'Set to indicate that BSP has NRF52'
+        value: 1
+
+    XTAL_32768:
+        description: 'External 32k oscillator available.'
+        value: 1
+
+    UART_0:
+        description: 'Whether to enable UART0'
+        value:  1
+    UART_0_PIN_TX:
+        description: 'TX pin for UART0'
+        value:  6
+    UART_0_PIN_RX:
+        description: 'RX pin for UART0'
+        value:  8
+    UART_0_PIN_RTS:
+        description: 'RTS pin for UART0'
+        value:  5
+    UART_0_PIN_CTS:
+        description: 'CTS pin for UART0'
+        value: 7
+
+    UART_1:
+        description: 'Whether to enable bitbanger UART1'
+        value:  0
+    UART_1_PIN_TX:
+        description: 'TX pin for UART1'
+        value:  -1
+    UART_1_PIN_RX:
+        description: 'RX pin for UART1'
+        value:  -1
+
+    SPI_0_MASTER:
+        description: 'SPI 0 master'
+        value:  1
+        restrictions:
+            - "!SPI_0_SLAVE"
+    SPI_0_MASTER_SS_PIN:
+        description: 'SPI 0 (master) SS pin number.'
+        value:  11
+    SPI_0_SLAVE:
+        description: 'SPI 0 slave'
+        value:  0
+        restrictions:
+            - "!SPI_0_MASTER"
+
+    TIMER_0:
+        description: 'NRF52 Timer 0'
+        value:  1
+    TIMER_1:
+        description: 'NRF52 Timer 1'
+        value:  0
+    TIMER_2:
+        description: 'NRF52 Timer 2'
+        value:  0
+    TIMER_3:
+        description: 'NRF52 Timer 3'
+        value:  0
+    TIMER_4:
+        description: 'NRF52 Timer 4'
+        value:  0
+    TIMER_5:
+        description: 'NRF52 RTC 0'
+        value:  0
+
+    I2C_0:
+        description: 'NRF52 I2C (TWI) interface 0'
+        value:  '1'
+
+    I2C_1:
+        description: 'NRF52 I2C (TWI) interface 1'
+        value:  '1'
+
+syscfg.vals:
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    MCU_DCDC_ENABLED: 1

--- a/hw/bsp/vbluno52/vbluno52_debug.cmd
+++ b/hw/bsp/vbluno52/vbluno52_debug.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/vbluno52/vbluno52_debug.sh
+++ b/hw/bsp/vbluno52/vbluno52_debug.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+#
+
+. $CORE_PATH/hw/scripts/openocd.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+CFG="-f interface/cmsis-dap.cfg -f target/nrf52.cfg"
+# Exit openocd when gdb detaches.
+EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"
+
+openocd_debug

--- a/hw/bsp/vbluno52/vbluno52_download.cmd
+++ b/hw/bsp/vbluno52/vbluno52_download.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/vbluno52/vbluno52_download.sh
+++ b/hw/bsp/vbluno52/vbluno52_download.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/openocd.sh
+
+CFG="-f interface/cmsis-dap.cfg -f target/nrf52.cfg"
+
+if [ "$MFG_IMAGE" ]; then
+    FLASH_OFFSET=0
+fi
+
+# We write the config registers for BPROT so that NVMC write
+# protection gets disabled for all blocks of the flash
+# We also write the DISABLEINDEBUG register so that, write
+# protection gets disabled in debug register by default
+CFG_POST_INIT="mww 0x40000600 0;mww 0x40000604 0;mww 0x40000608 1;\
+               mww 0x40000610 0;mww 0x40000614 0;
+              "
+
+common_file_to_load
+openocd_load
+openocd_reset_run

--- a/hw/bsp/vbluno52/vbluno52_no_boot.ld
+++ b/hw/bsp/vbluno52/vbluno52_no_boot.ld
@@ -1,0 +1,191 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x10000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __bssnz_start__
+ *   __bssnz_end__
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))
+        __isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > RAM
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        *(.preinit_array)
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        *(SORT(.init_array.*))
+        *(.init_array)
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM
+
+    /* Non-zeroed BSS.  This section is similar to BSS, with the following
+     * caveat:
+     *    1. It does not get zeroed at init-time.
+     */
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+


### PR DESCRIPTION
The VBLUno52 board from VNG (Nordic nRF52832 Cortex-M4 SoC based)

+ Abstract
    nRF52832 Cortex-M4
    Bluetooth Low Energy 5.0 (new)
    DAPLink interface: Flash, Debug, Virtual COM port
    UNO pinout
    4 power

Signed-off-by: iotvietmember <robotden@gmail.com>