### PR TITLE
Fix newlines removed from gdb output

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -64,7 +64,7 @@ jlink_load () {
     echo "quit" >> $GDB_CMD_FILE
 
     msgs=`arm-none-eabi-gdb -x $GDB_CMD_FILE 2>&1`
-    echo $msgs > $GDB_OUT_FILE
+    echo "$msgs" > $GDB_OUT_FILE
 
     rm $GDB_CMD_FILE
 
@@ -72,7 +72,7 @@ jlink_load () {
     # JLinkGDBServer always exits with non-zero error code, regardless of
     # whether there was an error during execution of it or not. So we cannot
     # use it.
-    echo $msgs
+    echo "$msgs"
 
     error=`echo $msgs | grep error`
     if [ -n "$error" ]; then


### PR DESCRIPTION
Newlines from the gdb output was removed, so it was really hard to find the real error in the blob of text that was output to the shell. Just adding quotes around the variable when echoing fixes the problem.

Without quotes:
![before](https://user-images.githubusercontent.com/149725/30064676-c85091a0-9252-11e7-9722-14112ffb4678.png)

With quotes:
![after](https://user-images.githubusercontent.com/149725/30064682-d02054e2-9252-11e7-83a2-14b36f01f478.png)
