### PR TITLE
Fix host unit test compiler error on mac

### DIFF
--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -408,7 +408,7 @@ ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
     evt2.subevent_code = BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT;
     evt2.status = BLE_ERR_SUCCESS;
     evt2.connection_handle = handle;
-    memcpy(evt2.features, (uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }, 8);
+    memcpy(evt2.features, ((uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }), 8);
 
     ble_gap_rx_rd_rem_sup_feat_complete(&evt2);
 


### PR DESCRIPTION
This addresses the following compiler error encountered in macOS:

```
    Compiling net/nimble/host/test/src/ble_hs_test_util.c
    net/nimble/host/test/src/ble_hs_test_util.c: In function 'ble_hs_test_util_create_rpa_conn':
    net/nimble/host/test/src/ble_hs_test_util.c:411:79: error: macro "memcpy" passed 10 arguments, but takes just 3
         memcpy(evt2.features, (uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }, 8);
                                                                                   ^
    net/nimble/host/test/src/ble_hs_test_util.c:411:5: error: statement with no effect [-Werror=unused-value]
         memcpy(evt2.features, (uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }, 8);
         ^
    cc1: all warnings being treated as errors
```

This error occurs on the mac because its standard library implements `memcpy()` as a macro rather than a function.  The reason for the error is explained here: https://stackoverflow.com/a/5559334.  Basically, the preprocessor doesn't understand the full C syntax, so arguments to
macros need special treatment.

The fix is to surround the compound literal argument with an extra set of parenthesis.