### PR TITLE
MYNEWT-828 SensorAPI: Sensor OIC notifications/triggers

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -37,7 +37,22 @@
 #include <id/id.h>
 #include <os/os_time.h>
 #include <defs/error.h>
-#include <sensor/accel.h>
+
+#if MYNEWT_VAL(BNO055_CLI)
+#include <bno055/bno055.h>
+#endif
+
+#if MYNEWT_VAL(TSL2561_CLI)
+#include <tsl2561/tsl2561.h>
+#endif
+
+#if MYNEWT_VAL(TCS34725_CLI)
+#include <tcs34725/tcs34725.h>
+#endif
+
+#if MYNEWT_VAL(BME280_CLI)
+#include <bme280/bme280.h>
+#endif
 
 #if MYNEWT_VAL(SENSOR_OIC)
 #include <oic/oc_api.h>

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -481,25 +481,25 @@ main(int argc, char **argv)
     /* Initialize BLE OIC GATT Server */
     sensor_ble_oic_server_init();
 
-    sad_low.sad_x = -20000;
-    sad_low.sad_y = -20000;
-    sad_low.sad_z = -20000;
+    sad_low.sad_x = 0.6712;
+    sad_low.sad_y = 0.6712;
+    sad_low.sad_z = 0.6712;
 
     sad_low.sad_x_is_valid = 1;
     sad_low.sad_y_is_valid = 1;
     sad_low.sad_z_is_valid = 1;
 
-    sad_high.sad_x = 0;
-    sad_high.sad_y = 0;
-    sad_high.sad_z = 0;
+    sad_high.sad_x = 0.6712;
+    sad_high.sad_y = 0.6712;
+    sad_high.sad_z = 0.6712;
 
     sad_high.sad_x_is_valid = 1;
     sad_high.sad_y_is_valid = 1;
     sad_high.sad_z_is_valid = 1;
 
     stt.stt_sensor_type = SENSOR_TYPE_ACCELEROMETER;
-    stt.stt_low_thresh = &sad_low;
-    stt.stt_high_thresh = &sad_high;
+    stt.stt_low_thresh.sad = &sad_low;
+    stt.stt_high_thresh.sad = &sad_high;
     stt.stt_algo = SENSOR_THRESH_ALGO_WATERMARK;
 
     sensor_set_thresh("lis2dh12_0", &stt);

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -496,8 +496,9 @@ main(int argc, char **argv)
     stt.stt_sensor_type = SENSOR_TYPE_ACCELEROMETER;
     stt.stt_low_thresh = &sad_low;
     stt.stt_high_thresh = &sad_high;
+    stt.stt_algo = SENSOR_THRESH_ALGO_WATERMARK;
 
