### PR TITLE
nimble/host: Refactor HCI commands sending functions

### DIFF
--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -257,19 +257,17 @@ ble_hs_hci_wait_for_ack(void)
 }
 
 int
-ble_hs_hci_cmd_tx(void *cmd, void *evt_buf, uint8_t evt_buf_len,
+ble_hs_hci_cmd_tx(uint16_t opcode, void *cmd, uint8_t cmd_len,
+                  void *evt_buf, uint8_t evt_buf_len,
                   uint8_t *out_evt_buf_len)
 {
     struct ble_hs_hci_ack ack;
-    uint16_t opcode;
     int rc;
-
-    opcode = get_le16(cmd);
 
     BLE_HS_DBG_ASSERT(ble_hs_hci_ack == NULL);
     ble_hs_hci_lock();
 
-    rc = ble_hs_hci_cmd_send_buf(cmd);
+    rc = ble_hs_hci_cmd_send_buf(opcode, cmd, cmd_len);
     if (rc != 0) {
         goto done;
     }
@@ -303,11 +301,11 @@ done:
 }
 
 int
-ble_hs_hci_cmd_tx_empty_ack(void *cmd)
+ble_hs_hci_cmd_tx_empty_ack(uint16_t opcode, void *cmd, uint8_t cmd_len)
 {
     int rc;
 
-    rc = ble_hs_hci_cmd_tx(cmd, NULL, 0, NULL);
+    rc = ble_hs_hci_cmd_tx(opcode, cmd, cmd_len, NULL, 0, NULL);
     if (rc != 0) {
         return rc;
     }

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -67,7 +67,7 @@ ble_hs_hci_cmd_write_hdr(uint8_t ogf, uint16_t ocf, uint8_t len, void *buf)
 }
 
 int
-ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len, const void *cmddata)
+ble_hs_hci_cmd_send(uint16_t opcode, uint8_t len, const void *cmddata)
 {
     uint8_t *buf;
     int rc;
@@ -75,7 +75,7 @@ ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len, const void *cmddata)
     buf = ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_CMD);
     BLE_HS_DBG_ASSERT(buf != NULL);
 
-    put_le16(buf, ogf << 10 | ocf);
+    put_le16(buf, opcode);
     buf[2] = len;
     if (len != 0) {
         memcpy(buf + BLE_HCI_CMD_HDR_LEN, cmddata, len);
@@ -83,7 +83,7 @@ ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len, const void *cmddata)
 
 #if !BLE_MONITOR
     BLE_HS_LOG(DEBUG, "ble_hs_hci_cmd_send: ogf=0x%02x ocf=0x%04x len=%d\n",
-               ogf, ocf, len);
+               BLE_HCI_OGF(opcode), BLE_HCI_OCF(opcode), len);
     ble_hs_log_flat_buf(buf, len + BLE_HCI_CMD_HDR_LEN);
     BLE_HS_LOG(DEBUG, "\n");
 #endif
@@ -100,12 +100,8 @@ ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len, const void *cmddata)
 }
 
 int
-ble_hs_hci_cmd_send_buf(void *buf)
+ble_hs_hci_cmd_send_buf(uint16_t opcode, void *buf, uint8_t buf_len)
 {
-    uint16_t opcode;
-    uint8_t *u8ptr;
-    uint8_t len;
-
     switch (ble_hs_sync_state) {
     case BLE_HS_SYNC_STATE_BAD:
         return BLE_HS_ENOTSYNCED;
@@ -124,13 +120,7 @@ ble_hs_hci_cmd_send_buf(void *buf)
         return BLE_HS_EUNKNOWN;
     }
 
-    u8ptr = buf;
-
-    opcode = get_le16(u8ptr + 0);
-    len = u8ptr[2];
-
-    return ble_hs_hci_cmd_send(BLE_HCI_OGF(opcode), BLE_HCI_OCF(opcode), len,
-                             u8ptr + BLE_HCI_CMD_HDR_LEN);
+    return ble_hs_hci_cmd_send(opcode, buf_len, buf);
 }
 
 
@@ -146,22 +136,7 @@ ble_hs_hci_cmd_send_buf(void *buf)
 static int
 ble_hs_hci_cmd_le_send(uint16_t ocf, uint8_t len, void *cmddata)
 {
-    return ble_hs_hci_cmd_send(BLE_HCI_OGF_LE, ocf, len, cmddata);
-}
-
-/**
- * Read BD_ADDR
- *
- * OGF = 0x04 (Informational parameters)
- * OCF = 0x0009
- */
-void
-ble_hs_hci_cmd_build_read_bd_addr(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_INFO_PARAMS,
-                             BLE_HCI_OCF_IP_RD_BD_ADDR,
-                             0, dst);
+    return ble_hs_hci_cmd_send(BLE_HCI_OP(BLE_HCI_OGF_LE, ocf), len, cmddata);
 }
 
 static int
@@ -230,12 +205,7 @@ int
 ble_hs_hci_cmd_build_le_set_adv_params(const struct hci_adv_params *adv,
                                        uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_ADV_PARAM_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_PARAMS,
-                       BLE_HCI_SET_ADV_PARAM_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_ADV_PARAM_LEN);
 
     return ble_hs_hci_cmd_body_le_set_adv_params(adv, dst);
 }
@@ -284,12 +254,7 @@ int
 ble_hs_hci_cmd_build_le_set_adv_data(const uint8_t *data, uint8_t len,
                                      uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_ADV_DATA_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_DATA,
-                       BLE_HCI_SET_ADV_DATA_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_ADV_DATA_LEN);
 
     return ble_hs_hci_cmd_body_le_set_adv_data(data, len, dst);
 }
@@ -315,12 +280,7 @@ int
 ble_hs_hci_cmd_build_le_set_scan_rsp_data(const uint8_t *data, uint8_t len,
                                           uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_SCAN_RSP_DATA_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_SCAN_RSP_DATA,
-                       BLE_HCI_SET_SCAN_RSP_DATA_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_SCAN_RSP_DATA_LEN);
 
     return ble_hs_hci_cmd_body_le_set_scan_rsp_data(data, len, dst);
 }
@@ -335,13 +295,7 @@ void
 ble_hs_hci_cmd_build_set_event_mask(uint64_t event_mask,
                                     uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_EVENT_MASK_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_CTLR_BASEBAND,
-                       BLE_HCI_OCF_CB_SET_EVENT_MASK,
-                       BLE_HCI_SET_EVENT_MASK_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_EVENT_MASK_LEN);
 
     ble_hs_hci_cmd_body_set_event_mask(event_mask, dst);
 }
