### PR TITLE
Use real runtime Bluetooth svc UUID (0xfe18).

### DIFF
--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -128,7 +128,7 @@ bleprph_advertise(void)
 #if MYNEWT_VAL(ADVERTISE_16BIT_UUID)
     /* Advertise the 16-bit CoAP-over-BLE service UUID in the scan response. */
     fields.uuids16 = (ble_uuid16_t[]) {
-        BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID)
+        BLE_UUID16_INIT(OC_GATT_SEC_SERVICE_UUID)
     };
     fields.num_uuids16 = 1;
     fields.uuids16_is_complete = 1;

--- a/apps/testbench/src/tbb.c
+++ b/apps/testbench/src/tbb.c
@@ -136,11 +136,11 @@ tbb_advertise(void)
     fields.name_len = strlen(name);
     fields.name_is_complete = 1;
 
-    fields.uuids128 = (ble_uuid128_t[]) {
-        BLE_UUID128_INIT(OC_GATT_SERVICE_UUID)
+    fields.uuids16 = (ble_uuid16_t[]) {
+        BLE_UUID16_INIT(OC_GATT_SEC_SERVICE_UUID)
     };
-    fields.num_uuids128 = 1;
-    fields.uuids128_is_complete = 1;
+    fields.num_uuids16 = 1;
+    fields.uuids16_is_complete = 1;
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {

--- a/net/oic/include/oic/oc_gatt.h
+++ b/net/oic/include/oic/oc_gatt.h
@@ -24,14 +24,12 @@
 extern "C" {
 #endif
 
-/* ADE3D529-C784-4F63-A987-EB69F70EE816 */
+/* Unsecure CoAP service: ADE3D529-C784-4F63-A987-EB69F70EE816 */
 #define OC_GATT_SERVICE_UUID  0x16, 0xe8, 0x0e, 0xf7, 0x69, 0xeb, 0x87, 0xa9, \
                               0x63, 0x4f, 0x84, 0xc7, 0x29, 0xd5, 0xe3, 0xad
 
-/* XXX: This UUID, its name, and its location in this file are all
- * tentative.
- */
-#define RUNTIME_COAP_SERVICE_UUID    0x9923
+/* Secure CoAP service. 0xfe18 */
+#define OC_GATT_SEC_SERVICE_UUID    0xfe18
 
 int oc_ble_coap_gatt_srv_init(void);
 void oc_ble_coap_conn_new(uint16_t conn_handle);

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -43,7 +43,7 @@ static const ble_uuid128_t oc_gatt_svc_uuid =
 
 /* 16-bit service UUID. */
 static const ble_uuid16_t runtime_coap_svc_uuid =
-    BLE_UUID16_INIT(RUNTIME_COAP_SERVICE_UUID);
+    BLE_UUID16_INIT(OC_GATT_SEC_SERVICE_UUID);
 
 /* request characteristic UUID */
 /* AD7B334F-4637-4B86-90B6-9D787F03D218 */


### PR DESCRIPTION
Prior to this commit, we were using an arbitrarily-chosen UUID: 0x9923.
The real UUID (0xfe18) is reserved with the Bluetooth SIG.