### PR TITLE
Remove extraneous #include.

### DIFF
--- a/net/nimble/transport/socket/src/ble_hci_socket.c
+++ b/net/nimble/transport/socket/src/ble_hci_socket.c
@@ -43,7 +43,6 @@
 #include <sys/uio.h>
 #include <unistd.h>
 #include <sys/socket.h>
-#include "os/os.h"
 
 #if MYNEWT_VAL(BLE_SOCK_USE_TCP)
 #include <sys/errno.h>


### PR DESCRIPTION
This include was causing build errors on a Linux system with the following identity:

```
    Linux bleh 4.4.0-93-generic #116-Ubuntu SMP Fri Aug 11 21:17:51 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

The build errors were:

```
    In file included from repos/apache-mynewt-core/kernel/os/include/os/os.h:77:0,
                     from repos/apache-mynewt-core/net/nimble/transport/socket/src/ble_hci_socket.c:46:
    repos/apache-mynewt-core/kernel/os/include/os/endian.h:43:40: error: expected declaration specifiers or ‘...’ before ‘(’ token
     #define os_bswap_32(x)    ((uint32_t) ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) | (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24)))
                                            ^
    In file included from repos/apache-mynewt-core/kernel/os/include/os/os.h:77:0,
                     from repos/apache-mynewt-core/net/nimble/transport/socket/src/ble_hci_socket.c:46:
    repos/apache-mynewt-core/kernel/os/include/os/endian.h:48:6: error: expected declaration specifiers or ‘...’ before ‘(’ token
         ((((x) & 0xff00) >> 8) |                        \
          ^
    In file included from repos/apache-mynewt-core/kernel/os/include/os/os.h:77:0,
                     from repos/apache-mynewt-core/net/nimble/transport/socket/src/ble_hci_socket.c:46:
    repos/apache-mynewt-core/kernel/os/include/os/endian.h:43:40: error: expected declaration specifiers or ‘...’ before ‘(’ token
     #define os_bswap_32(x)    ((uint32_t) ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) | (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24)))
                                            ^
    In file included from repos/apache-mynewt-core/kernel/os/include/os/os.h:77:0,
                     from repos/apache-mynewt-core/net/nimble/transport/socket/src/ble_hci_socket.c:46:
    repos/apache-mynewt-core/kernel/os/include/os/endian.h:48:6: error: expected declaration specifiers or ‘...’ before ‘(’ token
         ((((x) & 0xff00) >> 8) |                        \
```

The problem was caused by Mynewt's hton/ntoh macros interfering with the system's functions with the same name declared in `netinet/in.h`.

`os.h` gets included later in this file anyway (after the inclusion of `netinet/in.h`), so removing this include does not cause any problems.