@@ -350,13 +304,7 @@ void
 ble_hs_hci_cmd_build_set_event_mask2(uint64_t event_mask,
                                      uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_EVENT_MASK_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_CTLR_BASEBAND,
-                       BLE_HCI_OCF_CB_SET_EVENT_MASK2,
-                       BLE_HCI_SET_EVENT_MASK_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_EVENT_MASK_LEN);
 
     ble_hs_hci_cmd_body_set_event_mask(event_mask, dst);
 }
@@ -372,12 +320,7 @@ void
 ble_hs_hci_cmd_build_disconnect(uint16_t handle, uint8_t reason,
                                 uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_DISCONNECT_CMD_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LINK_CTRL, BLE_HCI_OCF_DISCONNECT_CMD,
-                             BLE_HCI_DISCONNECT_CMD_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_DISCONNECT_CMD_LEN);
 
     ble_hs_hci_cmd_body_disconnect(handle, reason, dst);
 }
@@ -392,56 +335,9 @@ void
 ble_hs_hci_cmd_build_le_set_event_mask(uint64_t event_mask,
                                        uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_LE_EVENT_MASK_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                       BLE_HCI_OCF_LE_SET_EVENT_MASK,
-                       BLE_HCI_SET_LE_EVENT_MASK_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_LE_EVENT_MASK_LEN);
 
     ble_hs_hci_cmd_body_le_set_event_mask(event_mask, dst);
-}
-
-/**
- * LE Read buffer size
- *
- * OGF = 0x08 (LE)
- * OCF = 0x0002
- *
- * @return int
- */
-void
-ble_hs_hci_cmd_build_le_read_buffer_size(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_BUF_SIZE,
-                             0, dst);
-}
-
-/**
- * LE Read buffer size
- *
- * OGF = 0x08 (LE)
- * OCF = 0x0002
- *
- * @return int
- */
-int
-ble_hs_hci_cmd_le_read_buffer_size(void)
-{
-    return ble_hs_hci_cmd_le_send(BLE_HCI_OCF_LE_RD_BUF_SIZE, 0, NULL);
-}
-
-/**
- * OGF=LE, OCF=0x0003
- */
-void
-ble_hs_hci_cmd_build_le_read_loc_supp_feat(uint8_t *dst, uint8_t dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_LOC_SUPP_FEAT,
-                       0, dst);
 }
 
 static void
@@ -454,12 +350,7 @@ void
 ble_hs_hci_cmd_build_le_set_adv_enable(uint8_t enable, uint8_t *dst,
                                        int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_ADV_ENABLE_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_ENABLE,
-                       BLE_HCI_SET_ADV_ENABLE_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_ADV_ENABLE_LEN);
 
     ble_hs_hci_cmd_body_le_set_adv_enable(enable, dst);
 }
@@ -511,12 +402,7 @@ ble_hs_hci_cmd_build_le_set_scan_params(uint8_t scan_type,
                                         uint8_t filter_policy,
                                         uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_SCAN_PARAM_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_SCAN_PARAMS,
-                       BLE_HCI_SET_SCAN_PARAM_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_SCAN_PARAM_LEN);
 
     return ble_hs_hci_cmd_body_le_set_scan_params(scan_type, scan_itvl,
                                               scan_window, own_addr_type,
@@ -535,14 +421,9 @@ void
 ble_hs_hci_cmd_build_le_set_scan_enable(uint8_t enable, uint8_t filter_dups,
                                         uint8_t *dst, uint8_t dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_SCAN_ENABLE_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_SCAN_ENABLE_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_SCAN_ENABLE,
-                       BLE_HCI_SET_SCAN_ENABLE_LEN, dst);
-
-    ble_hs_hci_cmd_body_le_set_scan_enable(enable, filter_dups,
-                                         dst + BLE_HCI_CMD_HDR_LEN);
+    ble_hs_hci_cmd_body_le_set_scan_enable(enable, filter_dups, dst);
 }
 
 static int
@@ -623,22 +504,9 @@ int
 ble_hs_hci_cmd_build_le_create_connection(const struct hci_create_conn *hcc,
                                           uint8_t *cmd, int cmd_len)
 {
-    BLE_HS_DBG_ASSERT(
-        cmd_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CREATE_CONN_LEN);
+    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_CREATE_CONN_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CREATE_CONN,
-                       BLE_HCI_CREATE_CONN_LEN, cmd);
-
-    return ble_hs_hci_cmd_body_le_create_connection(hcc,
-                                                cmd + BLE_HCI_CMD_HDR_LEN);
-}
-
-void
-ble_hs_hci_cmd_build_le_clear_whitelist(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CLEAR_WHITE_LIST,
-                       0, dst);
+    return ble_hs_hci_cmd_body_le_create_connection(hcc, cmd);
 }
 
 int
@@ -646,22 +514,9 @@ ble_hs_hci_cmd_build_le_add_to_whitelist(const uint8_t *addr,
                                          uint8_t addr_type,
                                          uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CHG_WHITE_LIST_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_WHITE_LIST,
-                       BLE_HCI_CHG_WHITE_LIST_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CHG_WHITE_LIST_LEN);
 
     return ble_hs_hci_cmd_body_le_whitelist_chg(addr, addr_type, dst);
