### PR TITLE
Printf fixes

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -289,6 +289,10 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 }
             }
 
+            if (ch == 'z') {
+                ch = *(fmt++);
+            }
+
             switch (ch) {
             case 0:
                 goto abort;

--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -219,15 +219,11 @@ intarg(int lng, int sign, va_list *va)
 
     case 2:
     default:
-        /* Pull the 64-bit number off the stack as a pair of 32-bit integers.
-         * The va_arg macro was reading from the wrong location when a 64-bit
-         * type was specified.
-         */
-        /* XXX: Look into this; may just be an incorrect setting when the
-         * compiler / newlib was built.
-         */
-        val = va_arg(*va, unsigned long);
-        val |= (unsigned long long)(va_arg(*va, unsigned long)) << 32;
+        if (sign) {
+            val = va_arg(*va, long long);
+        } else {
+            val = va_arg(*va, unsigned long long);
+        }
         break;
     }
 


### PR DESCRIPTION
**libc/baselibc: fix decoding 64-bit values in printf**
It was probably done this way to support 16-bit systems which we
don't support. Although the 32-bit numbers were read in wrong order.
The first 32 bits should be shifted left. The fix could also look
like this:

val = ((unsigned long long)va_arg(*va, unsigned long)) << 32;
val |= ((unsigned long long)va_arg(*va, unsigned long));

**libc/baselibc: ignore 'z' char in printf**
We can ignore size_t ('z') format specifier, because we support only
32-bit systems. It will also make it easier to port external libraries
which support 64-bit systems.