### PR TITLE
nimble/controller: Fix scan long advertising packets

### DIFF
--- a/hw/drivers/nimble/nrf51/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf51/src/ble_phy.c
@@ -660,7 +660,7 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.handle = 0;
     ble_hdr->rxinfo.phy = BLE_PHY_1M;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    ble_hdr->rxinfo.aux_data = NULL;
+    ble_hdr->rxinfo.user_data = NULL;
 #endif
 
     /*

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -789,7 +789,7 @@ ble_phy_rx_start_isr(void)
     ble_hdr->rxinfo.handle = 0;
     ble_hdr->rxinfo.phy = ble_phy_get_cur_phy();
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    ble_hdr->rxinfo.aux_data = NULL;
+    ble_hdr->rxinfo.user_data = NULL;
 #endif
 
     /*

--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -164,7 +164,7 @@ int ble_ll_scan_rx_isr_start(uint8_t pdu_type, uint16_t *rxflags);
 int ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok);
 
 /* Process a scan response PDU */
-void ble_ll_scan_rx_pkt_in(uint8_t pdu_type, uint8_t *rxbuf,
+void ble_ll_scan_rx_pkt_in(uint8_t pdu_type, struct os_mbuf *om,
                            struct ble_mbuf_hdr *hdr);
 
 /* Boolean function denoting whether or not the whitelist can be changed */
@@ -221,7 +221,7 @@ int ble_ll_scan_ext_initiator_start(struct hci_ext_create_conn *hcc,
 
 /* Called to parse extended advertising*/
 struct ble_ll_ext_adv;
-int ble_ll_scan_parse_ext_adv(uint8_t *rxbuf, struct ble_mbuf_hdr *ble_hdr,
+int ble_ll_scan_parse_ext_adv(struct os_mbuf *om, struct ble_mbuf_hdr *ble_hdr,
                               struct ble_ll_ext_adv *parsed_evt);
 
 void ble_ll_scan_aux_data_free(struct ble_ll_aux_data *aux_scan);

--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -720,7 +720,7 @@ ble_ll_rx_pkt_in(void)
             ble_ll_adv_rx_pkt_in(pdu_type, rxbuf, ble_hdr);
             break;
         case BLE_LL_STATE_SCANNING:
-            ble_ll_scan_rx_pkt_in(pdu_type, rxbuf, ble_hdr);
+            ble_ll_scan_rx_pkt_in(pdu_type, m, ble_hdr);
             break;
         case BLE_LL_STATE_INITIATING:
             ble_ll_init_rx_pkt_in(pdu_type, rxbuf, ble_hdr);

--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -2386,7 +2386,7 @@ ble_ll_adv_rx_isr_end(uint8_t pdu_type, struct os_mbuf *rxpdu, int crcok)
     } else {
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
         rxhdr = BLE_MBUF_HDR_PTR(rxpdu);
-        rxhdr->rxinfo.advsm = g_ble_ll_cur_adv_sm;
+        rxhdr->rxinfo.user_data = g_ble_ll_cur_adv_sm;
 #endif
         if (crcok) {
             if ((pdu_type == BLE_ADV_PDU_TYPE_SCAN_REQ) ||
@@ -2429,7 +2429,7 @@ ble_ll_adv_rx_pkt_in(uint8_t ptype, uint8_t *rxbuf, struct ble_mbuf_hdr *hdr)
     struct ble_ll_adv_sm *advsm;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    advsm = (struct ble_ll_adv_sm *)hdr->rxinfo.advsm;
+    advsm = (struct ble_ll_adv_sm *)hdr->rxinfo.user_data;
 #else
     advsm = &g_ble_ll_adv_sm[0];
 #endif
@@ -2837,7 +2837,7 @@ ble_ll_adv_send_conn_comp_ev(struct ble_ll_conn_sm *connsm,
     struct ble_ll_adv_sm *advsm;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    advsm = (struct ble_ll_adv_sm *)rxhdr->rxinfo.advsm;
+    advsm = (struct ble_ll_adv_sm *)rxhdr->rxinfo.user_data;
 #else
     advsm = &g_ble_ll_adv_sm[0];
 #endif

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -1736,7 +1736,7 @@ ble_ll_scan_parse_ext_adv(struct os_mbuf *om, struct ble_mbuf_hdr *ble_hdr,
     /* In the event we need information on primary and secondary PHY used during
      * advertising.
      */
-    aux_data = ble_hdr->rxinfo.aux_data;
+    aux_data = ble_hdr->rxinfo.user_data;
     if (!aux_data) {
         out_evt->prim_phy = ble_hdr->rxinfo.phy;
         goto done;
@@ -1942,7 +1942,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
             }
         }
 
-        ble_hdr->rxinfo.aux_data = aux_data;
+        ble_hdr->rxinfo.user_data = aux_data;
         scansm->cur_aux_data = NULL;
         rc = -1;
     }
@@ -2053,7 +2053,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
                 if (ble_hdr->rxinfo.channel <  BLE_PHY_NUM_DATA_CHANS) {
                     /* Let's keep the aux ptr as a reference to scan rsp */
-                    scansm->cur_aux_data = ble_hdr->rxinfo.aux_data;
+                    scansm->cur_aux_data = ble_hdr->rxinfo.user_data;
                     STATS_INC(ble_ll_stats, aux_scan_req_tx);
                 }
 #endif
@@ -2298,11 +2298,11 @@ ble_ll_scan_rx_pkt_in(uint8_t ptype, struct os_mbuf *om, struct ble_mbuf_hdr *hd
         }
 
         if (BLE_MBUF_HDR_AUX_INVALID(hdr)) {
-            ble_ll_scan_aux_data_free(hdr->rxinfo.aux_data);
+            ble_ll_scan_aux_data_free(hdr->rxinfo.user_data);
             goto scan_continue;
         }
 
-        aux_data = hdr->rxinfo.aux_data;
+        aux_data = hdr->rxinfo.user_data;
 
         /* Let's see if that packet contains aux ptr*/
         if (BLE_MBUF_HDR_WAIT_AUX(hdr)) {
@@ -2329,7 +2329,7 @@ ble_ll_scan_rx_pkt_in(uint8_t ptype, struct os_mbuf *om, struct ble_mbuf_hdr *hd
         if (!BLE_LL_CHECK_AUX_FLAG(aux_data, BLE_LL_AUX_CHAIN_BIT)) {
             /* If there is no chaining, we can remove data. Otherwise it is
              * already scheduled for next aux*/
-            ble_ll_scan_aux_data_free(hdr->rxinfo.aux_data);
+            ble_ll_scan_aux_data_free(hdr->rxinfo.user_data);
         }
 
         goto scan_continue;

--- a/net/nimble/include/nimble/ble.h
+++ b/net/nimble/include/nimble/ble.h
@@ -68,9 +68,7 @@ struct ble_mbuf_hdr_rxinfo
     int8_t  rssi;
     int8_t  phy;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    /* TODO  this could be just one user-data pointer */
-    void *advsm;   /* advertising state machine */
-    void *aux_data;
+    void *user_data;
 #endif
 };
 


### PR DESCRIPTION
This patch fixes corrupted long advertising data when BLE_EXT_ADV is
used. It is allowed now that advertising data are in the chain of
os_mbufs.