### PR TITLE
Fix compilation error in apps/sensors_test/main.c when SENSOR_OIC is disabled

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -73,7 +73,9 @@ static const oc_handler_t sensor_oic_handler = {
 /* Application-specified header. */
 #include "bleprph.h"
 
+#if MYNEWT_VAL(SENSOR_OIC)
 static int sensor_oic_gap_event(struct ble_gap_event *event, void *arg);
+#endif
 
 /** Log data. */
 struct log bleprph_log;


### PR DESCRIPTION
Fix the following compilation error:
    main.c:76:12: error: 'sensor_oic_gap_event' declared 'static' but never defined [-Werror=unused-function]
     static int sensor_oic_gap_event(struct ble_gap_event *event, void *arg);
                ^