### PR TITLE
nimble/test: Update unittests after features exchange changes

### DIFF
--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -59,6 +59,10 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
 
     TEST_ASSERT(ble_gap_master_in_progress());
 
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
+
     /* Receive successful connection complete event. */
     memset(&evt, 0, sizeof evt);
     evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
@@ -111,6 +115,10 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
 
     TEST_ASSERT(!ble_gap_master_in_progress());
     TEST_ASSERT(ble_gap_adv_active());
+
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive successful connection complete event. */
     memset(&evt, 0, sizeof evt);
@@ -172,6 +180,10 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
 
     TEST_ASSERT(!ble_gap_master_in_progress());
     TEST_ASSERT(ble_gap_adv_active());
+
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive successful connection complete event. */
     memset(&evt, 0, sizeof evt);

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -370,10 +370,12 @@ ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
                                  uint8_t peer_addr_type,
                                  const uint8_t *peer_id_addr,
                                  const uint8_t *peer_rpa,
+                                 uint8_t conn_features,
                                  ble_gap_event_fn *cb, void *cb_arg)
 {
     ble_addr_t addr;
     struct hci_le_conn_complete evt;
+    struct hci_le_rd_rem_supp_feat_complete evt2;
     int rc;
 
     addr.type = peer_addr_type;
@@ -381,6 +383,10 @@ ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
 
     ble_hs_test_util_connect(own_addr_type, &addr,
                              0, NULL, cb, cb_arg, 0);
+
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     memset(&evt, 0, sizeof evt);
     evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
@@ -398,6 +404,13 @@ ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
     rc = ble_gap_rx_conn_complete(&evt);
     TEST_ASSERT(rc == 0);
 
+    evt2.subevent_code = BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT;
+    evt2.status = BLE_ERR_SUCCESS;
+    evt2.connection_handle = handle;
+    memcpy(evt2.features, (uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }, 8);
+
+    ble_gap_rx_rd_rem_sup_feat_complete(&evt2);
+
     ble_hs_test_util_prev_hci_tx_clear();
 }
 
@@ -409,7 +422,19 @@ ble_hs_test_util_create_conn(uint16_t handle, const uint8_t *peer_id_addr,
 
     ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
                                      BLE_ADDR_PUBLIC, peer_id_addr,
-                                     null_addr, cb, cb_arg);
+                                     null_addr, BLE_HS_TEST_CONN_FEAT_ALL,
+                                     cb, cb_arg);
+}
+
+void
+ble_hs_test_util_create_conn_feat(uint16_t handle, const uint8_t *peer_id_addr,
+                             uint8_t conn_features, ble_gap_event_fn *cb, void *cb_arg)
+{
+    static uint8_t null_addr[6];
+
+    ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
+                                     BLE_ADDR_PUBLIC, peer_id_addr,
+                                     null_addr, conn_features, cb, cb_arg);
 }
 
 static void
@@ -862,8 +887,15 @@ ble_hs_test_util_conn_update(uint16_t conn_handle,
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
-        BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_CONN_UPDATE), hci_status);
+    /*
+     * 0xFF is magic value used for cases where we expect update over L2CAP to
+     * be triggered - in this case we don't need phony ack.
+     */
+    if (hci_status != 0xFF) {
+        ble_hs_test_util_set_ack(
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_CONN_UPDATE),
+                hci_status);
+    }
 
     rc = ble_gap_update_params(conn_handle, params);
     return rc;

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -71,6 +71,9 @@ struct ble_hs_test_util_att_group_type_entry {
         .hdh_len = (len)                                \
     })
 
+#define BLE_HS_TEST_CONN_FEAT_ALL               (0xFF)
+#define BLE_HS_TEST_CONN_FEAT_NO_CONN_PARAM     (0xFD)
+
 void ble_hs_test_util_prev_tx_enqueue(struct os_mbuf *om);
 struct os_mbuf *ble_hs_test_util_prev_tx_dequeue(void);
 struct os_mbuf *ble_hs_test_util_prev_tx_dequeue_pullup(void);
@@ -95,8 +98,12 @@ void ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
                                       uint8_t peer_addr_type,
                                       const uint8_t *peer_id_addr,
                                       const uint8_t *peer_rpa,
