### PR TITLE
MYNEWT-816 SensorAPI: Add API for sensor poller & fix the poller callout

### DIFF
--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -414,7 +414,7 @@ sensor_get_config(struct sensor *sensor, sensor_type_t type,
  * be triggered instead.
  */
 #define SENSOR_MGR_WAKEUP_TICKS (MYNEWT_VAL(SENSOR_MGR_WAKEUP_RATE) * \
-        (OS_TICKS_PER_SEC / 1000))
+    OS_TICKS_PER_SEC) / 1000
 
 int sensor_mgr_lock(void);
 void sensor_mgr_unlock(void);
@@ -481,6 +481,15 @@ struct sensor *sensor_mgr_find_next_bydevname(char *, struct sensor *);
  * @return 1 if matches, 0 if it doesn't match.
  */
 int sensor_mgr_match_bytype(struct sensor *sensor, void *arg);
+
+/**
+ * Set the sensor poll rate
+ *
+ * @param The devname
+ * @param The poll rate in milli seconds
+ */
+int
+sensor_set_poll_rate_ms(char *devname, uint32_t poll_rate);
 
 #if MYNEWT_VAL(SENSOR_CLI)
 char*

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -480,7 +480,7 @@ struct sensor *sensor_mgr_find_next_bydevname(char *, struct sensor *);
  *
  * @return 1 if matches, 0 if it doesn't match.
  */
-int sensor_mgr_match_bytype(struct sensor *sensor, void *arg);
+int sensor_mgr_match_bytype(struct sensor *, void *);
 
 /**
  * Set the sensor poll rate
@@ -489,11 +489,11 @@ int sensor_mgr_match_bytype(struct sensor *sensor, void *arg);
  * @param The poll rate in milli seconds
  */
 int
-sensor_set_poll_rate_ms(char *devname, uint32_t poll_rate);
+sensor_set_poll_rate_ms(char *, uint32_t);
 
 #if MYNEWT_VAL(SENSOR_CLI)
 char*
-sensor_ftostr(float num, char *fltstr, int len);
+sensor_ftostr(float, char *, int);
 #endif
 
 #if MYNEWT_VAL(SENSOR_OIC)

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -30,6 +30,7 @@
 #include "os/os_time.h"
 #include "os/os_cputime.h"
 #include "defs/error.h"
+#include "console/console.h"
 
 struct {
     struct os_mutex mgr_lock;
@@ -104,6 +105,36 @@ sensor_mgr_insert(struct sensor *sensor)
 }
 
 /**
+ * Set the sensor poll rate based on teh device name
+ *
+ * @param The devname
+ * @param The poll rate in milli seconds
+ */
+int
+sensor_set_poll_rate_ms(char *devname, uint32_t poll_rate)
+{
+    struct sensor *sensor;
+    int rc;
+
+    sensor = sensor_mgr_find_next_bydevname(devname, NULL);
+
+    if (!sensor) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    sensor_lock(sensor);
+
+    sensor->s_poll_rate = poll_rate;
+
+    sensor_unlock(sensor);
+
+    return 0;
+err:
+    return rc;
+}
+
+/**
  * Register the sensor with the global sensor list. This makes the sensor
  * searchable by other packages, who may want to look it up by type.
  *
@@ -162,7 +193,7 @@ sensor_mgr_poll_one(struct sensor *sensor, os_time_t now)
      * list.
      */
     os_time_ms_to_ticks(sensor->s_poll_rate, &sensor_ticks);
-    sensor->s_next_run = now + sensor_ticks;
+    sensor->s_next_run = sensor_ticks + now;
 
     /* Re-insert the sensor manager, with the new wakeup time. */
     sensor_mgr_insert(sensor);
@@ -170,7 +201,7 @@ sensor_mgr_poll_one(struct sensor *sensor, os_time_t now)
     /* Unlock the sensor to allow other access */
     sensor_unlock(sensor);
 
-    return (sensor->s_next_run);
+    return (sensor_ticks);
 err:
     /* Couldn't lock it.  Re-run task and spin until we get result. */
     return (0);
@@ -192,12 +223,13 @@ sensor_mgr_wakeup_event(struct os_event *ev)
     int rc;
 
     now = os_time_get();
-    task_next_wakeup = now + SENSOR_MGR_WAKEUP_TICKS;
+
+    task_next_wakeup = SENSOR_MGR_WAKEUP_TICKS;
 
     rc = sensor_mgr_lock();
     if (rc != 0) {
         /* Schedule again in 1 tick, see if we can reacquire the lock */
-        task_next_wakeup = now + 1;
+        task_next_wakeup = 1;
         goto done;
     }
 
@@ -217,8 +249,8 @@ sensor_mgr_wakeup_event(struct os_event *ev)
         }
 
         /* Sensor poll one completes the poll, updates the sensor's "next run,"
-         * and re-inserts it into the list.  It returns the next wakeup time
-         * for this sensor.
+         * and re-inserts it into the list.  It returns the next wakeup time in ticks
+         * from now ticks for this sensor.
          */
         next_wakeup = sensor_mgr_poll_one(cursor, now);
 
@@ -229,6 +261,7 @@ sensor_mgr_wakeup_event(struct os_event *ev)
         if (task_next_wakeup > next_wakeup) {
             task_next_wakeup = next_wakeup;
         }
+
     }
 
 done:

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -20,8 +20,8 @@
 
 syscfg.defs:
     SENSOR_MGR_WAKEUP_RATE:
-        description: 'The default wakeup rate of the sensor manager'
-        value: 1
+        description: 'The default wakeup rate of the sensor manager in ms'
+        value: 2000
 
     SENSOR_CLI:
         description: 'Whether or not to enable the sensor shell support'


### PR DESCRIPTION
- Adding API for setting sensor poller in ms
- Also fixing the sensor manager poller which was trying to reset the
  callout to absolute time instead of relative time
- Changing the syscfg for SENSOR_MGR_WAKEUP_RATE to 2000 ms