### PR TITLE
Prevent newt compatility warning for 0.0.0

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -42,9 +42,14 @@ repo.versions:
     "1.2-latest": "1.2.0"  # 1.2.0
 
 repo.newt_compatibility:
+    # Allow all versions for 0.0.0.  This is a workaround to prevent a warning
+    # from being displayed when newt doesn't know which version of the repo is
+    # present.
+    0.0.0:
+        0.0.0: good
+
     # Core 1.1.0+ requires newt 1.1.0+ (feature: self-overrides).
     1.2.0:
         1.1.0: good
     1.1.0:
         1.1.0: good
-


### PR DESCRIPTION
When the user's project.yml file specifies a floating version for a repo
(e.g., 0-latest), newt records a fake version in the project.state file
(e.g., 0.0.0).  This is a problem when determining if the version of a
newt is compatible with the current version of the repo, since the
actual version is not known.

This commit is a short-term workaround to prevent the warning from being
displayed.  It allows 0.0.0 of core to work with all versions of newt.
A long term fix is needed: we need to be able to determine the actual
version of the repo present in the user's project.