-}
-
-void
-ble_hs_hci_cmd_build_reset(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_RESET,
-                       0, dst);
 }
 
 /**
@@ -672,17 +527,11 @@ ble_hs_hci_cmd_build_reset(uint8_t *dst, int dst_len)
 int
 ble_hs_hci_cmd_reset(void)
 {
-    return ble_hs_hci_cmd_send(BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_RESET,
+    return ble_hs_hci_cmd_send(BLE_HCI_OP(BLE_HCI_OGF_CTLR_BASEBAND,
+                                          BLE_HCI_OCF_CB_RESET),
                                0, NULL);
 }
 
-void
-ble_hs_hci_cmd_build_read_adv_pwr(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR,
-                             0, dst);
-}
 
 /**
  * Read the transmit power level used for LE advertising channel packets.
@@ -692,23 +541,17 @@ ble_hs_hci_cmd_build_read_adv_pwr(uint8_t *dst, int dst_len)
 int
 ble_hs_hci_cmd_read_adv_pwr(void)
 {
-    return ble_hs_hci_cmd_send(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR,
-                             0, NULL);
-}
-
-void
-ble_hs_hci_cmd_build_le_create_conn_cancel(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CREATE_CONN_CANCEL,
-                       0, dst);
+    return ble_hs_hci_cmd_send(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                          BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR),
+                               0, NULL);
 }
 
 int
 ble_hs_hci_cmd_le_create_conn_cancel(void)
 {
-    return ble_hs_hci_cmd_send(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CREATE_CONN_CANCEL,
-                           0, NULL);
+    return ble_hs_hci_cmd_send(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                          BLE_HCI_OCF_LE_CREATE_CONN_CANCEL),
+                               0, NULL);
 }
 
 static int
@@ -731,12 +574,7 @@ int
 ble_hs_hci_cmd_build_le_conn_update(const struct hci_conn_update *hcu,
                                     uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CONN_UPDATE_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CONN_UPDATE,
-                       BLE_HCI_CONN_UPDATE_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CONN_UPDATE_LEN);
 
     return ble_hs_hci_cmd_body_le_conn_update(hcu, dst);
 }
@@ -782,12 +620,7 @@ void
 ble_hs_hci_cmd_build_le_lt_key_req_reply(
     const struct hci_lt_key_req_reply *hkr, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LT_KEY_REQ_REPLY_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_LT_KEY_REQ_REPLY,
-                       BLE_HCI_LT_KEY_REQ_REPLY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LT_KEY_REQ_REPLY_LEN);
 
     ble_hs_hci_cmd_body_le_lt_key_req_reply(hkr, dst);
 }
@@ -796,15 +629,9 @@ void
 ble_hs_hci_cmd_build_le_lt_key_req_neg_reply(uint16_t conn_handle,
                                              uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_LT_KEY_REQ_NEG_REPLY,
-                             BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
-
-    put_le16(dst + 0, conn_handle);
+    put_le16(dst, conn_handle);
 }
 
 static void
@@ -824,12 +651,7 @@ void
 ble_hs_hci_cmd_build_le_conn_param_reply(
     const struct hci_conn_param_reply *hcr, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CONN_PARAM_REPLY_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_REM_CONN_PARAM_RR,
-                       BLE_HCI_CONN_PARAM_REPLY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CONN_PARAM_REPLY_LEN);
 
     ble_hs_hci_cmd_body_le_conn_param_reply(hcr, dst);
 }
@@ -864,12 +686,7 @@ void
 ble_hs_hci_cmd_build_le_conn_param_neg_reply(
     const struct hci_conn_param_neg_reply *hcn, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CONN_PARAM_NEG_REPLY_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_REM_CONN_PARAM_NRR,
-                       BLE_HCI_CONN_PARAM_NEG_REPLY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CONN_PARAM_NEG_REPLY_LEN);
 
     ble_hs_hci_cmd_body_le_conn_param_neg_reply(hcn, dst);
 }
@@ -884,21 +701,6 @@ ble_hs_hci_cmd_le_conn_param_neg_reply(
 
     return ble_hs_hci_cmd_le_send(BLE_HCI_OCF_LE_REM_CONN_PARAM_NRR,
                               BLE_HCI_CONN_PARAM_NEG_REPLY_LEN, cmd);
-}
-
-/**
- * Get random data
- *
- * OGF = 0x08 (LE)
- * OCF = 0x0018
- *
- * @return int
- */
-void
-ble_hs_hci_cmd_build_le_rand(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RAND, 0, dst);
 }
 
 static void
@@ -918,12 +720,7 @@ void
 ble_hs_hci_cmd_build_le_start_encrypt(const struct hci_start_encrypt *cmd,
                                       uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_START_ENCRYPT_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_START_ENCRYPT,
-                       BLE_HCI_LE_START_ENCRYPT_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_START_ENCRYPT_LEN);
 
     ble_hs_hci_cmd_body_le_start_encrypt(cmd, dst);
 }
@@ -946,12 +743,7 @@ ble_hs_hci_cmd_body_read_rssi(uint16_t handle, uint8_t *dst)
 void
 ble_hs_hci_cmd_build_read_rssi(uint16_t handle, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_READ_RSSI_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_STATUS_PARAMS, BLE_HCI_OCF_RD_RSSI,
-                       BLE_HCI_READ_RSSI_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_READ_RSSI_LEN);
 
     ble_hs_hci_cmd_body_read_rssi(handle, dst);
 }
@@ -966,14 +758,7 @@ void
 ble_hs_hci_cmd_build_le_set_host_chan_class(const uint8_t *chan_map,
                                             uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_HOST_CHAN_CLASS_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_SET_HOST_CHAN_CLASS,
-                             BLE_HCI_SET_HOST_CHAN_CLASS_LEN,
-                             dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_HOST_CHAN_CLASS_LEN);
 
     memcpy(dst, chan_map, BLE_HCI_SET_HOST_CHAN_CLASS_LEN);
 }
@@ -988,14 +773,7 @@ void
 ble_hs_hci_cmd_build_le_read_chan_map(uint16_t conn_handle,
                                       uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_RD_CHANMAP_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_RD_CHAN_MAP,
-                             BLE_HCI_RD_CHANMAP_LEN,
-                             dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_RD_CHANMAP_LEN);
 
     put_le16(dst + 0, conn_handle);
 }
@@ -1033,12 +811,7 @@ ble_hs_hci_cmd_build_set_data_len(uint16_t connection_handle,
                                   uint16_t tx_octets, uint16_t tx_time,
                                   uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_DATALEN_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_DATA_LEN,
-                       BLE_HCI_SET_DATALEN_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_DATALEN_LEN);
 
     return ble_hs_hci_cmd_body_set_data_len(connection_handle, tx_octets,
                                           tx_time, dst);
@@ -1076,15 +849,10 @@ ble_hs_hci_cmd_build_add_to_resolv_list(
     uint8_t *dst,
     int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_ADD_TO_RESOLV_LIST_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST,
-                       BLE_HCI_ADD_TO_RESOLV_LIST_LEN, dst);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_ADD_TO_RESOLV_LIST_LEN);
 
     return ble_hs_hci_cmd_body_add_to_resolv_list(
-            padd->addr_type, padd->addr, padd->peer_irk, padd->local_irk,
-            dst + BLE_HCI_CMD_HDR_LEN);
+            padd->addr_type, padd->addr, padd->peer_irk, padd->local_irk, dst);
 }
 
 static int
