### PR TITLE
nimble: Fix setting advertising instance random address

### DIFF
--- a/net/nimble/host/src/ble_hs_hci_util.c
+++ b/net/nimble/host/src/ble_hs_hci_util.c
@@ -156,6 +156,11 @@ ble_hs_hci_util_set_random_addr(const uint8_t *addr)
     if (rc != 0) {
         return rc;
     }
+
+    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    if (rc != 0) {
+        return rc;
+    }
 #endif
 
     return 0;


### PR DESCRIPTION
This fix extended advertising with random address provided by application.