### PR TITLE
BLE Host - Add comments; move non-API declarations to private headers.

### DIFF
--- a/apps/blecent/src/blecent.h
+++ b/apps/blecent/src/blecent.h
@@ -48,11 +48,6 @@ extern struct log blecent_log;
 #define BLECENT_CHR_UNR_ALERT_STAT_UUID     0x2A45
 #define BLECENT_CHR_ALERT_NOT_CTRL_PT       0x2A44
 
-/** GATT server. */
-void gatt_svr_register(void);
-void gatt_svr_init_cfg(struct ble_hs_cfg *cfg);
-
-
 /** Misc. */
 void print_bytes(const uint8_t *bytes, int len);
 void print_mbuf(const struct os_mbuf *om);

--- a/apps/bletiny/src/gatt_svr.c
+++ b/apps/bletiny/src/gatt_svr.c
@@ -570,15 +570,6 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 }
 
 int
-gatt_svr_register(void)
-{
-    int rc;
-
-    rc = ble_gatts_register_svcs(gatt_svr_svcs, gatt_svr_register_cb, NULL);
-    return rc;
-}
-
-int
 gatt_svr_init(void)
 {
     int rc;

--- a/apps/btshell/src/gatt_svr.c
+++ b/apps/btshell/src/gatt_svr.c
@@ -570,15 +570,6 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
     }
 }
 
