### PR TITLE
nimble/phy: Fix build error on nRF52

### DIFF
--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -493,9 +493,11 @@ ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
     NRF_RADIO->INTENSET = RADIO_INTENSET_DISABLED_Msk;
 }
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
 static uint32_t
 ble_phy_get_ccm_datarate(void)
 {
+#if BLE_LL_BT5_PHY_SUPPORTED
     switch (g_ble_phy_data.phy_cur_phy_mode) {
     case BLE_PHY_MODE_1M:
         return CCM_MODE_DATARATE_1Mbit << CCM_MODE_DATARATE_Pos;
@@ -509,7 +511,11 @@ ble_phy_get_ccm_datarate(void)
 
     assert(0);
     return 0;
+#else
+    return CCM_MODE_DATARATE_1Mbit << CCM_MODE_DATARATE_Pos;
+#endif
 }
+#endif
 
 /**
  * Setup transceiver for receive.


### PR DESCRIPTION
nRF52 does not have symbols for 125/500 data rates in CCM defined (for
LE Coded PHY - we only allow 1M on nRF52 anyway).

Error: repos/apache-mynewt-core/hw/drivers/nimble/nrf52/src/ble_phy.c: In
function 'ble_phy_get_ccm_datarate':
repos/apache-mynewt-core/hw/drivers/nimble/nrf52/src/ble_phy.c:505:16:
error: 'CCM_MODE_DATARATE_125Kbps' undeclared (first use in this
function)
         return CCM_MODE_DATARATE_125Kbps << CCM_MODE_DATARATE_Pos;
                ^~~~~~~~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-core/hw/drivers/nimble/nrf52/src/ble_phy.c:505:16:
note: each undeclared identifier is reported only once for each function
it appears in
repos/apache-mynewt-core/hw/drivers/nimble/nrf52/src/ble_phy.c:507:16:
error: 'CCM_MODE_DATARATE_500Kbps' undeclared (first use in this
function)
         return CCM_MODE_DATARATE_500Kbps << CCM_MODE_DATARATE_Pos;
                ^~~~~~~~~~~~~~~~~~~~~~~~~