-    sensor_set_window_thresh("lis2dh12_0", &stt);
+    sensor_set_thresh("lis2dh12_0", &stt);
 
     sensor_set_poll_rate_ms("lis2dh12_0", 500);
 

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -456,9 +456,6 @@ ble_oic_log_init(void)
 int
 main(int argc, char **argv)
 {
-    struct sensor_type_traits stt;
-    struct sensor_accel_data sad_low;
-    struct sensor_accel_data sad_high;
 
 #ifdef ARCH_sim
     mcu_sim_parse_args(argc, argv);
@@ -480,31 +477,6 @@ main(int argc, char **argv)
 
     /* Initialize BLE OIC GATT Server */
     sensor_ble_oic_server_init();
-
-    sad_low.sad_x = 0.6712;
-    sad_low.sad_y = 0.6712;
-    sad_low.sad_z = 0.6712;
-
-    sad_low.sad_x_is_valid = 1;
-    sad_low.sad_y_is_valid = 1;
-    sad_low.sad_z_is_valid = 1;
-
-    sad_high.sad_x = 0.6712;
-    sad_high.sad_y = 0.6712;
-    sad_high.sad_z = 0.6712;
-
-    sad_high.sad_x_is_valid = 1;
-    sad_high.sad_y_is_valid = 1;
-    sad_high.sad_z_is_valid = 1;
-
-    stt.stt_sensor_type = SENSOR_TYPE_ACCELEROMETER;
-    stt.stt_low_thresh.sad = &sad_low;
-    stt.stt_high_thresh.sad = &sad_high;
-    stt.stt_algo = SENSOR_THRESH_ALGO_WATERMARK;
-
-    sensor_set_thresh("lis2dh12_0", &stt);
-
-    sensor_set_poll_rate_ms("lis2dh12_0", 3600000);
 
     /* log reboot */
     reboot_start(hal_reset_cause());

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -403,7 +403,7 @@ sensor_ble_oic_server_init(void)
     int rc;
 
     /* Set initial BLE device address. */
-    memcpy(g_dev_addr, (uint8_t[6]){0xdd, 0xdd, 0xdd, 0xdd, 0xcc, 0xcc}, 6);
+    memcpy(g_dev_addr, (uint8_t[6]){0x0a, 0xfa, 0xcf, 0xac, 0xfa, 0xc0}, 6);
 
     oc_ble_coap_gatt_srv_init();
 

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -481,17 +481,21 @@ main(int argc, char **argv)
     /* Initialize BLE OIC GATT Server */
     sensor_ble_oic_server_init();
 
-    sad_low.sad_x = 0;
-    sad_low.sad_y = 0;
-    sad_low.sad_z = 0;
+    sad_low.sad_x = -20000;
+    sad_low.sad_y = -20000;
+    sad_low.sad_z = -20000;
 
     sad_low.sad_x_is_valid = 1;
     sad_low.sad_y_is_valid = 1;
     sad_low.sad_z_is_valid = 1;
 
-    sad_high.sad_x_is_valid = 0;
-    sad_high.sad_y_is_valid = 0;
-    sad_high.sad_z_is_valid = 0;
+    sad_high.sad_x = 0;
+    sad_high.sad_y = 0;
+    sad_high.sad_z = 0;
+
+    sad_high.sad_x_is_valid = 1;
+    sad_high.sad_y_is_valid = 1;
+    sad_high.sad_z_is_valid = 1;
 
     stt.stt_sensor_type = SENSOR_TYPE_ACCELEROMETER;
     stt.stt_low_thresh = &sad_low;
@@ -500,7 +504,7 @@ main(int argc, char **argv)
 
     sensor_set_thresh("lis2dh12_0", &stt);
 
-    sensor_set_poll_rate_ms("lis2dh12_0", 500);
+    sensor_set_poll_rate_ms("lis2dh12_0", 3600000);
 
     /* log reboot */
     reboot_start(hal_reset_cause());

--- a/apps/sensors_test/syscfg.yml
+++ b/apps/sensors_test/syscfg.yml
@@ -56,6 +56,7 @@ syscfg.vals:
     OC_APP_RESOURCES : 20
 
     FLOAT_USER: 1
+    SENSOR_OIC_PERIODIC: 1
 
 syscfg.defs:
     SENSOR_BLE:

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -99,7 +99,9 @@ static const struct sensor_itf spi_0_itf_bme = {
 static const struct sensor_itf spi_0_itf_lis = {
     .si_type = SENSOR_ITF_SPI,
     .si_num = 0,
-    .si_cs_pin = 8
+    .si_cs_pin = 8,
+    .si_low_pin = 2,
+    .si_high_pin = 6
 };
 #endif
 #endif

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -241,7 +241,7 @@ config_lis2dh12_sensor(void)
     memset(&cfg, 0, sizeof(cfg));
 
     cfg.lc_s_mask = SENSOR_TYPE_ACCELEROMETER;
-    cfg.lc_rate = LIS2DH12_DATA_RATE_100HZ;
+    cfg.lc_rate = LIS2DH12_DATA_RATE_HN_1344HZ_L_5376HZ;
     cfg.lc_fs = LIS2DH12_FS_2G;
 
     rc = lis2dh12_config((struct lis2dh12 *)dev, &cfg);

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -241,7 +241,7 @@ config_lis2dh12_sensor(void)
     memset(&cfg, 0, sizeof(cfg));
 
     cfg.lc_s_mask = SENSOR_TYPE_ACCELEROMETER;
-    cfg.lc_rate = LIS2DH12_DATA_RATE_HN_1344HZ_L_5376HZ;
+    cfg.lc_rate = LIS2DH12_DATA_RATE_100HZ;
     cfg.lc_fs = LIS2DH12_FS_2G;
 
     rc = lis2dh12_config((struct lis2dh12 *)dev, &cfg);

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -294,6 +294,16 @@ lis2dh12_set_int1_duration(struct sensor_itf *itf, uint8_t dur);
 int
 lis2dh12_set_int2_duration(struct sensor_itf *itf, uint8_t dur);
 
+/**
+ * Set high pass filter cfg
+ *
+ * @param the sensor interface
+ * @param filter register settings
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_hpf_cfg(struct sensor_itf *itf, uint8_t reg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -200,6 +200,100 @@ lis2dh12_pull_up_disc(struct sensor_itf *itf, uint8_t disconnect);
 int
 lis2dh12_reset(struct sensor_itf *itf);
 
+/**
+ * Enable interrupt 2
+ *
+ * @param the sensor interface
+ * @param events to enable int for
+ */
+int
+lis2dh12_enable_int2(struct sensor_itf *itf, uint8_t *reg);
+
+/**
+ * Enable interrupt 1
+ *
+ * @param the sensor interface
+ * @param events to enable int for
+ */
+int
+lis2dh12_enable_int1(struct sensor_itf *itf, uint8_t *reg);
+
+/**
+ * Set interrupt threshold for int 1
+ *
+ * @param the sensor interface
+ * @param threshold
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_thresh(struct sensor_itf *itf, uint8_t ths);
+
+/**
+ * Set interrupt threshold for int 2
+ *
+ * @param the sensor interface
+ * @param threshold
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_thresh(struct sensor_itf *itf, uint8_t ths);
+
+/**
+ * Clear interrupt 1
+ *
+ * @param the sensor interface
+ */
+int
+lis2dh12_clear_int1(struct sensor_itf *itf);
+
+/**
+ * Clear interrupt 2
+ *
+ * @param the sensor interface
+ */
+int
+lis2dh12_clear_int2(struct sensor_itf *itf);
+
+/**
+ * Set interrupt pin configuration for interrupt 1
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
+
+/**
+ * Set interrupt pin configuration for interrupt 2
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
+
+/**
+ * Set interrupt 1 duration
+ *
+ * @param duration in N/ODR units
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_duration(struct sensor_itf *itf, uint8_t dur);
+
+/**
+ * Set interrupt 2 duration
+ *
+ * @param duration in N/ODR units
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_duration(struct sensor_itf *itf, uint8_t dur);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -32,7 +32,6 @@
 #include "lis2dh12/lis2dh12.h"
 #include "lis2dh12_priv.h"
 #include "hal/hal_gpio.h"
-#include "console/console.h"
 
 static struct hal_spi_settings spi_lis2dh12_settings = {
     .data_order = HAL_SPI_MSB_FIRST,
@@ -687,7 +686,6 @@ lis2dh12_set_fifo_mode(struct sensor_itf *itf, uint8_t mode)
     }
 
     if (mode == LIS2DH12_FIFO_M_BYPASS && reg != 0x20) {
-        console_printf("Bypass mode not set\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -1394,8 +1392,6 @@ lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
             }
         }
 
-        console_printf("int1 thresh reg::0x%2x", reg);
-
         rc = lis2dh12_set_int1_thresh(itf, reg);
         if (rc) {
             goto err;
@@ -1467,8 +1463,6 @@ lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
                 reg = acc_mg/tmp;
             }
         }
-
-        console_printf("int2 thresh reg::0x%2x\n", reg);
 
         rc = lis2dh12_set_int2_thresh(itf, reg);
         if (rc) {

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -1288,15 +1288,7 @@ lis2dh12_enable_int1(struct sensor_itf *itf, uint8_t *reg)
 static void
 lis2dh12_low_int1_irq_handler(void *arg)
 {
-    struct sensor_itf *itf;
-    struct sensor_read_ev_ctx *srec;
-
-    srec = arg;
-
     sensor_mgr_put_read_evt(arg);
-    itf = SENSOR_GET_ITF(srec->srec_sensor);
-    lis2dh12_clear_int1(itf);
-
 }
 
 /**
@@ -1307,15 +1299,7 @@ lis2dh12_low_int1_irq_handler(void *arg)
 static void
 lis2dh12_high_int2_irq_handler(void *arg)
 {
-    struct sensor_itf *itf;
-    struct sensor_read_ev_ctx *srec;
-
-    srec = arg;
-
     sensor_mgr_put_read_evt(arg);
-    itf = SENSOR_GET_ITF(srec->srec_sensor);
-    lis2dh12_clear_int2(itf);
-
 }
 
 /* Set the trigger threshold values and enable interrupts

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -685,7 +685,7 @@ lis2dh12_set_fifo_mode(struct sensor_itf *itf, uint8_t mode)
         goto err;
     }
 
-    if (mode == LIS2DH12_FIFO_M_BYPASS && reg != 0x20) {
+    if (mode == LIS2DH12_FIFO_M_BYPASS && reg != LIS2DH12_FIFO_SRC_EMPTY) {
         rc = SYS_EINVAL;
         goto err;
     }

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -81,10 +81,14 @@ static int lis2dh12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
 static int lis2dh12_sensor_get_config(struct sensor *, sensor_type_t,
         struct sensor_cfg *);
-
+static int
+lis2dh12_sensor_set_trigger_thresh(struct sensor *, sensor_type_t,
+                                   struct sensor_type_traits *);
 static const struct sensor_driver g_lis2dh12_sensor_driver = {
     lis2dh12_sensor_read,
-    lis2dh12_sensor_get_config
+    lis2dh12_sensor_get_config,
+    /* Setting trigger threshold is optional */
+    lis2dh12_sensor_set_trigger_thresh
 };
 
 /**
@@ -541,13 +545,25 @@ err:
 /**
  * Calculates the acceleration in m/s^2 from mg
  *
- * @param raw acc value
- * @param float ptr to return calculated value
+ * @param acc value in mg
+ * @param float ptr to return calculated value in ms2
  */
 void
-lis2dh12_calc_acc_ms2(int16_t raw_acc, float *facc)
+lis2dh12_calc_acc_ms2(int16_t acc_mg, float *acc_ms2)
 {
-    *facc = raw_acc * STANDARD_ACCEL_GRAVITY;
+    *acc_ms2 = acc_mg * STANDARD_ACCEL_GRAVITY;
+}
+
+/**
+ * Calculates the acceleration in mg from m/s^2
+ *
+ * @param acc value in m/s^2
+ * @param int16 ptr to return calculated value in mg
+ */
+void
+lis2dh12_calc_acc_mg(float acc_ms2, int16_t *acc_mg)
+{
+    *acc_mg = acc_ms2/STANDARD_ACCEL_GRAVITY;
 }
 
 /**
@@ -950,6 +966,7 @@ lis2dh12_sensor_read(struct sensor *sensor, sensor_type_t type,
         goto err;
     }
 
+    /* converting values from mg to ms^2 */
     lis2dh12_calc_acc_ms2(x, &fx);
     lis2dh12_calc_acc_ms2(y, &fy);
     lis2dh12_calc_acc_ms2(z, &fz);
@@ -985,6 +1002,364 @@ lis2dh12_sensor_get_config(struct sensor *sensor, sensor_type_t type,
     }
 
     cfg->sc_valtype = SENSOR_VALUE_TYPE_FLOAT_TRIPLET;
+
+    return 0;
+err:
+    return rc;
+}
+
+/**
+ * Set interrupt threshold for int 2
+ *
+ * @param the sensor interface
+ * @param threshold
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_thresh(struct sensor_itf *itf, uint8_t ths)
+{
+    int rc;
+
+    rc = lis2dh12_writelen(itf, LIS2DH12_REG_INT2_THS, &ths, 1);
+    if (rc) {
+        goto err;
+    }
+
+    return 0;
+err:
+    return rc;
+}
+
+/**
+ * Set interrupt threshold for int 1
+ *
+ * @param the sensor interface
+ * @param threshold
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_thresh(struct sensor_itf *itf, uint8_t ths)
+{
+
+    int rc;
+
+    rc = lis2dh12_writelen(itf, LIS2DH12_REG_INT1_THS, &ths, 1);
+    if (rc) {
+        goto err;
+    }
+
+    return 0;
+err:
+    return rc;
+}
+
+/**
+ * Clear interrupt 2
+ *
+ * @param the sensor interface
+ */
+int
+lis2dh12_clear_int2(struct sensor_itf *itf)
+{
+    uint8_t reg;
+
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT2_SRC, &reg, 1);
+}
+
+/**
+ * Clear interrupt 1
+ *
+ * @param the sensor interface
+ */
+int
+lis2dh12_clear_int1(struct sensor_itf *itf)
+{
+    uint8_t reg;
+
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT1_SRC, &reg, 1);
+}
+
+/**
+ * Enable interrupt 2
+ *
+ * @param the sensor interface
+ * @param events to enable int for
+ */
+int
+lis2dh12_enable_int2(struct sensor_itf *itf, uint8_t *reg)
+{
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT2_CFG, reg, 1);
+}
+
+/**
+ * Set interrupt pin configuration for interrupt 1
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
+{
+    uint8_t reg;
+
+    reg = ~0x08 & cfg;
+
+    return lis2dh12_writelen(itf, LIS2DH12_REG_CTRL_REG3, &reg, 1);
+}
+
+/**
+ * Set interrupt 1 duration
+ *
+ * @param duration in N/ODR units
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int1_duration(struct sensor_itf *itf, uint8_t dur)
+{
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT1_DURATION, &dur, 1);
+}
+
+/**
+ * Set interrupt 2 duration
+ *
+ * @param duration in N/ODR units
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_duration(struct sensor_itf *itf, uint8_t dur)
+{
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT2_DURATION, &dur, 1);
+}
+
+/**
+ * Set interrupt pin configuration for interrupt 2
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
+{
+    return lis2dh12_writelen(itf, LIS2DH12_REG_CTRL_REG3, &cfg, 1);
+}
+
+/**
+ * Enable interrupt 1
+ *
+ * @param the sensor interface
+ * @param events to enable int for
+ */
+int
+lis2dh12_enable_int1(struct sensor_itf *itf, uint8_t *reg)
+{
+    return lis2dh12_writelen(itf, LIS2DH12_REG_INT1_CFG, reg, 1);
+}
+
+/**
+ * IRQ handler for int1 for low threshold
+ *
+ * @param arg
+ */
+static void
+lis2dh12_low_irq_handler(void *arg)
+{
+    struct sensor *sensor = arg;
+
+    lis2dh12_sensor_read(sensor, sensor->s_mask, NULL, NULL, OS_TIMEOUT_NEVER);
+}
+
+/**
+ * IRQ handler for int1 for high threshold
+ *
+ * @param arg
+ */
+static void
+lis2dh12_high_irq_handler(void *arg)
+{
+    struct sensor *sensor = arg;
+
+    lis2dh12_sensor_read(sensor, sensor->s_mask, NULL, NULL, OS_TIMEOUT_NEVER);
+}
+
+/* Set the trigger threshold values and enable interrupts
+ *
+ * @param ptr to sensor
+ * @param the Sensor type
+ * @param low threshold
+ * @param high threshold
+ *
+ * @return 0 on success, non-zero on failure
+ */
+static int
+lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
+                                   sensor_type_t type,
+                                   struct sensor_type_traits *stt)
+{
+    int rc;
+    struct sensor_itf *itf;
+    uint8_t tmp;
+    sensor_data_t low_thresh;
+    sensor_data_t high_thresh;
+    int16_t acc_mg;
+    uint8_t reg;
+
+    itf = SENSOR_GET_ITF(sensor);
+
+    if (type != SENSOR_TYPE_ACCELEROMETER) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    memcpy(&low_thresh, &stt->stt_low_thresh, sizeof(low_thresh));
+    memcpy(&high_thresh, &stt->stt_high_thresh, sizeof(high_thresh));
+
+    rc = lis2dh12_get_full_scale(itf, &tmp);
+    if (rc) {
+        goto err;
+    }
+
+    if (tmp == LIS2DH12_FS_2G) {
+        tmp = 16;
+    } else if (tmp == LIS2DH12_FS_4G) {
+        tmp = 32;
+    } else if (tmp == LIS2DH12_FS_8G) {
+        tmp = 62;
+    } else if (tmp == LIS2DH12_FS_16G) {
+        tmp = 186;
+    } else {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    if (low_thresh.sad->sad_x_is_valid ||
+        low_thresh.sad->sad_y_is_valid ||
+        low_thresh.sad->sad_z_is_valid) {
+
+        if (low_thresh.sad->sad_x_is_valid) {
+            lis2dh12_calc_acc_mg(low_thresh.sad->sad_x, &acc_mg);
+            reg = acc_mg/tmp;
+        }
+
+        if (low_thresh.sad->sad_y_is_valid) {
+            lis2dh12_calc_acc_mg(low_thresh.sad->sad_y, &acc_mg);
+            if (reg > acc_mg/tmp) {
+                reg = acc_mg/tmp;
+            }
+        }
+
+        if (low_thresh.sad->sad_z_is_valid) {
+            lis2dh12_calc_acc_mg(low_thresh.sad->sad_z, &acc_mg);
+            if (reg > acc_mg/tmp) {
+                reg = acc_mg/tmp;
+            }
+        }
+
+        rc = lis2dh12_set_int1_thresh(itf, reg);
+        if (rc) {
+            goto err;
+        }
+
+        reg = LIS2DH12_CTRL_REG3_I1_IA1;
+
+        rc = lis2dh12_set_int1_pin_cfg(itf, reg);
+        if (rc) {
+            goto err;
+        }
+
+        rc = lis2dh12_set_int1_duration(itf, 10);
+        if (rc) {
+            goto err;
+        }
+
+        hal_gpio_irq_init(itf->si_low_pin, lis2dh12_low_irq_handler, sensor,
+                          HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+        if (rc) {
+            goto err;
+        }
+
+        hal_gpio_irq_enable(itf->si_low_pin);
+
+        reg =  low_thresh.sad->sad_x_is_valid ? LIS2DH12_INT2_CFG_XLIE : 0;
+        reg |= low_thresh.sad->sad_y_is_valid ? LIS2DH12_INT2_CFG_YLIE : 0;
+        reg |= low_thresh.sad->sad_z_is_valid ? LIS2DH12_INT2_CFG_ZLIE : 0;
+
+        rc = lis2dh12_clear_int1(itf);
+        if (rc) {
+            goto err;
+        }
+
+        rc = lis2dh12_enable_int1(itf, &reg);
+        if (rc) {
+            goto err;
+        }
+    }
+
+    if (high_thresh.sad->sad_x_is_valid ||
+        high_thresh.sad->sad_y_is_valid ||
+        high_thresh.sad->sad_z_is_valid) {
+
+        if (high_thresh.sad->sad_x_is_valid) {
+            lis2dh12_calc_acc_mg(high_thresh.sad->sad_x, &acc_mg);
+            reg = acc_mg/tmp;
+        }
+
+        if (high_thresh.sad->sad_y_is_valid) {
+            lis2dh12_calc_acc_mg(high_thresh.sad->sad_y, &acc_mg);
+            if (reg < acc_mg/tmp) {
+                reg = acc_mg/tmp;
+            }
+        }
+
+        if (high_thresh.sad->sad_z_is_valid) {
+            lis2dh12_calc_acc_mg(high_thresh.sad->sad_z, &acc_mg);
+            if (reg < acc_mg/tmp) {
+                reg = acc_mg/tmp;
+            }
+        }
+
+        rc = lis2dh12_set_int2_thresh(itf, reg);
+        if (rc) {
+            goto err;
+        }
+
+        reg = LIS2DH12_CTRL_REG6_I2_IA2;
+
+        rc = lis2dh12_set_int2_pin_cfg(itf, reg);
+        if (rc) {
+            goto err;
+        }
+
+        rc = lis2dh12_set_int2_duration(itf, 10);
+        if (rc) {
+            goto err;
+        }
+
+        hal_gpio_irq_init(itf->si_high_pin, lis2dh12_high_irq_handler, sensor,
+                          HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+        if (rc) {
+            goto err;
+        }
+
+        hal_gpio_irq_enable(itf->si_high_pin);
+
+        reg =  high_thresh.sad->sad_x_is_valid  ? LIS2DH12_INT2_CFG_XHIE : 0;
+        reg |= high_thresh.sad->sad_y_is_valid ? LIS2DH12_INT2_CFG_YHIE : 0;
+        reg |= high_thresh.sad->sad_z_is_valid ? LIS2DH12_INT2_CFG_ZHIE : 0;
+
+        rc = lis2dh12_clear_int2(itf);
+        if (rc) {
+            goto err;
+        }
+
+        rc = lis2dh12_enable_int2(itf, &reg);
+        if (rc) {
+            goto err;
+        }
+    }
 
     return 0;
 err:

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -129,14 +129,6 @@ typedef enum {
 #define SENSOR_ITF_UART   (2)
 
 /**
- * Sensor transport
- */
-#define SENSOR_TRANSPORT_OIC    0x0
-#define SENSOR_TRANSPORT_BLE    0x1
-#define SENSOR_TRANSPORT_LORA   0x2
-#define SENSOR_TRANSPORT_WIFI   0x3
-
-/**
  * Sensor threshold constants
  */
 #define SENSOR_THRESH_ALGO_WINDOW     0x1

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -256,9 +256,24 @@ typedef int (*sensor_read_func_t)(struct sensor *, sensor_type_t,
 typedef int (*sensor_get_config_func_t)(struct sensor *, sensor_type_t,
         struct sensor_cfg *);
 
+/**
+ * Set the trigger and threshold values for a specific sensor for the sensor
+ * type.
+ *
+ * @param ptr to the sensor
+ * @param type of sensor
+ * @param low threshold
+ * @param high threshold
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*sensor_set_trigger_thresh_t)(struct sensor *, sensor_type_t,
+                                           struct sensor_type_traits *stt);
+
 struct sensor_driver {
     sensor_read_func_t sd_read;
     sensor_get_config_func_t sd_get_config;
+    sensor_set_trigger_thresh_t sd_set_trigger_thresh;
 };
 
 struct sensor_timestamp {
@@ -280,7 +295,29 @@ struct sensor_itf {
 
     /* Sensor address */
     uint16_t si_addr;
+
+    /* Sensor interface low int pin */
+    uint8_t si_low_pin;
+
+    /* Sensor interface high int pin */
+    uint8_t si_high_pin;
 };
+
+typedef union {
+    struct sensor_mag_data   *smd;
+    struct sensor_accel_data *sad;
+    struct sensor_euler_data *sed;
+    struct sensor_quat_data  *sqd;
+    struct sensor_accel_data *slad;
+    struct sensor_accel_data *sgrd;
+    struct sensor_gyro_data  *sgd;
+    struct sensor_temp_data  *std;
+    struct sensor_temp_data  *satd;
+    struct sensor_light_data *sld;
+    struct sensor_color_data *scd;
+    struct sensor_press_data *spd;
+    struct sensor_humid_data *srhd;
+}sensor_data_t;
 
 /*
  * Return the OS device structure corresponding to this sensor
@@ -594,7 +631,7 @@ sensor_get_type_traits_byname(char *, struct sensor_type_traits **,
                               sensor_type_t);
 
 /**
- * Set the windowed thresholds for a sensor
+ * Set the thresholds along with the comparison algo for a sensor
  *
  * @param name of the sensor
  * @param Ptr to sensor type traits containing thresholds
@@ -602,7 +639,7 @@ sensor_get_type_traits_byname(char *, struct sensor_type_traits **,
  * @return 0 on success, non-zero on failure
  */
 int
-sensor_set_window_thresh(char *, struct sensor_type_traits *);
+sensor_set_thresh(char *, struct sensor_type_traits *);
 
 /**
  * Set the watermark thresholds for a sensor

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -734,8 +734,6 @@ sensor_read_data_func(struct sensor *sensor, void *arg, void *data,
     }
 }
 
-uint32_t read_event;
-
 /**
  * Puts read event on the sensor manager evq
  *
@@ -744,7 +742,6 @@ uint32_t read_event;
 void
 sensor_mgr_put_read_evt(void *arg)
 {
-    read_event++;
     sensor_read_event.ev_arg = arg;
     os_eventq_put(sensor_mgr_evq_get(), &sensor_read_event);
 }

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -638,6 +638,8 @@ sensor_init(struct sensor *sensor, struct os_dev *dev)
     }
     sensor->s_dev = dev;
 
+    sensor->s_poll_rate = OS_TIMEOUT_NEVER;
+
     return (0);
 err:
     return (rc);

--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -575,7 +575,8 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
             goto err;
         }
 
-        rc = sensor_read(sensor, type, sensor_oic_encode, NULL,
+        rc = sensor_read(sensor, type, sensor_oic_encode,
+                         (uintptr_t *)SENSOR_IGN_LISTENER,
                          OS_TIMEOUT_NEVER);
         if (rc) {
             goto err;

--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -739,7 +739,7 @@ sensor_oic_init(void)
                 if (rc) {
                     break;
                 }
-                sensor_trigger_init(sensor, type, SENSOR_TRANSPORT_OIC);
+                sensor_trigger_init(sensor, type, sensor_oic_tx_trigger);
             }
             i++;
         }

--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -46,6 +46,7 @@
 #include <oic/oc_rep.h>
 #include <oic/oc_ri.h>
 #include <oic/oc_api.h>
+#include <oic/messaging/coap/observe.h>
 
 static const char g_s_oic_dn[] = "x.mynewt.snsr.";
 
@@ -53,6 +54,10 @@ static int
 sensor_oic_encode(struct sensor* sensor, void *arg, void *databuf,
                   sensor_type_t type)
 {
+
+    if (!databuf) {
+        return SYS_EINVAL;
+    }
 
     switch(type) {
         /* Gyroscope supported */
@@ -529,7 +534,6 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
 {
     int rc;
     struct sensor *sensor;
-    struct sensor_listener listener;
     char *devname;
     char *typename;
     sensor_type_t type;
@@ -562,8 +566,6 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
     case OC_IF_BASELINE:
         oc_process_baseline_interface(request->resource);
     case OC_IF_R:
-        /* Register a listener and then trigger/read a bunch of samples */
-        memset(&listener, 0, sizeof(listener));
 
         typename =
             &(request->resource->types.oa_arr.s[sizeof(g_s_oic_dn) - 1]);
@@ -573,19 +575,7 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
             goto err;
         }
 
-        listener.sl_sensor_type = type;
-        listener.sl_func = sensor_oic_encode;
-
-        rc = sensor_register_listener(sensor, &listener);
-        if (rc) {
-            goto err;
-        }
-
-        /* Sensor read results.  Every time a sensor is read, all of its
-         * listeners are called by default.  Specify NULL as a callback,
-         * because we just want to run all the listeners.
-         */
-        rc = sensor_read(sensor, listener.sl_sensor_type, NULL, NULL,
+        rc = sensor_read(sensor, type, sensor_oic_encode, NULL,
                          OS_TIMEOUT_NEVER);
         if (rc) {
             goto err;
@@ -596,23 +586,130 @@ sensor_oic_get_data(oc_request_t *request, oc_interface_mask_t interface)
         break;
     }
 
-    sensor_unregister_listener(sensor, &listener);
     oc_rep_end_root_object();
     oc_send_response(request, OC_STATUS_OK);
     return;
 err:
-    sensor_unregister_listener(sensor, &listener);
     oc_send_response(request, OC_STATUS_NOT_FOUND);
+}
+
+/**
+ * Transmit OIC trigger
+ *
+ * @param ptr to the sensor
+ * @param ptr to sensor data
+ * @param The sensor type
+ *
+ * @return 0 on sucess, non-zero on failure
+ */
+int
+sensor_oic_tx_trigger(struct sensor *sensor, void *arg, sensor_type_t type)
+{
+    oc_request_t request = {};
+    oc_response_t response = {};
+    oc_response_buffer_t response_buffer;
+    struct os_mbuf *m = NULL;
+    struct sensor_type_traits *stt;
+    int rc;
+
+    (void)request;
+
+    memset(&response_buffer, 0, sizeof(response_buffer));
+    stt = sensor_get_type_traits_bytype(type, sensor);
+    if (!stt->stt_oic_res->num_observers) {
+        return 0;
+    }
+
+    m = os_msys_get_pkthdr(0, 0);
+    if (!m) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    response_buffer.buffer = m;
+    response_buffer.block_offset = NULL;
+    response.response_buffer = &response_buffer;
+    request.resource = stt->stt_oic_res;
+    request.response = &response;
+    oc_rep_new(m);
+    oc_rep_start_root_object();
+    rc = sensor_oic_encode(sensor, NULL, arg, type);
+    if (rc) {
+        goto err;
+    }
+    oc_rep_end_root_object();
+    oc_send_response(&request, OC_STATUS_OK);
+    coap_notify_observers(stt->stt_oic_res, &response_buffer, NULL);
+    os_mbuf_free_chain(m);
+
+    return 0;
+err:
+    return rc;
+}
+
+static int
+sensor_oic_add_resource(struct sensor *sensor, sensor_type_t type)
+{
+    char *typename;
+    char tmpstr[COAP_MAX_URI];
+    struct sensor_type_traits *stt;
+    int rc;
+
+    stt = sensor_get_type_traits_bytype(type, sensor);
+    if (!stt) {
+        stt = malloc(sizeof(struct sensor_type_traits));
+        memset(stt, 0, sizeof(struct sensor_type_traits));
+        sensor_lock(sensor);
+        SLIST_INSERT_HEAD(&sensor->s_type_traits_list, stt, stt_next);
+        sensor_unlock(sensor);
+    }
+
+    typename = NULL;
+
+    rc = sensor_type_to_typename(&typename, type, sensor);
+    if (rc) {
+        return rc;
+    }
+
+    memset(tmpstr, 0, sizeof(tmpstr));
+    snprintf(tmpstr, sizeof(tmpstr), "/%s/%s",
+             sensor->s_dev->od_name, typename);
+
+    sensor_lock(sensor);
+
+    stt->stt_sensor_type = type;
+
+    stt->stt_oic_res = oc_new_resource(tmpstr, 1, 0);
+
+    memset(tmpstr, 0, sizeof(tmpstr));
+    snprintf(tmpstr, sizeof(tmpstr), "%s%s", g_s_oic_dn, typename);
+    oc_resource_bind_resource_type(stt->stt_oic_res, tmpstr);
+    oc_resource_bind_resource_interface(stt->stt_oic_res, OC_IF_R);
+    oc_resource_set_default_interface(stt->stt_oic_res, OC_IF_R);
+
+    oc_resource_set_discoverable(stt->stt_oic_res);
+
+#if MYNEWT_VAL(SENSOR_OIC_PERIODIC)
+    oc_resource_set_periodic_observable_ms(stt->stt_oic_res,
+                                           MYNEWT_VAL(SENSOR_OIC_OBS_RATE));
+#else
+    oc_resource_set_observable(stt->stt_oic_res);
+#endif
+    oc_resource_set_request_handler(stt->stt_oic_res, OC_GET,
+                                    sensor_oic_get_data);
+
+    oc_add_resource(stt->stt_oic_res);
+
+    sensor_unlock(sensor);
+
+    return 0;
 }
 
 void
 sensor_oic_init(void)
 {
-    oc_resource_t *res;
     struct sensor *sensor;
-    char tmpstr[COAP_MAX_URI];
     sensor_type_t type;
-    char *typename;
     int i;
     int rc;
 
@@ -632,33 +729,16 @@ sensor_oic_init(void)
         }
 
         i = 0;
-        typename = NULL;
 
         /* Iterate through N types of sensors */
         while (i < 32) {
             type = (1 << i);
             if (sensor_mgr_match_bytype(sensor, &type)) {
-                rc = sensor_type_to_typename(&typename, type, sensor);
+                rc = sensor_oic_add_resource(sensor, type);
                 if (rc) {
                     break;
                 }
-
-                memset(tmpstr, 0, sizeof(tmpstr));
-                snprintf(tmpstr, sizeof(tmpstr), "/%s/%s", sensor->s_dev->od_name, typename);
-
-                res = oc_new_resource(tmpstr, 1, 0);
-
-                memset(tmpstr, 0, sizeof(tmpstr));
-                snprintf(tmpstr, sizeof(tmpstr), "%s%s", g_s_oic_dn, typename);
-                oc_resource_bind_resource_type(res, tmpstr);
-                oc_resource_bind_resource_interface(res, OC_IF_R);
-                oc_resource_set_default_interface(res, OC_IF_R);
-
-                oc_resource_set_discoverable(res);
-                oc_resource_set_periodic_observable_ms(res, MYNEWT_VAL(SENSOR_OIC_OBS_RATE));
-                oc_resource_set_request_handler(res, OC_GET,
-                                                sensor_oic_get_data);
-                oc_add_resource(res);
+                sensor_trigger_init(sensor, type, SENSOR_TRANSPORT_OIC);
             }
             i++;
         }

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -44,3 +44,7 @@ syscfg.defs:
     SENSOR_MGR_EVQ:
         description: 'Specify the eventq to be used by sensor mgr'
         value:
+
+    SENSOR_OIC_PERIODIC:
+        description: 'Sensor polling is periodic'
+        value: 0


### PR DESCRIPTION
- Add API for setting threshold based on polling mechanism
- Also allow the API to set thresholds based on interrupts mechanism
- Design is as follows: 
i. It adds a list of structures sensor_traits_list to the sensor structure which keeps track of per type thresholds, oic resources, algorithm, etc. These thresholds are then compared with the readings from the sensor at the specific poll rates based on algorithms decided by the developer: `SENSOR_THRESH_ALGO_WINDOW` and `SENSOR_THRESH_ALGO_WATERMARK`. 
`SENSOR_THRESH_ALGO_WINDOW`: Sensor data is compared to thresholds making a window.
`SENSOR_THRESH_ALGO_WATERMARK`: Sensor data is compared to thresholds based on watermarks
Notifications are sent if conditions are satisfied as per the above algorithms.
If a set_thresh callback is specified in the driver, this callback will get called which will enable interrupts based notifications for specific sensor drivers. An example of this can be seen in [hw/drivers/sensors/lis2dh12/src/lis2dh12.c](https://github.com/apache/mynewt-core/compare/master...vrahane:sensor_notif?expand=1#diff-18789c89dd99a5f02122ee67a80b82a1).
ii. Syscfg `SENSOR_OIC_PERIODIC`: This is a new syscfg which enables or disables periodic observation of sensor resources. By default it is enabled in the sensors test app.
iii. There were two fields added to `struct sensor_itf`: `si_low_pin` & `si_high_pin` which lets the developer specify the interrupt pins in the bsp along with the interface and chip select if any.
iv. A lot of functions were added to the lis2dh12 driver to support interrupt functionality.
(The current interrupt config for lis2dh12 enables the low thresh interrupts and high thresh interrupts but it somehow only generates an interrupt on a change in the accelerometer data crossing a threshold instead of generating one based on threshold regardless, this needs to be investigated further). 
Jira Ticket: https://issues.apache.org/jira/browse/MYNEWT-828

Example:
```
stt = (struct sensor_type_traits) {
     .stt_sensor_type = SENSOR_TYPE_ACCELEROMETER,
     .stt_low_thresh.sad = &sad_low,
     .stt_high_thresh.sad = &sad_high,
     .stt_algo = SENSOR_THRESH_ALGO_WATERMARK
};

sad_low = (struct sensor_accel_data) {
     .sad_x = 0.6712,
     .sad_x_is_valid = 1,
     .sad_y = 0.6712,
     .sad_y_is_valid = 1,
     .sad_z = 0.6712,
     .sad_z_is_valid = 1,
};
 
sad_high = (struct sensor_accel_data) {
    .sad_x = 0.6712,
    .sad_x_is_valid = 1,
    .sad_y = 0.6712,
    .sad_y_is_valid = 1,
    .sad_z = 0.6712,
    .sad_z_is_valid = 1,
};
 
sensor_set_thresh("lis2dh12_0", &stt);

```