-int
-gatt_svr_register(void)
-{
-    int rc;
-
-    rc = ble_gatts_register_svcs(gatt_svr_svcs, gatt_svr_register_cb, NULL);
-    return rc;
-}
-
 void
 gatt_svr_print_svcs(void)
 {

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -138,20 +138,20 @@ struct ble_gap_sec_state {
 };
 
 /**
- * @param discoverable_mode     One of the following constants:
- *                                  o BLE_GAP_DISC_MODE_NON
- *                                      (non-discoverable; 3.C.9.2.2).
- *                                  o BLE_GAP_DISC_MODE_LTD
- *                                      (limited-discoverable; 3.C.9.2.3).
- *                                  o BLE_GAP_DISC_MODE_GEN
- *                                      (general-discoverable; 3.C.9.2.4).
- * @param connectable_mode      One of the following constants:
+ * conn_mode:                   One of the following constants:
  *                                  o BLE_GAP_CONN_MODE_NON
  *                                      (non-connectable; 3.C.9.3.2).
  *                                  o BLE_GAP_CONN_MODE_DIR
  *                                      (directed-connectable; 3.C.9.3.3).
  *                                  o BLE_GAP_CONN_MODE_UND
  *                                      (undirected-connectable; 3.C.9.3.4).
+ * disc_mode:                   One of the following constants:
+ *                                  o BLE_GAP_DISC_MODE_NON
+ *                                      (non-discoverable; 3.C.9.2.2).
+ *                                  o BLE_GAP_DISC_MODE_LTD
+ *                                      (limited-discoverable; 3.C.9.2.3).
+ *                                  o BLE_GAP_DISC_MODE_GEN
+ *                                      (general-discoverable; 3.C.9.2.4).
  */
 struct ble_gap_adv_params {
     /*** Mandatory fields. */
@@ -598,7 +598,6 @@ int ble_gap_terminate(uint16_t conn_handle, uint8_t hci_reason);
 int ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count);
 int ble_gap_update_params(uint16_t conn_handle,
                           const struct ble_gap_upd_params *params);
-int ble_gap_dbg_update_active(uint16_t conn_handle);
 int ble_gap_security_initiate(uint16_t conn_handle);
 int ble_gap_pair_initiate(uint16_t conn_handle);
 int ble_gap_encryption_initiate(uint16_t conn_handle, const uint8_t *ltk,

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -412,43 +412,10 @@ struct ble_gatt_register_ctxt {
     };
 };
 
-/**
- * Contains counts of resources required by the GATT server.  The contents of
- * this struct are generally used to populate a configuration struct before
- * the host is initialized.
- */
-struct ble_gatt_resources {
-    /** Number of services. */
-    uint16_t svcs;
-
-    /** Number of included services. */
-    uint16_t incs;
-
-    /** Number of characteristics. */
-    uint16_t chrs;
-
-    /** Number of descriptors. */
-    uint16_t dscs;
-
-    /**
-     * Number of client characteristic configuration descriptors.  Each of
-     * these also contributes to the total descriptor count.
-     */
-    uint16_t cccds;
-
-    /** Total number of ATT attributes. */
-    uint16_t attrs;
-};
-
 typedef void ble_gatt_register_fn(struct ble_gatt_register_ctxt *ctxt,
                                   void *arg);
 
-int ble_gatts_register_svcs(const struct ble_gatt_svc_def *svcs,
-                            ble_gatt_register_fn *register_cb,
-                            void *cb_arg);
 int ble_gatts_add_svcs(const struct ble_gatt_svc_def *svcs);
-int ble_gatts_count_resources(const struct ble_gatt_svc_def *svcs,
-                              struct ble_gatt_resources *res);
 int ble_gatts_count_cfg(const struct ble_gatt_svc_def *defs);
 
 void ble_gatts_chr_updated(uint16_t chr_def_handle);
@@ -462,7 +429,6 @@ int ble_gatts_find_dsc(const ble_uuid_t *svc_uuid, const ble_uuid_t *chr_uuid,
 typedef void (*ble_gatt_svc_foreach_fn)(const struct ble_gatt_svc_def *svc,
                                         uint16_t handle,
                                         uint16_t end_group_handle);
-void ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb);
 void ble_gatts_show_local(void);
 
 #ifdef __cplusplus

--- a/net/nimble/host/src/ble_att.c
+++ b/net/nimble/host/src/ble_att.c
@@ -406,7 +406,8 @@ ble_att_truncate_to_mtu(const struct ble_l2cap_chan *att_chan,
  *
  * @param conn_handle           The handle of the connection to query.
  *
- * @return                      The specified connection's ATT MTU.
+ * @return                      The specified connection's ATT MTU, or 0 if
+ *                                  there is no such connection.
  */
 uint16_t
 ble_att_mtu(uint16_t conn_handle)
@@ -502,7 +503,8 @@ ble_att_rx(struct ble_l2cap_chan *chan)
 }
 
 /**
- * Retrieves the preferred ATT MTU.
+ * Retrieves the preferred ATT MTU.  This is the value indicated by the device
+ * during an ATT MTU exchange.
  *
  * @return                      The preferred ATT MTU.
  */

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -1929,7 +1929,7 @@ done:
 
 /**
  * Configures the fields to include in subsequent advertisements.  This is a
- * higher-level version of ble_gap_adv_set_data().
+ * convenience wrapper for ble_gap_adv_set_data().
  *
  * @param adv_fields            Specifies the advertisement data.
  *
@@ -1961,7 +1961,7 @@ ble_gap_adv_set_fields(const struct ble_hs_adv_fields *adv_fields)
 
 /**
  * Configures the fields to include in subsequent scan responses.  This is a
- * higher-level version of ble_gap_adv_rsp_set_data().
+ * convenience wrapper for ble_gap_adv_rsp_set_data().
  *
  * @param adv_fields            Specifies the scan response data.
  *

--- a/net/nimble/host/src/ble_gap_priv.h
+++ b/net/nimble/host/src/ble_gap_priv.h
@@ -21,6 +21,7 @@
 #define H_BLE_GAP_CONN_
 
 #include <inttypes.h>
+#include "syscfg/syscfg.h"
 #include "stats/stats.h"
 #include "host/ble_gap.h"
 #ifdef __cplusplus
@@ -102,6 +103,10 @@ void ble_gap_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_gap_timer(void);
 
 int ble_gap_init(void);
+
+#if MYNEWT_VAL(BLE_HS_DEBUG)
+int ble_gap_dbg_update_active(uint16_t conn_handle);
+#endif
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/src/ble_gatt_priv.h
+++ b/net/nimble/host/src/ble_gatt_priv.h
@@ -149,11 +149,43 @@ int ble_gattc_init(void);
 #define BLE_GATTS_INC_SVC_LEN_NO_UUID           4
 #define BLE_GATTS_INC_SVC_LEN_UUID              6
 
+/**
+ * Contains counts of resources required by the GATT server.  The contents of
+ * this struct are generally used to populate a configuration struct before
+ * the host is initialized.
+ */
+struct ble_gatt_resources {
+    /** Number of services. */
+    uint16_t svcs;
+
+    /** Number of included services. */
+    uint16_t incs;
+
+    /** Number of characteristics. */
+    uint16_t chrs;
+
+    /** Number of descriptors. */
+    uint16_t dscs;
+
+    /**
+     * Number of client characteristic configuration descriptors.  Each of
+     * these also contributes to the total descriptor count.
+     */
+    uint16_t cccds;
+
+    /** Total number of ATT attributes. */
+    uint16_t attrs;
+};
+
 int ble_gatts_rx_indicate_ack(uint16_t conn_handle, uint16_t chr_val_handle);
 int ble_gatts_send_next_indicate(uint16_t conn_handle);
 void ble_gatts_tx_notifications(void);
 void ble_gatts_bonding_restored(uint16_t conn_handle);
 void ble_gatts_connection_broken(uint16_t conn_handle);
+void ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb);
+int ble_gatts_register_svcs(const struct ble_gatt_svc_def *svcs,
+                            ble_gatt_register_fn *register_cb,
+                            void *cb_arg);
 
 /*** @misc. */
 int ble_gatts_conn_can_alloc(void);

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -1951,7 +1951,7 @@ ble_gatts_add_svcs(const struct ble_gatt_svc_def *svcs)
  *                              BLE_HS_EINVAL if the svcs array contains an
  *                                  invalid resource definition.
  */
