### PR TITLE
nimble/controller: Fix scheduler advertising halt error

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_adv.h
+++ b/net/nimble/controller/include/controller/ble_ll_adv.h
@@ -176,7 +176,7 @@ void ble_ll_adv_scheduled(struct ble_ll_adv_sm *, uint32_t sch_start);
 void ble_ll_adv_event_rmvd_from_sched(struct ble_ll_adv_sm *advsm);
 
 /* Called to halt currently running advertising event */
-void ble_ll_adv_halt(struct ble_ll_adv_sm *advsm);
+void ble_ll_adv_halt(void);
 
 /* Called to determine if advertising is enabled */
 uint8_t ble_ll_adv_enabled(void);

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -554,9 +554,11 @@ ble_ll_adv_set_sched(struct ble_ll_adv_sm *advsm)
  * Context: Interrupt
  */
 void
-ble_ll_adv_halt(struct ble_ll_adv_sm *advsm)
+ble_ll_adv_halt(void)
 {
-    ble_ll_adv_tx_done(advsm);
+    if (g_ble_ll_cur_adv_sm != NULL) {
+        ble_ll_adv_tx_done(g_ble_ll_cur_adv_sm);
+    }
 }
 
 /**

--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -876,7 +876,7 @@ ble_ll_sched_execute_item(struct ble_ll_sched_item *sch)
             ble_ll_state_set(BLE_LL_STATE_STANDBY);
         } else if (lls == BLE_LL_STATE_ADV) {
             STATS_INC(ble_ll_stats, sched_state_adv_errs);
-            ble_ll_adv_halt((struct ble_ll_adv_sm *)sch->cb_arg);
+            ble_ll_adv_halt();
         } else {
             STATS_INC(ble_ll_stats, sched_state_conn_errs);
             ble_ll_conn_event_halt();


### PR DESCRIPTION
MYNEWT-810: This fixes the scheduler error where the controller
would send the wrong state machine to the advertising halt
function and an incorrect event would get sent to the LL for
processing.