@@ -1107,37 +875,9 @@ ble_hs_hci_cmd_build_remove_from_resolv_list(uint8_t addr_type,
                                              const uint8_t *addr,
                                              uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_RMV_FROM_RESOLV_LIST_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_RMV_FROM_RESOLV_LIST_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RMV_RESOLV_LIST,
-                       BLE_HCI_RMV_FROM_RESOLV_LIST_LEN, dst);
-
-    return ble_hs_hci_cmd_body_remove_from_resolv_list(addr_type, addr,
-                                                dst + BLE_HCI_CMD_HDR_LEN);
-}
-
-int
-ble_hs_hci_cmd_build_clear_resolv_list(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CLR_RESOLV_LIST,
-                       0, dst);
-
-    return 0;
-}
-
-int
-ble_hs_hci_cmd_build_read_resolv_list_size(uint8_t *dst, int dst_len)
-{
-    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CMD_HDR_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_RD_RESOLV_LIST_SIZE,
-                             0, dst);
-
-    return 0;
+    return ble_hs_hci_cmd_body_remove_from_resolv_list(addr_type, addr, dst);
 }
 
 static int
@@ -1160,16 +900,10 @@ ble_hs_hci_cmd_build_read_peer_resolv_addr(uint8_t peer_identity_addr_type,
                                            uint8_t *dst,
                                            int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_RD_PEER_RESOLV_ADDR_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_RD_PEER_RESOLV_ADDR,
-                             BLE_HCI_RD_PEER_RESOLV_ADDR_LEN, dst);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_RD_PEER_RESOLV_ADDR_LEN);
 
     return ble_hs_hci_cmd_body_read_peer_resolv_addr(peer_identity_addr_type,
-                                                   peer_identity_addr,
-                                                   dst + BLE_HCI_CMD_HDR_LEN);
+                                                   peer_identity_addr, dst);
 }
 
 static int
@@ -1196,16 +930,10 @@ ble_hs_hci_cmd_build_read_lcl_resolv_addr(uint8_t local_identity_addr_type,
                                           uint8_t *dst,
                                           int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_RD_LOC_RESOLV_ADDR_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_RD_LOCAL_RESOLV_ADDR,
-                             BLE_HCI_RD_LOC_RESOLV_ADDR_LEN, dst);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_RD_LOC_RESOLV_ADDR_LEN);
 
     return ble_hs_hci_cmd_body_read_lcl_resolv_addr(local_identity_addr_type,
-                                                  local_identity_addr,
-                                                  dst + BLE_HCI_CMD_HDR_LEN);
+                                                  local_identity_addr, dst);
 }
 
 static int
@@ -1225,14 +953,9 @@ ble_hs_hci_cmd_body_set_addr_res_en(uint8_t enable, uint8_t *dst)
 int
 ble_hs_hci_cmd_build_set_addr_res_en(uint8_t enable, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_ADDR_RESOL_ENA_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_ADDR_RESOL_ENA_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADDR_RES_EN,
-                       BLE_HCI_SET_ADDR_RESOL_ENA_LEN, dst);
-
-    return ble_hs_hci_cmd_body_set_addr_res_en(enable,
-                                             dst + BLE_HCI_CMD_HDR_LEN);
+    return ble_hs_hci_cmd_body_set_addr_res_en(enable, dst);
 }
 
 static int
@@ -1254,14 +977,9 @@ int
 ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
     uint16_t timeout, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_RESOLV_PRIV_ADDR_TO_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_RESOLV_PRIV_ADDR_TO_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_RPA_TMO,
