### PR TITLE
Allow GATT services to be registered after startup

### DIFF
--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -235,7 +235,7 @@ struct ble_gatt_chr_def {
      * At registration time, this is filled in with the characteristic's value
      * attribute handle.
      */
-    uint16_t * const val_handle;
+    uint16_t *val_handle;
 };
 
 struct ble_gatt_svc_def {

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -430,6 +430,8 @@ typedef void (*ble_gatt_svc_foreach_fn)(const struct ble_gatt_svc_def *svc,
                                         uint16_t handle,
                                         uint16_t end_group_handle);
 void ble_gatts_show_local(void);
+int ble_gatts_reset(void);
+int ble_gatts_start(void);
 
 #ifdef __cplusplus
 }

--- a/net/nimble/host/include/host/ble_uuid.h
+++ b/net/nimble/host/include/host/ble_uuid.h
@@ -104,6 +104,7 @@ typedef union {
 
 int ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len);
 int ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2);
+void ble_uuid_copy(ble_uuid_any_t *dst, const ble_uuid_t *src);
 char *ble_uuid_to_str(const ble_uuid_t *uuid, char *dst);
 uint16_t ble_uuid_u16(const ble_uuid_t *uuid);
 

--- a/net/nimble/host/src/ble_att_priv.h
+++ b/net/nimble/host/src/ble_att_priv.h
@@ -216,6 +216,7 @@ void ble_att_svr_prep_clear(struct ble_att_prep_entry_list *prep_list);
 int ble_att_svr_read_handle(uint16_t conn_handle, uint16_t attr_handle,
                             uint16_t offset, struct os_mbuf *om,
                             uint8_t *out_att_err);
+void ble_att_svr_reset(void);
 int ble_att_svr_init(void);
 
 

--- a/net/nimble/host/src/ble_gatt_priv.h
+++ b/net/nimble/host/src/ble_gatt_priv.h
@@ -190,7 +190,6 @@ int ble_gatts_register_svcs(const struct ble_gatt_svc_def *svcs,
 /*** @misc. */
 int ble_gatts_conn_can_alloc(void);
 int ble_gatts_conn_init(struct ble_gatts_conn *gatts_conn);
-int ble_gatts_start(void);
 int ble_gatts_init(void);
 
 #ifdef __cplusplus

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -307,6 +307,34 @@ ble_gatts_chr_inc_val_stat(uint8_t gatt_op)
     }
 }
 
+/**
+ * Indicates whether the set of registered services can be modified.  The
+ * service set is mutable if:
+ *     o No peers are connected, and
+ *     o No GAP operations are active (advertise, discover, or connect).
+ *
+ * @return                      true if the GATT service set can be modified;
+ *                              false otherwise.
+ */
+static bool
+ble_gatts_mutable(void)
+{
+    /* Ensure no active GAP procedures. */
+    if (ble_gap_adv_active() ||
+        ble_gap_disc_active() ||
+        ble_gap_conn_active()) {
+
+        return false;
+    }
+
+    /* Ensure no established connections. */
+    if (ble_hs_conn_first() != NULL) {
+        return false;
+    }
+
+    return true;
+}
+
 static int
 ble_gatts_val_access(uint16_t conn_handle, uint16_t attr_handle,
                      uint16_t offset, struct ble_gatt_access_ctxt *gatt_ctxt,
@@ -1139,6 +1167,18 @@ ble_gatts_free_mem(void)
     ble_gatts_svc_entries = NULL;
 }
 
+/**
+ * Makes all registered services available to peers.  This function gets called
+ * automatically by the NimBLE host on startup; manual calls are only necessary
+ * for replacing the set of supported services with a new one.  This function
+ * requires that:
+ *     o No peers are connected, and
+ *     o No GAP operations are active (advertise, discover, or connect).
+ *
+ * @return                      0 on success;
+ *                              A BLE host core return code on unexpected
+ *                                  error.
+ */
 int
 ble_gatts_start(void)
 {
@@ -1151,6 +1191,12 @@ ble_gatts_start(void)
     int rc;
     int i;
 
+    ble_hs_lock(); 
+    if (!ble_gatts_mutable()) {
+        rc = BLE_HS_EBUSY;
+        goto done;
+    }
+
     ble_gatts_free_mem();
 
     if (ble_hs_max_client_configs > 0) {
@@ -1159,7 +1205,7 @@ ble_gatts_start(void)
                              sizeof (struct ble_gatts_clt_cfg)));
         if (ble_gatts_clt_cfg_mem == NULL) {
             rc = BLE_HS_ENOMEM;
-            goto err;
+            goto done;
         }
     }
 
