### PR TITLE
jlink.sh; dump registers after writing flash.

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -57,6 +57,10 @@ jlink_load () {
     echo "target remote localhost:3333" >> $GDB_CMD_FILE
     echo "mon reset" >> $GDB_CMD_FILE
     echo "restore $FILE_NAME binary $FLASH_OFFSET" >> $GDB_CMD_FILE
+
+    # XXXX 'newt run' was not always updating the flash on nrf52dk. With
+    # 'info reg' in place it seems to work every time. Not sure why.
+    echo "info reg" >> $GDB_CMD_FILE
     echo "quit" >> $GDB_CMD_FILE
 
     msgs=`arm-none-eabi-gdb -x $GDB_CMD_FILE 2>&1`


### PR DESCRIPTION
'newt run' was not always updating the flash on nrf52dk. With this workaround in place it seems to work every time.

Not sure why this fixes it. Trying to dump the contents of flash to a file after 'restore' did NOT fix it. Not only that, dump returns the data that I was trying to write, as if it had worked. Attaching to target afterwards showed that flash had not been updated.

Might be some write caching issue, but not sure where it is at.