-                       BLE_HCI_SET_RESOLV_PRIV_ADDR_TO_LEN, dst);
-
-    return ble_hs_hci_cmd_body_set_resolv_priv_addr_timeout(
-        timeout, dst + BLE_HCI_CMD_HDR_LEN);
+    return ble_hs_hci_cmd_body_set_resolv_priv_addr_timeout(timeout, dst);
 }
 
 /*
@@ -1270,12 +988,7 @@ ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
 int
 ble_hs_hci_cmd_build_le_read_phy(uint16_t conn_handle, uint8_t *dst, int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_RD_PHY_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_PHY,
-                             BLE_HCI_LE_RD_PHY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_RD_PHY_LEN);
 
     put_le16(dst, conn_handle);
 
@@ -1339,14 +1052,9 @@ ble_hs_hci_cmd_build_le_set_default_phy(uint8_t tx_phys_mask, uint8_t rx_phys_ma
                                         uint8_t *dst, int dst_len)
 {
 
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_DEFAULT_PHY_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_SET_DEFAULT_PHY_LEN);
 
     memset(dst, 0, dst_len);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_DEFAULT_PHY,
-                             BLE_HCI_LE_SET_DEFAULT_PHY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
 
     return ble_hs_hci_cmd_body_le_set_default_phy(tx_phys_mask, rx_phys_mask,
                                                   dst);
@@ -1392,14 +1100,9 @@ ble_hs_hci_cmd_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
                                 uint8_t *dst, int dst_len)
 {
 
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_PHY_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_SET_PHY_LEN);
 
     memset(dst, 0, dst_len);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PHY,
-                             BLE_HCI_LE_SET_PHY_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
 
     return ble_hs_hci_cmd_body_le_set_phy(conn_handle, tx_phys_mask,
                                           rx_phys_mask, phy_opts, dst);
@@ -1431,12 +1134,7 @@ ble_hs_hci_cmd_build_le_enh_recv_test(uint8_t rx_chan, uint8_t phy,
                                       uint8_t mod_idx,
                                       uint8_t *dst, uint16_t dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-            dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_ENH_RCVR_TEST_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ENH_RCVR_TEST,
-                             BLE_HCI_LE_ENH_RCVR_TEST_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_ENH_RCVR_TEST_LEN);
 
     return ble_hs_hci_cmd_body_le_enhanced_recv_test(rx_chan, phy, mod_idx, dst);
 }
@@ -1471,12 +1169,7 @@ ble_hs_hci_cmd_build_le_enh_trans_test(uint8_t tx_chan, uint8_t test_data_len,
                                        uint8_t packet_payload_idx, uint8_t phy,
                                        uint8_t *dst, uint16_t dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-            dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_ENH_TRANS_TEST_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ENH_TRANS_TEST,
-                             BLE_HCI_LE_ENH_TRANS_TEST_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_ENH_TRANS_TEST_LEN);
 
     return ble_hs_hci_cmd_body_le_enhanced_trans_test(tx_chan, test_data_len,
                                                       packet_payload_idx,
@@ -1560,23 +1253,12 @@ ble_hs_hci_cmd_build_le_set_ext_scan_params(uint8_t own_addr_type,
                                             struct ble_hs_hci_ext_scan_param *params[],
                                             uint8_t *dst, uint16_t dst_len)
 {
-
-    uint8_t cmd_len = 0;
-
     if (phy_count == 0) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
-    cmd_len = BLE_HCI_LE_EXT_SCAN_BASE_LEN +
-                    BLE_HCI_LE_EXT_SCAN_SINGLE_PARAM_LEN * phy_count;
-
-    BLE_HS_DBG_ASSERT(
-            dst_len >= BLE_HCI_CMD_HDR_LEN + cmd_len);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_SET_EXT_SCAN_PARAM,
-                             cmd_len, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_EXT_SCAN_BASE_LEN +
+                              BLE_HCI_LE_EXT_SCAN_SINGLE_PARAM_LEN * phy_count);
 
     return ble_hs_hci_cmd_body_le_set_ext_scan_param(own_addr_type,
                                                      filter_policy,
@@ -1614,17 +1296,10 @@ ble_hs_hci_cmd_build_le_set_ext_scan_enable(uint8_t enable,
                                             uint8_t *dst, uint16_t dst_len)
 {
 
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_EXT_SCAN_ENABLE_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_SET_EXT_SCAN_ENABLE_LEN);
 
-        ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE,
-                                 BLE_HCI_OCF_LE_SET_EXT_SCAN_ENABLE,
-                                 BLE_HCI_LE_SET_EXT_SCAN_ENABLE_LEN, dst);
-        dst += BLE_HCI_CMD_HDR_LEN;
-
-        return ble_hs_hci_cmd_body_le_set_ext_scan_enable(enable,
-                                                          filter_dups,
-                                                          duration, period, dst);
+    return ble_hs_hci_cmd_body_le_set_ext_scan_enable(enable, filter_dups,
+                                                      duration, period, dst);
 }
 
 static int
@@ -1763,7 +1438,7 @@ ble_hs_hci_cmd_build_le_ext_create_conn(const struct hci_ext_create_conn *hcc,
 {
     uint8_t size;
 
-    size = BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_EXT_CREATE_CONN_BASE_LEN;
+    size = BLE_HCI_LE_EXT_CREATE_CONN_BASE_LEN;
     if (hcc->init_phy_mask & BLE_HCI_LE_PHY_1M_PREF_MASK) {
         size += sizeof(struct hci_ext_conn_params);
     }
@@ -1778,11 +1453,7 @@ ble_hs_hci_cmd_build_le_ext_create_conn(const struct hci_ext_create_conn *hcc,
 
     BLE_HS_DBG_ASSERT(cmd_len >= size);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_EXT_CREATE_CONN,
-                             size, cmd);
-
-    return ble_hs_hci_cmd_body_le_ext_create_conn(hcc,
-                                                  cmd + BLE_HCI_CMD_HDR_LEN);
+    return ble_hs_hci_cmd_body_le_ext_create_conn(hcc, cmd);
 }
 
 int
@@ -1790,12 +1461,7 @@ ble_hs_hci_cmd_build_le_ext_adv_set_random_addr(uint8_t handle,
                                                 const uint8_t *addr,
                                                 uint8_t *cmd, int cmd_len)
 {
-    BLE_HS_DBG_ASSERT(cmd_len >=
-                    BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_ADV_SET_RND_ADDR_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_SET_RND_ADDR,
-                             BLE_HCI_LE_SET_ADV_SET_RND_ADDR_LEN, cmd);
-    cmd += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_LE_SET_ADV_SET_RND_ADDR_LEN);
 
     cmd[0] = handle;
     memcpy(cmd + 1, addr, BLE_DEV_ADDR_LEN);
@@ -1809,11 +1475,7 @@ ble_hs_hci_cmd_build_le_ext_adv_data(uint8_t handle, uint8_t operation,
                                      const uint8_t *data, uint8_t data_len,
                                      uint8_t *cmd, int cmd_len)
 {
-    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_CMD_HDR_LEN + 4 + data_len);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_DATA,
-                             4 + data_len, cmd);
-    cmd += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(cmd_len >= 4 + data_len);
 
     cmd[0] = handle;
     cmd[1] = operation;
@@ -1830,11 +1492,7 @@ ble_hs_hci_cmd_build_le_ext_adv_scan_rsp(uint8_t handle, uint8_t operation,
                                          const uint8_t *data, uint8_t data_len,
                                          uint8_t *cmd, int cmd_len)
 {
-    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_CMD_HDR_LEN + 4 + data_len);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_SCAN_RSP_DATA,
-                             4 + data_len, cmd);
-    cmd += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(cmd_len >= 4 + data_len);
 
     cmd[0] = handle;
     cmd[1] = operation;
@@ -1852,11 +1510,7 @@ ble_hs_hci_cmd_build_le_ext_adv_enable(uint8_t enable, uint8_t sets_num,
 {
     int i;
 
-    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_CMD_HDR_LEN + 2 + (sets_num * 4));
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_ENABLE,
-                             2 + (sets_num * 4), cmd);
-    cmd += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(cmd_len >= 2 + (sets_num * 4));
 
     cmd[0] = enable;
     cmd[1] = sets_num;
@@ -1881,12 +1535,7 @@ ble_hs_hci_cmd_build_le_ext_adv_params(uint8_t handle,
 {
     uint32_t tmp;
 
-    BLE_HS_DBG_ASSERT(cmd_len >=
-                      BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_EXT_ADV_PARAM_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_PARAM,
-                             BLE_HCI_LE_SET_EXT_ADV_PARAM_LEN, cmd);
-    cmd += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_LE_SET_EXT_ADV_PARAM_LEN);
 
     cmd[0] = handle;
     put_le16(&cmd[1], params->properties);
@@ -1940,12 +1589,7 @@ ble_hs_hci_cmd_build_le_set_priv_mode(const uint8_t *addr, uint8_t addr_type,
                                       uint8_t priv_mode, uint8_t *dst,
                                       uint16_t dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_PRIVACY_MODE_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE,
-                             BLE_HCI_LE_SET_PRIVACY_MODE_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_LE_SET_PRIVACY_MODE_LEN);
 
     return ble_hs_hci_cmd_body_le_set_priv_mode(addr, addr_type, priv_mode, dst);
 }
@@ -1966,14 +1610,9 @@ ble_hs_hci_cmd_build_set_random_addr(const uint8_t *addr,
 
     memcpy(r_addr.addr, addr, sizeof(r_addr.addr));
 
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_RAND_ADDR_LEN);
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_SET_RAND_ADDR_LEN);
 
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_RAND_ADDR,
-                       BLE_HCI_SET_RAND_ADDR_LEN, dst);
-
-    return ble_hs_hci_cmd_body_set_random_addr(&r_addr,
-                                             dst + BLE_HCI_CMD_HDR_LEN);
+    return ble_hs_hci_cmd_body_set_random_addr(&r_addr, dst);
 }
 
 static void
@@ -1986,12 +1625,7 @@ int
 ble_hs_hci_cmd_build_le_read_remote_feat(uint16_t handle, uint8_t *dst,
                                                                  int dst_len)
 {
-    BLE_HS_DBG_ASSERT(
-        dst_len >= BLE_HCI_CMD_HDR_LEN + BLE_HCI_CONN_RD_REM_FEAT_LEN);
-
-    ble_hs_hci_cmd_write_hdr(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_REM_FEAT,
-                             BLE_HCI_CONN_RD_REM_FEAT_LEN, dst);
-    dst += BLE_HCI_CMD_HDR_LEN;
+    BLE_HS_DBG_ASSERT(dst_len >= BLE_HCI_CONN_RD_REM_FEAT_LEN);
 
     ble_hs_hci_cmd_body_le_read_remote_feat(handle, dst);
 

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -69,9 +69,10 @@ struct ble_hs_hci_ext_conn_params {
 };
 #endif
 
-int ble_hs_hci_cmd_tx(void *cmd, void *evt_buf, uint8_t evt_buf_len,
+int ble_hs_hci_cmd_tx(uint16_t opcode, void *cmd, uint8_t cmd_len,
+                      void *evt_buf, uint8_t evt_buf_len,
                       uint8_t *out_evt_buf_len);
-int ble_hs_hci_cmd_tx_empty_ack(void *cmd);
+int ble_hs_hci_cmd_tx_empty_ack(uint16_t opcode, void *cmd, uint8_t cmd_len);
 void ble_hs_hci_rx_ack(uint8_t *ack_ev);
 void ble_hs_hci_init(void);
 
@@ -96,10 +97,9 @@ int ble_hs_hci_evt_process(uint8_t *data);
 uint16_t ble_hs_hci_util_opcode_join(uint8_t ogf, uint16_t ocf);
 void ble_hs_hci_cmd_write_hdr(uint8_t ogf, uint16_t ocf, uint8_t len,
                               void *buf);
-int ble_hs_hci_cmd_send(uint8_t ogf, uint16_t ocf, uint8_t len,
+int ble_hs_hci_cmd_send(uint16_t opcode, uint8_t len,
                         const void *cmddata);
-int ble_hs_hci_cmd_send_buf(void *cmddata);
-void ble_hs_hci_cmd_build_read_bd_addr(uint8_t *dst, int dst_len);
+int ble_hs_hci_cmd_send_buf(uint16_t opcode, void *buf, uint8_t buf_len);
 void ble_hs_hci_cmd_build_set_event_mask(uint64_t event_mask,
                                          uint8_t *dst, int dst_len);
 void ble_hs_hci_cmd_build_set_event_mask2(uint64_t event_mask, uint8_t *dst,
@@ -120,9 +120,7 @@ int ble_hs_hci_cmd_build_le_set_adv_params(const struct hci_adv_params *adv,
                                            uint8_t *dst, int dst_len);
 void ble_hs_hci_cmd_build_le_set_event_mask(uint64_t event_mask,
                                             uint8_t *dst, int dst_len);
-void ble_hs_hci_cmd_build_le_read_buffer_size(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_le_read_buffer_size(void);
-void ble_hs_hci_cmd_build_le_read_loc_supp_feat(uint8_t *dst, uint8_t dst_len);
 void ble_hs_hci_cmd_build_le_set_adv_enable(uint8_t enable, uint8_t *dst,
                                             int dst_len);
 int ble_hs_hci_cmd_le_set_adv_enable(uint8_t enable);
@@ -138,15 +136,11 @@ void ble_hs_hci_cmd_build_le_set_scan_enable(uint8_t enable,
 int ble_hs_hci_cmd_le_set_scan_enable(uint8_t enable, uint8_t filter_dups);
 int ble_hs_hci_cmd_build_le_create_connection(
     const struct hci_create_conn *hcc, uint8_t *cmd, int cmd_len);
-void ble_hs_hci_cmd_build_le_clear_whitelist(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_build_le_add_to_whitelist(const uint8_t *addr,
                                              uint8_t addr_type,
                                              uint8_t *dst, int dst_len);
-void ble_hs_hci_cmd_build_reset(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_reset(void);
-void ble_hs_hci_cmd_build_read_adv_pwr(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_read_adv_pwr(void);
-void ble_hs_hci_cmd_build_le_create_conn_cancel(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_le_create_conn_cancel(void);
 int ble_hs_hci_cmd_build_le_conn_update(const struct hci_conn_update *hcu,
                                         uint8_t *dst, int dst_len);
@@ -162,7 +156,6 @@ void ble_hs_hci_cmd_build_le_conn_param_neg_reply(
     const struct hci_conn_param_neg_reply *hcn, uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_le_conn_param_neg_reply(
     const struct hci_conn_param_neg_reply *hcn);
-void ble_hs_hci_cmd_build_le_rand(uint8_t *dst, int dst_len);
 void ble_hs_hci_cmd_build_le_start_encrypt(const struct hci_start_encrypt *cmd,
                                            uint8_t *dst, int dst_len);
 int ble_hs_hci_set_buf_sz(uint16_t pktlen, uint8_t max_pkts);
@@ -180,8 +173,6 @@ int ble_hs_hci_cmd_build_add_to_resolv_list(
     uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_build_remove_from_resolv_list(
     uint8_t addr_type, const uint8_t *addr, uint8_t *dst, int dst_len);
-int ble_hs_hci_cmd_build_read_resolv_list_size(uint8_t *dst, int dst_len);
-int ble_hs_hci_cmd_build_clear_resolv_list(uint8_t *dst, int dst_len);
 int ble_hs_hci_cmd_build_read_peer_resolv_addr(
     uint8_t peer_identity_addr_type, const uint8_t *peer_identity_addr,
     uint8_t *dst, int dst_len);

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -33,23 +33,24 @@ const uint8_t default_irk[16] = {
 static int
 ble_hs_pvcy_set_addr_timeout(uint16_t timeout)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_RESOLV_PRIV_ADDR_TO_LEN];
+    uint8_t buf[BLE_HCI_SET_RESOLV_PRIV_ADDR_TO_LEN];
     int rc;
 
-    rc = ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(
-            timeout, buf, sizeof(buf));
-
+    rc = ble_hs_hci_cmd_build_set_resolv_priv_addr_timeout(timeout, buf,
+                                                           sizeof(buf));
     if (rc != 0) {
         return rc;
     }
 
-    return ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    return ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                        BLE_HCI_OCF_LE_SET_RPA_TMO),
+                             buf, sizeof(buf), NULL, 0, NULL);
 }
 
 static int
 ble_hs_pvcy_set_resolve_enabled(int enable)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_ADDR_RESOL_ENA_LEN];
+    uint8_t buf[BLE_HCI_SET_ADDR_RESOL_ENA_LEN];
     int rc;
 
     rc = ble_hs_hci_cmd_build_set_addr_res_en(enable, buf, sizeof(buf));
@@ -57,7 +58,9 @@ ble_hs_pvcy_set_resolve_enabled(int enable)
         return rc;
     }
 
-    rc = ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
+                           buf, sizeof(buf), NULL, 0, NULL);
     if (rc != 0) {
         return rc;
     }
@@ -68,16 +71,18 @@ ble_hs_pvcy_set_resolve_enabled(int enable)
 int
 ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_RMV_FROM_RESOLV_LIST_LEN];
+    uint8_t buf[BLE_HCI_RMV_FROM_RESOLV_LIST_LEN];
     int rc;
 
-    rc = ble_hs_hci_cmd_build_remove_from_resolv_list(
-        addr_type, addr, buf, sizeof(buf));
+    rc = ble_hs_hci_cmd_build_remove_from_resolv_list(addr_type, addr,
+                                                      buf, sizeof(buf));
     if (rc != 0) {
         return rc;
     }
 
-    rc = ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_RMV_RESOLV_LIST),
+                           buf, sizeof(buf), NULL, 0, NULL);
     if (rc != 0) {
         return rc;
     }
@@ -88,15 +93,11 @@ ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr)
 static int
 ble_hs_pvcy_clear_entries(void)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN ];
     int rc;
 
-    rc = ble_hs_hci_cmd_build_clear_resolv_list(buf, sizeof(buf));
-    if (rc != 0) {
-        return rc;
-    }
-
-    rc = ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_CLR_RESOLV_LIST),
+                           NULL, 0, NULL, 0, NULL);
     if (rc != 0) {
         return rc;
     }
@@ -109,7 +110,7 @@ ble_hs_pvcy_add_entry(const uint8_t *addr, uint8_t addr_type,
                       const uint8_t *irk)
 {
     struct hci_add_dev_to_resolving_list add;
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_ADD_TO_RESOLV_LIST_LEN];
+    uint8_t buf[BLE_HCI_ADD_TO_RESOLV_LIST_LEN];
     int rc;
 
     add.addr_type = addr_type;
@@ -122,7 +123,9 @@ ble_hs_pvcy_add_entry(const uint8_t *addr, uint8_t addr_type,
         return rc;
     }
 
-    rc = ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
+                           buf, sizeof(buf), NULL, 0, NULL);
     if (rc != 0) {
         return rc;
     }
@@ -210,7 +213,7 @@ ble_hs_pvcy_our_irk(const uint8_t **out_irk)
 int
 ble_hs_pvcy_set_mode(const ble_addr_t *addr, uint8_t priv_mode)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_SET_PRIVACY_MODE_LEN];
+    uint8_t buf[BLE_HCI_LE_SET_PRIVACY_MODE_LEN];
     int rc;
 
     rc = ble_hs_hci_cmd_build_le_set_priv_mode(addr->val, addr->type, priv_mode,
@@ -219,5 +222,7 @@ ble_hs_pvcy_set_mode(const ble_addr_t *addr, uint8_t priv_mode)
         return rc;
     }
 
-    return ble_hs_hci_cmd_tx(buf, NULL, 0, NULL);
+    return ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                        BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
+                             buf, sizeof(buf), NULL, 0, NULL);
 }

--- a/net/nimble/host/src/ble_hs_startup.c
+++ b/net/nimble/host/src/ble_hs_startup.c
@@ -27,13 +27,13 @@ static int
 ble_hs_startup_le_read_sup_f_tx(void)
 {
     uint8_t ack_params[BLE_HCI_RD_LOC_SUPP_FEAT_RSPLEN];
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN];
     uint8_t ack_params_len;
     uint32_t feat;
     int rc;
 
-    ble_hs_hci_cmd_build_le_read_loc_supp_feat(buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx(buf, ack_params, sizeof ack_params,
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_RD_LOC_SUPP_FEAT),
+                           NULL,0, ack_params, sizeof ack_params,
                            &ack_params_len);
     if (rc != 0) {
         return rc;
@@ -55,14 +55,13 @@ ble_hs_startup_le_read_buf_sz_tx(void)
 {
     uint16_t pktlen;
     uint8_t ack_params[BLE_HCI_RD_BUF_SIZE_RSPLEN];
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN];
     uint8_t ack_params_len;
     uint8_t max_pkts;
     int rc;
 
-    ble_hs_hci_cmd_build_le_read_buffer_size(buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx(buf, ack_params, sizeof ack_params,
-                           &ack_params_len);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_RD_BUF_SIZE),NULL, 0,
+                           ack_params, sizeof ack_params, &ack_params_len);
     if (rc != 0) {
         return rc;
     }
@@ -86,12 +85,12 @@ static int
 ble_hs_startup_read_bd_addr(void)
 {
     uint8_t ack_params[BLE_HCI_IP_RD_BD_ADDR_ACK_PARAM_LEN];
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN];
     uint8_t ack_params_len;
     int rc;
 
-    ble_hs_hci_cmd_build_read_bd_addr(buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx(buf, ack_params, sizeof ack_params,
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_INFO_PARAMS,
+                                      BLE_HCI_OCF_IP_RD_BD_ADDR),
+                           NULL, 0, ack_params, sizeof ack_params,
                            &ack_params_len);
     if (rc != 0) {
         return rc;
@@ -108,7 +107,7 @@ ble_hs_startup_read_bd_addr(void)
 static int
 ble_hs_startup_le_set_evmask_tx(void)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_LE_EVENT_MASK_LEN];
+    uint8_t buf[BLE_HCI_SET_LE_EVENT_MASK_LEN];
     int rc;
 
     /**
@@ -130,7 +129,9 @@ ble_hs_startup_le_set_evmask_tx(void)
      *     0x0000000000080000 LE Channel Selection Algorithm Event
      */
     ble_hs_hci_cmd_build_le_set_event_mask(0x00000000000F1A7F, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                                BLE_HCI_OCF_LE_SET_EVENT_MASK),
