### PR TITLE
BLE Host - Don't abort reset if HCI restart fails.

### DIFF
--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -275,10 +275,11 @@ ble_hs_reset(void)
 
     ble_hs_sync_state = 0;
 
-    rc = ble_hci_trans_reset();
-    if (rc != 0) {
-        return rc;
-    }
+    /* Reset transport.  Assume success; there is nothing we can do in case of
+     * failure.  If the transport failed to reset, the host will reset itself
+     * again when it fails to sync with the controller.
+     */
+    (void)ble_hci_trans_reset();
 
     ble_hs_clear_data_queue(&ble_hs_tx_q);
     ble_hs_clear_data_queue(&ble_hs_rx_q);


### PR DESCRIPTION
While the host is resetting, it attempts to restart the HCI transport.  This may involve some communication with hardware.  For example, when the UART transport resets, it closes, reopens, and reconfigures the UART.

### Old behavior:
If the HCI transport fails to restart due to a hardware failure, the host aborts its reset.  As a consequence, stale connections remain open, and the reset callback does not get called.

### New behavior:
The host restarts the HCI transport and assumes success.  If the transport failed to reset, the host will reset itself again when it fails to sync with the controller.