@@ -1168,7 +1214,7 @@ ble_gatts_start(void)
             malloc(ble_hs_max_services * sizeof *ble_gatts_svc_entries);
         if (ble_gatts_svc_entries == NULL) {
             rc = BLE_HS_ENOMEM;
-            goto err;
+            goto done;
         }
     }
 
@@ -1179,13 +1225,14 @@ ble_gatts_start(void)
                                      ble_hs_cfg.gatts_register_cb,
                                      ble_hs_cfg.gatts_register_arg);
         if (rc != 0) {
-            goto err;
+            goto done;
         }
     }
     ble_gatts_free_svc_defs();
 
     if (ble_gatts_num_cfgable_chrs == 0) {
-        return 0;
+        rc = 0;
+        goto done;
     }
 
     /* Initialize client-configuration memory pool. */
@@ -1195,7 +1242,7 @@ ble_gatts_start(void)
                          "ble_gatts_clt_cfg_pool");
     if (rc != 0) {
         rc = BLE_HS_EOS;
-        goto err;
+        goto done;
     }
 
     /* Allocate the cached array of handles for the configuration
@@ -1204,7 +1251,7 @@ ble_gatts_start(void)
     ble_gatts_clt_cfgs = os_memblock_get(&ble_gatts_clt_cfg_pool);
     if (ble_gatts_clt_cfgs == NULL) {
         rc = BLE_HS_ENOMEM;
-        goto err;
+        goto done;
     }
 
     /* Fill the cache. */
@@ -1223,11 +1270,13 @@ ble_gatts_start(void)
         }
     }
 
-    return 0;
+done:
+    if (rc != 0) {
+        ble_gatts_free_mem();
+        ble_gatts_free_svc_defs();
+    }
 
-err:
-    ble_gatts_free_mem();
-    ble_gatts_free_svc_defs();
+    ble_hs_unlock();
     return rc;
 }
 
@@ -1729,7 +1778,8 @@ ble_gatts_find_svc_entry(const ble_uuid_t *uuid)
 }
 
 static int
