### PR TITLE
MYNEWT-813 RTT console i/p limited to 16 chrs

### DIFF
--- a/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf.h
+++ b/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf.h
@@ -82,7 +82,7 @@ Revision: $Rev: 4351 $
 #define SEGGER_RTT_MAX_NUM_DOWN_BUFFERS           (3)     // Max. number of down-buffers (H->T) available on this target  (Default: 3)
 
 #define BUFFER_SIZE_UP                            (MYNEWT_VAL(RTT_BUFFER_SIZE_UP))  // Size of the buffer for terminal output of target, up to host (Default: 1k)
-#define BUFFER_SIZE_DOWN                          (16)    // Size of the buffer for terminal input to target from host (Usually keyboard input) (Default: 16)
+#define BUFFER_SIZE_DOWN                          (MYNEWT_VAL(RTT_BUFFER_SIZE_DOWN))    // Size of the buffer for terminal input to target from host (Usually keyboard input) (Default: 16)
 
 #define SEGGER_RTT_PRINTF_BUFFER_SIZE             (64u)    // Size of buffer for RTT printf to bulk-send chars via RTT     (Default: 64)
 

--- a/hw/drivers/rtt/syscfg.yml
+++ b/hw/drivers/rtt/syscfg.yml
@@ -22,3 +22,6 @@ syscfg.defs:
     RTT_BUFFER_SIZE_UP:
         description: 'Size of the output buffer'
         value: 1024
+    RTT_BUFFER_SIZE_DOWN:
+        description: 'Size of the input buffer'
+        value: 16


### PR DESCRIPTION
- Segger RTT takes input of 16 max based on BUFFER_SIZE_DOWN defined in
hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf.h. This should be made a
syscfg. I was seeing issues with Thingy with jLinkExe version 6.00c, where I
could not issue sensor read command on it, based on the echo it seems
that the code just takes 16 characters of input.
Fix is to define MYNEWT_VAL(RTT_BUFFER_SIZE_DOWN) in syscfg.yml and set
it by default to a higher number if somebody would like to get it
working with jLinkExe version 6.00c.