### PR TITLE
Clear LED define for the VBLUno51, VBLUno52 board.

### DIFF
--- a/hw/bsp/vbluno51/include/bsp/bsp.h
+++ b/hw/bsp/vbluno51/include/bsp/bsp.h
@@ -37,10 +37,8 @@ extern uint8_t _ram_start;
 #define RAM_SIZE        0x8000
 
 /* LED pins */
-#define LED 			(7)
-
-#define LED_BLINK_PIN   LED
-#define LED_2           LED
+#define LED_BLINK_PIN   (7)
+#define LED_2           (7)
 
 /* BUTTON pins */
 #define BUT				(15)

--- a/hw/bsp/vbluno52/include/bsp/bsp.h
+++ b/hw/bsp/vbluno52/include/bsp/bsp.h
@@ -40,9 +40,8 @@ extern uint8_t _ram_start;
 #define RAM_SIZE        0x10000
 
 /* LED pin */
-#define LED 			(12)
-#define LED_BLINK_PIN   LED
-#define LED_2           LED
+#define LED_BLINK_PIN   (12)
+#define LED_2           (12)
 
 /* BUTTON pin */
 #define BUT 			(17)


### PR DESCRIPTION
Clear LED define for the VBLUno51, VBLUno52 board.

Because `LED` was be used in other file

Signed-off-by: iotvietmember <robotden@gmail.com>