+                                     buf, sizeof(buf));
     if (rc != 0) {
         return rc;
     }
@@ -141,7 +142,7 @@ ble_hs_startup_le_set_evmask_tx(void)
 static int
 ble_hs_startup_set_evmask_tx(void)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_SET_EVENT_MASK_LEN];
+    uint8_t buf[BLE_HCI_SET_EVENT_MASK_LEN];
     int rc;
 
     /**
@@ -153,7 +154,9 @@ ble_hs_startup_set_evmask_tx(void)
      *     0x2000000000000000 LE Meta-Event
      */
     ble_hs_hci_cmd_build_set_event_mask(0x2000000002008090, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_CTLR_BASEBAND,
+                                                BLE_HCI_OCF_CB_SET_EVENT_MASK),
+                                     buf, sizeof(buf));
     if (rc != 0) {
         return rc;
     }
@@ -163,7 +166,9 @@ ble_hs_startup_set_evmask_tx(void)
      *     0x0000000000800000 Authenticated Payload Timeout Event
      */
     ble_hs_hci_cmd_build_set_event_mask2(0x0000000000800000, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_CTLR_BASEBAND,
+                                                BLE_HCI_OCF_CB_SET_EVENT_MASK2),
+                                     buf, sizeof(buf));
     if (rc != 0) {
         BLE_HS_LOG(WARN, "ble_hs_startup_set_evmask_tx() failed\n");
     }
