### PR TITLE
oic: Per-resource transport layer sec requirements

### DIFF
--- a/net/oic/include/oic/oc_api.h
+++ b/net/oic/include/oic/oc_api.h
@@ -81,6 +81,10 @@ void oc_process_baseline_interface(oc_resource_t *resource);
 #ifdef OC_SECURITY
 void oc_resource_make_secure(oc_resource_t *resource);
 #endif /* OC_SECURITY */
+#if MYNEWT_VAL(OC_TRANS_SECURITY)
+void oc_resource_set_trans_security(oc_resource_t *resource,
+                                    bool enc, bool auth);
+#endif
 
 void oc_resource_set_discoverable(oc_resource_t *resource);
 void oc_resource_set_observable(oc_resource_t *resource);

--- a/net/oic/include/oic/oc_ri.h
+++ b/net/oic/include/oic/oc_ri.h
@@ -28,13 +28,17 @@ extern "C" {
 
 typedef enum { OC_GET = 1, OC_POST, OC_PUT, OC_DELETE } oc_method_t;
 
-typedef enum {
+typedef enum oc_resource_properties {
   OC_DISCOVERABLE = (1 << 0),
   OC_OBSERVABLE = (1 << 1),
   OC_ACTIVE = (1 << 2),
   OC_SECURE = (1 << 4),
   OC_PERIODIC = (1 << 6),
+  OC_TRANS_ENC = (1 << 7),    /* Requires transport layer encryption. */
+  OC_TRANS_AUTH = (1 << 8),   /* Requires transport layer authentication. */
 } oc_resource_properties_t;
+
+#define OC_TRANS_SEC_MASK (OC_TRANS_ENC | OC_TRANS_AUTH)
 
 typedef enum {
   OC_STATUS_OK = 0,
@@ -63,6 +67,7 @@ typedef enum {
 
 struct oc_separate_response;
 struct oc_response_buffer;
+struct oc_endpoint;
 
 typedef struct oc_response {
     struct oc_separate_response *separate_response;
@@ -94,7 +99,7 @@ typedef enum {
 #define NUM_OC_CORE_RESOURCES (__NUM_OC_CORE_RESOURCES__ + MAX_NUM_DEVICES)
 
 typedef struct oc_request {
-    oc_endpoint_t *origin;
+    struct oc_endpoint *origin;
     struct oc_resource *resource;
     const char *query;
     int query_len;

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -117,6 +117,8 @@ oc_endpoint_size(struct oc_endpoint *oe)
 uint16_t oc_connectivity_get_dtls_port(void);
 #endif /* OC_SECURITY */
 
+enum oc_resource_properties
+oc_get_trans_security(const struct oc_endpoint *oe);
 int oc_connectivity_init(void);
 void oc_connectivity_shutdown(void);
 

--- a/net/oic/src/api/oc_server_api.c
+++ b/net/oic/src/api/oc_server_api.c
@@ -142,6 +142,33 @@ oc_resource_make_secure(oc_resource_t *resource)
 }
 #endif /* OC_SECURITY */
 
+#if MYNEWT_VAL(OC_TRANS_SECURITY)
+/**
+ * Configures the specified resource with a minimum set of transport layer
+ * security requirements.
+ *
+ * @param resource              The resource to configure.
+ * @param enc                   Whether transport layer encryption is required.
+ * @param auth                  Whether transport layer authentication is
+ *                                  required.
+ */
+void
+oc_resource_set_trans_security(oc_resource_t *resource, bool enc, bool auth)
+{
+    if (enc) {
+        resource->properties |= OC_TRANS_ENC;
+    } else {
+        resource->properties &= ~OC_TRANS_ENC;
+    }
+
+    if (auth) {
+        resource->properties |= OC_TRANS_AUTH;
+    } else {
+        resource->properties &= ~OC_TRANS_AUTH;
+    }
+}
+#endif
+
 void
 oc_resource_set_discoverable(oc_resource_t *resource)
 {

--- a/net/oic/src/port/mynewt/adaptor.c
+++ b/net/oic/src/port/mynewt/adaptor.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <log/log.h>
 #include "oic/oc_log.h"
+#include "oic/oc_ri.h"
 #include "port/oc_connectivity.h"
 #include "adaptor.h"
 
@@ -111,6 +112,35 @@ oc_send_multicast_message(struct os_mbuf *m)
         m = n;
     }
     funcs[(sizeof(funcs) / sizeof(funcs[0])) - 1](m);
+}
+
+/**
+ * Retrieves the specified endpoint's transport layer security properties.
+ */
+oc_resource_properties_t
+oc_get_trans_security(const struct oc_endpoint *oe)
+{
+    switch (oe->oe.flags) {
+#if (MYNEWT_VAL(OC_TRANSPORT_GATT) == 1)
+    case GATT:
+        return oc_get_trans_security_gatt(&oe->oe_ble);
+#endif
+#if (MYNEWT_VAL(OC_TRANSPORT_IP) == 1) && (MYNEWT_VAL(OC_TRANSPORT_IPV6) == 1)
+    case IP:
+        return 0;
+#endif
+#if (MYNEWT_VAL(OC_TRANSPORT_IP) == 1) && (MYNEWT_VAL(OC_TRANSPORT_IPV4) == 1)
+    case IP4:
+        return 0;
+#endif
+#if (MYNEWT_VAL(OC_TRANSPORT_SERIAL) == 1)
+    case SERIAL:
+        return 0;
+#endif
+    default:
+        OC_LOG_ERROR("Unknown transport option %u\n", oe->oe.flags);
+        return 0;
+    }
 }
 
 void

--- a/net/oic/src/port/mynewt/adaptor.h
+++ b/net/oic/src/port/mynewt/adaptor.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+enum oc_resource_properties;
+
 struct os_eventq *oc_evq_get(void);
 
 #if (MYNEWT_VAL(OC_TRANSPORT_IP) == 1) && (MYNEWT_VAL(OC_TRANSPORT_IPV6) == 1)
@@ -43,6 +45,8 @@ void oc_send_buffer_ip4_mcast(struct os_mbuf *);
 int oc_connectivity_init_gatt(void);
 void oc_connectivity_shutdown_gatt(void);
 void oc_send_buffer_gatt(struct os_mbuf *);
+enum oc_resource_properties
+oc_get_trans_security_gatt(const struct oc_endpoint_ble *oe_ble);
 #endif
 
 #if (MYNEWT_VAL(OC_TRANSPORT_SERIAL) == 1)

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -26,6 +26,7 @@
 #include <stats/stats.h>
 #include "oic/oc_gatt.h"
 #include "oic/oc_log.h"
+#include "oic/oc_ri.h"
 #include "messaging/coap/coap.h"
 #include "api/oc_buffer.h"
 #include "port/oc_connectivity.h"
@@ -424,6 +425,32 @@ err:
     os_mbuf_free_chain(m);
     STATS_INC(oc_ble_stats, oerr);
 #endif
+}
+
+/**
+ * Retrieves the specified BLE endpoint's transport layer security properties.
+ */
+oc_resource_properties_t
+oc_get_trans_security_gatt(const struct oc_endpoint_ble *oe_ble)
+{
+    oc_resource_properties_t props;
+    struct ble_gap_conn_desc desc;
+    int rc;
+
+    rc = ble_gap_conn_find(oe_ble->conn_handle, &desc);
+    if (rc != 0) {
+        return 0;
+    }
+
+    props = 0;
+    if (desc.sec_state.encrypted) {
+        props |= OC_TRANS_ENC;
+    }
+    if (desc.sec_state.authenticated) {
+        props |= OC_TRANS_AUTH;
+    }
+
+    return props;
 }
 
 #endif

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -75,3 +75,8 @@ syscfg.defs:
     OC_LOGGING:
         description: 'Logging enabled'
         value: 0
+
+    OC_TRANS_SECURITY:
+        description: >
+            Enables per-resource transport layer security requirements.
+        value: 1


### PR DESCRIPTION
Each resource can be configured to require transport layer encryption, transport layer authentication, neither, or both.  When a peer accesses the resource, the OIC server verifies the security properties of the underlying connection.  If the minimum security requirements are not
met, the server responds with a 403 forbidden error.

This form of security is an alternative to the "coaps" DTLS security that is defined in the CoAP spec.
