### PR TITLE
Bootloader api

### DIFF
--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -28,7 +28,6 @@ pkg.keywords:
 pkg.deps:
     - hw/hal
     - kernel/os
-    - boot/bootutil
     - encoding/tinycbor
     - encoding/base64
     - sys/flash_map
@@ -36,6 +35,7 @@ pkg.deps:
 
 pkg.req_apis:
     - console
+    - bootloader
 
 pkg.cflags.SELFTEST:
     - -DBOOT_SERIAL_DETECT_PIN=0

--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -25,6 +25,9 @@ pkg.keywords:
     - boot
     - bootloader
 
+pkg.apis:
+    - bootloader
+
 pkg.deps: 
     - hw/hal
     - crypto/mbedtls

--- a/boot/split/pkg.yml
+++ b/boot/split/pkg.yml
@@ -24,8 +24,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - split
 
-pkg.deps: 
-    - boot/bootutil
+pkg.req_apis:
+    - bootloader
 
 pkg.init:
     split_app_init: 500

--- a/hw/bsp/nrf52840pdk/pkg.yml
+++ b/hw/bsp/nrf52840pdk/pkg.yml
@@ -82,7 +82,6 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - boot/bootutil
     - hw/mcu/nordic/nrf52xxx
     - libc/baselibc
     - sys/flash_map

--- a/mgmt/imgmgr/pkg.yml
+++ b/mgmt/imgmgr/pkg.yml
@@ -24,7 +24,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
     - boot/split
     - encoding/base64
     - mgmt/mgmt
@@ -32,6 +31,7 @@ pkg.deps:
 
 pkg.req_apis:
     - newtmgr
+    - bootloader
 
 pkg.deps.IMGMGR_FS:
     - fs/fs

--- a/sys/coredump/pkg.yml
+++ b/sys/coredump/pkg.yml
@@ -26,6 +26,8 @@ pkg.keywords:
 
 pkg.deps:
     - hw/hal
-    - boot/bootutil
     - mgmt/imgmgr
     - sys/flash_map
+
+pkg.req_apis:
+    - bootloader


### PR DESCRIPTION
Add bootloader as an API; and from packages which depend on boot/bootutil, depend on the API rather than the actual package.
This makes it easier to use bootloader from mcuboot project.