### PR TITLE
os_task: Moved the initialisation of t_stacktop and t_stacksize.

### DIFF
--- a/kernel/os/src/os_task.c
+++ b/kernel/os/src/os_task.c
@@ -129,10 +129,10 @@ os_task_init(struct os_task *t, const char *name, os_task_func_t func,
     }
 
     _clear_stack(stack_bottom, stack_size);
-    t->t_stackptr = os_arch_task_stack_init(t, &stack_bottom[stack_size],
-            stack_size);
     t->t_stacktop = &stack_bottom[stack_size];
     t->t_stacksize = stack_size;
+    t->t_stackptr = os_arch_task_stack_init(t, &stack_bottom[stack_size],
+            stack_size);
 
     STAILQ_FOREACH(task, &g_os_task_list, t_os_task_list) {
         assert(t->t_prio != task->t_prio);

--- a/kernel/os/src/os_task.c
+++ b/kernel/os/src/os_task.c
@@ -131,8 +131,8 @@ os_task_init(struct os_task *t, const char *name, os_task_func_t func,
     _clear_stack(stack_bottom, stack_size);
     t->t_stacktop = &stack_bottom[stack_size];
     t->t_stacksize = stack_size;
-    t->t_stackptr = os_arch_task_stack_init(t, &stack_bottom[stack_size],
-            stack_size);
+    t->t_stackptr = os_arch_task_stack_init(t, t->t_stacktop,
+            t->t_stacksize);
 
     STAILQ_FOREACH(task, &g_os_task_list, t_os_task_list) {
         assert(t->t_prio != task->t_prio);


### PR DESCRIPTION
So they can be modified by the architecture dependent stack init.

As discussed [here](https://github.com/apache/mynewt-core/pull/474#discussion_r131878603)