### PR TITLE
Delay start events until end of main()

### DIFF
--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -325,7 +325,7 @@ sensor_mgr_evq_get(void)
 static void
 sensor_mgr_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&sensor_mgr.mgr_eventq, evq, NULL);
+    sensor_mgr.mgr_eventq = evq;
 }
 
 static void

--- a/kernel/os/include/os/os_eventq.h
+++ b/kernel/os/include/os/os_eventq.h
@@ -55,8 +55,11 @@ void os_eventq_run(struct os_eventq *evq);
 struct os_event *os_eventq_poll(struct os_eventq **, int, os_time_t);
 void os_eventq_remove(struct os_eventq *, struct os_event *);
 struct os_eventq *os_eventq_dflt_get(void);
+
+/* [DEPRECATED] */
 void os_eventq_designate(struct os_eventq **dst, struct os_eventq *val,
                          struct os_event *start_ev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_eventq.c
+++ b/kernel/os/src/os_eventq.c
@@ -310,6 +310,9 @@ os_eventq_dflt_get(void)
 }
 
 /**
+ * [DEPRECATED - packages should manually enqueue start events to the default
+ * task instead of calling this function]
+ *
  * Reassigns an event queue pointer to the specified value.  This function is
  * used for configuring a package to use a particular event queue.  A package's
  * event queue can generally be reassigned repeatedly.  If the package has a

--- a/mgmt/newtmgr/src/newtmgr.c
+++ b/mgmt/newtmgr/src/newtmgr.c
@@ -58,7 +58,7 @@ mgmt_evq_get(void)
 void
 mgmt_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&nmgr_evq, evq, NULL);
+    nmgr_evq = evq;
 }
 
 static int

--- a/mgmt/oicmgr/src/oicmgr.c
+++ b/mgmt/oicmgr/src/oicmgr.c
@@ -62,7 +62,7 @@ mgmt_evq_get(void)
 void
 mgmt_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&omgr_state.os_evq, evq, &omgr_state.os_event);
+    omgr_state.os_evq = evq;
 }
 
 static int
@@ -295,6 +295,13 @@ oicmgr_init(void)
     }
 
     mgmt_evq_set(os_eventq_dflt_get());
+
+    /* Enqueue the start event to the default event queue.  Using the default
+     * queue ensures the event won't run until the end of main().  This allows
+     * the application to configure this package in the meantime.
+     */
+    os_eventq_put(os_eventq_dflt_get(), &omgr_state.os_event);
+
     return (0);
 err:
     return (rc);

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -121,7 +121,7 @@ ble_hs_evq_get(void)
 void
 ble_hs_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&ble_hs_evq, evq, &ble_hs_ev_start);
+    ble_hs_evq = evq;
 }
 
 int
@@ -637,6 +637,12 @@ ble_hs_init(void)
     ble_hci_trans_cfg_hs(ble_hs_hci_rx_evt, NULL, ble_hs_rx_data, NULL);
 
     ble_hs_evq_set(os_eventq_dflt_get());
+
+    /* Enqueue the start event to the default event queue.  Using the default
+     * queue ensures the event won't run until the end of main().  This allows
+     * the application to configure this package in the meantime.
+     */
+    os_eventq_put(os_eventq_dflt_get(), &ble_hs_ev_start);
 
 #if BLE_MONITOR
     ble_monitor_new_index(0, (uint8_t[6]){ }, "nimble0");

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -39,8 +39,6 @@ uint8_t g_dev_addr[BLE_DEV_ADDR_LEN];
 #define BLE_HS_TEST_UTIL_LE_OPCODE(ocf) \
     ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE, (ocf))
 
-struct os_eventq ble_hs_test_util_evq;
-
 static STAILQ_HEAD(, os_mbuf_pkthdr) ble_hs_test_util_prev_tx_queue;
 struct os_mbuf *ble_hs_test_util_prev_tx_cur;
 
@@ -2397,7 +2395,6 @@ ble_hs_test_util_init_no_start(void)
 {
     sysinit();
 
-    os_eventq_init(&ble_hs_test_util_evq);
     STAILQ_INIT(&ble_hs_test_util_prev_tx_queue);
     ble_hs_test_util_prev_tx_cur = NULL;
 
@@ -2413,8 +2410,6 @@ ble_hs_test_util_init_no_start(void)
     ble_hs_max_attrs = 64;
 
     ble_hs_test_util_prev_hci_tx_clear();
-
-    ble_hs_evq_set(&ble_hs_test_util_evq);
 
     ble_hs_cfg.store_read_cb = ble_hs_test_util_store_read;
     ble_hs_cfg.store_write_cb = ble_hs_test_util_store_write;

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -32,7 +32,6 @@ struct ble_l2cap_chan;
 struct hci_disconn_complete;
 struct hci_create_conn;
 
-extern struct os_eventq ble_hs_test_util_evq;
 extern const struct ble_gap_adv_params ble_hs_test_util_adv_params;
 
 struct ble_hs_test_util_num_completed_pkts_entry {

--- a/net/nimble/host/test/src/ble_os_test.c
+++ b/net/nimble/host/test/src/ble_os_test.c
@@ -368,7 +368,7 @@ static void
 ble_os_test_app_task_handler(void *arg)
 {
     while (1) {
-        os_eventq_run(&ble_hs_test_util_evq);
+        os_eventq_run(os_eventq_dflt_get());
     }
 }
 

--- a/net/oic/src/port/mynewt/adaptor.c
+++ b/net/oic/src/port/mynewt/adaptor.c
@@ -40,7 +40,7 @@ oc_evq_get(void)
 void
 oc_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&oc_evq, evq, NULL);
+    oc_evq = evq;
 }
 
 void

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -49,7 +49,7 @@ static struct console_input buf[MYNEWT_VAL(SHELL_MAX_CMD_QUEUED)];
 void
 shell_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&shell_evq, evq, NULL);
+    shell_evq = evq;
     console_set_queues(&avail_queue, shell_evq);
 }
 

--- a/test/runtest/src/runtest.c
+++ b/test/runtest/src/runtest.c
@@ -55,7 +55,7 @@ run_evq_get(void)
 void
 run_evq_set(struct os_eventq *evq)
 {
-    os_eventq_designate(&run_evq, evq, NULL);
+    run_evq = evq;
 }
 
 /*


### PR DESCRIPTION
Packages currently have two initialization phases: 1) init, and 2) start:

*init:* Runs automatically during sysinit.
*start:* A start event can optionally be put on the package's event queue; it runs when the event is processed.

The second phase is useful when the package has some settings that must be configure at runtime, but before the package starts.

The problem arises when a package is assigned a dedicated task and event queue.  If the task is higher priority than the default task, it will preempt the default task with the package's start event, before the application has had a chance to finish configuring the package.

This PR makes it so that start events always run in the default task, even if the package has been configured to run in a different one.  This ensures the start events won't run until the end of main() when the default event queue is processed.  Since start events always run in the default task, it is important that they not do much more than configure their package.