### PR TITLE
PIC32: Fix stack align

### DIFF
--- a/kernel/os/include/os/arch/pic32/os/os_arch.h
+++ b/kernel/os/include/os/arch/pic32/os/os_arch.h
@@ -38,7 +38,8 @@ typedef uint32_t os_sr_t;
 /* Stack type, aligned to a 32-bit word. */
 #define OS_STACK_PATTERN    (0xdeadbeef)
 
-typedef uint32_t os_stack_t;
+/* uint64_t in an attempt to get the stack 8 aligned */
+typedef uint64_t os_stack_t;
 #define OS_ALIGNMENT        (4)
 #define OS_STACK_ALIGNMENT  (8)
 
@@ -48,7 +49,7 @@ typedef uint32_t os_stack_t;
  * Stack sizes for common OS tasks
  */
 #define OS_SANITY_STACK_SIZE (64)
-#define OS_IDLE_STACK_SIZE (64)
+#define OS_IDLE_STACK_SIZE (256)
 
 #define OS_STACK_ALIGN(__nmemb) \
     (OS_ALIGN((__nmemb), OS_STACK_ALIGNMENT))

--- a/kernel/os/src/arch/pic32/os_arch_pic32.c
+++ b/kernel/os/src/arch/pic32/os_arch_pic32.c
@@ -137,13 +137,15 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* If stack does not have space for the FPU context, assume the
     thread won't use it. */
     int lazy_space = os_bytes_to_stack_aligned_words(sizeof(struct ctx_fp));
-    if ((lazy_space + ctx_space + 4) >= size) {
+    if ((lazy_space + ctx_space + 4) >= (size * sizeof(os_stack_t))) {
         /* stack too small */
         stack_top -= 4;
     } else {
         struct ctx_fp ctx_fp;
         ctx_fp.fcsr = 0;
-        memcpy(stack_top - os_bytes_to_stack_aligned_words(sizeof(struct ctx_fp)), &ctx_fp, sizeof(ctx_fp));
+        memcpy(stack_top -
+            os_bytes_to_stack_aligned_words(sizeof(struct ctx_fp)),
+            &ctx_fp, sizeof(ctx_fp));
         stack_top -= lazy_space + 4;
     }
 #else


### PR DESCRIPTION
Sometimes the stack was not 8-aligned causing FPU load/store problems (and is incompatible with the ABI). Changing the type to uint64_t seems to fix it but I don't think this is portable so if anyone has any ideas for a better fix please let me know!