### PR TITLE
baselibc: Fix compilation with GCC7

### DIFF
--- a/libc/baselibc/src/sprintf.c
+++ b/libc/baselibc/src/sprintf.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdint.h>
 
 int sprintf(char *buffer, const char *format, ...)
 {
@@ -11,7 +12,7 @@ int sprintf(char *buffer, const char *format, ...)
 	int rv;
 
 	va_start(ap, format);
-	rv = vsnprintf(buffer, ~(size_t) 0, format, ap);
+	rv = vsnprintf(buffer, SIZE_MAX/2, format, ap);
 	va_end(ap);
 
 	return rv;

--- a/libc/baselibc/src/vsprintf.c
+++ b/libc/baselibc/src/vsprintf.c
@@ -4,8 +4,9 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdint.h>
 
 int vsprintf(char *buffer, const char *format, va_list ap)
 {
-	return vsnprintf(buffer, ~(size_t) 0, format, ap);
+	return vsnprintf(buffer, SIZE_MAX/2, format, ap);
 }


### PR DESCRIPTION
repos/apache-mynewt-core/libc/baselibc/src/sprintf.c:15:5: error:
     specified bound 4294967295 exceeds maximum object size 2147483647
     [-Werror=format-truncation=]
  rv = vsnprintf(buffer, SIZE_MAX, format, ap);
  ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

repos/apache-mynewt-core/libc/baselibc/src/vsprintf.c:10:9: error:
     specified bound 4294967295 exceeds maximum object size 2147483647
     [-Werror=format-truncation=]
  return vsnprintf(buffer, ~(size_t) 0, format, ap);

GCC limits maximum object size to MAX_SIZE/2 (or PTRDIFF_MAX).