### PR TITLE
nimble: Allow to hide/restore services from clients in runtime

### DIFF
--- a/apps/bletiny/src/cmd.c
+++ b/apps/bletiny/src/cmd.c
@@ -4109,6 +4109,54 @@ cmd_svcchg(int argc, char **argv)
     return 0;
 }
 
+/*****************************************************************************
+ * $svcvis                                                                   *
+ *****************************************************************************/
+
+static void
+bletiny_svcvis_help(void)
+{
+#if !MYNEWT_VAL(BLETINY_HELP)
+    bletiny_help_disabled();
+    return;
+#endif
+
+    console_printf("Available svcvis params: \n");
+    help_cmd_uint16("handle");
+    help_cmd_bool("vis");
+}
+
+static int
+cmd_svcvis(int argc, char **argv)
+{
+    uint16_t handle;
+    bool vis;
+    int rc;
+
+    if (argc > 1 && strcmp(argv[1], "help") == 0) {
+        bletiny_svcvis_help();
+        return 0;
+    }
+
+    handle = parse_arg_uint16("handle", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'handle' parameter\n");
+        help_cmd_uint16("handle");
+        return rc;
+    }
+
+    vis = parse_arg_bool("vis", &rc);
+    if (rc != 0) {
+        console_printf("invalid 'vis' parameter\n");
+        help_cmd_bool("vis");
+        return rc;
+    }
+
+    ble_gatts_svc_set_visibility(handle, vis);
+
+    return 0;
+}
+
 static const struct cmd_entry cmd_phy_entries[];
 
 static int
@@ -4312,6 +4360,7 @@ static struct cmd_entry cmd_b_entries[] = {
     { "write",      cmd_write },
     { "svcchg",     cmd_svcchg },
     { "phy",        cmd_phy },
+    { "svcvis",     cmd_svcvis },
     { NULL, NULL }
 };
 

--- a/net/nimble/host/include/host/ble_gatt.h
+++ b/net/nimble/host/include/host/ble_gatt.h
@@ -416,6 +416,7 @@ typedef void ble_gatt_register_fn(struct ble_gatt_register_ctxt *ctxt,
                                   void *arg);
 
 int ble_gatts_add_svcs(const struct ble_gatt_svc_def *svcs);
+int ble_gatts_svc_set_visibility(uint16_t handle, int visible);
 int ble_gatts_count_cfg(const struct ble_gatt_svc_def *defs);
 
 void ble_gatts_chr_updated(uint16_t chr_def_handle);

--- a/net/nimble/host/src/ble_att_priv.h
+++ b/net/nimble/host/src/ble_att_priv.h
@@ -219,6 +219,8 @@ int ble_att_svr_read_handle(uint16_t conn_handle, uint16_t attr_handle,
 void ble_att_svr_reset(void);
 int ble_att_svr_init(void);
 
+void ble_att_svr_hide_range(uint16_t start_handle, uint16_t end_handle);
+void ble_att_svr_restore_range(uint16_t start_handle, uint16_t end_handle);
 
 /*** $clt */
 

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -46,6 +46,7 @@
 
 STAILQ_HEAD(ble_att_svr_entry_list, ble_att_svr_entry);
 static struct ble_att_svr_entry_list ble_att_svr_list;
+static struct ble_att_svr_entry_list ble_att_svr_hidden_list;
 
 static uint16_t ble_att_svr_id;
 
@@ -2654,6 +2655,80 @@ done:
     return rc;
 }
 