+                                      uint8_t conn_features,
                                       ble_gap_event_fn *cb, void *cb_arg);
 void ble_hs_test_util_create_conn(uint16_t handle, const uint8_t *addr,
+                                  ble_gap_event_fn *cb, void *cb_arg);
+void ble_hs_test_util_create_conn_feat(uint16_t handle, const uint8_t *addr,
+                                  uint8_t conn_features,
                                   ble_gap_event_fn *cb, void *cb_arg);
 int ble_hs_test_util_connect(uint8_t own_addr_type,
                                    const ble_addr_t *peer_addr,

--- a/net/nimble/host/test/src/ble_os_test.c
+++ b/net/nimble/host/test/src/ble_os_test.c
@@ -144,6 +144,10 @@ ble_gap_direct_connect_test_task_handler(void *arg)
     TEST_ASSERT(!ble_os_test_misc_conn_exists(BLE_HS_CONN_HANDLE_NONE));
     TEST_ASSERT(!cb_called);
 
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
+
     /* Receive an HCI connection-complete event. */
     memset(&evt, 0, sizeof evt);
     evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
@@ -305,6 +309,9 @@ ble_gap_terminate_test_task_handler(void *arg)
     ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
                              &addr1, 0, NULL, ble_gap_terminate_cb,
                              &disconn_handle, 0);
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
     memset(&conn_evt, 0, sizeof conn_evt);
     conn_evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
     conn_evt.status = BLE_ERR_SUCCESS;
@@ -316,6 +323,9 @@ ble_gap_terminate_test_task_handler(void *arg)
     ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
                              &addr2, 0, NULL, ble_gap_terminate_cb,
                              &disconn_handle, 0);
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
     memset(&conn_evt, 0, sizeof conn_evt);
     conn_evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
     conn_evt.status = BLE_ERR_SUCCESS;

--- a/net/nimble/host/test/src/ble_sm_test_util.c
+++ b/net/nimble/host/test/src/ble_sm_test_util.c
@@ -537,6 +537,7 @@ ble_sm_test_util_init_good(struct ble_sm_test_params *params,
     ble_hs_test_util_create_rpa_conn(2, out_us->addr_type, out_us->rpa,
                                      out_peer->addr_type,
                                      out_peer->id_addr, out_peer->rpa,
+                                     BLE_HS_TEST_CONN_FEAT_ALL,
                                      ble_sm_test_util_conn_cb,
                                      NULL);
 
@@ -1613,6 +1614,7 @@ ble_sm_test_util_peer_bonding_good(int send_enc_req,
 
     ble_hs_test_util_create_rpa_conn(2, our_addr_type, our_rpa, peer_addr_type,
                                      peer_id_addr, peer_rpa,
+                                     BLE_HS_TEST_CONN_FEAT_ALL,
                                      ble_sm_test_util_conn_cb, NULL);
 
     /* This test inspects and modifies the connection object after unlocking
@@ -1743,7 +1745,8 @@ ble_sm_test_util_us_bonding_good(int send_enc_req, uint8_t our_addr_type,
 
     ble_hs_test_util_create_rpa_conn(2, our_addr_type, our_rpa,
                                      peer_addr_type, peer_id_addr,
-                                     peer_rpa, ble_sm_test_util_conn_cb, NULL);
+                                     peer_rpa, BLE_HS_TEST_CONN_FEAT_ALL,
+                                     ble_sm_test_util_conn_cb, NULL);
 
     /* This test inspects and modifies the connection object after unlocking
      * the host mutex.  It is not OK for real code to do this, but this test
@@ -2919,6 +2922,7 @@ ble_sm_test_util_repeat_pairing(struct ble_sm_test_params *params, int sc)
     ble_hs_test_util_create_rpa_conn(2, our_entity.addr_type, our_entity.rpa,
                                      peer_entity.addr_type,
                                      peer_entity.id_addr, peer_entity.rpa,
+                                     BLE_HS_TEST_CONN_FEAT_ALL,
                                      ble_sm_test_util_conn_cb,
                                      NULL);
     ble_hs_lock();


### PR DESCRIPTION
After connection complete event host will read peers features and then
will use this information when selecting procedure for connection
parameters update. Both changes requires unittests to be updated:
- phony ack is added for complete event since it will send extra HCI
  command if connection is successful
- features event is injected to set features properly
- connection update failover from HCI to L2CAP is removed since this
  is selected based on features