-int
+static int
 ble_gatts_count_resources(const struct ble_gatt_svc_def *svcs,
                           struct ble_gatt_resources *res)
 {

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -111,6 +111,13 @@ ble_hs_evq_get(void)
     return ble_hs_evq;
 }
 
+/**
+ * Designates the specified event queue for NimBLE host work.  By default, the
+ * host uses the default event queue and runs in the main task.  This function
+ * is useful if you want the host to run in a different task.
+ *
+ * @param evq                   The event queue to use for host work.
+ */
 void
 ble_hs_evq_set(struct os_eventq *evq)
 {
@@ -441,6 +448,13 @@ ble_hs_notifications_sched(void)
     os_eventq_put(ble_hs_evq_get(), &ble_hs_ev_tx_notifications);
 }
 
+/**
+ * Causes the host to reset the NimBLE stack as soon as possible.  The
+ * application is notified when the reset occurs via the host reset callback.
+ *
+ * @param reason                The host error code that gets passed to the
+ *                                  reset callback.
+ */
 void
 ble_hs_sched_reset(int reason)
 {
@@ -503,7 +517,7 @@ ble_hs_start(void)
  *
  * @return                      0 on success; nonzero on failure.
  */
-int
+static int
 ble_hs_rx_data(struct os_mbuf *om, void *arg)
 {
     int rc;

--- a/net/nimble/host/src/ble_uuid.c
+++ b/net/nimble/host/src/ble_uuid.c
@@ -50,6 +50,18 @@ static int verify_uuid(const ble_uuid_t *uuid)
 }
 #endif
 
+/**
+ * Constructs a UUID object from a byte array.
+ *
+ * @param uuid                  On success, this gets populated with the
+ *                                  constructed UUID.
+ * @param buf                   The source buffer to parse.
+ * @param len                   The size of the buffer, in bytes.
+ *
+ * @return                      0 on success;
+ *                              BLE_HS_EINVAL if the source buffer does not
+ *                                  contain a valid UUID.
+ */
 int
 ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len)
 {
@@ -71,6 +83,15 @@ ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len)
     return BLE_HS_EINVAL;
 }
 
+/**
+ * Compares two Bluetooth UUIDs.
+ *
+ * @param uuid1                 The first UUID to compare.
+ * @param uuid2                 The second UUID to compare.
+ *
+ * @return                      0 if the two UUIDs are equal;
+ *                              nonzero if the UUIDs differ.
+ */
 int
 ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
 {
@@ -95,6 +116,19 @@ ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
     return 0;
 }
 
+/**
+ * Converts the specified UUID to its string representation.
+ *
+ * Example string representations:
+ *     o 16-bit:  0x1234
+ *     o 32-bit:  0x12345678
+ *     o 128-bit: 12345678-1234-1234-1234-123456789abc
+ *
+ * @param uuid                  The source UUID to convert.
+ * @param dst                   The destination buffer.
+ *
+ * @return                      A pointer to the supplied destination buffer.
+ */
 char *
 ble_uuid_to_str(const ble_uuid_t *uuid, char *dst)
 {
@@ -125,6 +159,14 @@ ble_uuid_to_str(const ble_uuid_t *uuid, char *dst)
     return dst;
 }
 
+/**
+ * Converts the specified 16-bit UUID to a uint16_t.
+ *
+ * @param uuid                  The source UUID to convert.
+ *
+ * @return                      The converted integer on success;
+ *                              0 if the specified UUID is not 16 bits.
+ */
 uint16_t
 ble_uuid_u16(const ble_uuid_t *uuid)
 {


### PR DESCRIPTION
* Add API documentation in comments above some public functions.
* Move prototypes for non-API functions into "[...]_priv.h" headers.
* Delete some obsolete and unused functions.