### PR TITLE
sys/console: Provide default implementation of console_out()

### DIFF
--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -84,6 +84,16 @@ static struct os_eventq *avail_queue;
 static struct os_eventq *lines_queue;
 static completion_cb completion;
 
+/*
+ * Default implementation in case all consoles are disabled - we just ignore any
+ * output to console.
+ */
+int __attribute__((weak))
+console_out(int c)
+{
+    return c;
+}
+
 void
 console_echo(int on)
 {


### PR DESCRIPTION
The weak symbol will be used if all consoles are disabled effectively
disabling console io, but retaining console code so application still
builds without problems. This makes easy to just disable console in
particular target without need to modify the application.