### PR TITLE
Sensor evq

### DIFF
--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -321,7 +321,7 @@ sensor_mgr_evq_get(void)
     return (sensor_mgr.mgr_eventq);
 }
 
-void
+static void
 sensor_mgr_evq_set(struct os_eventq *evq)
 {
     os_eventq_designate(&sensor_mgr.mgr_eventq, evq, NULL);

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -31,6 +31,7 @@
 #include "os/os_cputime.h"
 #include "defs/error.h"
 #include "console/console.h"
+#include "syscfg/syscfg.h"
 
 struct {
     struct os_mutex mgr_lock;
@@ -333,7 +334,11 @@ sensor_mgr_init(void)
     struct os_timeval ostv;
     struct os_timezone ostz;
 
+#ifdef MYNEWT_VAL_SENSOR_MGR_EVQ
+    sensor_mgr_evq_set(MYNEWT_VAL(SENSOR_MGR_EVQ));
+#else
     sensor_mgr_evq_set(os_eventq_dflt_get());
+#endif
 
     /**
      * Initialize sensor polling callout and set it to fire on boot.

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -43,4 +43,4 @@ syscfg.defs:
 
     SENSOR_MGR_EVQ:
         description: 'Specify the eventq to be used by sensor mgr'
-        value: 0
+        value:

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -40,3 +40,7 @@ syscfg.defs:
     SENSOR_OIC_OBS_RATE:
         description: 'Set OIC server observation rate in milli seconds'
         value: 1000
+
+    SENSOR_MGR_EVQ:
+        description: 'Specify the eventq to be used by sensor mgr'
+        value: 0


### PR DESCRIPTION
- Make sensor_mgr_evq_set() static
- Make sensor_mgr_evq_set() arg a syscfg with default picking up default evq.