### PR TITLE
testbench/boot serial unittest; add dependency to bootutil.

### DIFF
--- a/apps/bleprph/pkg.yml
+++ b/apps/bleprph/pkg.yml
@@ -24,6 +24,7 @@ pkg.keywords:
 
 pkg.deps: 
     - boot/split
+    - boot/bootutil
     - kernel/os 
     - mgmt/imgmgr
     - mgmt/newtmgr

--- a/apps/bleprph_oic/pkg.yml
+++ b/apps/bleprph_oic/pkg.yml
@@ -23,6 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
+    - boot/bootutil
     - kernel/os 
     - net/nimble/controller
     - net/nimble/host

--- a/apps/testbench/pkg.yml
+++ b/apps/testbench/pkg.yml
@@ -25,6 +25,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
+    - "@apache-mynewt-core/boot/bootutil"
     - "@apache-mynewt-core/boot/split_app"
     - "@apache-mynewt-core/encoding/json/test"
     - "@apache-mynewt-core/kernel/os"

--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -24,6 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - boot/boot_serial
+    - boot/bootutil
     - test/testutil
 
 pkg.deps.SELFTEST:


### PR DESCRIPTION
Prev checkin broke few apps which did not depend on bootutil explicitly.