### PR TITLE
boot_serial; access uart driver directly instead of going through console.

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -37,8 +37,6 @@
 #include <os/os_malloc.h>
 #include <os/os_cputime.h>
 
-#include <console/console.h>
-
 #include <tinycbor/cbor.h>
 #include <tinycbor/cbor_buf_reader.h>
 #include <base64/base64.h>
@@ -83,34 +81,6 @@ bs_cbor_writer(struct cbor_encoder_writer *cew, const char *data, int len)
     cew->bytes_written += len;
 
     return 0;
-}
-
-/*
- * Looks for 'name' from NULL-terminated json data in buf.
- * Returns pointer to first character of value for that name.
- * Returns NULL if 'name' is not found.
- */
-char *
-bs_find_val(char *buf, char *name)
-{
-    char *ptr;
-
-    ptr = strstr(buf, name);
-    if (!ptr) {
-        return NULL;
-    }
-    ptr += strlen(name);
-
-    while (*ptr != '\0') {
-        if (*ptr != ':' && !isspace(*ptr)) {
-            break;
-        }
-        ++ptr;
-    }
-    if (*ptr == '\0') {
-        ptr = NULL;
-    }
-    return ptr;
 }
 
 /*
@@ -221,29 +191,6 @@ bs_upload(char *buf, int len)
     long long int data_len = UINT_MAX;
     size_t slen;
     char name_str[8];
-    /*
-    const struct cbor_attr_t attr[4] = {
-        [0] = {
-            .attribute = "data",
-            .type = CborAttrByteStringType,
-            .addr.bytestring.data = img_data,
-            .addr.bytestring.len = &img_blen,
-            .len = sizeof(img_data)
-        },
-        [1] = {
-            .attribute = "off",
-            .type = CborAttrUnsignedIntegerType,
-            .addr.uinteger = &off,
-            .nodefault = true
-        },
-        [2] = {
-            .attribute = "len",
-            .type = CborAttrUnsignedIntegerType,
-            .addr.uinteger = &data_len,
-            .nodefault = true
-        }
-    };
-     */
     const struct flash_area *fap = NULL;
     int rc;
 
@@ -388,11 +335,15 @@ out:
 }
 
 /*
- * Console echo control. Send empty response, don't do anything.
+ * Console echo control/image erase. Send empty response, don't do anything.
  */
 static void
-bs_echo_ctl(char *buf, int len)
+bs_empty_rsp(char *buf, int len)
 {
+    cbor_encoder_create_map(&bs_root, &bs_rsp, CborIndefiniteLength);
+    cbor_encode_text_stringz(&bs_rsp, "rc");
+    cbor_encode_int(&bs_rsp, 0);
+    cbor_encoder_close_container(&bs_root, &bs_rsp);
     boot_serial_output();
 }
 
@@ -403,12 +354,7 @@ bs_echo_ctl(char *buf, int len)
 static int
 bs_reset(char *buf, int len)
 {
-    cbor_encoder_create_map(&bs_root, &bs_rsp, CborIndefiniteLength);
-    cbor_encode_text_stringz(&bs_rsp, "rc");
-    cbor_encode_int(&bs_rsp, 0);
-    cbor_encoder_close_container(&bs_root, &bs_rsp);
-
-    boot_serial_output();
+    bs_empty_rsp(buf, len);
     os_cputime_delay_usecs(250000);
     hal_system_reset();
 }
@@ -449,12 +395,13 @@ boot_serial_input(char *buf, int len)
             bs_upload(buf, len);
             break;
         default:
+            bs_empty_rsp(buf, len);
             break;
         }
     } else if (hdr->nh_group == MGMT_GROUP_ID_DEFAULT) {
         switch (hdr->nh_id) {
         case NMGR_ID_CONS_ECHO_CTRL:
-            bs_echo_ctl(buf, len);
+            bs_empty_rsp(buf, len);
             break;
         case NMGR_ID_RESET:
             bs_reset(buf, len);
@@ -488,7 +435,7 @@ boot_serial_output(void)
     crc = crc16_ccitt(crc, data, len);
     crc = htons(crc);
 
-    console_write(pkt_start, sizeof(pkt_start));
+    boot_serial_uart_write(pkt_start, sizeof(pkt_start));
 
     totlen = len + sizeof(*bs_hdr) + sizeof(crc);
     totlen = htons(totlen);
@@ -502,8 +449,8 @@ boot_serial_output(void)
     memcpy(&buf[totlen], &crc, sizeof(crc));
     totlen += sizeof(crc);
     totlen = base64_encode(buf, totlen, encoded_buf, 1);
-    console_write(encoded_buf, totlen);
-    console_write("\n", 1);
+    boot_serial_uart_write(encoded_buf, totlen);
+    boot_serial_uart_write("\n\r", 2);
 }
 
 /*
@@ -578,9 +525,8 @@ boot_serial_start(int max_input)
     tick = os_cputime_get32();
 #endif
 
-    rc = console_init(NULL);
+    rc = boot_serial_uart_open();
     assert(rc == 0);
-    console_echo(0);
 
     buf = os_malloc(max_input);
     dec = os_malloc(max_input);
@@ -595,7 +541,7 @@ boot_serial_start(int max_input)
             tick = os_cputime_get32();
         }
 #endif
-        rc = console_read(buf + off, max_input - off, &full_line);
+        rc = boot_serial_uart_read(buf + off, max_input - off, &full_line);
         if (rc <= 0 && !full_line) {
             continue;
         }

--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -68,8 +68,14 @@ struct nmgr_hdr {
  */
 #define IMGMGR_NMGR_ID_STATE            0
 #define IMGMGR_NMGR_ID_UPLOAD           1
+#define IMGMGR_NMGR_ID_ERASE            5
 
 void boot_serial_input(char *buf, int len);
+
+int boot_serial_uart_open(void);
+void boot_serial_uart_close(void);
+int boot_serial_uart_read(char *str, int cnt, int *newline);
+void boot_serial_uart_write(char *ptr, int cnt);
 
 #ifdef __cplusplus
 }

--- a/boot/boot_serial/src/boot_uart.c
+++ b/boot/boot_serial/src/boot_uart.c
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include <stddef.h>
+#include <inttypes.h>
+
+#include <uart/uart.h>
+
+/*
+ * RX is a ring buffer, which gets drained constantly.
+ * TX blocks until buffer has been completely transmitted.
+ */
+#define CONSOLE_HEAD_INC(cr) (((cr)->head + 1) & (sizeof((cr)->buf) - 1))
+#define CONSOLE_TAIL_INC(cr) (((cr)->tail + 1) & (sizeof((cr)->buf) - 1))
+
+struct {
+    uint8_t head;
+    uint8_t tail;
+    uint8_t buf[16];
+} bs_uart_rx;
+
+struct {
+    uint8_t *ptr;
+    int cnt;
+} volatile bs_uart_tx;
+
+static struct uart_dev *bs_uart;
+
+static int bs_rx_char(void *arg, uint8_t byte);
+static int bs_tx_char(void *arg);
+
+int
+boot_serial_uart_open(void)
+{
+    struct uart_conf uc = {
+        .uc_speed = MYNEWT_VAL(CONSOLE_UART_BAUD),
+        .uc_databits = 8,
+        .uc_stopbits = 1,
+        .uc_parity = UART_PARITY_NONE,
+        .uc_flow_ctl = MYNEWT_VAL(CONSOLE_UART_FLOW_CONTROL),
+        .uc_tx_char = bs_tx_char,
+        .uc_rx_char = bs_rx_char,
+    };
+
+    bs_uart = (struct uart_dev *)os_dev_open(MYNEWT_VAL(CONSOLE_UART_DEV),
+      OS_TIMEOUT_NEVER, &uc);
+    if (!bs_uart) {
+        return -1;
+    }
+    return 0;
+}
+
+void
+boot_serial_uart_close(void)
+{
+}
+
+static int
+bs_rx_char(void *arg, uint8_t byte)
+{
+    if (CONSOLE_HEAD_INC(&bs_uart_rx) == bs_uart_rx.tail) {
+        /*
+         * RX queue full. Reader must drain this.
+         */
+        return -1;
+    }
+    bs_uart_rx.buf[bs_uart_rx.head] = byte;
+    bs_uart_rx.head = CONSOLE_HEAD_INC(&bs_uart_rx);
+    return 0;
+}
+
+static uint8_t
+bs_pull_char(void)
+{
+    uint8_t ch;
+
+    ch = bs_uart_rx.buf[bs_uart_rx.tail];
+    bs_uart_rx.tail = CONSOLE_TAIL_INC(&bs_uart_rx);
+    return ch;
+}
+
+int
+boot_serial_uart_read(char *str, int cnt, int *newline)
+{
+    int i;
+    int sr;
+    uint8_t ch;
+
+    *newline = 0;
+    OS_ENTER_CRITICAL(sr);
+    for (i = 0; i < cnt; i++) {
+        if (bs_uart_rx.head == bs_uart_rx.tail) {
+            break;
+        }
+
+        ch = bs_pull_char();
+        if (ch == '\n') {
+            *str = '\0';
+            *newline = 1;
+            break;
+        }
+        *str++ = ch;
+    }
+    OS_EXIT_CRITICAL(sr);
+    if (i > 0 || *newline) {
+        uart_start_rx(bs_uart);
+    }
+    return i;
+}
+
+static int
+bs_tx_char(void *arg)
+{
+    uint8_t ch;
+
+    if (!bs_uart_tx.cnt) {
+        return -1;
+    }
+
+    bs_uart_tx.cnt--;
+    ch = *bs_uart_tx.ptr;
+    bs_uart_tx.ptr++;
+    return ch;
+}
+
+void
+boot_serial_uart_write(char *ptr, int cnt)
+{
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+    bs_uart_tx.ptr = (uint8_t *)ptr;
+    bs_uart_tx.cnt = cnt;
+    OS_EXIT_CRITICAL(sr);
+
+    uart_start_tx(bs_uart);
+    while (bs_uart_tx.cnt);
+}
+
+