@@ -174,11 +179,11 @@ ble_hs_startup_set_evmask_tx(void)
 static int
 ble_hs_startup_reset_tx(void)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN];
     int rc;
 
-    ble_hs_hci_cmd_build_reset(buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_CTLR_BASEBAND,
+                                                BLE_HCI_OCF_CB_RESET),
+                                     NULL, 0);
     if (rc != 0) {
         return rc;
     }

--- a/net/nimble/host/src/ble_sm.c
+++ b/net/nimble/host/src/ble_sm.c
@@ -1036,11 +1036,13 @@ ble_sm_chk_store_overflow(uint16_t conn_handle)
 static int
 ble_sm_start_encrypt_tx(struct hci_start_encrypt *cmd)
 {
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LE_START_ENCRYPT_LEN];
+    uint8_t buf[BLE_HCI_LE_START_ENCRYPT_LEN];
     int rc;
 
     ble_hs_hci_cmd_build_le_start_encrypt(cmd, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx_empty_ack(buf);
+    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                                BLE_HCI_OCF_LE_START_ENCRYPT),
+                                          buf, sizeof(buf));
     if (rc != 0) {
         return rc;
     }
@@ -1223,7 +1225,7 @@ ble_sm_ltk_req_reply_tx(uint16_t conn_handle, uint8_t *ltk)
 {
     struct hci_lt_key_req_reply cmd;
     uint16_t ack_conn_handle;
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LT_KEY_REQ_REPLY_LEN];
+    uint8_t buf[BLE_HCI_LT_KEY_REQ_REPLY_LEN];
     uint8_t ack_params_len;
     int rc;
 
