### PR TITLE
MYNEWT-815 SensorAPI: Add type to data_func,listen

### DIFF
--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -494,12 +494,14 @@ bme280_sensor_read(struct sensor *sensor, sensor_type_t type,
     int32_t rawtemp;
     int32_t rawpress;
     int32_t rawhumid;
-    struct sensor_temp_data std;
-    struct sensor_press_data spd;
-    struct sensor_humid_data shd;
+    struct sensor_itf *itf;
     struct bme280 *bme280;
     int rc;
-    struct sensor_itf *itf;
+    union {
+        struct sensor_temp_data std;
+        struct sensor_press_data spd;
+        struct sensor_humid_data shd;
+    } databuf;
 
     if (!(type & SENSOR_TYPE_PRESSURE)    &&
         !(type & SENSOR_TYPE_AMBIENT_TEMPERATURE) &&
@@ -539,7 +541,7 @@ bme280_sensor_read(struct sensor *sensor, sensor_type_t type,
         }
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &spd);
+        rc = data_func(sensor, data_arg, &databuf.spd, SENSOR_TYPE_PRESSURE);
         if (rc) {
             goto err;
         }
@@ -559,7 +561,7 @@ bme280_sensor_read(struct sensor *sensor, sensor_type_t type,
         }
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &std);
+        rc = data_func(sensor, data_arg, &databuf.std, SENSOR_TYPE_AMBIENT_TEMPERATURE);
         if (rc) {
             goto err;
         }