+static void
+ble_att_svr_move_entries(struct ble_att_svr_entry_list *src,
+                         struct ble_att_svr_entry_list *dst,
+                         uint16_t start_handle, uint16_t end_handle)
+{
+
+    struct ble_att_svr_entry *entry;
+    struct ble_att_svr_entry *prev;
+    struct ble_att_svr_entry *remove;
+    struct ble_att_svr_entry *insert;
+
+    /* Find first matching element to move */
+    remove = NULL;
+    entry = STAILQ_FIRST(src);
+    while (entry && entry->ha_handle_id < start_handle) {
+        remove = entry;
+        entry = STAILQ_NEXT(entry, ha_next);
+    }
+
+    /* Nothing to remove? */
+    if (!entry) {
+        return;
+    }
+
+    /* Find element after which we'll put moved elements */
+    prev = NULL;
+    insert = STAILQ_FIRST(dst);
+    while (insert && insert->ha_handle_id < start_handle) {
+        prev = insert;
+        insert = STAILQ_NEXT(insert, ha_next);
+    }
+    insert = prev;
+
+    /* Move elements */
+    while (entry && entry->ha_handle_id <= end_handle) {
+        /* Remove either from head or after prev (which is current one) */
+        if (remove == NULL) {
+            STAILQ_REMOVE_HEAD(src, ha_next);
+        } else {
+            STAILQ_REMOVE_AFTER(src, remove, ha_next);
+        }
+
+        /* Insert current element */
+        if (insert == NULL) {
+            STAILQ_INSERT_HEAD(dst, entry, ha_next);
+            insert = STAILQ_FIRST(dst);
+        } else {
+            STAILQ_INSERT_AFTER(dst, insert, entry, ha_next);
+            insert = entry;
+        }
+
+        /* Calculate next candidate to remove */
+        if (remove == NULL) {
+            entry = STAILQ_FIRST(src);
+        } else {
+            entry = STAILQ_NEXT(remove, ha_next);
+        }
+    }
+}
+
+void
+ble_att_svr_hide_range(uint16_t start_handle, uint16_t end_handle)
+{
+    ble_att_svr_move_entries(&ble_att_svr_list, &ble_att_svr_hidden_list,
+                             start_handle, end_handle);
+}
+
+void
+ble_att_svr_restore_range(uint16_t start_handle, uint16_t end_handle)
+{
+    ble_att_svr_move_entries(&ble_att_svr_hidden_list, &ble_att_svr_list,
+                             start_handle, end_handle);
+}
+
 void
 ble_att_svr_reset(void)
 {
@@ -2661,6 +2736,11 @@ ble_att_svr_reset(void)
 
     while ((entry = STAILQ_FIRST(&ble_att_svr_list)) != NULL) {
         STAILQ_REMOVE_HEAD(&ble_att_svr_list, ha_next);
+        ble_att_svr_entry_free(entry);
+    }
+
+    while ((entry = STAILQ_FIRST(&ble_att_svr_hidden_list)) != NULL) {
+        STAILQ_REMOVE_HEAD(&ble_att_svr_hidden_list, ha_next);
         ble_att_svr_entry_free(entry);
     }
 
@@ -2725,6 +2805,7 @@ ble_att_svr_init(void)
     }
 
     STAILQ_INIT(&ble_att_svr_list);
+    STAILQ_INIT(&ble_att_svr_hidden_list);
 
     ble_att_svr_id = 0;
 

--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -2000,6 +2000,27 @@ done:
     return rc;
 }
 
+int
+ble_gatts_svc_set_visibility(uint16_t handle, int visible)
+{
+    int i;
+
+    for (i = 0; i < ble_gatts_num_svc_entries; i++) {
+        struct ble_gatts_svc_entry *entry = &ble_gatts_svc_entries[i];
+
+        if (entry->handle == handle) {
+            if (visible) {
+                ble_att_svr_restore_range(entry->handle, entry->end_group_handle);
+            } else {
+                ble_att_svr_hide_range(entry->handle, entry->end_group_handle);
+            }
+            return 0;
+        }
+    }
+
+    return BLE_HS_ENOENT;
+}
+
 /**
  * Accumulates counts of each resource type required by the specified service
  * definition array.  This function is generally used to calculate some host


### PR DESCRIPTION
This is substitute for registering and unregistering services in runtime.

Instead of the above, we allow already registered service to be hidden from clients (its attributes are removed from attributes list in ATT server). This can be done at any time and does not need any in terms of GATT services handling - we just move attributes from "default" list to "hidden" list so they are not picked by any ATT API.

So basically, if there are services A and B which cannot exists in ATT DB at the same time (like in Mesh), application should register both of them and then just toggle visibility in runtime.