--- a/boot/boot_serial/src/boot_uart.c
+++ b/boot/boot_serial/src/boot_uart.c
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#include <syscfg/syscfg.h>
+
 #include <uart/uart.h>
 
 /*
@@ -139,6 +141,19 @@ bs_tx_char(void *arg)
     return ch;
 }
 
+#if MYNEWT_VAL(SELFTEST)
+/*
+ * OS is not running, so native uart 'driver' cannot run either.
+ * At the moment unit tests don't check the responses to messages it
+ * sends, so we can drop the outgoing data here.
+ */
+void
+boot_serial_uart_write(char *ptr, int cnt)
+{
+}
+
+#else
+
 void
 boot_serial_uart_write(char *ptr, int cnt)
 {
@@ -153,4 +168,4 @@ boot_serial_uart_write(char *ptr, int cnt)
     while (bs_uart_tx.cnt);
 }
 
-
+#endif

--- a/boot/boot_serial/test/src/testcases/boot_serial_setup.c
+++ b/boot/boot_serial/test/src/testcases/boot_serial_setup.c
@@ -20,5 +20,8 @@
 
 TEST_CASE(boot_serial_setup)
 {
+    int rc;
 
+    rc = boot_serial_uart_open();
+    assert(rc == 0);
 }

--- a/sys/console/stub/syscfg.yml
+++ b/sys/console/stub/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,18 +17,13 @@
 # under the License.
 #
 
-pkg.name: apps/boot
-pkg.type: app
-pkg.description: Boot loader application.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-    - loader
-
-pkg.deps:
-    - boot/bootutil
-    - kernel/os
-    - sys/console/stub
-
-pkg.deps.BOOT_SERIAL.OVERWRITE:
-    - boot/boot_serial
+syscfg.defs:
+    CONSOLE_UART_BAUD:
+        description: 'Console UART baud rate.'
+        value: '115200'
+    CONSOLE_UART_FLOW_CONTROL:
+        description: 'Console UART flow control.'
+        value: 'UART_FLOW_CTL_NONE'
+    CONSOLE_UART_DEV:
+        description: 'Console UART device.'
+        value: '"uart0"'


### PR DESCRIPTION
This is for space savings. Before the change:
objsize
   text	   data	    bss	    dec	    hex	filename
  16248	     84	   5352	  21684	   54b4	/Users/marko/src2/incubator-mynewt-blinky/bin/targets/boot_nrf52_serial/app/apps/boot/boot.elf

After the change:
   text	   data	    bss	    dec	    hex	filename
  14816	     76	   4996	  19888	   4db0	/Users/marko/src2/incubator-mynewt-blinky/bin/targets/boot_nrf52_serial/app/apps/boot/boot.elf
