### PR TITLE
Clicker: Implement GPIO, SPI, I2C and Timer HAL

### DIFF
--- a/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
+++ b/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
@@ -47,6 +47,9 @@ extern uint8_t _ccram_start;
 /* UART */
 #define UART_CNT        (4)
 
+/* SPI */
+#define SPI_CNT         (2)
+
 #define NFFS_AREA_MAX    (8)
 
 #ifdef __cplusplus

--- a/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
+++ b/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
@@ -39,6 +39,11 @@ extern uint8_t _ccram_start;
 #define RAM_SIZE        (128 * 1024)
 #define CCRAM_SIZE      (64 * 1024)
 
+/* LED pins */
+#define LED_1           MCU_GPIO_PORTB(1)
+#define LED_2           MCU_GPIO_PORTB(2)
+#define LED_BLINK_PIN   LED_1
+
 /* UART */
 #define UART_CNT 4
 

--- a/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
+++ b/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
@@ -45,7 +45,7 @@ extern uint8_t _ccram_start;
 #define LED_BLINK_PIN   LED_1
 
 /* UART */
-#define UART_CNT 4
+#define UART_CNT        (4)
 
 #define NFFS_AREA_MAX    (8)
 

--- a/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
+++ b/hw/bsp/pic32mx470_6lp_clicker/include/bsp/bsp.h
@@ -50,6 +50,9 @@ extern uint8_t _ccram_start;
 /* SPI */
 #define SPI_CNT         (2)
 
+/* I2C */
+#define I2C_CNT         (2)
+
 #define NFFS_AREA_MAX    (8)
 
 #ifdef __cplusplus

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -93,6 +93,19 @@ static const struct mips_spi_cfg spi1_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_0)
+/*
+ * I2C 0 (Mikrobus connector)
+ *   SCL -> RD10
+ *   SDA -> RD9
+ */
+static const struct mips_i2c_cfg hal_i2c0_cfg = {
+    .scl = MCU_GPIO_PORTD(10),
+    .sda = MCU_GPIO_PORTD(9),
+    .frequency = 400000
+};
+#endif
+
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
 {
@@ -135,6 +148,11 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(SPI_1_MASTER)
     rc = hal_spi_init(1, &spi1_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, &hal_i2c0_cfg);
     assert(rc == 0);
 #endif
 

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -21,7 +21,8 @@
 #include <hal/hal_bsp.h>
 #include <syscfg/syscfg.h>
 
-#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || \
+    MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>
 #include <mcu/mcu.h>

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -23,6 +23,11 @@
 #include <mcu/mcu.h>
 #include <mcu/mips_hal.h>
 
+#if MYNEWT_VAL(TIMER_0) || MYNEWT_VAL(TIMER_1) || MYNEWT_VAL(TIMER_2) || \
+    MYNEWT_VAL(TIMER_3)
+#include "hal/hal_timer.h"
+#endif
+
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || \
     MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3)
 #include <uart/uart.h>
@@ -116,6 +121,26 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+#if MYNEWT_VAL(TIMER_0)
+    rc = hal_timer_init(0, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_1)
+    rc = hal_timer_init(1, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_2)
+    rc = hal_timer_init(2, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_3)
+    rc = hal_timer_init(3, NULL);
+    assert(rc == 0);
+#endif
 
 #if MYNEWT_VAL(UART_0)
     rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -20,13 +20,17 @@
 
 #include <hal/hal_bsp.h>
 #include <syscfg/syscfg.h>
+#include <mcu/mcu.h>
+#include <mcu/mips_hal.h>
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || \
     MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>
-#include <mcu/mcu.h>
-#include <mcu/mips_hal.h>
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER)
+#include "hal/hal_spi.h"
 #endif
 
 #include <xc.h>
@@ -61,6 +65,34 @@ static const struct mips_uart_cfg uart2_cfg = {
 static struct uart_dev os_bsp_uart3;
 #endif
 
+#if MYNEWT_VAL(SPI_0_MASTER)
+/*
+ * SPI 0 (connected to CA8210)
+ *   MOSI -> RD4
+ *   MISO -> RD3
+ *   SCK  -> RD2
+ */
+static const struct mips_spi_cfg spi0_cfg = {
+    .mosi = MCU_GPIO_PORTD(4),
+    .miso = MCU_GPIO_PORTD(3),
+    .sck = MCU_GPIO_PORTD(2)
+};
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER)
+/*
+ * SPI 1 (Mikrobus connector)
+ *   MOSI -> RG8
+ *   MISO -> RG7
+ *   SCK  -> RG6
+ */
+static const struct mips_spi_cfg spi1_cfg = {
+    .mosi = MCU_GPIO_PORTG(8),
+    .miso = MCU_GPIO_PORTG(7),
+    .sck = MCU_GPIO_PORTG(6)
+};
+#endif
+
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
 {
@@ -93,6 +125,16 @@ hal_bsp_init(void)
 #if MYNEWT_VAL(UART_3)
     rc = os_dev_create((struct os_dev *) &os_bsp_uart3, "uart3",
         OS_DEV_INIT_PRIMARY, 0, uart_hal_init, 0);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = hal_spi_init(0, &spi0_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER)
+    rc = hal_spi_init(1, &spi1_cfg, HAL_SPI_TYPE_MASTER);
     assert(rc == 0);
 #endif
 

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -24,6 +24,8 @@
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>
+#include <mcu/mcu.h>
+#include <mcu/mips_hal.h>
 #endif
 
 #include <xc.h>
@@ -40,10 +42,18 @@ static struct uart_dev os_bsp_uart0;
 
 #if MYNEWT_VAL(UART_1)
 static struct uart_dev os_bsp_uart1;
+static const struct mips_uart_cfg uart1_cfg = {
+    .tx = MCU_GPIO_PORTD(11),
+    .rx = MCU_GPIO_PORTB(9)
+};
 #endif
 
 #if MYNEWT_VAL(UART_2)
 static struct uart_dev os_bsp_uart2;
+static const struct mips_uart_cfg uart2_cfg = {
+    .tx = MCU_GPIO_PORTF(4),
+    .rx = MCU_GPIO_PORTF(5)
+};
 #endif
 
 #if MYNEWT_VAL(UART_3)
@@ -69,13 +79,13 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(UART_1)
     rc = os_dev_create((struct os_dev *) &os_bsp_uart1, "uart1",
-        OS_DEV_INIT_PRIMARY, 0, uart_hal_init, 0);
+        OS_DEV_INIT_PRIMARY, 0, uart_hal_init, &uart1_cfg);
     assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(UART_2)
     rc = os_dev_create((struct os_dev *) &os_bsp_uart2, "uart2",
-        OS_DEV_INIT_PRIMARY, 0, uart_hal_init, 0);
+        OS_DEV_INIT_PRIMARY, 0, uart_hal_init, &uart2_cfg);
     assert(rc == 0);
 #endif
 

--- a/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
@@ -29,11 +29,11 @@ syscfg.defs:
         value:  1
 
     UART_1:
-        description: 'Whether to enable UART1'
+        description: 'Whether to enable UART1 (serial pads)'
         value:  1
 
     UART_2:
-        description: 'Whether to enable UART2'
+        description: 'Whether to enable UART2 (Mikrobus)'
         value:  1
 
     UART_3:

--- a/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
@@ -24,6 +24,22 @@ syscfg.defs:
         description: 'System clock frequency, defined in hal_bsp.c'
         value:  80000000ul
 
+    TIMER_0:
+        description: "Whether to enable Timer 0"
+        value:  1
+
+    TIMER_1:
+        description: "Whether to enable Timer 1"
+        value:  0
+
+    TIMER_2:
+        description: "Whether to enable Timer 2"
+        value:  0
+
+    TIMER_3:
+        description: "Whether to enable Timer 3"
+        value:  0
+
     UART_0:
         description: 'Whether to enable UART0'
         value:  1

--- a/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
@@ -40,5 +40,13 @@ syscfg.defs:
         description: 'Whether to enable UART3'
         value:  1
 
+    SPI_0_MASTER:
+        description: 'SPI connected to CA8210'
+        value:  1
+
+    SPI_1_MASTER:
+        description: 'SPI on Mikrobus connector'
+        value:  1
+
 syscfg.vals:
     CONSOLE_UART_DEV: '"uart2"'

--- a/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
@@ -48,5 +48,9 @@ syscfg.defs:
         description: 'SPI on Mikrobus connector'
         value:  1
 
+    I2C_0:
+        description: 'I2C on Mikrobus connector'
+        value:  1
+
 syscfg.vals:
     CONSOLE_UART_DEV: '"uart2"'

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/mcu.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/mcu.h
@@ -22,4 +22,19 @@
 
 #include "p32mx470f512h.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MCU_GPIO_PORTB(pin)	((1 * 16) + (pin & 0xF))
+#define MCU_GPIO_PORTC(pin)	((2 * 16) + (pin & 0xF))
+#define MCU_GPIO_PORTD(pin)	((3 * 16) + (pin & 0xF))
+#define MCU_GPIO_PORTE(pin)	((4 * 16) + (pin & 0xF))
+#define MCU_GPIO_PORTF(pin)	((5 * 16) + (pin & 0xF))
+#define MCU_GPIO_PORTG(pin)	((6 * 16) + (pin & 0xF))
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __MCU_MCU_H_ */

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
@@ -39,6 +39,13 @@ struct mips_spi_cfg {
     uint8_t sck;
 };
 
+/* I/O pins for I2C, also set frequency */
+struct mips_i2c_cfg {
+    uint8_t scl;
+    uint8_t sda;
+    uint32_t frequency;
+};
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(__os_sr) do {__os_sr = __builtin_get_isr_state(); \
         __builtin_disable_interrupts();} while(0)

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
@@ -32,6 +32,13 @@ struct mips_uart_cfg {
     uint8_t rx;
 };
 
