### PR TITLE
MYNEWT-268 BLE Host - enable factory reset

### DIFF
--- a/net/nimble/host/include/host/ble_store.h
+++ b/net/nimble/host/include/host/ble_store.h
@@ -283,6 +283,8 @@ int ble_store_iterate(int obj_type,
                       ble_store_iterator_fn *callback,
                       void *cookie);
 
+int ble_store_clear(void);
+
 /*** Utility functions. */
 
 int ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs,

--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -381,3 +381,40 @@ ble_store_iterate(int obj_type,
         idx++;
     }
 }
+
+/**
+ * Deletes all objects from the BLE host store.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int
+ble_store_clear(void)
+{
+    const uint8_t obj_types[] = {
+        BLE_STORE_OBJ_TYPE_OUR_SEC,
+        BLE_STORE_OBJ_TYPE_PEER_SEC,
+        BLE_STORE_OBJ_TYPE_CCCD,
+    };
+    union ble_store_key key;
+    int obj_type;
+    int rc;
+    int i;
+
+    /* A zeroed key will always retrieve the first value. */
+    memset(&key, 0, sizeof key);
+
+    for (i = 0; i < sizeof obj_types / sizeof obj_types[0]; i++) {
+        obj_type = obj_types[i];
+
+        do {
+            rc = ble_store_delete(obj_type, &key);
+        } while (rc == 0);
+
+        /* BLE_HS_ENOENT means we deleted everything. */
+        if (rc != BLE_HS_ENOENT) {
+            return rc;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
(Jira ticket: https://issues.apache.org/jira/browse/MYNEWT-268)gg

This commit adds a new function to the host API:

    /**
     * Deletes all objects from the BLE host store.
     *
     * @return                      0 on success; nonzero on failure.
     */
    int
    ble_store_clear(void)

This function can be used to effect a factory reset.