### PR TITLE
Enable configuration of slot 0 boot validation

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1050,7 +1050,7 @@ boot_go(struct boot_rsp *rsp)
 
     switch (swap_type) {
     case BOOT_SWAP_TYPE_NONE:
-#ifdef BOOTUTIL_VALIDATE_SLOT0
+#if MYNEWT_VAL(BOOTUTIL_VALIDATE_SLOT0)
         rc = boot_validate_slot(0);
         if (rc != 0) {
             return BOOT_EBADIMAGE;

--- a/boot/bootutil/syscfg.yml
+++ b/boot/bootutil/syscfg.yml
@@ -28,3 +28,6 @@ syscfg.defs:
     BOOTUTIL_SIGN_EC256:
         description: 'Images are signed using ECDSA NIST P-256.'
         value: '0'
+    BOOTUTIL_VALIDATE_SLOT0:
+        description: 'Always validate slot 0 on bootup.'
+        value: '0'


### PR DESCRIPTION
This makes possible to configure via syscfg.yml the ability to
validate slot 0 on every boot.

Signed-off-by: Fabio Utzig <utzig@apache.org>