@@ -579,7 +581,7 @@ bme280_sensor_read(struct sensor *sensor, sensor_type_t type,
         }
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &shd);
+        rc = data_func(sensor, data_arg, &databuf.shd, SENSOR_TYPE_RELATIVE_HUMIDITY);
         if (rc) {
             goto err;
         }

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -963,7 +963,7 @@ lis2dh12_sensor_read(struct sensor *sensor, sensor_type_t type,
     sad.sad_z_is_valid = 1;
 
     /* Call data function */
-    rc = data_func(sensor, data_arg, &sad);
+    rc = data_func(sensor, data_arg, &sad, SENSOR_TYPE_ACCELEROMETER);
     if (rc != 0) {
         goto err;
     }

--- a/hw/drivers/sensors/sim/src/generic_accel.c
+++ b/hw/drivers/sensors/sim/src/generic_accel.c
@@ -142,7 +142,7 @@ sim_accel_sensor_read(struct sensor *sensor, sensor_type_t type,
 
     /* Call data function for each of the generated readings. */
     for (i = 0; i < num_samples; i++) {
-        rc = data_func(sensor, data_arg, &sad);
+        rc = data_func(sensor, data_arg, &sad, SENSOR_TYPE_ACCELEROMETER);
         if (rc != 0) {
             goto err;
         }

--- a/hw/drivers/sensors/sim/src/generic_mag.c
+++ b/hw/drivers/sensors/sim/src/generic_mag.c
@@ -142,7 +142,7 @@ sim_mag_sensor_read(struct sensor *sensor, sensor_type_t type,
 
     /* Call data function for each of the generated readings. */
     for (i = 0; i < num_samples; i++) {
-        rc = data_func(sensor, data_arg, &smd);
+        rc = data_func(sensor, data_arg, &smd, SENSOR_TYPE_MAGNETIC_FIELD);
         if (rc != 0) {
             goto err;
         }

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -909,7 +909,7 @@ tcs34725_sensor_read(struct sensor *sensor, sensor_type_t type,
         }
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &scd);
+        rc = data_func(sensor, data_arg, &scd, SENSOR_TYPE_COLOR);
         if (rc != 0) {
             goto err;
         }

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -798,7 +798,7 @@ tsl2561_sensor_read(struct sensor *sensor, sensor_type_t type,
         sld.sld_lux_is_valid  = 1;
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &sld);
+        rc = data_func(sensor, data_arg, &sld, SENSOR_TYPE_LIGHT);
         if (rc != 0) {
             goto err;
         }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -149,10 +149,12 @@ struct sensor_cfg {
  * @param The sensor for which data is being returned
  * @param The argument provided to sensor_read() function.
  * @param A single sensor reading for that sensor listener
+ * @param The sensor type for the data function
  *
  * @return 0 on success, non-zero error code on failure.
  */
-typedef int (*sensor_data_func_t)(struct sensor *, void *, void *);
+typedef int (*sensor_data_func_t)(struct sensor *, void *, void *,
+             sensor_type_t);
 
 /**
  *

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -153,7 +153,7 @@ sensor_mgr_poll_one(struct sensor *sensor, os_time_t now)
      * listeners are called by default.  Specify NULL as a callback,
      * because we just want to run all the listeners.
      */
-    sensor_read(sensor, SENSOR_TYPE_ALL, NULL, NULL, OS_TIMEOUT_NEVER);
+    sensor_read(sensor, sensor->s_mask, NULL, NULL, OS_TIMEOUT_NEVER);
 
     /* Remove the sensor from the sensor list for insert. */
     sensor_mgr_remove(sensor);
@@ -594,20 +594,23 @@ err:
 }
 
 static int
-sensor_read_data_func(struct sensor *sensor, void *arg, void *data)
+sensor_read_data_func(struct sensor *sensor, void *arg, void *data,
+                      sensor_type_t type)
 {
     struct sensor_listener *listener;
     struct sensor_read_ctx *ctx;
 
     /* Notify all listeners first */
     SLIST_FOREACH(listener, &sensor->s_listener_list, sl_next) {
-        listener->sl_func(sensor, listener->sl_arg, data);
+        if (listener->sl_sensor_type & type) {
+            listener->sl_func(sensor, listener->sl_arg, data, type);
+        }
     }
 
     /* Call data function */
     ctx = (struct sensor_read_ctx *) arg;
     if (ctx->user_func != NULL) {
-        return (ctx->user_func(sensor, ctx->user_arg, data));
+        return (ctx->user_func(sensor, ctx->user_arg, data, type));
     } else {
         return (0);
     }
@@ -674,7 +677,7 @@ sensor_read(struct sensor *sensor, sensor_type_t type,
     sensor_up_timestamp(sensor);
 
     rc = sensor->s_funcs->sd_read(sensor, type, sensor_read_data_func, &src,
-            timeout);
+                                  timeout);
     if (rc) {
         goto err;
     }

--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -50,11 +50,9 @@
 static const char g_s_oic_dn[] = "x.mynewt.snsr.";
 
 static int
-sensor_oic_encode(struct sensor* sensor, void *arg, void *databuf)
+sensor_oic_encode(struct sensor* sensor, void *arg, void *databuf,
+                  sensor_type_t type)
 {
-    sensor_type_t type;
-
-    type = *(sensor_type_t *)arg;
 
     switch(type) {
         /* Gyroscope supported */
@@ -577,7 +575,6 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
 
         listener.sl_sensor_type = type;
         listener.sl_func = sensor_oic_encode;
-        listener.sl_arg = (void *)&listener.sl_sensor_type;
 
         rc = sensor_register_listener(sensor, &listener);
         if (rc) {

--- a/hw/sensor/src/sensor_shell.c
+++ b/hw/sensor/src/sensor_shell.c
@@ -65,7 +65,6 @@ struct sensor_poll_data {
 };
 
 struct sensor_shell_read_ctx {
-    sensor_type_t type;
     int num_entries;
 };
 
@@ -237,7 +236,8 @@ sensor_ftostr(float num, char *fltstr, int len)
 }
 
 static int
-sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
+sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data,
+                           sensor_type_t type)
 {
     struct sensor_shell_read_ctx *ctx;
     struct sensor_accel_data *sad;
@@ -261,9 +261,9 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
                    (int)sensor->s_sts.st_ostv.tv_usec,
                    (unsigned int)sensor->s_sts.st_cputime);
 
-    if (ctx->type == SENSOR_TYPE_ACCELEROMETER ||
-        ctx->type == SENSOR_TYPE_LINEAR_ACCEL  ||
-        ctx->type == SENSOR_TYPE_GRAVITY) {
+    if (type == SENSOR_TYPE_ACCELEROMETER ||
+        type == SENSOR_TYPE_LINEAR_ACCEL  ||
+        type == SENSOR_TYPE_GRAVITY) {
 
         sad = (struct sensor_accel_data *) data;
         if (sad->sad_x_is_valid) {
@@ -278,7 +278,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_MAGNETIC_FIELD) {
+    if (type == SENSOR_TYPE_MAGNETIC_FIELD) {
         smd = (struct sensor_mag_data *) data;
         if (smd->smd_x_is_valid) {
             console_printf("x = %s ", sensor_ftostr(smd->smd_x, tmpstr, 13));
@@ -292,7 +292,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_GYROSCOPE) {
+    if (type == SENSOR_TYPE_GYROSCOPE) {
         sgd = (struct sensor_gyro_data *) data;
         if (sgd->sgd_x_is_valid) {
             console_printf("x = %s ", sensor_ftostr(sgd->sgd_x, tmpstr, 13));
@@ -306,7 +306,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_LIGHT) {
+    if (type == SENSOR_TYPE_LIGHT) {
         sld = (struct sensor_light_data *) data;
         if (sld->sld_full_is_valid) {
             console_printf("Full = %u, ", sld->sld_full);
@@ -320,8 +320,8 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_TEMPERATURE      ||
-        ctx->type == SENSOR_TYPE_AMBIENT_TEMPERATURE) {
+    if (type == SENSOR_TYPE_TEMPERATURE      ||
+        type == SENSOR_TYPE_AMBIENT_TEMPERATURE) {
 
         std = (struct sensor_temp_data *) data;
         if (std->std_temp_is_valid) {
@@ -330,7 +330,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_EULER) {
+    if (type == SENSOR_TYPE_EULER) {
         sed = (struct sensor_euler_data *) data;
         if (sed->sed_h_is_valid) {
             console_printf("h = %s", sensor_ftostr(sed->sed_h, tmpstr, 13));
@@ -344,7 +344,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_ROTATION_VECTOR) {
+    if (type == SENSOR_TYPE_ROTATION_VECTOR) {
         sqd = (struct sensor_quat_data *) data;
         if (sqd->sqd_x_is_valid) {
             console_printf("x = %s ", sensor_ftostr(sqd->sqd_x, tmpstr, 13));
@@ -361,7 +361,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_COLOR) {
+    if (type == SENSOR_TYPE_COLOR) {
         scd = (struct sensor_color_data *) data;
         if (scd->scd_r_is_valid) {
             console_printf("r = %u, ", scd->scd_r);
@@ -403,7 +403,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_PRESSURE) {
+    if (type == SENSOR_TYPE_PRESSURE) {
         spd = (struct sensor_press_data *) data;
         if (spd->spd_press_is_valid) {
             console_printf("pressure = %s Pa",
@@ -412,7 +412,7 @@ sensor_shell_read_listener(struct sensor *sensor, void *arg, void *data)
         console_printf("\n");
     }
 
-    if (ctx->type == SENSOR_TYPE_RELATIVE_HUMIDITY) {
+    if (type == SENSOR_TYPE_RELATIVE_HUMIDITY) {
         shd = (struct sensor_humid_data *) data;
         if (shd->shd_humid_is_valid) {
             console_printf("relative humidity = %s%%rh",
@@ -537,8 +537,6 @@ sensor_cmd_read(char *name, sensor_type_t type, struct sensor_poll_data *spd)
                        (int)type, name);
         return rc;
     }
-
-    ctx.type = type;
 
     listener.sl_sensor_type = type;
     listener.sl_func = sensor_shell_read_listener;


### PR DESCRIPTION
- Adding type field as a parameter to data_func callback and the listener function. It helps in letting the callback and listener know which type of data the callback or the listener is looking at.
- Fixing bno055 driver read function so that all data can be read instead of reading data for a single sensor type.
- Calling listener only for a specific type, filtering based on the mask. Earlier the listener would not honor the listener.