### PR TITLE
native_sockets - Add syscfg settings.

### DIFF
--- a/net/ip/native_sockets/syscfg.yml
+++ b/net/ip/native_sockets/syscfg.yml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    NATIVE_SOCKETS_MAX:
+        description: 'The number of allocated sockets.'
+        value: 8
+    NATIVE_SOCKETS_MAX_UDP:
+        description: 'The maximum UDP datagram size (send and receive).'
+        value: 2048
+    NATIVE_SOCKETS_POLL_ITVL:
+        description: >
+            The frequency at which to poll for received data.  Units
+            are OS ticks.
+        value: 'OS_TICKS_PER_SEC / 5'
+    NATIVE_SOCKETS_STACK_SZ:
+        description: 'The size of the native sockets task stack, in bytes.'
+        value: 4096
+    NATIVE_SOCKETS_PRIO:
+        description: 'The priority of the native sockets task.'
+        value: 2


### PR DESCRIPTION
The motivation for this change was to allow the polling interval to be changed.  The default value, 200ms, was making blehostd rather sluggish during image upgrade.