### PR TITLE
Give HCI socket transport its own task.

### DIFF
--- a/net/nimble/transport/socket/syscfg.yml
+++ b/net/nimble/transport/socket/syscfg.yml
@@ -64,3 +64,10 @@ syscfg.defs:
         description: 'linux kernel device'
         value: 0
 
+    BLE_SOCK_TASK_PRIO:
+        description: 'Priority of the HCI socket task.'
+        value: 9
+
+    BLE_SOCK_STACK_SIZE:
+        description: 'Size of the HCI socket stack (units=words).'
+        value: 80


### PR DESCRIPTION
This prevents deadlock while the host waits for a command-complete event from the controller.  This is a slightly modified patch written by @rymanluk (changes include: adding a few syscfg settings, minor renames).