### PR TITLE
Enables newt resigned images

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -101,6 +101,7 @@ bootutil_img_validate(struct image_header *hdr, const struct flash_area *fap,
     MYNEWT_VAL(BOOTUTIL_SIGN_EC256)
     uint32_t sig_off = 0;
     uint32_t sig_len = 0;
+    int i;
 #endif
     struct image_tlv tlv;
     uint8_t buf[256];
@@ -208,10 +209,12 @@ bootutil_img_validate(struct image_header *hdr, const struct flash_area *fap,
         return -1;
     }
 
-    if (hdr->ih_key_id >= bootutil_key_cnt) {
-        return -1;
+    for (i = 0; i < bootutil_key_cnt; i++) {
+        rc = bootutil_verify_sig(hash, sizeof(hash), buf, sig_len, i);
+        if (!rc) {
+            break;
+        }
     }
-    rc = bootutil_verify_sig(hash, sizeof(hash), buf, sig_len, hdr->ih_key_id);
     if (rc) {
         return -1;
     }


### PR DESCRIPTION
This removes use of key-id when looking for a sign key and tries to
validate images using every available key in the bootloader, adding
compatibility with "newt resign-image" command which accepts whatever
key-id was supplied by the user.

Signed-off-by: Fabio Utzig <utzig@apache.org>