### PR TITLE
Do not allow both SPI 0 and I2C 0 to be enabled on the EE-02 board.

### DIFF
--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -54,6 +54,7 @@ syscfg.defs:
         value:  1
         restrictions:
             - "!SPI_0_SLAVE"
+            - "!I2C_0"
     SPI_0_MASTER_SS_PIN:
         description: 'SPI 0 (master) SS pin number.'
         value:  22
@@ -62,6 +63,7 @@ syscfg.defs:
         value:  0
         restrictions:
             - "!SPI_0_MASTER"
+            - "!I2C_0"
 
     TIMER_0:
         description: 'NRF52 Timer 0'
@@ -85,6 +87,15 @@ syscfg.defs:
     I2C_0:
         description: 'NRF52 I2C (TWI) interface 0'
         value:  0
+        restrictions:
+            - "!SPI_0_MASTER"
+            - "!SPI_0_SLAVE"
+    I2C_1:
+        description: 'NRF52 I2C (TWI) interface 1'
+        value:  0
+        restrictions:
+            - "!SPI_1_MASTER"
+            - "!SPI_1_SLAVE"
 
 syscfg.defs.BLE_LP_CLOCK:
     TIMER_0:


### PR DESCRIPTION
On nRF52, SPI 0 shares resources with I2C 0, so they cannot both be enabled at the same time.

Also add I2C_1 (with analogous restrictions with SPI 1).  Don’t add SPI_1 yet as we had trouble getting it to work.

More ideally, it seems like we ought to be able to use both SPI 0 and I2C 0, not simultaneously but by disabling them at runtime while they are not in use.  This is surely a much larger change.