### PR TITLE
nordic: LF clock modifications

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -26,6 +26,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -157,6 +158,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -102,6 +98,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 # The module on the board has +/- 40 ppm crystal. A value of 5 is
 # for crystals in the range of 31 to 50 ppm.

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -22,6 +22,7 @@
 #include "bsp/bsp.h"
 #include <nrf52.h>
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -142,6 +143,9 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
 
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);

--- a/hw/bsp/arduino_primo_nrf52/syscfg.yml
+++ b/hw/bsp/arduino_primo_nrf52/syscfg.yml
@@ -28,10 +28,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -116,6 +112,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768_SYNTH:
-        description: 'Synthesize 32k clock.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -82,6 +78,7 @@ syscfg.vals:
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    XTAL_32768_SYNTH: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -24,18 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-        restrictions:
-            - "!XTAL_32768_SYNTH"
-
-    XTAL_32768_SYNTH:
-        description: 'Synthesize 32k clock.'
-        value: 0
-        restrictions:
-            - "!XTAL_32768"
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -101,6 +89,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 0
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -24,18 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 0
-        restrictions:
-            - "!XTAL_32768_SYNTH"
-
-    XTAL_32768_SYNTH:
-        description: 'Synthesize 32k clock.'
-        value: 1
-        restrictions:
-            - "!XTAL_32768"
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -101,6 +89,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768_SYNTH: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -25,6 +25,7 @@
 #include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "mcu/nrf52_hal.h"
@@ -137,6 +138,9 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
 
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);

--- a/hw/bsp/bmd300eval/syscfg.yml
+++ b/hw/bsp/bmd300eval/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -104,6 +100,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -157,6 +157,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/nrf51-arduino_101/syscfg.yml
+++ b/hw/bsp/nrf51-arduino_101/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -78,6 +74,7 @@ syscfg.vals:
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -105,6 +101,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -83,6 +79,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -24,14 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-    
-    XTAL_RC:
-        description: 'RC LF Clock'
-        value: 0
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -87,6 +79,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -28,6 +28,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -217,6 +218,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/nrf52-thingy/syscfg.yml
+++ b/hw/bsp/nrf52-thingy/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -106,6 +102,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -26,6 +26,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -148,6 +149,9 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
 
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);

--- a/hw/bsp/nrf52840pdk/syscfg.yml
+++ b/hw/bsp/nrf52840pdk/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52840'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -102,6 +98,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -26,6 +26,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -170,6 +171,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/nrf52dk/syscfg.yml
+++ b/hw/bsp/nrf52dk/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -118,6 +114,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -23,6 +23,7 @@
 #include "bsp/bsp.h"
 #include "nrf52.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "mcu/nrf52_hal.h"
 #include "os/os_cputime.h"
 #include "sysflash/sysflash.h"
@@ -154,6 +155,9 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
 
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -23,6 +23,7 @@
 #include "bsp/bsp.h"
 #include "nrf52.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "mcu/nrf52_hal.h"
 #include "os/os_cputime.h"
 #include "sysflash/sysflash.h"
@@ -131,6 +132,9 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
 
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);

--- a/hw/bsp/rb-nano2/syscfg.yml
+++ b/hw/bsp/rb-nano2/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -89,6 +85,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -28,6 +28,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -275,6 +276,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/ruuvi_tag_revb2/syscfg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -107,6 +103,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -26,6 +26,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
@@ -150,6 +151,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -103,6 +99,7 @@ syscfg.vals:
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
     SX1276_SPI_IDX: 0
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/vbluno51/syscfg.yml
+++ b/hw/bsp/vbluno51/syscfg.yml
@@ -24,10 +24,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF51'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
@@ -86,6 +82,7 @@ syscfg.vals:
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -26,6 +26,7 @@
 #include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
+#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
@@ -165,6 +166,10 @@ hal_bsp_init(void)
     int rc;
 
     (void)rc;
+
+    /* Make sure system clocks have started */
+    hal_system_clock_start();
+
 #if MYNEWT_VAL(TIMER_0)
     rc = hal_timer_init(0, NULL);
     assert(rc == 0);

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
     UART_0:
         description: 'Whether to enable UART0'
         value:  1
@@ -106,6 +102,7 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
+    XTAL_32768: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
@@ -26,21 +26,10 @@
 #include <nrf51_bitfields.h>
 #include <mcu/nrf51_hal.h>
 
-/* Must have external 32.768 crystal or used synthesized */
-#if (MYNEWT_VAL(XTAL_32768) == 1) && (MYNEWT_VAL(XTAL_32768_SYNTH) == 1) && (MYNEWT_VAL(XTAL_RC) == 1)
-#error "Cannot configure both external and synthesized 32.768 xtal sources"
-#endif
-
-#if (MYNEWT_VAL(XTAL_32768) == 0) && (MYNEWT_VAL(XTAL_32768_SYNTH) == 0) && (MYNEWT_VAL(XTAL_RC) == 0)
-#error "Must configure either external or synthesized 32.768 xtal source"
-#endif
-
-#define OS_TICK_CMPREG  0
 #define RTC_FREQ        32768
 #define OS_TICK_TIMER   NRF_RTC1
 #define OS_TICK_IRQ     RTC1_IRQn
