### PR TITLE
hw/mcu/nordic: HFXO was not being turned on by hal timer

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_timer.c
@@ -660,9 +660,10 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
     /* disable interrupts */
     __HAL_DISABLE_INTERRUPTS(ctx);
 
-    /* XXX: only do this if it is HFCLK */
     /* Make sure HFXO is started */
-    if ((NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) == 0) {
+    if ((NRF_CLOCK->HFCLKSTAT &
+         (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) !=
+        (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) {
         NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
         NRF_CLOCK->TASKS_HFCLKSTART = 1;
         while (1) {

--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -635,7 +635,9 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
     __HAL_DISABLE_INTERRUPTS(ctx);
 
     /* Make sure HFXO is started */
-    if ((NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) == 0) {
+    if ((NRF_CLOCK->HFCLKSTAT &
+         (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) !=
+        (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) {
         NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
         NRF_CLOCK->TASKS_HFCLKSTART = 1;
         while (1) {


### PR DESCRIPTION
The hal_timer code for the nordic MCU's was not turning on the HFXO if one of the non-RTC timers was used by an application. The HFCLK source was running but was using HFINT (the internal oscillator) which is not very accurate. The code now turns on the HFXO. As noted in the commit, this does increase current consumption. It might be a good idea to add a config variable to use either HFINT or HFXO but I suspect that if people want to turn on these timers they want it more accurate than the HFINT (which I have seen be 6000 ppm off!)