### PR TITLE
Unquote quoted zeros and ones in bsp syscfg files.

### DIFF
--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -84,7 +84,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -75,7 +75,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF51 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -75,7 +75,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF51 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/nina-b1/syscfg.yml
+++ b/hw/bsp/nina-b1/syscfg.yml
@@ -102,7 +102,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -65,7 +65,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF51 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -65,7 +65,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF51 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/nrf52-thingy/syscfg.yml
+++ b/hw/bsp/nrf52-thingy/syscfg.yml
@@ -84,7 +84,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
     LIS2DH12_ONB:
         description: 'NRF52 Thingy onboard lis2dh12 sensor'

--- a/hw/bsp/nrf52840pdk/syscfg.yml
+++ b/hw/bsp/nrf52840pdk/syscfg.yml
@@ -84,7 +84,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52840 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/nrf52dk/syscfg.yml
+++ b/hw/bsp/nrf52dk/syscfg.yml
@@ -84,7 +84,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
     PWM_0:
         description: 'NRF52 PWM 0'

--- a/hw/bsp/rb-blend2/syscfg.yml
+++ b/hw/bsp/rb-blend2/syscfg.yml
@@ -89,7 +89,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/ruuvi_tag_revb2/syscfg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/syscfg.yml
@@ -81,7 +81,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
     BME280_ONB:
         description: 'ruuvi-tag onboard bme280 sensor'

--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -84,7 +84,7 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '0'
+        value:  0
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/vbluno51/syscfg.yml
+++ b/hw/bsp/vbluno51/syscfg.yml
@@ -65,11 +65,11 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF51 I2C (TWI) interface 0'
-        value:  '1'
+        value:  1
 
     I2C_1:
         description: 'NRF51 I2C (TWI) interface 1'
-        value:  '1'
+        value:  1
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -84,11 +84,11 @@ syscfg.defs:
 
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
-        value:  '1'
+        value:  1
 
     I2C_1:
         description: 'NRF52 I2C (TWI) interface 1'
-        value:  '1'
+        value:  1
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:


### PR DESCRIPTION
This has no effect on behavior.  These values are used exclusively in `#if MYNEWT_VAL(~)` contexts.

The inexperienced reader is led to wonder what significance the quotes might have.