### PR TITLE
nimble/controller: Use privacy device mode on host before BT 5

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/net/nimble/controller/include/controller/ble_ll_resolv.h
@@ -86,6 +86,10 @@ int ble_ll_resolv_gen_rpa(uint8_t *addr, uint8_t addr_type, uint8_t *rpa,
 /* Set the resolvable private address timeout */
 int ble_ll_resolv_set_rpa_tmo(uint8_t *cmdbuf);
 
+/* Set default privacy mode */
+void
+ble_ll_resolv_set_def_priv_mode(uint8_t mode);
+
 /* Set the privacy mode */
 int ble_ll_resolve_set_priv_mode(uint8_t *cmdbuf);
 

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -1523,6 +1523,13 @@ ble_ll_adv_set_enable(uint8_t instance, uint8_t enable, int duration,
         rc = BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
+#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY) == 1)
+    /* If devices uses legacy commands let's assume BLE_HCI_PRIVACY_DEVICE for
+     * all the peer devices as a default mode
+     */
+    ble_ll_resolv_set_def_priv_mode(BLE_HCI_PRIVACY_DEVICE);
+#endif
+
     return rc;
 }
 

--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -33,6 +33,7 @@
 #include "controller/ble_ll_ctrl.h"
 #include "controller/ble_ll_scan.h"
 #include "controller/ble_ll_adv.h"
+#include "controller/ble_ll_resolv.h"
 #include "ble_ll_conn_priv.h"
 
 /*
@@ -530,6 +531,13 @@ ble_ll_conn_create(uint8_t *cmdbuf)
         /* Set the connection state machine we are trying to create. */
         g_ble_ll_conn_create_sm = connsm;
     }
+
+#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY) == 1)
+    /* If devices uses legacy commands let's assume BLE_HCI_PRIVACY_DEVICE for
+     * all the peer devices as a default mode
+     */
+    ble_ll_resolv_set_def_priv_mode(BLE_HCI_PRIVACY_DEVICE);
+#endif
 
     return rc;
 }

--- a/net/nimble/controller/src/ble_ll_resolv.c
+++ b/net/nimble/controller/src/ble_ll_resolv.c
@@ -44,6 +44,8 @@ struct ble_ll_resolv_data g_ble_ll_resolv_data;
 
 struct ble_ll_resolv_entry g_ble_ll_resolv_list[MYNEWT_VAL(BLE_LL_RESOLV_LIST_SIZE)];
 
+uint8_t g_default_privacy_mode = BLE_HCI_PRIVACY_NETWORK;
+
 static int
 ble_ll_is_controller_busy(void)
 {
@@ -246,8 +248,7 @@ ble_ll_resolv_list_add(uint8_t *cmdbuf)
         swap_buf(rl->rl_peer_irk, cmdbuf + 7, 16);
         swap_buf(rl->rl_local_irk, cmdbuf + 23, 16);
 
-        /* By default use ptivacy network mode */
-        rl->rl_priv_mode = BLE_HCI_PRIVACY_NETWORK;
+        rl->rl_priv_mode = g_default_privacy_mode;
 
         /*
          * Add peer IRK to HW resolving list. If we can add it, also
@@ -375,6 +376,12 @@ ble_ll_resolv_set_rpa_tmo(uint8_t *cmdbuf)
     g_ble_ll_resolv_data.rpa_tmo = tmo_secs * OS_TICKS_PER_SEC;
     return os_callout_reset(&g_ble_ll_resolv_data.rpa_timer,
                             (int32_t)g_ble_ll_resolv_data.rpa_tmo);
+}
+
+void
+ble_ll_resolv_set_def_priv_mode(uint8_t mode)
+{
+    g_default_privacy_mode = mode;
 }
 
 int


### PR DESCRIPTION
Controller does not know what Bluetooth version is supported by Host.
In order to avoid issues with reconnecting device due to
PRIVACY_MODE_NETWORK used as default on the controller, it tries to
figure out if Host is < BT5. If so PRIVACY_MODE_DEVICE is used
