### PR TITLE
Set explicit default values for LSM303DLHC mag

### DIFF
--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -290,7 +290,7 @@ lsm303dlhc_init(struct os_dev *dev, void *arg)
     }
 
     /* Add the accelerometer/magnetometer driver */
-    rc = sensor_set_driver(sensor, SENSOR_TYPE_LINEAR_ACCEL |
+    rc = sensor_set_driver(sensor, SENSOR_TYPE_ACCELEROMETER |
             SENSOR_TYPE_MAGNETIC_FIELD,
             (struct sensor_driver *) &g_lsm303dlhc_sensor_driver);
     if (rc != 0) {
@@ -408,7 +408,7 @@ lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
     }databuf;
 
     /* If the read isn't looking for accel or mag data, don't do anything. */
-    if (!(type & SENSOR_TYPE_LINEAR_ACCEL) &&
+    if (!(type & SENSOR_TYPE_ACCELEROMETER) &&
        (!(type & SENSOR_TYPE_MAGNETIC_FIELD))) {
         rc = SYS_EINVAL;
         goto err;
@@ -418,7 +418,7 @@ lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
     lsm = (struct lsm303dlhc *) SENSOR_GET_DEVICE(sensor);
 
     /* Get a new accelerometer sample */
-    if (type & SENSOR_TYPE_LINEAR_ACCEL) {
+    if (type & SENSOR_TYPE_ACCELEROMETER) {
         x = y = z = 0;
         rc = lsm303dlhc_read48(itf, lsm->cfg.acc_addr,
                                LSM303DLHC_REGISTER_ACCEL_OUT_X_L_A | 0x80,
@@ -475,7 +475,7 @@ lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
         databuf.sad.sad_z_is_valid = 1;
 
         /* Call data function */
-        rc = data_func(sensor, data_arg, &databuf.sad, SENSOR_TYPE_LINEAR_ACCEL);
+        rc = data_func(sensor, data_arg, &databuf.sad, SENSOR_TYPE_ACCELEROMETER);
         if (rc != 0) {
             goto err;
         }
@@ -582,7 +582,7 @@ lsm303dlhc_sensor_get_config(struct sensor *sensor, sensor_type_t type,
 {
     int rc;
 
-    if ((type != SENSOR_TYPE_LINEAR_ACCEL) &&
+    if ((type != SENSOR_TYPE_ACCELEROMETER) &&
         (type != SENSOR_TYPE_MAGNETIC_FIELD)) {
         rc = SYS_EINVAL;
         goto err;

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -255,6 +255,10 @@ config_lsm303dlhc_sensor(void)
     lsmcfg.acc_addr = LSM303DLHC_ADDR_ACCEL;
     /* Device I2C addr for magnetometer */
     lsmcfg.mag_addr = LSM303DLHC_ADDR_MAG;
+    /* Set default mag gain to +/-1.3 gauss */
+    lsmcfg.mag_gain = LSM303DLHC_MAG_GAIN_1_3;
+    /* Set default mag sample rate to 15Hz */
+    lsmcfg.mag_rate = LSM303DLHC_MAG_RATE_15;
 
     lsmcfg.mask = SENSOR_TYPE_LINEAR_ACCEL|
                   SENSOR_TYPE_MAGNETIC_FIELD;

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -260,7 +260,7 @@ config_lsm303dlhc_sensor(void)
     /* Set default mag sample rate to 15Hz */
     lsmcfg.mag_rate = LSM303DLHC_MAG_RATE_15;
 
-    lsmcfg.mask = SENSOR_TYPE_LINEAR_ACCEL|
+    lsmcfg.mask = SENSOR_TYPE_ACCELEROMETER|
                   SENSOR_TYPE_MAGNETIC_FIELD;
 
     rc = lsm303dlhc_config((struct lsm303dlhc *) dev, &lsmcfg);


### PR DESCRIPTION
This PR avoids repetitive warnings in the shell when the LSM303DLHC is used.

The default values corresponds to the IC values coming out of reset (+/-1.3 gauss and 15Hz sample rate on the magnetometer).