### PR TITLE
native-armv7; stack initialization 

### DIFF
--- a/kernel/os/src/arch/sim-armv7/os_arch_stack_frame.s
+++ b/kernel/os/src/arch/sim-armv7/os_arch_stack_frame.s
@@ -29,7 +29,7 @@
 os_arch_frame_init:
     mov	    r1, sp
     mov	    sp, r0		/* stack for the task starts from sf */
-    sub     sp, sp, #20
+    sub     sp, sp, #24	/* stack must be aligned by 8 */
     str	    r1, [sp, #12]
     str     lr, [sp, #16]	/* Store LR there */
     str     r0, [sp, #4]	/* Store sf pointer to stack */
@@ -40,6 +40,7 @@ os_arch_frame_init:
     beq     end
     mov	    r1, r0
     ldr     r0, [sp, #4]
+    and     sp, sp, #0xfffffff8
     bl      os_arch_task_start
 end:
     ldr	    r1, [sp, #16]	/* return $sp for the callee */

--- a/kernel/sim/src/sim_sched_nosig.c
+++ b/kernel/sim/src/sim_sched_nosig.c
@@ -27,7 +27,7 @@
  * "signals" implementation.
  *
  * To use this version of sim, disable the MCU_NATIVE_USE_SIGNALS syscfg
- * setting.  
+ * setting.
  */
 
 #include "syscfg/syscfg.h"

--- a/kernel/sim/src/sim_sched_sig.c
+++ b/kernel/sim/src/sim_sched_sig.c
@@ -26,7 +26,7 @@
  * causing deadlock or memory corruption.
  *
  * To use this version of sim, enable the MCU_NATIVE_USE_SIGNALS syscfg
- * setting.  
+ * setting.
  */
 
 #include "syscfg/syscfg.h"


### PR DESCRIPTION
…for tasks was violating ARM call rules.

Task stack init routine departed with $sp pointing to value which was not aligned to 8 byte boundary.