@@ -1231,8 +1233,10 @@ ble_sm_ltk_req_reply_tx(uint16_t conn_handle, uint8_t *ltk)
     memcpy(cmd.long_term_key, ltk, 16);
 
     ble_hs_hci_cmd_build_le_lt_key_req_reply(&cmd, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx(buf, &ack_conn_handle, sizeof ack_conn_handle,
-                           &ack_params_len);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_LT_KEY_REQ_REPLY),
+                           buf, sizeof(buf), &ack_conn_handle,
+                           sizeof(ack_conn_handle), &ack_params_len);
     if (rc != 0) {
         return rc;
     }
@@ -1251,13 +1255,15 @@ static int
 ble_sm_ltk_req_neg_reply_tx(uint16_t conn_handle)
 {
     uint16_t ack_conn_handle;
-    uint8_t buf[BLE_HCI_CMD_HDR_LEN + BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN];
+    uint8_t buf[BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN];
     uint8_t ack_params_len;
     int rc;
 
     ble_hs_hci_cmd_build_le_lt_key_req_neg_reply(conn_handle, buf, sizeof buf);
-    rc = ble_hs_hci_cmd_tx(buf, &ack_conn_handle, sizeof ack_conn_handle,
-                           &ack_params_len);
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_LT_KEY_REQ_NEG_REPLY),
+                           buf, sizeof(buf), &ack_conn_handle,
+                           sizeof(ack_conn_handle), &ack_params_len);
     if (rc != 0) {
         return rc;
     }

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -39,6 +39,9 @@ extern "C" {
 
 #define BLE_HCI_OPCODE_NOP                  (0)
 
+/* Set opcode based on OCF and OGF */
+#define BLE_HCI_OP(ogf, ocf)            ((ocf) | ((ogf) << 10))
+
 /* Get the OGF and OCF from the opcode in the command */
 #define BLE_HCI_OGF(opcode)                 (((opcode) >> 10) & 0x003F)
 #define BLE_HCI_OCF(opcode)                 ((opcode) & 0x03FF)


### PR DESCRIPTION
This refactors the way HCI commands are constructed and pass to
controller. Instead of embedding opcode and len in command parameters
buffer just pass it along with it. This has few adventages:
 - opcode OCF/OGF are contructed once on build time
 - buffer is always pass along with len
 - code is less confusing for static analysis tools (0 len buffer is
   always pass as NULL so no dangling pointers)
 - it is easier to follow (and debug)

Nice bonus is ROM size reduction of net_nimble_host.a (54304->53710).

This is also first step to making use of packed structures for HCI
command instead of builders functions. This should reduce code size
even further.