-ble_gatts_find_svc_chr_attr(const ble_uuid_t *svc_uuid, const ble_uuid_t *chr_uuid,
+ble_gatts_find_svc_chr_attr(const ble_uuid_t *svc_uuid,
+                            const ble_uuid_t *chr_uuid,
                             struct ble_gatts_svc_entry **out_svc_entry,
                             struct ble_att_svr_entry **out_att_chr)
 {
@@ -1905,7 +1955,7 @@ ble_gatts_find_dsc(const ble_uuid_t *svc_uuid, const ble_uuid_t *chr_uuid,
 
 /**
  * Queues a set of service definitions for registration.  All services queued
- * in this manner get registered when ble_hs_init() is called.
+ * in this manner get registered when ble_gatts_start() is called.
  *
  * @param svcs                  An array of service definitions to queue for
  *                                  registration.  This array must be
@@ -1919,18 +1969,30 @@ int
 ble_gatts_add_svcs(const struct ble_gatt_svc_def *svcs)
 {
     void *p;
+    int rc;
+
+    ble_hs_lock(); 
+    if (!ble_gatts_mutable()) {
+        rc = BLE_HS_EBUSY;
+        goto done;
+    }
 
     p = realloc(ble_gatts_svc_defs,
                 (ble_gatts_num_svc_defs + 1) * sizeof *ble_gatts_svc_defs);
     if (p == NULL) {
-        return BLE_HS_ENOMEM;
+        rc = BLE_HS_ENOMEM;
+        goto done;
     }
 
     ble_gatts_svc_defs = p;
     ble_gatts_svc_defs[ble_gatts_num_svc_defs] = svcs;
     ble_gatts_num_svc_defs++;
 
-    return 0;
+    rc = 0;
+
+done:
+    ble_hs_unlock();
+    return rc;
 }
 
 /**
@@ -2090,6 +2152,41 @@ ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb)
            ble_gatts_svc_entries[i].handle,
            ble_gatts_svc_entries[i].end_group_handle);
     }
+}
+
+/**
+ * Resets the GATT server to its initial state.  On success, this function
+ * removes all supported services, characteristics, and descriptors.  This
+ * function requires that:
+ *     o No peers are connected, and
+ *     o No GAP operations are active (advertise, discover, or connect).
+ *
+ * @return                      0 on success;
+ *                              BLE_HS_EBUSY if the GATT server could not be
+ *                                  reset due to existing connections or active
+ *                                  GAP procedures.
+ */
+int
+ble_gatts_reset(void)
+{
+    int rc;
+
+    ble_hs_lock();
+
+    if (!ble_gatts_mutable()) {
+        rc = BLE_HS_EBUSY;
+    } else {
+        /* Unregister all ATT attributes. */
+        ble_att_svr_reset();
+        ble_gatts_num_cfgable_chrs = 0;
+        rc = 0;
+
+        /* Note: gatts memory gets freed on next call to ble_gatts_start(). */
+    }
+
+    ble_hs_unlock();
+
+    return rc;
 }
 
 int

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -945,7 +945,7 @@ ble_gatts_register_svc(const struct ble_gatt_svc_def *svc,
      * arg).
      */
     rc = ble_att_svr_register(uuid, BLE_ATT_F_READ, 0, out_handle,
-                                     ble_gatts_svc_access, (void *)svc);
+                              ble_gatts_svc_access, (void *)svc);
     if (rc != 0) {
         return rc;
     }
@@ -1198,6 +1198,11 @@ ble_gatts_start(void)
     }
 
     ble_gatts_free_mem();
+
+    rc = ble_att_svr_start();
+    if (rc != 0) {
+        goto done;
+    }
 
     if (ble_hs_max_client_configs > 0) {
         ble_gatts_clt_cfg_mem = malloc(

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -493,11 +493,6 @@ ble_hs_start(void)
     os_callout_init(&ble_hs_timer_timer, ble_hs_evq_get(),
                     ble_hs_timer_exp, NULL);
 
-    rc = ble_att_svr_start();
-    if (rc != 0) {
-        return rc;
-    }
-
     rc = ble_gatts_start();
     if (rc != 0) {
         return rc;

--- a/net/nimble/host/src/ble_uuid.c
+++ b/net/nimble/host/src/ble_uuid.c
@@ -116,6 +116,25 @@ ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
     return 0;
 }
 
+void
+ble_uuid_copy(ble_uuid_any_t *dst, const ble_uuid_t *src)
+{
+    switch (src->type) {
+    case BLE_UUID_TYPE_16:
+        dst->u16 = *(const ble_uuid16_t *)src;
+        break;
+    case BLE_UUID_TYPE_32:
+        dst->u32 = *(const ble_uuid32_t *)src;
+        break;
+    case BLE_UUID_TYPE_128:
+        dst->u128 = *(const ble_uuid128_t *)src;
+        break;
+    default:
+        BLE_HS_DBG_ASSERT(0);
+        break;
+    }
+}
+
 /**
  * Converts the specified UUID to its string representation.
  *

--- a/net/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/net/nimble/host/test/src/ble_gatts_notify_test.c
@@ -229,20 +229,15 @@ ble_gatts_notify_test_misc_init(uint16_t *out_conn_handle, int bonding,
     struct ble_hs_conn *conn;
     uint16_t flags;
     int exp_num_cccds;
-    int rc;
 
     ble_hs_test_util_init();
-
     ble_gatts_notify_test_num_events = 0;
 
-
-    rc = ble_gatts_register_svcs(ble_gatts_notify_test_svcs,
-                                 ble_gatts_notify_test_misc_reg_cb, NULL);
-    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_reg_svcs(ble_gatts_notify_test_svcs,
+                              ble_gatts_notify_test_misc_reg_cb,
+                              NULL);
     TEST_ASSERT_FATAL(ble_gatts_notify_test_chr_1_def_handle != 0);
     TEST_ASSERT_FATAL(ble_gatts_notify_test_chr_2_def_handle != 0);
-
-    ble_gatts_start();
 
     ble_hs_test_util_create_conn(2, ble_gatts_notify_test_peer_addr,
                                  ble_gatts_notify_test_util_gap_event, NULL);
@@ -1016,7 +1011,6 @@ TEST_CASE(ble_gatts_notify_test_disallowed)
     uint16_t chr1_val_handle;
     uint16_t chr2_val_handle;
     uint16_t chr3_val_handle;
-    int rc;
 
     const struct ble_gatt_svc_def svcs[] = { {
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
@@ -1046,13 +1040,10 @@ TEST_CASE(ble_gatts_notify_test_disallowed)
 
     ble_hs_test_util_init();
 
-    rc = ble_gatts_register_svcs(svcs, NULL, NULL);
-    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_reg_svcs(svcs, NULL, NULL);
     TEST_ASSERT_FATAL(chr1_val_handle != 0);
     TEST_ASSERT_FATAL(chr2_val_handle != 0);
     TEST_ASSERT_FATAL(chr3_val_handle != 0);
-
-    ble_gatts_start();
 
     ble_hs_test_util_create_conn(2, ble_gatts_notify_test_peer_addr,
                                  ble_gatts_notify_test_util_gap_event, NULL);

--- a/net/nimble/host/test/src/ble_gatts_read_test.c
+++ b/net/nimble/host/test/src/ble_gatts_read_test.c
@@ -73,13 +73,11 @@ static uint16_t ble_gatts_read_test_chr_2_val_handle;
 static void
 ble_gatts_read_test_misc_init(uint16_t *out_conn_handle)
 {
-    int rc;
-
     ble_hs_test_util_init();
 
-    rc = ble_gatts_register_svcs(ble_gatts_read_test_svcs,
-                                 ble_gatts_read_test_misc_reg_cb, NULL);
-    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_reg_svcs(ble_gatts_read_test_svcs,
+                              ble_gatts_read_test_misc_reg_cb,
+                              NULL);
     TEST_ASSERT_FATAL(ble_gatts_read_test_chr_1_def_handle != 0);
     TEST_ASSERT_FATAL(ble_gatts_read_test_chr_1_val_handle ==
                       ble_gatts_read_test_chr_1_def_handle + 1);

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -2393,6 +2393,26 @@ ble_hs_test_util_store_delete(int obj_type, const union ble_store_key *key)
 }
 
 void
+ble_hs_test_util_reg_svcs(const struct ble_gatt_svc_def *svcs,
+                          ble_gatt_register_fn *reg_cb,
+                          void *cb_arg)
+{
+    int rc;
+
+    ble_hs_cfg.gatts_register_cb = reg_cb;
+    ble_hs_cfg.gatts_register_arg = cb_arg;
+
+    rc = ble_gatts_reset();
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = ble_gatts_add_svcs(svcs);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = ble_gatts_start();
+    TEST_ASSERT_FATAL(rc == 0);
+}
+
+void
 ble_hs_test_util_init_no_start(void)
 {
     sysinit();

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -294,6 +294,9 @@ void ble_hs_test_util_post_test(void *arg);
 int ble_hs_test_util_num_cccds(void);
 int ble_hs_test_util_num_our_secs(void);
 int ble_hs_test_util_num_peer_secs(void);
+void ble_hs_test_util_reg_svcs(const struct ble_gatt_svc_def *svcs,
+                               ble_gatt_register_fn *reg_cb,
+                               void *cb_arg);
 void ble_hs_test_util_init_no_start(void);
 void ble_hs_test_util_init(void);
 


### PR DESCRIPTION
Prior to this change, supported GATT services could only be registered once.  This change allows the set of supported servces to be replaced "on the fly".

```
/**
 * Resets the GATT server to its initial state.  On success, this function
 * removes all supported services, characteristics, and descriptors.  This
 * function requires that:
 *     o No peers are connected, and
 *     o No GAP operations are active (advertise, discover, or connect).
 *
 * @return                      0 on success;
 *                              BLE_HS_EBUSY if the GATT server could not be
 *                                  reset due to existing connections or active
 *                                  GAP procedures.
 */
int
ble_gatts_reset(void)

/**
 * Makes all registered services available to peers.  This function gets called
 * automatically by the NimBLE host on startup; manual calls are only necessary
 * for replacing the set of supported services with a new one.  This function
 * requires that:
 *     o No peers are connected, and
 *     o No GAP operations are active (advertise, discover, or connect).
 *
 * @return                      0 on success;
 *                              A BLE host core return code on unexpected
 *                                  error.
 */
int
ble_gatts_start(void)
```