### PR TITLE
nimble/controller: Disable LL logs

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll.h
+++ b/net/nimble/controller/include/controller/ble_ll.h
@@ -485,11 +485,6 @@ ble_ll_get_addr_type(uint8_t txrxflag)
     return BLE_HCI_ADV_OWN_ADDR_PUBLIC;
 }
 
-/*
- * XXX: temporary LL debug log. Will get removed once we transition to real
- * log
- */
-#define BLE_LL_LOG
 #include "console/console.h"
 
 #define BLE_LL_LOG_ID_PHY_SETCHAN       (1)


### PR DESCRIPTION
Seems like this was enabled some time ago by mistake and consumed
4K of RAM for no reason.