### PR TITLE
nimble/host: fix event flag check

### DIFF
--- a/net/nimble/host/src/ble_gatts.c
+++ b/net/nimble/host/src/ble_gatts.c
@@ -617,7 +617,7 @@ ble_gatts_subscribe_event(uint16_t conn_handle, uint16_t attr_handle,
                           uint8_t reason,
                           uint8_t prev_flags, uint8_t cur_flags)
 {
-    if (prev_flags != cur_flags) {
+    if ((prev_flags ^ cur_flags) & ~BLE_GATTS_CLT_CFG_F_RESERVED) {
         ble_gap_subscribe_event(conn_handle,
                                 attr_handle,
                                 reason,


### PR DESCRIPTION
Previous check resulted in assert in ble_gap_subscribe_event when
prev_flags had BLE_GATTS_CLT_CFG_F_MODIFIED bit set