### PR TITLE
nimble/controller: Fix legacy scanning

### DIFF
--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -1066,9 +1066,11 @@ ble_ll_scan_sm_start(struct ble_ll_scan_sm *scansm)
     scansm->scan_enabled = 1;
 
     /* Set first advertising channel */
+    assert(scansm->cur_phy != PHY_NOT_CONFIGURED);
     scansm->phy_data[scansm->cur_phy].scan_chan = BLE_PHY_ADV_CHAN_START;
 
-    if (scansm->next_phy != scansm->cur_phy) {
+    if (scansm->next_phy != PHY_NOT_CONFIGURED &&
+            scansm->next_phy != scansm->cur_phy) {
         scansm->phy_data[scansm->next_phy].scan_chan = BLE_PHY_ADV_CHAN_START;
     }
 


### PR DESCRIPTION
In legacy scanning next_phy is unconfigured so we should not try to
configure channels for next_phy as it will corrupt some random
memory.

Also add assert to make sure cur_phy is always configured, because it
should be.