### PR TITLE
nRF MCUs: build-time check for an enabled low-frequency timer

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
@@ -26,6 +26,15 @@
 #include <nrf51_bitfields.h>
 #include <mcu/nrf51_hal.h>
 
+/* The OS scheduler requires a low-frequency timer. */
+#if MYNEWT_VAL(OS_SCHEDULING)       && \
+    !MYNEWT_VAL(XTAL_32768)         && \
+    !MYNEWT_VAL(XTAL_RC)            && \
+    !MYNEWT_VAL(XTAL_32768_SYNTH)
+
+    #error The OS scheduler requires a low-frequency timer; enable one of: XTAL_32768, XTAL_RC, or XTAL_32768_SYNTH
+#endif
+
 #define RTC_FREQ        32768
 #define OS_TICK_TIMER   NRF_RTC1
 #define OS_TICK_IRQ     RTC1_IRQn

--- a/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
@@ -24,6 +24,15 @@
 #include "nrf.h"
 #include "bsp/cmsis_nvic.h"
 
+/* The OS scheduler requires a low-frequency timer. */
+#if MYNEWT_VAL(OS_SCHEDULING)       && \
+    !MYNEWT_VAL(XTAL_32768)         && \
+    !MYNEWT_VAL(XTAL_RC)            && \
+    !MYNEWT_VAL(XTAL_32768_SYNTH)
+
+    #error The OS scheduler requires a low-frequency timer; enable one of: XTAL_32768, XTAL_RC, or XTAL_32768_SYNTH
+#endif
+
 #define RTC_FREQ            32768       /* in Hz */
 #define OS_TICK_TIMER       NRF_RTC1
 #define OS_TICK_IRQ         RTC1_IRQn


### PR DESCRIPTION
The nRF51 and nRF52 MCUs require exactly one low-frequency timer setting to be enabled.  Syscfg restrictions ensure that no more than one is enabled, but is not capable of verifying that at least one is enabled.  This PR adds a compile-time check that at least one of these settings is enabled.