### PR TITLE
util/parse: Fix parse_ull return type.

### DIFF
--- a/util/parse/include/parse/parse.h
+++ b/util/parse/include/parse/parse.h
@@ -31,7 +31,7 @@ parse_ull_bounds(const char *sval,
 long long
 parse_ll(const char *sval, int *out_status);
 
-long long
+unsigned long long
 parse_ull(const char *sval, int *out_status);
 
 int

--- a/util/parse/src/parse.c
+++ b/util/parse/src/parse.c
@@ -142,7 +142,7 @@ parse_ll(const char *sval, int *out_status)
  * @return                      The parsed number on success;
  *                              unspecified on error.
  */
-long long
+unsigned long long
 parse_ull(const char *sval, int *out_status)
 {
     return parse_ull_bounds(sval, 0, ULLONG_MAX, out_status);


### PR DESCRIPTION
This function should return an unsigned long long; it was returning long long instead.