### PR TITLE
tinycbor: Fix compilation with GCC 7

### DIFF
--- a/encoding/tinycbor/include/tinycbor/compilersupport_p.h
+++ b/encoding/tinycbor/include/tinycbor/compilersupport_p.h
@@ -168,11 +168,6 @@ extern "C" {
 #  define unreachable() do {} while (0)
 #endif
 
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && \
-    (__GNUC__ * 100 + __GNUC_MINOR__ >= 404)
-#  pragma GCC optimize("-ffunction-sections")
-#endif
-
 static inline bool add_check_overflow(size_t v1, size_t v2, size_t *r)
 {
 #if ((defined(__GNUC__) && (__GNUC__ >= 5)) && !defined(__INTEL_COMPILER)) || __has_builtin(__builtin_add_overflow)


### PR DESCRIPTION
GCC 7 reports a bad option is -ffunction-sections is specified through
pragma. Since this never really worked also in older versions of GCC
just remove it.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81368