-
-
+#define OS_TICK_CMPREG      3   /* generate timer interrupt */
 #define RTC_COMPARE_INT_MASK(ccreg) (1UL << ((ccreg) + 16))
 
 static uint32_t lastocmp;
@@ -183,9 +172,6 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
      * rolls over.
      */
     nrf51_max_idle_ticks = (1UL << 22) / timer_ticks_per_ostick;
-
-    /* Make sure system clocks have started */
-    hal_system_clock_start();
 
     /* disable interrupts */
     __HAL_DISABLE_INTERRUPTS(ctx);

--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -31,3 +31,27 @@ syscfg.defs:
             external circuitry so is defined to be zero by default and
             expected to be overridden by the BSP.
         value: 0
+
+# The XTAL_xxx definitions are used to set the clock source used for the low
+# frequency clock. It is required that at least one of these sources is
+# enabled (the bsp should set one of these clock sources).
+    XTAL_32768:
+        description: 'External 32k oscillator LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_RC"
+
+    XTAL_RC:
+        description: 'internal RC LF clock source'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_32768"
+
+    XTAL_32768_SYNTH:
+        description: 'Synthesized 32k LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_RC"
+            - "!XTAL_32768"

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -32,11 +32,7 @@
 extern "C" {
 #endif
 
-#if MYNEWT_VAL(XTAL_32768)
 #define OS_TICKS_PER_SEC    (128)
-#else
-#define OS_TICKS_PER_SEC    (1000)
-#endif
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
@@ -24,24 +24,11 @@
 #include "nrf.h"
 #include "bsp/cmsis_nvic.h"
 
-
-#if MYNEWT_VAL(XTAL_32768)
 #define RTC_FREQ            32768       /* in Hz */
 #define OS_TICK_TIMER       NRF_RTC1
 #define OS_TICK_IRQ         RTC1_IRQn
 #define OS_TICK_CMPREG      3   /* generate timer interrupt */
-#define OS_TICK_PRESCALER   1   /* prescaler to generate timer freq */
-#define TIMER_LT(__t1, __t2)    ((((__t1) - (__t2)) & 0xffffff) > 0x800000)
 #define RTC_COMPARE_INT_MASK(ccreg) (1UL << ((ccreg) + 16))
-#else
-#define OS_TICK_TIMER       NRF_TIMER1
-#define OS_TICK_IRQ         TIMER1_IRQn
-#define OS_TICK_CMPREG      0   /* generate timer interrupt */
-#define OS_TICK_COUNTER     1   /* capture current timer value */
-#define OS_TICK_PRESCALER   4   /* prescaler to generate 1MHz timer freq */
-#define TIMER_LT(__t1, __t2)    ((int32_t)((__t1) - (__t2)) < 0)
-#define TIMER_COMPARE_INT_MASK(ccreg)   (1UL << ((ccreg) + 16))
-#endif
 
 struct hal_os_tick
 {
@@ -82,33 +69,17 @@ sub24(uint32_t x, uint32_t y)
 static inline uint32_t
 nrf52_os_tick_counter(void)
 {
-    /*
-     * Make sure we are not interrupted between invoking the capture task
-     * and reading the value.
-     */
-    OS_ASSERT_CRITICAL();
-
-#if MYNEWT_VAL(XTAL_32768)
     return OS_TICK_TIMER->COUNTER;
-#else
-    /*
-     * Capture the current timer value and return it.
-     */
-    OS_TICK_TIMER->TASKS_CAPTURE[OS_TICK_COUNTER] = 1;
-    return (OS_TICK_TIMER->CC[OS_TICK_COUNTER]);
-#endif
 }
 
 static inline void
 nrf52_os_tick_set_ocmp(uint32_t ocmp)
 {
+    int delta;
     uint32_t counter;
 
     OS_ASSERT_CRITICAL();
     while (1) {
-#if MYNEWT_VAL(XTAL_32768)
-        int delta;
-
         ocmp &= 0xffffff;
         OS_TICK_TIMER->CC[OS_TICK_CMPREG] = ocmp;
         counter = nrf52_os_tick_counter();
@@ -125,13 +96,6 @@ nrf52_os_tick_set_ocmp(uint32_t ocmp)
         if (delta > 2) {
             break;
         }
-#else
-        OS_TICK_TIMER->CC[OS_TICK_CMPREG] = ocmp;
-        counter = nrf52_os_tick_counter();
-        if (TIMER_LT(counter, ocmp)) {
-            break;
-        }
-#endif
         ocmp += g_hal_os_tick.ticks_per_ostick;
     }
 }
@@ -139,6 +103,7 @@ nrf52_os_tick_set_ocmp(uint32_t ocmp)
 static void
 nrf52_timer_handler(void)
 {
+    int delta;
     int ticks;
     os_sr_t sr;
     uint32_t counter;
@@ -147,8 +112,6 @@ nrf52_timer_handler(void)
     OS_ENTER_CRITICAL(sr);
 
     /* Calculate elapsed ticks and advance OS time. */
-#if MYNEWT_VAL(XTAL_32768)
-    int delta;
 
     counter = nrf52_os_tick_counter();
     delta = sub24(counter, g_hal_os_tick.lastocmp);
@@ -161,17 +124,6 @@ nrf52_timer_handler(void)
     /* Update the time associated with the most recent tick */
     g_hal_os_tick.lastocmp = (g_hal_os_tick.lastocmp +
         (ticks * g_hal_os_tick.ticks_per_ostick)) & 0xffffff;
-#else
-    counter = nrf52_os_tick_counter();
-    ticks = (counter - g_hal_os_tick.lastocmp) / g_hal_os_tick.ticks_per_ostick;
-    os_time_advance(ticks);
-
-    /* Clear timer interrupt */
-    OS_TICK_TIMER->EVENTS_COMPARE[OS_TICK_CMPREG] = 0;
-
-    /* Update the time associated with the most recent tick */
-    g_hal_os_tick.lastocmp += ticks * g_hal_os_tick.ticks_per_ostick;
-#endif
 
     /* Update the output compare to interrupt at the next tick */
     nrf52_os_tick_set_ocmp(g_hal_os_tick.lastocmp + g_hal_os_tick.ticks_per_ostick);
@@ -210,12 +162,10 @@ os_tick_idle(os_time_t ticks)
     }
 }
 
-#if MYNEWT_VAL(XTAL_32768)
 void
 os_tick_init(uint32_t os_ticks_per_sec, int prio)
 {
     uint32_t sr;
-    uint32_t mask;
 
     assert(RTC_FREQ % os_ticks_per_sec == 0);
 
@@ -228,22 +178,6 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
      * rolls over.
      */
     g_hal_os_tick.max_idle_ticks = (1UL << 22) / g_hal_os_tick.ticks_per_ostick;
-
-    /* Turn on the LFCLK */
-    NRF_CLOCK->TASKS_LFCLKSTOP = 1;
-    NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
-    NRF_CLOCK->LFCLKSRC = CLOCK_LFCLKSRC_SRC_Xtal;
-    NRF_CLOCK->TASKS_LFCLKSTART = 1;
-
-    /* Wait here till started! */
-    mask = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSTAT_SRC_Xtal;
-    while (1) {
-        if (NRF_CLOCK->EVENTS_LFCLKSTARTED) {
-            if ((NRF_CLOCK->LFCLKSTAT & mask) == mask) {
-                break;
-            }
-        }
-    }
 
     /* disable interrupts */
     OS_ENTER_CRITICAL(sr);
@@ -271,37 +205,3 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
 
     OS_EXIT_CRITICAL(sr);
 }
-#else
-void
-os_tick_init(uint32_t os_ticks_per_sec, int prio)
-{
-    g_hal_os_tick.ticks_per_ostick = 1000000 / os_ticks_per_sec;
-
-    /*
-     * The maximum number of timer ticks allowed to elapse during idle is
-     * limited to 1/4th the number of timer ticks before the 32-bit counter
-     * rolls over.
-     */
-    g_hal_os_tick.max_idle_ticks = (1UL << 30) / g_hal_os_tick.ticks_per_ostick;
-
-    /*
-     * Program OS_TICK_TIMER to operate at 1MHz and trigger an output
-     * compare interrupt at a rate of 'os_ticks_per_sec'.
-     */
-    OS_TICK_TIMER->TASKS_STOP = 1;
-    OS_TICK_TIMER->TASKS_CLEAR = 1;
-    OS_TICK_TIMER->MODE = TIMER_MODE_MODE_Timer;
-    OS_TICK_TIMER->BITMODE = TIMER_BITMODE_BITMODE_32Bit;
-    OS_TICK_TIMER->PRESCALER = OS_TICK_PRESCALER;
-
-    OS_TICK_TIMER->CC[OS_TICK_CMPREG] = g_hal_os_tick.ticks_per_ostick;
-    OS_TICK_TIMER->INTENSET = TIMER_COMPARE_INT_MASK(OS_TICK_CMPREG);
-    OS_TICK_TIMER->EVENTS_COMPARE[OS_TICK_CMPREG] = 0;
-
-    NVIC_SetPriority(OS_TICK_IRQ, prio);
-    NVIC_SetVector(OS_TICK_IRQ, (uint32_t)nrf52_timer_handler);
-    NVIC_EnableIRQ(OS_TICK_IRQ);
-
-    OS_TICK_TIMER->TASKS_START = 1;     /* start the os tick timer */
-}
-#endif

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -19,6 +19,7 @@
 
 #include <mcu/cortex_m4.h>
 #include "hal/hal_system.h"
+#include "nrf.h"
 
 /**
  * Function called at startup. Called after BSS and .data initialized but
@@ -56,4 +57,79 @@ int
 hal_debugger_connected(void)
 {
     return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+}
+
+/**
+ * hal system clock start
+ *
+ * Makes sure the LFCLK and/or HFCLK is started.
+ */
+void
+hal_system_clock_start(void)
+{
+    uint32_t mask;
+
+#if MYNEWT_VAL(XTAL_32768)
+    /* Check if this clock source is already running */
+    mask = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSTAT_SRC_Xtal;
+    if ((NRF_CLOCK->LFCLKSTAT & mask) != mask) {
+        NRF_CLOCK->TASKS_LFCLKSTOP = 1;
+        NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
+        NRF_CLOCK->LFCLKSRC = CLOCK_LFCLKSRC_SRC_Xtal;
+        NRF_CLOCK->TASKS_LFCLKSTART = 1;
+
+        /* Wait here till started! */
+        while (1) {
+            if (NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+                if ((NRF_CLOCK->LFCLKSTAT & mask) == mask) {
+                    break;
+                }
+            }
+        }
+    }
+#endif
+
+#if MYNEWT_VAL(XTAL_32768_SYNTH)
+    /* Must turn on HFLCK for synthesized 32768 crystal */
+    mask = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSRC_SRC_Synth;
+    if ((NRF_CLOCK->LFCLKSTAT & mask) != mask) {
+        mask = CLOCK_HFCLKSTAT_STATE_Msk | CLOCK_HFCLKSTAT_SRC_Msk;
+        if ((NRF_CLOCK->HFCLKSTAT & mask) != mask) {
+            NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
+            NRF_CLOCK->TASKS_HFCLKSTART = 1;
+            while (1) {
+                if ((NRF_CLOCK->EVENTS_HFCLKSTARTED) != 0) {
+                    break;
+                }
+            }
+        }
+
+        NRF_CLOCK->TASKS_LFCLKSTOP = 1;
+        NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
+        NRF_CLOCK->LFCLKSRC = CLOCK_LFCLKSRC_SRC_Synth;
+        NRF_CLOCK->TASKS_LFCLKSTART = 1;
+        while (1) {
+            if (NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+                mask = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSRC_SRC_Synth;
+                if ((NRF_CLOCK->LFCLKSTAT & mask) == mask) {
+                    break;
+                }
+            }
+        }
+    }
+#endif
+#if MYNEWT_VAL(XTAL_RC)
+    NRF_CLOCK->TASKS_LFCLKSTOP = 1;
+    NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
+    NRF_CLOCK->LFCLKSRC = CLOCK_LFCLKSRC_SRC_RC;
+    NRF_CLOCK->TASKS_LFCLKSTART = 1;
+    while (1) {
+        if (NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+            mask = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSRC_SRC_RC;
+            if ((NRF_CLOCK->LFCLKSTAT & mask) == mask) {
+                break;
+            }
+        }
+    }
+#endif
 }

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -31,3 +31,27 @@ syscfg.defs:
             external circuitry so is defined to be zero by default and
             expected to be overridden by the BSP.
         value: 0
+
+# The XTAL_xxx definitions are used to set the clock source used for the low
+# frequency clock. It is required that at least one of these sources is
+# enabled (the bsp should set one of these clock sources).
+    XTAL_32768:
+        description: 'External 32k oscillator LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_RC"
+
+    XTAL_RC:
+        description: 'internal RC LF clock source'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_32768"
+
+    XTAL_32768_SYNTH:
+        description: 'Synthesized 32k LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_RC"
+            - "!XTAL_32768"


### PR DESCRIPTION
The following changes were made to the code regarding the LF
clock for nordic platforms. The initial impetus for this change
was that there was no support for using a synthesized 32kHz clock
for nrf52 platforms. LF clock management was different between
the nrf51 and nrf52 as well and this commit is intended to make
them consistent. Here is a list of the changes made:

1) Always turn on the LF clock for nordic bsps/platforms.
2) Move the LF clock source syscfg definitions from the BSP into
the mcu.
3) BSP now sets the proper LF clock based on the BSP hw (either
external, synthesized or internal RC oscillator).
4) The OS will now always use the 32768 crystal for OS time. All
code that dealt with it using a different clock source has been
removed.
5) Both the nrf51 and nrf52 now use the same RTC time resources.