### PR TITLE
sys/shell: add condition to newtmgr dependencies

### DIFF
--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -26,8 +26,11 @@ pkg.keywords:
 pkg.deps:
     - kernel/os
     - time/datetime
+
+pkg.deps.SHELL_NEWTMGR:
     - encoding/base64
     - util/crc
+
 pkg.req_apis:
     - console
 


### PR DESCRIPTION
These packages are used only by newtmgr part of shell code.