+/* I/O pins for SPI, SS pin is not handled by the driver */
+struct mips_spi_cfg {
+    uint8_t mosi;
+    uint8_t miso;
+    uint8_t sck;
+};
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(__os_sr) do {__os_sr = __builtin_get_isr_state(); \
         __builtin_disable_interrupts();} while(0)

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/mips_hal.h
@@ -26,6 +26,12 @@
 extern "C" {
 #endif
 
+/* I/O pins for UART */
+struct mips_uart_cfg {
+    uint8_t tx;
+    uint8_t rx;
+};
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(__os_sr) do {__os_sr = __builtin_get_isr_state(); \
         __builtin_disable_interrupts();} while(0)

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/pps.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/pps.h
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* This file defines the Periphal Pin Select module within this MCU */
+
+#ifndef __MCU_PPS_H__
+#define __MCU_PPS_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NO_CONNECT      (0)
+
+/* Input */
+#define INT3_IN_FUNC    (0)
+#define T2CK_IN_FUNC    (1)
+#define IC3_IN_FUNC     (2)
+#define U1RX_IN_FUNC    (3)
+#define U2RX_IN_FUNC    (4)
+#define U5CTS_IN_FUNC   (5)
+#define REFCLKI_IN_FUNC (6)
+
+#define INT4_IN_FUNC    (16 + 0)
+#define T5CK_IN_FUNC    (16 + 1)
+#define IC4_IN_FUNC     (16 + 2)
+#define U3RX_IN_FUNC    (16 + 3)
+#define U4CTS_IN_FUNC   (16 + 4)
+#define SDI1_IN_FUNC    (16 + 5)
+#define SDI2_IN_FUNC    (16 + 6)
+
+#define INT2_IN_FUNC    (32 + 0)
+#define T4CK_IN_FUNC    (32 + 1)
+#define IC2_IN_FUNC     (32 + 2)
+#define IC5_IN_FUNC     (32 + 3)
+#define U1CTS_IN_FUNC   (32 + 4)
+#define U2CTS_IN_FUNC   (32 + 5)
+#define SS1_IN_FUNC     (32 + 6)
+
+#define INT1_IN_FUNC    (48 + 0)
+#define T3CK_IN_FUNC    (48 + 1)
+#define IC1_IN_FUNC     (48 + 2)
+#define U3CTS_IN_FUNC   (48 + 3)
+#define U4RX_IN_FUNC    (48 + 4)
+#define U5RX_IN_FUNC    (48 + 5)
+#define SS2_IN_FUNC     (48 + 6)
+#define OCFA_IN_FUNC    (48 + 7)
+
+/* Output */
+#define U3TX_OUT_FUNC       (0b0001)
+#define U4RTS_OUT_FUNC      (0b0010)
+#define SDO2_OUT_FUNC       (0b0110)
+#define OC3_OUT_FUNC        (0b1011)
+#define C2OUT_OUT_FUNC      (0b1101)
+
+#define U2TX_OUT_FUNC       (0b0001)
+#define U1TX_OUT_FUNC       (0b0011)
+#define U5RTS_OUT_FUNC      (0b0100)
+#define SDO1_OUT_FUNC       (0b1000)
+#define OC4_OUT_FUNC        (0b1011)
+
+#define U3RTS_OUT_FUNC      (0b0001)
+#define U4TX_OUT_FUNC       (0b0010)
+#define REFCLKO_OUT8_FUNC   (0b0011)
+#define U5TX_OUT_FUNC       (0b0100)
+#define SS1_OUT_FUNC        (0b0111)
+#define OC5_OUT_FUNC        (0b1011)
+#define C1OUT_OUT_FUNC      (0b1101)
+
+#define U2RTS_OUT_FUNC      (0b0001)
+#define U1RTS_OUT_FUNC      (0b0011)
+#define U5TX_OUT_FUNC       (0b0100)
+#define SS2_OUT_FUNC        (0b0110)
+#define SDO1_OUT_FUNC       (0b1000)
+#define OC2_OUT_FUNC        (0b1011)
+#define OC1_OUT_FUNC        (0b1100)
+
+/**
+ * @brief Configure pin as a peripheral output
+ *
+ * @param pin
+ * @param func
+ * @return 0 if successful, -1 otherwise
+ */
+int pps_configure_output(uint8_t pin, uint8_t func);
+
+/**
+ * @brief Configure pin as a peripheral input
+ *
+ * @param pin
+ * @param func
+ * @return 0 if successful, -1 otherwise
+ */
+int pps_configure_input(uint8_t pin, uint8_t func);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_PPS_H__ */

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_gpio.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_gpio.c
@@ -1,0 +1,414 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/os.h>
+#include <hal/hal_gpio.h>
+#include <mcu/mips_hal.h>
+#include <mcu/p32mx470f512h.h>
+
+#define GPIO_INDEX(pin)     ((pin) & 0x0F)
+#define GPIO_PORT(pin)      (((pin) >> 4) & 0x0F)
+#define GPIO_MASK(pin)      (1 << GPIO_INDEX(pin))
+
+#define PORTx(P)        (base_address[P].gpio[0x0])
+#define LATxCLR(P)      (base_address[P].gpio[0x14 / 0x4])
+#define LATxSET(P)      (base_address[P].gpio[0x18 / 0x4])
+#define LATxINV(P)      (base_address[P].gpio[0x1C / 0x4])
+#define ODCxCLR(P)      (base_address[P].gpio[0x24 / 0x4])
+#define CNPUxCLR(P)     (base_address[P].gpio[0x34 / 0x4])
+#define CNPUxSET(P)     (base_address[P].gpio[0x38 / 0x4])
+#define CNPDxCLR(P)     (base_address[P].gpio[0x44 / 0x4])
+#define CNPDxSET(P)     (base_address[P].gpio[0x48 / 0x4])
+#define CNCONxSET(P)    (base_address[P].gpio[0x58 / 0x4])
+#define CNENxCLR(P)     (base_address[P].gpio[0x64 / 0x4])
+#define CNENxSET(P)     (base_address[P].gpio[0x68 / 0x4])
+#define CNSTATx(P)      (base_address[P].gpio[0x70 / 0x4])
+#define CNSTATxCLR(P)   (base_address[P].gpio[0x74 / 0x4])
+#define ANSELxCLR(P)    (base_address[P].ansel[0x04 / 0x4])
+#define TRISxCLR(P)     (base_address[P].tris[0x04 / 0x4])
+#define TRISxSET(P)     (base_address[P].tris[0x08 / 0x4])
+
+struct hal_gpio_irq_t {
+    int                    pin;
+    hal_gpio_irq_trig_t    trig;
+    hal_gpio_irq_handler_t handler;
+    void                   *arg;
+};
+
+#define HAL_GPIO_MAX_IRQ    (8)
+static struct hal_gpio_irq_t hal_gpio_irqs[HAL_GPIO_MAX_IRQ];
+
+struct pic32_gpio_t {
+    volatile uint32_t * gpio;
+    volatile uint32_t * ansel;
+    volatile uint32_t * tris;
+};
+
+static struct pic32_gpio_t base_address[] = {
+    {
+        /* No PORT A on PIC32MX470F512H */
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTB_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELB,
+        .tris  = (volatile uint32_t *)&TRISB
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTC_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELC,
+        .tris  = (volatile uint32_t *)&TRISC
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTD_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELD,
+        .tris  = (volatile uint32_t *)&TRISD
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTE_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELE,
+        .tris  = (volatile uint32_t *)&TRISE
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTF_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELF,
+        .tris  = (volatile uint32_t *)&TRISF
+    },
+    {
+        .gpio  = (volatile uint32_t *)_PORTG_BASE_ADDRESS,
+        .ansel = (volatile uint32_t *)&ANSELG,
+        .tris  = (volatile uint32_t *)&TRISG
+    }
+};
+
+static uint8_t
+hal_gpio_find_pin(int pin)
+{
+    uint8_t index = 0;
+
+    while (index < HAL_GPIO_MAX_IRQ) {
+        if (hal_gpio_irqs[index].pin == pin) {
+            break;
+        }
+
+        ++index;
+    }
+
+    return index;
+}
+
+static uint8_t
+hal_gpio_find_empty_slot(void)
+{
+    uint8_t index = 0;
+
+    while (index < HAL_GPIO_MAX_IRQ) {
+        if (hal_gpio_irqs[index].handler == NULL) {
+            break;
+        }
+
+        ++index;
+    }
+
+    return index;
+}
+
+static void
+hal_gpio_handle_isr(uint32_t port)
+{
+    uint8_t index = 0;
+    for (index = 0; index < HAL_GPIO_MAX_IRQ; ++index) {
+        uint32_t mask, val;
+
+        if (hal_gpio_irqs[index].handler == NULL) {
+            continue;
+        }
+
+        if (GPIO_PORT(hal_gpio_irqs[index].pin) != port) {
+            continue;
+        }
+
+        mask = GPIO_MASK(hal_gpio_irqs[index].pin);
+        if (CNSTATx(port) & mask != mask) {
+            continue;
+        }
+
+        val = PORTx(port) & mask;
+        if ((val && (hal_gpio_irqs[index].trig & HAL_GPIO_TRIG_RISING)) ||
+            (!val && (hal_gpio_irqs[index].trig & HAL_GPIO_TRIG_FALLING))) {
+            hal_gpio_irqs[index].handler(hal_gpio_irqs[index].arg);
+        }
+        CNSTATxCLR(port) = mask;
+    }
+}
+
+void
+__attribute__((interrupt(IPL1AUTO), vector(_CHANGE_NOTICE_VECTOR)))
+hal_gpio_isr(void)
+{
+    if (IFS1 & _IFS1_CNBIF_MASK) {
+        hal_gpio_handle_isr(1);
+        IFS1CLR = _IFS1_CNBIF_MASK;
+    }
+
+    if (IFS1 & _IFS1_CNCIF_MASK) {
+        hal_gpio_handle_isr(2);
+        IFS1CLR = _IFS1_CNCIF_MASK;
+    }
+
+    if (IFS1 & _IFS1_CNDIF_MASK) {
+        hal_gpio_handle_isr(3);
+        IFS1CLR = _IFS1_CNDIF_MASK;
+    }
+
+    if (IFS1 & _IFS1_CNEIF_MASK) {
+        hal_gpio_handle_isr(4);
+        IFS1CLR = _IFS1_CNEIF_MASK;
+    }
+
+    if (IFS1 & _IFS1_CNFIF_MASK) {
+        hal_gpio_handle_isr(5);
+        IFS1CLR = _IFS1_CNFIF_MASK;
+    }
+
+    if (IFS1 & _IFS1_CNGIF_MASK) {
+        hal_gpio_handle_isr(6);
+        IFS1CLR = _IFS1_CNGIF_MASK;
+    }
+}
+
+int
+hal_gpio_init_in(int pin, hal_gpio_pull_t pull)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    /* Configure pin as digital */
+    ANSELxCLR(port) = mask;
+
+    ODCxCLR(port) = mask;
+
+    switch (pull) {
+        case HAL_GPIO_PULL_NONE:
+            CNPUxCLR(port) = mask;
+            CNPDxCLR(port) = mask;
+            break;
+
+        case HAL_GPIO_PULL_DOWN:
+            CNPUxCLR(port) = mask;
+            CNPDxSET(port) = mask;
+            break;
+
+        case HAL_GPIO_PULL_UP:
+            CNPUxSET(port) = mask;
+            CNPDxCLR(port) = mask;
+            break;
+
+        default:
+            return -1;
+    }
+
+    /* Configure pin direction as input */
+    TRISxSET(port) = mask;
+
+    return 0;
+}
+
+int
+hal_gpio_init_out(int pin, int val)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    /* Configure pin as digital */
+    ANSELxCLR(port) = mask;
+
+    /* Disable pull-up, pull-down and open drain */
+    CNPUxCLR(port) = mask;
+    CNPDxCLR(port) = mask;
+    ODCxCLR(port) = mask;
+
+    if (val) {
+        LATxSET(port) = mask;
+    } else {
+        LATxCLR(port) = mask;
+    }
+
+    /* Configure pin direction as output */
+    TRISxCLR(port) = mask;
+
+    return 0;
+}
+
+void
+hal_gpio_write(int pin, int val)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    if (val) {
+        LATxSET(port) = mask;
+    } else {
+        LATxCLR(port) = mask;
+    }
+}
+
+int
+hal_gpio_read(int pin)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    return !!(PORTx(port) & mask);
+}
+
+int
+hal_gpio_toggle(int pin)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    LATxINV(port) = mask;
+
+    /*
+     * One instruction cycle is required between a write and a read
+     * operation on the same port.
+     */
+    asm volatile ("nop");
+
+    return !!(PORTx(port) & mask);
+}
+
+int
+hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
+                  hal_gpio_irq_trig_t trig, hal_gpio_pull_t pull)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+    uint32_t ctx;
+    int ret;
+    uint8_t index;
+
+    /* HAL_GPIO_TRIG_LOW and HAL_GPIO_TRIG_HIGH are not supported */
+    if (trig == HAL_GPIO_TRIG_LOW ||
+        trig == HAL_GPIO_TRIG_HIGH ||
+        trig == HAL_GPIO_TRIG_NONE) {
+        return -1;
+    }
+
+    /* Remove any existing irq handler attached to the pin */
+    hal_gpio_irq_release(pin);
+    hal_gpio_irq_disable(pin);
+
+    index = hal_gpio_find_empty_slot();
+    if (index == HAL_GPIO_MAX_IRQ) {
+        return -1;
+    }
+
+    ret = hal_gpio_init_in(pin, pull);
+    if (ret < 0) {
+        return ret;
+    }
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    hal_gpio_irqs[index].arg = arg;
+    hal_gpio_irqs[index].pin = pin;
+    hal_gpio_irqs[index].trig = trig;
+    hal_gpio_irqs[index].handler = handler;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+}
+
+void
+hal_gpio_irq_release(int pin)
+{
+    uint32_t ctx;
+    uint8_t index = hal_gpio_find_pin(pin);
+    if (index == HAL_GPIO_MAX_IRQ) {
+        return;
+    }
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    hal_gpio_irqs[index].handler = NULL;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+}
+
+void
+hal_gpio_irq_enable(int pin)
+{
+    uint32_t port, mask, ctx;
+
+    uint8_t index = hal_gpio_find_pin(pin);
+    if (index == HAL_GPIO_MAX_IRQ)
+        return;
+
+    port = GPIO_PORT(pin);
+    mask = GPIO_MASK(pin);
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    CNCONxSET(port) = _CNCONB_ON_MASK;
+    CNENxSET(port) = mask;
+
+    /* Read PORT register to clear mismatch condition on CN input pin */
+    (void)PORTx(port);
+
+    /* Set Change Notice interrupt priority */
+    IPC8CLR = _IPC8_CNIP_MASK | _IPC8_CNIS_MASK;
+    IPC8SET = 1 << _IPC8_CNIP_POSITION;
+
+    /* Clear interrupt flag and enable Change Notification interrupt */
+    switch (port) {
+        case 1:
+            IFS1CLR = _IFS1_CNBIF_MASK;
+            IEC1SET = _IEC1_CNBIE_MASK;
+            break;
+        case 2:
+            IFS1CLR = _IFS1_CNCIF_MASK;
+            IEC1SET = _IEC1_CNCIE_MASK;
+            break;
+        case 3:
+            IFS1CLR = _IFS1_CNDIF_MASK;
+            IEC1SET = _IEC1_CNDIE_MASK;
+            break;
+        case 4:
+            IFS1CLR = _IFS1_CNEIF_MASK;
+            IEC1SET = _IEC1_CNEIE_MASK;
+            break;
+        case 5:
+            IFS1CLR = _IFS1_CNFIF_MASK;
+            IEC1SET = _IEC1_CNFIE_MASK;
+            break;
+        case 6:
+            IFS1CLR = _IFS1_CNGIF_MASK;
+            IEC1SET = _IEC1_CNGIE_MASK;
+            break;
+    }
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+}
+
+void
+hal_gpio_irq_disable(int pin)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    CNENxCLR(port) = mask;
+}

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_i2c.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_i2c.c
@@ -1,0 +1,276 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <xc.h>
+#include "syscfg/syscfg.h"
+#include "bsp/bsp.h"
+#include <hal/hal_gpio.h>
+#include <hal/hal_i2c.h>
+#include <mcu/p32mx470f512h.h>
+#include "mcu/mips_hal.h"
+#include <os/os_time.h>
+
+#define I2CxCON(I)              (base_address[I][0x00 / 0x04])
+#define I2CxCONCLR(I)           (base_address[I][0x04 / 0x04])
+#define I2CxCONSET(I)           (base_address[I][0x08 / 0x04])
+#define I2CxSTAT(I)             (base_address[I][0x10 / 0x04])
+#define I2CxBRG(I)              (base_address[I][0x40 / 0x04])
+#define I2CxTRN(I)              (base_address[I][0x50 / 0x04])
+#define I2CxRCV(I)              (base_address[I][0x60 / 0x04])
+#define WRITE_MODE              (0)
+#define READ_MODE               (1)
+#define PULSE_GOBBLER_DELAY     (104)   /* In nanoseconds */
+
+static volatile uint32_t *base_address[I2C_CNT] = {
+    (volatile uint32_t *)_I2C1_BASE_ADDRESS,
+    (volatile uint32_t *)_I2C2_BASE_ADDRESS,
+};
+
+static int
+send_byte(uint8_t i2c_num, uint8_t data, uint32_t deadline)
+{
+    I2CxTRN(i2c_num) = data;
+
+    while (I2CxSTAT(i2c_num) & _I2C1STAT_TRSTAT_MASK) {
+        if (os_time_get() > deadline) {
+            return 0;
+        }
+    }
+
+    if (I2CxSTAT(i2c_num) & _I2C1STAT_ACKSTAT_MASK) {   /* NACK received */
+        return 0;
+    }
+
+    return 1;
+}
+
+static int
+receive_byte(uint8_t i2c_num, uint8_t *data, uint8_t nak, uint32_t deadline)
+{
+    I2CxCONSET(i2c_num) = _I2C1CON_RCEN_MASK;
+
+    /* Wait for some data in RX FIFO */
+    while (!(I2CxSTAT(i2c_num) & _I2C1STAT_RBF_MASK)) {
+        if (os_time_get() > deadline) {
+            return 0;
+        }
+    }
+
+    /* Send ACK/NAK */
+    if (nak) {
+        I2CxCONSET(i2c_num) = _I2C1CON_ACKDT_MASK;
+    } else {
+        I2CxCONCLR(i2c_num) = _I2C1CON_ACKDT_MASK;
+    }
+
+    I2CxCONSET(i2c_num) = _I2C1CON_ACKEN_MASK;
+    while (!(I2CxCON(i2c_num) & _I2C1CON_ACKEN_MASK)) {
+        if (os_time_get() > deadline) {
+            return 0;
+        }
+    }
+
+    *data = I2CxRCV(i2c_num);
+    return 1;
+}
+
+static int
+send_address(uint8_t i2c_num, uint8_t address, uint8_t read_byte,
+             uint32_t deadline)
+{
+    return send_byte(i2c_num, (address << 1) | (read_byte & 0x1), deadline);
+}
+
+static int
+send_start(uint8_t i2c_num, uint32_t deadline)
+{
+    I2CxCONSET(i2c_num) = _I2C1CON_SEN_MASK;
+    while (I2CxCON(i2c_num) & _I2C1CON_SEN_MASK) {
+        if (os_time_get() > deadline) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int
+send_stop(uint8_t i2c_num, uint32_t deadline)
+{
+    I2CxCONSET(i2c_num) = _I2C1CON_PEN_MASK;
+    while (I2CxCON(i2c_num) & _I2C1CON_PEN_MASK) {
+        if (os_time_get() > deadline) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static uint32_t
+hal_i2c_get_peripheral_clock(void)
+{
+    uint32_t divisor = 1;
+    divisor <<= (OSCCON & _OSCCON_PBDIV_MASK) >> _OSCCON_PBDIV_POSITION;
+    return MYNEWT_VAL(CLOCK_FREQ) / divisor;
+}
+
+int
+hal_i2c_init(uint8_t i2c_num, void *cfg)
+{
+    struct mips_i2c_cfg *config;
+    uint64_t baudrate = 0;
+
+    if (cfg == NULL) {
+        return -1;
+    }
+
+    config = (struct mips_i2c_cfg *)cfg;
+
+    /* Configure SCL and SDA as digital output */
+    if (hal_gpio_init_out(config->scl, 1) ||
+        hal_gpio_init_out(config->sda, 1)) {
+        return -1;
+    }
+
+    I2CxCON(i2c_num) = 0;
+
+    /*
+     * From PIC32 family reference manual,
+     * Section 24. Inter-Integrated Circuit, Equation 24-1:
+     *
+     *               10^9
+     *              -------  - PGD
+     *              2*Fsck
+     * baudrate = ----------------- * Pbclk - 2
+     *                10^9
+     */
+    baudrate =
+        (1000 * 1000 * 1000) / (2 * config->frequency) - PULSE_GOBBLER_DELAY;
+    baudrate *= hal_i2c_get_peripheral_clock();
+    baudrate /= (1000 * 1000 * 1000);
+    baudrate -= 2;
+
+    /* I2CxBRG must not be set to 0 or 1 */
+    if (baudrate == 0 || baudrate == 1)
+        return -2;
+
+    I2CxBRG(i2c_num) = baudrate;
+    I2CxCONSET(i2c_num) = _I2C1CON_SMEN_MASK;
+    I2CxCONSET(i2c_num) = _I2C1CON_ON_MASK;
+
+    return 0;
+}
+
+int
+hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                     uint32_t timeout, uint8_t last_op)
+{
+    uint16_t byte_sent_count = 0;
+    int ret = 0;
+    uint32_t deadline = os_time_get() + timeout;
+
+    if (send_start(i2c_num, deadline)) {
+        ret = -1;
+        goto hal_i2c_master_write_stop;
+    }
+
+    if (send_address(i2c_num, pdata->address, WRITE_MODE, deadline) != 1) {
+        ret = -1;
+        goto hal_i2c_master_write_stop;
+    }
+
+    while (byte_sent_count < pdata->len) {
+        if (send_byte(i2c_num, pdata->buffer[byte_sent_count],
+                      deadline) != 1) {
+            ret = -1;
+            goto hal_i2c_master_write_stop;
+        }
+        ++byte_sent_count;
+    }
+
+    if (!last_op) {
+        return ret;
+    }
+
+hal_i2c_master_write_stop:
+    if (send_stop(i2c_num, deadline)) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+int
+hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                    uint32_t timeout, uint8_t last_op)
+{
+    int ret = 0;
+    uint16_t byte_received_count = 0;
+    uint32_t deadline = os_time_get() + timeout;
+
+    if (i2c_num >= I2C_CNT) {
+        return -1;
+    }
+
+    if (send_start(i2c_num, deadline)) {
+        ret = -1;
+        goto hal_i2c_master_read_stop;
+    }
+
+    if (send_address(i2c_num, pdata->address, READ_MODE, deadline) != 1) {
+        ret = -1;
+        goto hal_i2c_master_read_stop;
+    }
+
+    while (byte_received_count < pdata->len) {
+        if (receive_byte(i2c_num, &pdata->buffer[byte_received_count],
+                         (byte_received_count + 1) == pdata->len,
+                         deadline) != 1) {
+            ret = -1;
+            goto hal_i2c_master_read_stop;
+        }
+        ++byte_received_count;
+    }
+
+    if (!last_op) {
+        return ret;
+    }
+
+hal_i2c_master_read_stop:
+    if (send_stop(i2c_num, deadline)) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+int
+hal_i2c_master_probe(uint8_t i2c_num, uint8_t address,
+                     uint32_t timeout)
+{
+    struct hal_i2c_master_data data;
+    uint8_t buffer;
+
+    data.address = address;
+    data.buffer = NULL;
+    data.len = 0;
+
+    return hal_i2c_master_read(i2c_num, &data, timeout, 1);
+}

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
@@ -1,0 +1,492 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdbool.h>
+#include "bsp/bsp.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_spi.h"
+#include "mcu/mcu.h"
+#include "mcu/mips_hal.h"
+#include "mcu/p32mx470f512h.h"
+#include "mcu/pps.h"
+#include "syscfg/syscfg.h"
+
+#define SPIxCON(P)          (base_address[P][0x0 / 0x4])
+#define SPIxCONCLR(P)       (base_address[P][0x4 / 0x4])
+#define SPIxCONSET(P)       (base_address[P][0x8 / 0x4])
+#define SPIxSTAT(P)         (base_address[P][0x10 / 0x4])
+#define SPIxSTATCLR(P)      (base_address[P][0x14 / 0x4])
+#define SPIxBUF(P)          (base_address[P][0x20 / 0x4])
+#define SPIxBRG(P)          (base_address[P][0x30 / 0x4])
+#define SPIxCON2(P)         (base_address[P][0x40 / 0x4])
+
+static volatile uint32_t * base_address[SPI_CNT] = {
+    (volatile uint32_t *)_SPI1_BASE_ADDRESS,
+    (volatile uint32_t *)_SPI2_BASE_ADDRESS,
+};
+
+struct hal_spi {
+    bool                      slave;
+    uint8_t                   *txbuf;
+    uint8_t                   *rxbuf;
+    int                       len;
+    int                       txcnt;
+    int                       rxcnt;
+    hal_spi_txrx_cb           callback;
+    void                      *arg;
+    const struct mips_spi_cfg *pins;
+    uint32_t                  con;
+    uint32_t                  brg;
+};
+
+static struct hal_spi spis[SPI_CNT];
+
+static void
+hal_spi_power_up(int spi_num)
+{
+    uint32_t mask = 0;
+
+    switch (spi_num) {
+        case 0:
+            mask = _PMD5_SPI1MD_MASK;
+            break;
+        case 1:
+            mask = _PMD5_SPI2MD_MASK;
+            break;
+    }
+
+    if (!(PMD5 & mask))
+        return;
+
+    PMD5CLR = mask;
+
+    /* It appeared that powering down the SPI module also clears SPIxBRG and SPIxCON */
+    SPIxBRG(spi_num) = spis[spi_num].brg;
+    SPIxCON(spi_num) = spis[spi_num].con;
+}
+
+static void
+hal_spi_power_down(int spi_num)
+{
+    /* It appeared that powering down the SPI module also clears SPIxBRG and SPIxCON */
+    spis[spi_num].brg = SPIxBRG(spi_num);
+    spis[spi_num].con = SPIxCON(spi_num);
+
+    switch (spi_num) {
+        case 0:
+            PMD5SET = _PMD5_SPI1MD_MASK;
+            break;
+        case 1:
+            PMD5SET = _PMD5_SPI2MD_MASK;
+            break;
+    }
+}
+
+static int
+hal_spi_config_master(int spi_num, struct hal_spi_settings *psettings)
+{
+    uint32_t pbclk, pbdiv;
+
+    /*
+     * Make sure that the SPI module is not powered down.
+     * If the module is powered down, one cannot write to registers.
+     */
+    hal_spi_power_up(spi_num);
+
+    SPIxCON(spi_num) = 0;
+    SPIxCON2(spi_num) = 0;
+
+    /* Clear RX FIFO */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPITBE_MASK)) {
+        volatile int rdata = SPIxBUF(spi_num);
+        (void)rdata;
+    }
+
+    /* The SPI module only supports MSB first */
+    if (psettings->data_order == HAL_SPI_LSB_FIRST) {
+        return -1;
+    }
+
+    /* Only 8-bit word size is supported */
+    if (psettings->word_size != HAL_SPI_WORD_SIZE_8BIT) {
+        return -1;
+    }
+
+    switch (psettings->data_mode) {
+        case HAL_SPI_MODE0:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
+        case HAL_SPI_MODE1:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKE_MASK;
+            break;
+        case HAL_SPI_MODE2:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
+            break;
+        case HAL_SPI_MODE3:
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
+        default:
+            return -1;
+    }
+
+    /*
+     * From equation 23-1 of Section 23 of PIC32 FRM:
+     *
+     *                 Fpb2
+     * Fsck =  -------------------
+     *          2 * (SPIxBRG + 1)
+     */
+    pbdiv = (OSCCON & _OSCCON_PBDIV_MASK) >> _OSCCON_PBDIV_POSITION;
+    pbclk = MYNEWT_VAL(CLOCK_FREQ) / (pbdiv + 1);
+    SPIxBRG(spi_num) = (pbclk / (2 * psettings->baudrate)) - 1;
+
+    SPIxSTATCLR(spi_num) = _SPI1STAT_SPIROV_MASK;
+    SPIxCONSET(spi_num) = _SPI1CON_ENHBUF_MASK | _SPI1CON_MSTEN_MASK;
+
+    return 0;
+}
+
+static int
+hal_spi_config_pins(int spi_num, uint8_t mode)
+{
+    int ret = 0;
+
+    if (hal_gpio_init_out(spis[spi_num].pins->mosi, 0) ||
+        hal_gpio_init_out(spis[spi_num].pins->sck, 1) ||
+        hal_gpio_init_in(spis[spi_num].pins->miso, HAL_GPIO_PULL_NONE)) {
+        return -1;
+    }
+
+    /*
+     * To avoid any glitches when turning off and on module, the SCK pin must
+     * be set to the correct value depending on the mode.
+     */
+    switch (mode) {
+        case HAL_SPI_MODE0:
+        case HAL_SPI_MODE1:
+            hal_gpio_write(spis[spi_num].pins->sck, 0);
+            break;
+        case HAL_SPI_MODE2:
+        case HAL_SPI_MODE3:
+            hal_gpio_write(spis[spi_num].pins->sck, 1);
+            break;
+    }
+
+    switch (spi_num) {
+        case 0:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO1_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI1_IN_FUNC);
+            break;
+        case 1:
+            ret += pps_configure_output(spis[spi_num].pins->mosi,
+                                        SDO2_OUT_FUNC);
+            ret += pps_configure_input(spis[spi_num].pins->miso,
+                                       SDI2_IN_FUNC);
+            break;
+    }
+
+    return ret;
+}
+
+static void
+hal_spi_enable_int(int spi_num)
+{
+    switch (spi_num) {
+        case 0:
+            IFS1CLR = _IFS1_SPI1TXIF_MASK;
+            IEC1SET = _IEC1_SPI1TXIE_MASK;
+            break;
+        case 1:
+            IFS1CLR = _IFS1_SPI2TXIF_MASK;
+            IEC1SET = _IEC1_SPI2TXIE_MASK;
+            break;
+    }
+}
+
+static void
+hal_spi_disable_int(int spi_num)
+{
+    switch (spi_num) {
+        case 0:
+            IFS1CLR = _IFS1_SPI1TXIF_MASK;
+            IEC1CLR = _IEC1_SPI1TXIE_MASK;
+            break;
+        case 1:
+            IFS1CLR = _IFS1_SPI2TXIF_MASK;
+            IEC1CLR = _IEC1_SPI2TXIE_MASK;
+            break;
+    }
+}
+
+static void
+hal_spi_handle_isr(int spi_num)
+{
+    /* Read everything in RX FIFO */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK)) {
+        volatile uint32_t rxdata = SPIxBUF(spi_num);
+        if (spis[spi_num].rxbuf && spis[spi_num].rxcnt) {
+            *spis[spi_num].rxbuf++ = rxdata;
+            --spis[spi_num].rxcnt;
+        }
+    }
+
+    if (spis[spi_num].txcnt == 0 && spis[spi_num].rxcnt == 0) {
+        spis[spi_num].txbuf = NULL;
+        spis[spi_num].rxbuf = NULL;
+
+        if (spis[spi_num].callback) {
+            spis[spi_num].callback(spis[spi_num].arg, spis[spi_num].len);
+        }
+        hal_spi_disable_int(spi_num);
+    }
+
+
+    /* Fill TX FIFO */
+    while (spis[spi_num].txcnt &&
+           !(SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK)) {
+        SPIxBUF(spi_num) = *spis[spi_num].txbuf++;
+        --spis[spi_num].txcnt;
+    }
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI_1_VECTOR)))
+hal_spi1_isr(void)
+{
+    hal_spi_handle_isr(0);
+    IFS1CLR = _IFS1_SPI1TXIF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_SPI_2_VECTOR)))
+hal_spi2_isr(void)
+{
+    hal_spi_handle_isr(1);
+    IFS1CLR = _IFS1_SPI2TXIF_MASK;
+}
+
+int
+hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
+{
+    if (spi_type != HAL_SPI_TYPE_MASTER &&
+        spi_type != HAL_SPI_TYPE_SLAVE) {
+        return -1;
+    }
+
+    spis[spi_num].slave = spi_type;
+    spis[spi_num].pins = cfg;
+
+    return 0;
+}
+
+int
+hal_spi_config(int spi_num, struct hal_spi_settings *psettings)
+{
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    /* Configure pins */
+    if (spis[spi_num].pins) {
+        if (hal_spi_config_pins(spi_num, psettings->data_mode)) {
+            return -1;
+        }
+    }
+
+    return hal_spi_config_master(spi_num, psettings);
+}
+
+int
+hal_spi_set_txrx_cb(int spi_num, hal_spi_txrx_cb txrx_cb, void *arg)
+{
+    if (SPIxCON(spi_num) & _SPI1CON_ON_MASK) {
+        return -1;
+    }
+
+    spis[spi_num].callback = txrx_cb;
+    spis[spi_num].arg = arg;
+    return 0;
+}
+
+int
+hal_spi_enable(int spi_num)
+{
+    hal_spi_power_up(spi_num);
+    SPIxCONSET(spi_num) = _SPI1CON_ON_MASK;
+
+    return 0;
+}
+
+int
+hal_spi_disable(int spi_num)
+{
+    /*
+     * Disabling SPI clears the FIFO, so this makes sure that everything was
+     * sent before disabling the module.
+     */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SPITBE_MASK)) {
+    }
+
+    SPIxCONCLR(spi_num) = _SPI1CON_ON_MASK;
+    hal_spi_power_down(spi_num);
+
+    return 0;
+}
+
+uint16_t
+hal_spi_tx_val(int spi_num, uint16_t val)
+{
+    if (spis[spi_num].slave) {
+        return 0xFFFF;
+    }
+
+    /* Wait until there is some space in TX FIFO */
+    while (SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK) {
+    }
+
+    SPIxBUF(spi_num) = val;
+
+    /* Wait until RX FIFO is not empty */
+    while (SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK) {
+    }
+
+    return SPIxBUF(spi_num);
+}
+
+int
+hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    uint8_t *tx = (uint8_t *)txbuf;
+    uint8_t *rx = (uint8_t *)rxbuf;
+
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    while (cnt--) {
+        uint8_t rdata;
+        if (tx) {
+            /* Wait until there is some space in TX FIFO */
+            while (SPIxSTAT(spi_num) & _SPI1STAT_SPITBF_MASK) {
+            }
+
+            SPIxBUF(spi_num) = *tx++;
+        }
+
+        /* Wait until RX FIFO is not empty */
+        while (SPIxSTAT(spi_num) & _SPI1STAT_SPIRBE_MASK) {
+        }
+
+        /* Always read RX FIFO to avoid overrun */
+        rdata = SPIxBUF(spi_num);
+
+        if (rx) {
+            *rx++ = rdata;
+        }
+    }
+
+    return 0;
+}
+
+int
+hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    uint32_t ctx;
+
+    /* Slave mode not supported */
+    if (spis[spi_num].slave) {
+        return -1;
+    }
+
+    if (txbuf == NULL) {
+        return -1;
+    }
+
+    /* Check if a transfer is pending */
+    if (spis[spi_num].rxbuf != NULL || spis[spi_num].txbuf != NULL) {
+        return -1;
+    }
+
+    spis[spi_num].txbuf = txbuf;
+    spis[spi_num].rxbuf = rxbuf;
+    spis[spi_num].txcnt = cnt;
+    spis[spi_num].rxcnt = cnt;
+    spis[spi_num].len = cnt;
+
+    /* Configure SPIxTXIF to trigger when TX FIFO is empty */
+    SPIxCONCLR(spi_num) = _SPI1CON_STXISEL_MASK;
+    SPIxCONSET(spi_num) = 0b01 << _SPI1CON_STXISEL_POSITION;
+
+    /* Set interrupt priority */
+    switch (spi_num) {
+        case 0:
+            IPC7CLR = _IPC7_SPI1IS_MASK | _IPC7_SPI1IP_MASK;
+            IPC7SET = 2 << _IPC7_SPI1IP_POSITION;
+            break;
+        case 1:
+            IPC8CLR = _IPC8_SPI2IS_MASK | _IPC8_SPI2IP_MASK;
+            IPC8SET = 2 << _IPC8_SPI2IP_POSITION;
+            break;
+    }
+
+    /* Enable interrupt */
+    hal_spi_enable_int(spi_num);
+
+    return 0;
+}
+
+int
+hal_spi_slave_set_def_tx_val(int spi_num, uint16_t val)
+{
+    /* Slave mode not supported */
+    return -1;
+}
+
+int
+hal_spi_abort(int spi_num)
+{
+    /* Cannot abort transfer if spi is not enabled */
+    if (!(SPIxCON(spi_num) & _SPI1CON_ON_MASK)) {
+        return -1;
+    }
+
+    hal_spi_disable_int(spi_num);
+    spis[spi_num].txbuf = NULL;
+    spis[spi_num].rxbuf = NULL;
+    spis[spi_num].txcnt = 0;
+    spis[spi_num].rxcnt = 0;
+    spis[spi_num].len = 0;
+
+    /* Make sure that we finished transmitting current byte before turning off module */
+    while (!(SPIxSTAT(spi_num) & _SPI1STAT_SRMT_MASK)) {
+    }
+
+    /* Clear TX and RX FIFO by turning off and on module */
+    SPIxCONCLR(spi_num) = _SPI1CON_ON_MASK;
+    asm volatile ("nop");
+    SPIxCONSET(spi_num) = _SPI1CON_ON_MASK;
+
+    return 0;
+}

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_timer.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_timer.c
@@ -1,0 +1,464 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/os.h>
+#include <stdint.h>
+#include <string.h>
+#include <xc.h>
+#include "hal/hal_timer.h"
+#include "mcu/mips_hal.h"
+
+#define PIC32MX_TIMER_COUNT         (4)
+#define PIC32MX_PRESCALER_COUNT     (8)
+
+#define TxCON(T)        (base_address[T][0x0 / 0x4])
+#define TxCONCLR(T)     (base_address[T][0x4 / 0x4])
+#define TxCONSET(T)     (base_address[T][0x8 / 0x4])
+#define TMRx(T)         (base_address[T][0x10 / 0x4])
+#define PRx(T)          (base_address[T][0x20 / 0x4])
+
+static volatile uint32_t * base_address[PIC32MX_TIMER_COUNT] = {
+    (volatile uint32_t *)_TMR2_BASE_ADDRESS,
+    (volatile uint32_t *)_TMR3_BASE_ADDRESS,
+    (volatile uint32_t *)_TMR4_BASE_ADDRESS,
+    (volatile uint32_t *)_TMR5_BASE_ADDRESS,
+};
+
+static uint32_t timer_prescalers[PIC32MX_PRESCALER_COUNT] =
+{1, 2, 4, 8, 16, 32, 64, 256};
+
+struct pic32_timer {
+    uint32_t index;
+    uint32_t counter;
+    uint32_t frequency;     /* Holds the true frequency of the timer */
+    TAILQ_HEAD(hal_timer_qhead, hal_timer) hal_timer_queue;
+};
+static struct pic32_timer timers[PIC32MX_TIMER_COUNT];
+
+
+static inline uint32_t
+hal_timer_get_prescaler(int timer_num)
+{
+    uint32_t index =
+        (TxCON(timer_num) & _T2CON_TCKPS_MASK) >> _T2CON_TCKPS_POSITION;
+    return timer_prescalers[index];
+}
+
+static inline uint32_t
+hal_timer_get_peripheral_base_clock(void)
+{
+    uint32_t divisor = 1;
+    divisor <<= (OSCCON & _OSCCON_PBDIV_MASK) >> _OSCCON_PBDIV_POSITION;
+    return MYNEWT_VAL(CLOCK_FREQ) / divisor;
+}
+
+static void
+hal_timer_enable_int(int timer_num)
+{
+    switch (timer_num) {
+        case 0:
+            IPC2CLR = _IPC2_T2IP_MASK | _IPC2_T2IS_MASK;
+            IPC2SET = 3 << _IPC2_T2IP_POSITION;
+            IFS0CLR = _IFS0_T2IF_MASK;
+            IEC0SET = _IEC0_T2IE_MASK;
+            break;
+        case 1:
+            IPC3CLR = _IPC3_T3IP_MASK | _IPC3_T3IS_MASK;
+            IPC3SET = 3 << _IPC3_T3IP_POSITION;
+            IFS0CLR = _IFS0_T3IF_MASK;
+            IEC0SET = _IEC0_T3IE_MASK;
+            break;
+        case 2:
+            IPC4CLR = _IPC4_T4IP_MASK | _IPC4_T4IS_MASK;
+            IPC4SET = 3 << _IPC4_T4IP_POSITION;
+            IFS0CLR = _IFS0_T4IF_MASK;
+            IEC0SET = _IEC0_T4IE_MASK;
+            break;
+        case 3:
+            IPC5CLR = _IPC5_T5IP_MASK | _IPC5_T5IS_MASK;
+            IPC5SET = 3 << _IPC5_T5IP_POSITION;
+            IFS0CLR = _IFS0_T5IF_MASK;
+            IEC0SET = _IEC0_T5IE_MASK;
+            break;
+    }
+}
+
+static void
+hal_timer_disable_int(int timer_num)
+{
+    switch (timer_num) {
+        case 0:
+            IEC0CLR = _IEC0_T2IE_MASK;
+            IFS0CLR = _IFS0_T2IF_MASK;
+            break;
+        case 1:
+            IEC0CLR = _IEC0_T3IE_MASK;
+            IFS0CLR = _IFS0_T3IF_MASK;
+            break;
+        case 2:
+            IEC0CLR = _IEC0_T4IE_MASK;
+            IFS0CLR = _IFS0_T4IF_MASK;
+            break;
+        case 3:
+            IEC0CLR = _IEC0_T5IE_MASK;
+            IFS0CLR = _IFS0_T5IF_MASK;
+            break;
+    }
+
+}
+
+static void
+update_period_register(int timer_num)
+{
+    if (TAILQ_EMPTY(&timers[timer_num].hal_timer_queue)) {
+        PRx(timer_num) = UINT16_MAX;
+    } else {
+        struct hal_timer *first = TAILQ_FIRST(
+            &timers[timer_num].hal_timer_queue);
+        uint32_t ticks = hal_timer_read(timer_num);
+
+        if (ticks >= first->expiry) {
+            /*
+             * Create a timer interrupt immediately. This case must never
+             * execute inside the interrupt handler (otherwise we would skip
+             * the interrupt).
+             */
+            PRx(timer_num) = TMRx(timer_num) + 1;
+        } else {
+            uint32_t delta = ticks - first->expiry;
+            if (delta > UINT16_MAX)
+                delta = UINT16_MAX;
+
+            PRx(timer_num) = delta;
+        }
+    }
+}
+
+static inline void
+update_counter(int timer_num)
+{
+    timers[timer_num].counter += PRx(timer_num);
+}
+
+static void
+handle_timer_list(int timer_num)
+{
+    uint32_t current_tick = hal_timer_read(timer_num);
+    struct hal_timer *entry;
+
+    while ((entry = TAILQ_FIRST(&timers[timer_num].hal_timer_queue)) !=
+           NULL) {
+        if (entry->expiry <= current_tick) {
+            TAILQ_REMOVE(&timers[timer_num].hal_timer_queue, entry, link);
+            entry->link.tqe_prev = NULL;
+            entry->link.tqe_next = NULL;
+            entry->cb_func(entry->cb_arg);
+        } else {
+            break;
+        }
+    }
+
+    /*
+     * Even if the list is left unchanged, the period register still needs to
+     * be computed again to ensure that the first callback in the list will
+     * be called on time.
+     */
+    update_period_register(timer_num);
+}
+
+void
+__attribute__((interrupt(IPL3AUTO), vector(_TIMER_2_VECTOR)))
+timer2_isr(void)
+{
+    update_counter(0);
+    handle_timer_list(0);
+
+    IFS0CLR = _IFS0_T2IF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL3AUTO), vector(_TIMER_3_VECTOR)))
+timer3_isr(void)
+{
+    update_counter(1);
+    handle_timer_list(1);
+
+    IFS0CLR = _IFS0_T3IF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL3AUTO), vector(_TIMER_4_VECTOR)))
+timer4_isr(void)
+{
+    update_counter(2);
+    handle_timer_list(2);
+
+    IFS0CLR = _IFS0_T4IF_MASK;
+}
+
+void
+__attribute__((interrupt(IPL3AUTO), vector(_TIMER_5_VECTOR)))
+timer5_isr(void)
+{
+    update_counter(3);
+    handle_timer_list(3);
+
+    IFS0CLR = _IFS0_T5IF_MASK;
+}
+
+int
+hal_timer_init(int timer_num, void *cfg)
+{
+    if (timer_num >= PIC32MX_TIMER_COUNT)
+        return -1;
+
+    TxCON(timer_num) = 0;
+    timers[timer_num].index = timer_num;
+    timers[timer_num].counter = 0;
+
+    hal_timer_enable_int(timer_num);
+
+    return 0;
+}
+
+int
+hal_timer_deinit(int timer_num)
+{
+    struct hal_timer *timer;
+
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return -1;
+    }
+
+    TxCON(timer_num) = 0;
+    hal_timer_disable_int(timer_num);
+    while ((timer = TAILQ_FIRST(&timers[timer_num].hal_timer_queue)) !=
+           NULL) {
+        TAILQ_REMOVE(&timers[timer_num].hal_timer_queue, timer, link);
+    }
+
+    return 0;
+}
+
+int
+hal_timer_config(int timer_num, uint32_t freq_hz)
+{
+    int i;
+    uint32_t pr;
+    uint32_t ideal_prescaler;
+
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return -1;
+    }
+
+    if (freq_hz == 0) {
+        return -1;
+    }
+
+    ideal_prescaler = hal_timer_get_peripheral_base_clock() / freq_hz;
+    if (ideal_prescaler > 256) {
+        return -1;
+    }
+
+    if (ideal_prescaler == 1) {
+        i = 0;
+    } else {
+        /* Find closest prescaler */
+        for (i = 1; i < PIC32MX_PRESCALER_COUNT; ++i) {
+            if (ideal_prescaler <= timer_prescalers[i]) {
+                uint32_t min_delta = ideal_prescaler - timer_prescalers[i - 1];
+                uint32_t max_delta = timer_prescalers[i] - ideal_prescaler;
+                if (min_delta < max_delta) {
+                    i -= 1;
+                }
+                break;
+            }
+        }
+    }
+
+    TxCON(timer_num) = 0;
+
+    TxCONCLR(timer_num) = _T2CON_TCKPS_MASK;
+    TxCONSET(timer_num) = (i << _T2CON_TCKPS_POSITION) & _T2CON_TCKPS_MASK;
+
+    /* Set PR to its maximum value to minimize timer interrupts */
+    PRx(timer_num) = UINT16_MAX;
+    TMRx(timer_num) = 0;
+
+    timers[timer_num].frequency = hal_timer_get_peripheral_base_clock() /
+                                  timer_prescalers[i];
+
+    /* Start timer */
+    TxCONSET(timer_num) = _T2CON_TON_MASK;
+
+    return 0;
+}
+
+uint32_t
+hal_timer_get_resolution(int timer_num)
+{
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return 0;
+    }
+
+    return 1000000000 / timers[timer_num].frequency;
+}
+
+uint32_t
+hal_timer_read(int timer_num)
+{
+    uint32_t tmr, counter, ctx;
+
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return 0;
+    }
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    tmr = TMRx(timer_num);
+    counter = timers[timer_num].counter;
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return tmr + counter;
+}
+
+int
+hal_timer_delay(int timer_num, uint32_t ticks)
+{
+    uint32_t until;
+
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return -1;
+    }
+
+    until = hal_timer_read(timer_num) + ticks;
+    while ((int32_t)(hal_timer_read(timer_num) - until) <= 0) {
+    }
+
+    return 0;
+}
+
+int
+hal_timer_set_cb(int timer_num, struct hal_timer *timer, hal_timer_cb cb_func,
+                 void *arg)
+{
+    if (timer_num >= PIC32MX_TIMER_COUNT) {
+        return -1;
+    }
+
+    memset(timer, 0, sizeof(struct hal_timer));
+    timer->bsp_timer = &timers[timer_num];
+    timer->cb_func = cb_func;
+    timer->cb_arg = arg;
+
+    return 0;
+}
+
+int
+hal_timer_start(struct hal_timer *timer, uint32_t ticks)
+{
+    uint32_t tick;
+    struct pic32_timer *bsp_timer;
+
+    if (timer == NULL || ticks == 0) {
+        return -1;
+    }
+
+    bsp_timer = (struct pic32_timer *)(timer->bsp_timer);
+    if (bsp_timer == NULL) {
+        return -1;
+    }
+
+    tick = hal_timer_read(bsp_timer->index) + ticks;
+    return hal_timer_start_at(timer, tick);
+}
+
+int
+hal_timer_start_at(struct hal_timer *timer, uint32_t tick)
+{
+    os_sr_t ctx;
+    struct pic32_timer *bsp_timer;
+
+    if ((timer == NULL) || (timer->link.tqe_prev != NULL) ||
+        (timer->cb_func == NULL)) {
+        return -1;
+    }
+
+    bsp_timer = (struct pic32_timer *)timer->bsp_timer;
+    if (bsp_timer == NULL) {
+        return -1;
+    }
+
+    timer->expiry = tick;
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    /* Add to callback queue, order using expiry tick in increasing order */
+    if (TAILQ_EMPTY(&bsp_timer->hal_timer_queue)) {
+        TAILQ_INSERT_HEAD(&bsp_timer->hal_timer_queue, timer, link);
+    } else {
+        struct hal_timer *entry;
+        TAILQ_FOREACH(entry, &bsp_timer->hal_timer_queue, link) {
+            if ((int32_t)(timer->expiry - entry->expiry) < 0) {
+                TAILQ_INSERT_BEFORE(entry, timer, link);
+                break;
+            }
+        }
+        if (!entry) {
+            TAILQ_INSERT_TAIL(&bsp_timer->hal_timer_queue, timer, link);
+        }
+    }
+
+    update_period_register(bsp_timer->index);
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+}
+
+int
+hal_timer_stop(struct hal_timer *timer)
+{
+    os_sr_t ctx;
+    struct pic32_timer *bsp_timer;
+
+    if (timer == NULL) {
+        return -1;
+    }
+
+    bsp_timer = (struct pic32_timer *)timer->bsp_timer;
+    if (bsp_timer == NULL) {
+        return -1;
+    }
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    if (timer->link.tqe_prev != NULL) {
+        TAILQ_REMOVE(&bsp_timer->hal_timer_queue, timer, link);
+        timer->link.tqe_prev = NULL;
+        timer->link.tqe_next = NULL;
+    }
+
+    update_period_register(bsp_timer->index);
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+}

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
@@ -155,15 +155,16 @@ uart_receive_ready(int port)
 static void
 uart_transmit_ready(int port)
 {
-    int c = uarts[port].u_tx_func(uarts[port].u_func_arg);
-    if (c < 0) {
-        uart_disable_tx_int(port);
-
-        /* call tx done cb */
-        if (uarts[port].u_tx_done) {
-            uarts[port].u_tx_done(uarts[port].u_func_arg);
+    while(!(UxSTA(port) & _U1STA_UTXBF_MASK)) {
+        int c = uarts[port].u_tx_func(uarts[port].u_func_arg);
+        if (c < 0) {
+            uart_disable_tx_int(port);
+            /* call tx done cb */
+            if (uarts[port].u_tx_done) {
+                uarts[port].u_tx_done(uarts[port].u_func_arg);
+            }
+            break;
         }
-    } else {
         UxTXREG(port) = (uint32_t)c & 0xff;
     }
 }

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
@@ -21,6 +21,7 @@
 #include "bsp/bsp.h"
 #include "syscfg/syscfg.h"
 #include "mcu/mips_hal.h"
+#include "mcu/pps.h"
 #include <assert.h>
 #include <stdlib.h>
 
@@ -33,6 +34,7 @@ struct hal_uart {
     hal_uart_tx_char u_tx_func;
     hal_uart_tx_done u_tx_done;
     void *u_func_arg;
+    const struct mips_uart_cfg *u_pins;
 };
 static struct hal_uart uarts[UART_CNT];
 
@@ -297,6 +299,12 @@ hal_uart_blocking_tx(int port, uint8_t data)
 int
 hal_uart_init(int port, void *arg)
 {
+    if (port >= UART_CNT) {
+        return -1;
+    }
+
+    uarts[port].u_pins = arg;
+
     return 0;
 }
 
@@ -336,6 +344,34 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         break;
     default:
         return -1;
+    }
+
+    /* Configure TX/RX pins */
+    if (uarts[port].u_pins) {
+        int ret = 0;
+        switch(port) {
+        case 0:
+            ret += pps_configure_output(uarts[port].u_pins->tx, U1TX_OUT_FUNC);
+            ret += pps_configure_input(uarts[port].u_pins->rx, U1RX_IN_FUNC);
+            break;
+        case 1:
+            ret += pps_configure_output(uarts[port].u_pins->tx, U2TX_OUT_FUNC);
+            ret += pps_configure_input(uarts[port].u_pins->rx, U2RX_IN_FUNC);
+            break;
+        case 2:
+            ret += pps_configure_output(uarts[port].u_pins->tx, U3TX_OUT_FUNC);
+            ret += pps_configure_input(uarts[port].u_pins->rx, U3RX_IN_FUNC);
+            break;
+        case 3:
+            ret += pps_configure_output(uarts[port].u_pins->tx, U4TX_OUT_FUNC);
+            ret += pps_configure_input(uarts[port].u_pins->rx, U4RX_IN_FUNC);
+            break;
+        default:
+            return -1;
+        }
+        if (ret) {
+            return -1;
+        }
     }
 
     uint16_t divisor = peripheral_clk / (4 * baudrate) - 1;

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
@@ -27,6 +27,20 @@
 
 #include <xc.h>
 
+#define UxMODE(U)           (base_address[U][0x0 / 0x4])
+#define UxMODESET(U)        (base_address[U][0x8 / 0x4])
+#define UxSTA(U)            (base_address[U][0x10 / 0x4])
+#define UxTXREG(U)          (base_address[U][0x20 / 0x4])
+#define UxRXREG(U)          (base_address[U][0x30 / 0x4])
+#define UxBRG(U)            (base_address[U][0x40 / 0x4])
+
+static volatile uint32_t* base_address[UART_CNT] = {
+    (volatile uint32_t *)_UART1_BASE_ADDRESS,
+    (volatile uint32_t *)_UART2_BASE_ADDRESS,
+    (volatile uint32_t *)_UART3_BASE_ADDRESS,
+    (volatile uint32_t *)_UART4_BASE_ADDRESS,
+};
+
 struct hal_uart {
     volatile uint8_t u_rx_stall:1;
     volatile uint8_t u_rx_data;
@@ -128,20 +142,7 @@ uart_enable_rx_int(int port)
 static void
 uart_receive_ready(int port)
 {
-    switch (port) {
-        case 0:
-            uarts[port].u_rx_data = U1RXREG;
-            break;
-        case 1:
-            uarts[port].u_rx_data = U2RXREG;
-            break;
-        case 2:
-            uarts[port].u_rx_data = U3RXREG;
-            break;
-        case 3:
-            uarts[port].u_rx_data = U4RXREG;
-            break;
-    }
+    uarts[port].u_rx_data = UxRXREG(port);
 
     int c = uarts[port].u_rx_func(uarts[port].u_func_arg,
                                     uarts[port].u_rx_data);
@@ -163,21 +164,7 @@ uart_transmit_ready(int port)
             uarts[port].u_tx_done(uarts[port].u_func_arg);
         }
     } else {
-        /* write char out */
-        switch (port) {
-            case 0:
-                U1TXREG = (uint32_t)c & 0xff;
-                break;
-            case 1:
-                U2TXREG = (uint32_t)c & 0xff;
-                break;
-            case 2:
-                U3TXREG = (uint32_t)c & 0xff;
-                break;
-            case 3:
-                U4TXREG = (uint32_t)c & 0xff;
-                break;
-        }
+        UxTXREG(port) = (uint32_t)c & 0xff;
     }
 }
 
