### PR TITLE
Adding missing LED pin macros to nRF52dk bsp.h

### DIFF
--- a/hw/bsp/nrf52dk/include/bsp/bsp.h
+++ b/hw/bsp/nrf52dk/include/bsp/bsp.h
@@ -40,8 +40,11 @@ extern uint8_t _ram_start;
 #define RAM_SIZE        0x10000
 
 /* LED pins */
-#define LED_BLINK_PIN   (17)
+#define LED_1           (17)
 #define LED_2           (18)
+#define LED_3           (19)
+#define LED_4           (20)
+#define LED_BLINK_PIN   (LED_1)
 
 #if MYNEWT_VAL(BOOT_SERIAL)
 #define BOOT_SERIAL_DETECT_PIN          13 /* Button 1 */


### PR DESCRIPTION
LED's 1, 3 and 4 are not defined on hw/bsp/nrf52dk/include/bsp/bsp.h
This commit adds the missing macro definitions.