### PR TITLE
nimble/sm: Use privacy device mode as default

### DIFF
--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -244,6 +244,17 @@ ble_store_write_peer_sec(const struct ble_store_value_sec *value_sec)
         if (rc != 0) {
             return rc;
         }
+
+        /* FIXME Controller is BT5.0 and default privacy mode is network which can
+         * cause problems for apps which are not aware of it. We need to sort it
+         * out somehow. For now we set device mode for all of the peer devices and
+         * application should change it to network if needed
+         */
+        rc = ble_hs_pvcy_set_mode(&value_sec->peer_addr,
+                                  BLE_GAP_PRIVATE_MODE_DEVICE);
+        if (rc != 0) {
+            return rc;
+        }
     }
 
     return 0;

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -285,14 +285,6 @@ ble_hs_test_util_build_cmd_status(uint8_t *dst, int len,
     put_le16(dst + 4, opcode);
 }
 
-#define BLE_HS_TEST_UTIL_PHONY_ACK_MAX  64
-struct ble_hs_test_util_phony_ack {
-    uint16_t opcode;
-    uint8_t status;
-    uint8_t evt_params[256];
-    uint8_t evt_params_len;
-};
-
 static struct ble_hs_test_util_phony_ack
 ble_hs_test_util_phony_acks[BLE_HS_TEST_UTIL_PHONY_ACK_MAX];
 static int ble_hs_test_util_num_phony_acks;
@@ -351,7 +343,7 @@ ble_hs_test_util_set_ack(uint16_t opcode, uint8_t status)
     ble_hs_test_util_set_ack_params(opcode, status, NULL, 0);
 }
 
-static void
+void
 ble_hs_test_util_set_ack_seq(struct ble_hs_test_util_phony_ack *acks)
 {
     int i;

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -63,6 +63,14 @@ struct ble_hs_test_util_att_group_type_entry {
     const ble_uuid_t *uuid;
 };
 
+#define BLE_HS_TEST_UTIL_PHONY_ACK_MAX  64
+struct ble_hs_test_util_phony_ack {
+    uint16_t opcode;
+    uint8_t status;
+    uint8_t evt_params[256];
+    uint8_t evt_params_len;
+};
+
 #define BLE_HS_TEST_UTIL_L2CAP_HCI_HDR(handle, pb, len) \
     ((struct hci_data_hdr) {                            \
         .hdh_handle_pb_bc = ((handle)  << 0) |          \
@@ -82,6 +90,7 @@ void ble_hs_test_util_prev_tx_queue_clear(void);
 void ble_hs_test_util_set_ack_params(uint16_t opcode, uint8_t status,
                                      void *params, uint8_t params_len);
 void ble_hs_test_util_set_ack(uint16_t opcode, uint8_t status);
+void ble_hs_test_util_set_ack_seq(struct ble_hs_test_util_phony_ack *acks);
 void *ble_hs_test_util_get_first_hci_tx(void);
 void *ble_hs_test_util_get_last_hci_tx(void);
 void ble_hs_test_util_enqueue_hci_tx(void *cmd);

--- a/net/nimble/host/test/src/ble_sm_test_util.c
+++ b/net/nimble/host/test/src/ble_sm_test_util.c
@@ -2049,9 +2049,19 @@ ble_sm_test_util_rx_keys(struct ble_sm_test_params *params,
         ble_sm_test_util_rx_master_id(2, peer_master_id, 0);
     }
     if (peer_key_dist & BLE_SM_PAIR_KEY_DIST_ID) {
-        ble_hs_test_util_set_ack(
-            ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
-                                        BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0);
+
+        ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
+            {
+                .opcode = ble_hs_hci_util_opcode_join(
+                                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
+            } ,
+            {
+                .opcode = ble_hs_hci_util_opcode_join(
+                                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
+            },
+            { 0 }
+        }));
+
         ble_sm_test_util_rx_id_info(2, peer_id_info, 0);
         ble_sm_test_util_rx_id_addr_info(2, peer_id_addr_info, 0);
     }


### PR DESCRIPTION
In order to not brake existing applications lets use privacy
device mode instead of network mode which is default in the
Controller accorting to BT 5 specification.