@@ -264,36 +251,10 @@ hal_uart_start_tx(int port)
 void
 hal_uart_blocking_tx(int port, uint8_t data)
 {
-    switch (port){
-    case 0:
-        /* wait for transmit holding register to be empty */
-        while(!(U1STA & _U1STA_TRMT_MASK)) {
-        }
-        /* write to transmit register */
-        U1TXREG = data;
-        break;
-    case 1:
-        /* wait for transmit holding register to be empty */
-        while(!(U2STA & _U2STA_TRMT_MASK)) {
-        }
-        /* write to transmit register */
-        U2TXREG = data;
-        break;
-    case 2:
-        /* wait for transmit holding register to be empty */
-        while(!(U3STA & _U3STA_TRMT_MASK)) {
-        }
-        /* write to transmit register */
-        U3TXREG = data;
-        break;
-    case 3:
-        /* wait for transmit holding register to be empty */
-        while(!(U4STA & _U4STA_TRMT_MASK)) {
-        }
-        /* write to transmit register */
-        U4TXREG = data;
-        break;
+    while (!(UxSTA(port) & _U1STA_TRMT_MASK)) {
     }
+
+    UxTXREG(port) = data;
 }
 
 int
@@ -376,14 +337,14 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
 
     uint16_t divisor = peripheral_clk / (4 * baudrate) - 1;
 
+    UxMODE(port) = 0;
+    __asm__("nop");
+    UxBRG(port) = divisor;
+    UxMODE(port) = mode;
+    UxSTA(port) = _U1STA_URXEN_MASK | _U1STA_UTXEN_MASK;
+
     switch (port) {
     case 0:
-        /* disable */
-        U1MODE = 0;
-        __asm__("nop");
-        U1BRG = divisor;
-        U1MODE = mode;
-        U1STA = _U1STA_URXEN_MASK | _U1STA_UTXEN_MASK;
         /* clear RX interrupt flag */
         IFS1CLR = _IFS1_U1RXIF_MASK;
 
@@ -396,15 +357,8 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         /* set interrupt subpriority */
         IPC7CLR = _IPC7_U1IS_MASK;
         IPC7SET = (0 << _IPC7_U1IS_POSITION); // subpriority 0
-        U1MODESET = _U1MODE_ON_MASK;
         break;
     case 1:
-        /* disable */
-        U2MODE = 0;
-        __asm__("nop");
-        U2BRG = divisor;
-        U2MODE = mode;
-        U2STA = _U2STA_URXEN_MASK | _U2STA_UTXEN_MASK;
         /* clear RX interrupt flag */
         IFS1CLR = _IFS1_U2RXIF_MASK;
 
@@ -417,15 +371,8 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         /* set interrupt subpriority */
         IPC9CLR = _IPC9_U2IS_MASK;
         IPC9SET = (0 << _IPC9_U2IS_POSITION); // subpriority 0
-        U2MODESET = _U2MODE_ON_MASK;
         break;
     case 2:
-        /* disable */
-        U3MODE = 0;
-        __asm__("nop");
-        U3BRG = divisor;
-        U3MODE = mode;
-        U3STA = _U3STA_URXEN_MASK | _U3STA_UTXEN_MASK;
         /* clear RX interrupt flag */
         IFS1CLR = _IFS1_U3RXIF_MASK;
 
@@ -438,15 +385,8 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         /* set interrupt subpriority */
         IPC9CLR = _IPC9_U3IS_MASK;
         IPC9SET = (0 << _IPC9_U3IS_POSITION); // subpriority 0
-        U3MODESET = _U3MODE_ON_MASK;
         break;
     case 3:
-        /* disable */
-        U4MODE = 0;
-        __asm__("nop");
-        U4BRG = divisor;
-        U4MODE = mode;
-        U4STA = _U4STA_URXEN_MASK | _U4STA_UTXEN_MASK;
         /* clear RX interrupt flag */
         IFS2CLR = _IFS2_U4RXIF_MASK;
 
@@ -459,41 +399,23 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         /* set interrupt subpriority */
         IPC9CLR = _IPC9_U4IS_MASK;
         IPC9SET = (0 << _IPC9_U4IS_POSITION); // subpriority 0
-        U4MODESET = _U4MODE_ON_MASK;
         break;
     }
+
+    UxMODESET(port) = _U1MODE_ON_MASK;
+
     return 0;
 }
 
 int
 hal_uart_close(int port)
 {
-    switch(port) {
-    case 0:
-        /* disable */
-        U1MODE = 0;
-        /* disable RX interrupt */
-        IEC1CLR = _IEC1_U1RXIE_MASK;
-        break;
-    case 1:
-        /* disable */
-        U2MODE = 0;
-        /* disable RX interrupt */
-        IEC1CLR = _IEC1_U2RXIE_MASK;
-        break;
-    case 2:
-        U3MODE = 0;
-        /* disable RX interrupt */
-        IEC1CLR = _IEC1_U3RXIE_MASK;
-        break;
-    case 3:
-        /* disable */
-        U4MODE = 0;
-        /* disable RX interrupt */
-        IEC2CLR = _IEC2_U4RXIE_MASK;
-        break;
-    default:
+    if (port >= UART_CNT) {
         return -1;
     }
+
+    UxMODE(port) = 0;
+    uart_disable_rx_int(port);
+
     return 0;
 }

--- a/hw/mcu/microchip/pic32mx470f512h/src/pps.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/pps.c
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <xc.h>
+#include "mcu/mcu.h"
+#include "mcu/pps.h"
+
+#define MCU_GPIO_UNDEF                  (0xFF)
+#define PPS_BASE_ADDRESS                (0xBF80FB00)
+#define PPS_PORT_SPACING                (0x40)
+
+static volatile uint32_t *input_regs[4][16] = {
+    {
+        &INT3R,
+        &T2CKR,
+        &IC3R,
+        &U1RXR,
+        &U2RXR,
+        &U5CTSR,
+        &REFCLKIR
+    },
+    {
+        &INT4R,
+        &T5CKR,
+        &IC4R,
+        &U3RXR,
+        &U4CTSR,
+        &SDI1R,
+        &SDI2R
+    },
+    {
+        &INT2R,
+        &T4CKR,
+        &IC2R,
+        &IC5R,
+        &U1CTSR,
+        &U2CTSR,
+        &SS1R
+    },
+    {
+        &INT1R,
+        &T3CKR,
+        &IC1R,
+        &U3CTSR,
+        &U4RXR,
+        &U5RXR,
+        &SS2R,
+        &OCFAR
+    }
+};
+
+static const uint8_t output_pins[4][16] = {
+    {
+        MCU_GPIO_PORTD(2),
+        MCU_GPIO_PORTG(8),
+        MCU_GPIO_PORTF(4),
+        MCU_GPIO_PORTD(10),
+        MCU_GPIO_PORTF(1),
+        MCU_GPIO_PORTB(9),
+        MCU_GPIO_PORTB(10),
+        MCU_GPIO_PORTC(14),
+        MCU_GPIO_PORTB(5),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    },
+    {
+        MCU_GPIO_PORTD(3),
+        MCU_GPIO_PORTG(7),
+        MCU_GPIO_PORTF(5),
+        MCU_GPIO_PORTD(11),
+        MCU_GPIO_PORTF(0),
+        MCU_GPIO_PORTB(1),
+        MCU_GPIO_PORTE(5),
+        MCU_GPIO_PORTC(13),
+        MCU_GPIO_PORTB(3),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    },
+    {
+        MCU_GPIO_PORTD(9),
+        MCU_GPIO_PORTG(6),
+        MCU_GPIO_PORTB(8),
+        MCU_GPIO_PORTB(15),
+        MCU_GPIO_PORTD(4),
+        MCU_GPIO_PORTB(0),
+        MCU_GPIO_PORTE(3),
+        MCU_GPIO_PORTB(7),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_PORTB(2)
+    },
+    {
+        MCU_GPIO_PORTD(1),
+        MCU_GPIO_PORTG(9),
+        MCU_GPIO_PORTB(14),
+        MCU_GPIO_PORTD(0),
+        MCU_GPIO_PORTD(8),
+        MCU_GPIO_PORTB(6),
+        MCU_GPIO_PORTD(5),
+        MCU_GPIO_PORTB(2),
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF,
+        MCU_GPIO_UNDEF
+    }
+};
+
+int
+pps_configure_output(uint8_t pin, uint8_t func)
+{
+    uint32_t port = pin >> 4;
+    uint32_t index = pin & 0xF;
+    volatile uint32_t *ptr;
+
+    if (func >= 16) {
+        return -1;
+    }
+
+    ptr = (volatile uint32_t *) (PPS_BASE_ADDRESS +
+                                 (port * PPS_PORT_SPACING) + index * 4);
+
+    *ptr = func;
+    return 0;
+}
+
+int
+pps_configure_input(uint8_t pin, uint8_t func)
+{
+    uint8_t index = func >> 4;
+    uint8_t val;
+
+    if (index > 3) {
+        return -1;
+    }
+
+    func &= 0xF;
+    if (input_regs[index][func]  == NULL) {
+        return -1;
+    }
+
+    for (val = 0; val < 16; ++val) {
+        if (output_pins[index][val] == pin) {
+            break;
+        }
+    }
+    if (val == 16) {
+        return -1;
+    }
+
+    *input_regs[index][func] = val;
+    return 0;
+}


### PR DESCRIPTION
This pull request adds the following features for the 6LoWPAN Clicker:
- GPIO (+ LED's)
- Peripheral Pin Select
- SPI (master only)
- I2C
- Timer
- Some improvements regarding to UART

The implementation is very similar to the code I wrote for the Wi-Fire (PIC32MZ).