### PR TITLE
Add hal_system_init in startup file for VBLUno51 board

### DIFF
--- a/hw/bsp/vbluno51/src/arch/cortex_m0/gcc_startup_nrf51.s
+++ b/hw/bsp/vbluno51/src/arch/cortex_m0/gcc_startup_nrf51.s
@@ -185,6 +185,9 @@ Reset_Handler:
 
     LDR     R0, =SystemInit
     BLX     R0
+
+    BL      hal_system_init
+
     LDR     R0, =_start
     BX      R0
 


### PR DESCRIPTION
Add `BL hal_system_init` in startup file (` hw/bsp/vbluno51/src/arch/cortex_m0/gcc_startup_nrf51.s`) for VBLUno51 board

Signed-off-by: iotvietmember <robotden@gmail.com>