### PR TITLE
nimble/ll: Increase stack for ble_ll_task

### DIFF
--- a/net/nimble/controller/src/ble_ll.c
+++ b/net/nimble/controller/src/ble_ll.c
@@ -204,7 +204,7 @@ static void ble_ll_event_dbuf_overflow(struct os_event *ev);
 /* TODO: This is for testing. Check it we really need it */
 #define BLE_LL_STACK_SIZE   (128)
 #else
-#define BLE_LL_STACK_SIZE   (80)
+#define BLE_LL_STACK_SIZE   (90)
 #endif
 
 struct os_task g_ble_ll_task;


### PR DESCRIPTION
Default stack size for ble_ll_task is too low.

Failing scenario can be reproduced using optimized bleprph build for
nRF51 (M0). We have following call stack:

os_eventq_put() at os_eventq.c:99 0x8d7e
ble_hs_enqueue_hci_event() at ble_hs.c:431 0x14204
ble_hs_hci_rx_evt() at ble_hs_hci.c:357 0x14d4a
ble_hci_trans_ll_evt_tx() at ble_hci_ram.c:95 0x1b860
ble_ll_hci_event_send() at ble_ll_hci.c:79 0xec90
ble_ll_conn_comp_event_send() at ble_ll_conn_hci.c:250 0xd6a2
ble_ll_adv_send_conn_comp_ev() at ble_ll_adv.c:2,849 0xb490
ble_ll_conn_created() at ble_ll_conn.c:2,511 0xc0e4
ble_ll_conn_slave_start() at ble_ll_conn.c:4,076 0xd2e6
ble_ll_adv_conn_req_rxd() at ble_ll_adv.c:2,341 0xb3f0
ble_ll_adv_rx_pkt_in() at ble_ll_adv.c:2,456 0xb3f0
ble_ll_rx_pkt_in() at ble_ll.c:720 0xa43a
ble_ll_event_rx_pkt() at ble_ll.c:982 0xa43a
os_eventq_run() at os_eventq.c:178 0x8e38
ble_ll_task() at ble_ll.c:1,025 0xa2ae
0x0

The os_eventq_put() causes a context switch (interrupt) and registers
put on stack overwrite memory outside stack - we're 4 bytes (a single
register) off here. The overwritten memory is a g_dev_addr so our
address changes unexpectedly after successful connection.

This works fine on debug build and on nRF52 due to differents stack
usage. For example, on optimized build for M0, gcc aligns uint8_t on
stack for faster access thus increases its usage if there are local
uint8_t variables in function (like in ble_ll_conn_comp_event_send).

This patch increases stack size by 10 elements (40 bytes) to have some
free space left in case something extra pops up.