### PR TITLE
net/lora: Additional modifications

### DIFF
--- a/hw/drivers/lora/sx1276/src/sx1276-board.c
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.c
@@ -64,6 +64,8 @@ void SX1276IoInit( void )
     rc = hal_gpio_init_out(RADIO_NSS, 1);
     assert(rc == 0);
 
+    hal_spi_disable(RADIO_SPI_IDX);
+
     spi_settings.data_order = HAL_SPI_MSB_FIRST;
     spi_settings.data_mode = HAL_SPI_MODE0;
     spi_settings.baudrate = MYNEWT_VAL(SX1276_SPI_BAUDRATE);

--- a/hw/drivers/lora/sx1276/src/sx1276.c
+++ b/hw/drivers/lora/sx1276/src/sx1276.c
@@ -28,7 +28,7 @@ Maintainer: Miguel Luis, Gregory Cristian and Wael Guibene
 #include "sx1276-board.h"
 #include "node/lora_priv.h"
 
-#if !MYNEWT_VAL(LORA_MAC_TIMER_NUM)
+#if MYNEWT_VAL(LORA_MAC_TIMER_NUM) == -1
 #error "Must define a Lora MAC timer number"
 #else
 #define SX1276_TIMER_NUM    MYNEWT_VAL(LORA_MAC_TIMER_NUM)

--- a/net/lora/node/include/node/lora_priv.h
+++ b/net/lora/node/include/node/lora_priv.h
@@ -36,6 +36,8 @@ int lora_node_join(uint8_t *dev_eui, uint8_t *app_eui, uint8_t *app_key,
                    uint8_t trials);
 int lora_node_link_check(void);
 struct os_eventq *lora_node_mac_evq_get(void);
+void lora_node_reset_txq_timer(void);
+bool lora_node_txq_empty(void);
 
 /* Lora debug log */
 #define LORA_NODE_DEBUG_LOG

--- a/net/lora/node/src/lora_node.c
+++ b/net/lora/node/src/lora_node.c
@@ -181,14 +181,14 @@ lora_node_mcps_request(struct os_mbuf *om)
 }
 
 #if !MYNEWT_VAL(LORA_NODE_CLI)
-static void
+void
 lora_node_reset_txq_timer(void)
 {
     /* XXX: For now, just reset timer to fire off in one second */
     os_callout_reset(&g_lora_mac_data.lm_txq_timer, OS_TICKS_PER_SEC);
 }
 
-static bool
+bool
 lora_node_txq_empty(void)
 {
     bool rc;
@@ -229,11 +229,6 @@ lora_node_mac_mcps_confirm(McpsConfirm_t *confirm)
     lpkt->txdinfo.uplink_cntr = confirm->UpLinkCounter;
     lpkt->txdinfo.uplink_freq = confirm->UpLinkFrequency;
     lora_app_mcps_confirm(om);
-
-    /* Reset transmit queue timer as there may be packets on transmit queue */
-    if (!lora_node_txq_empty()) {
-        lora_node_reset_txq_timer();
-    }
 }
 
 /* MAC MCPS-Indicate primitive  */


### PR DESCRIPTION
A few additional changes with this commit. The first was to
disable the sx1276 spi before configuration. This should not
be needed but in case the spi was enabled prior to running
this image this change makes sure to disable it first. The second change
was to check for the lora timer number to be -1 (and not 0).
This insures that a timer number was set in the syscfg. The user
must choose a valid timer number. The last change was to make sure
that we check for additional enqueued transmissions after we are
finished with one.