### PR TITLE
[MYNEWT-783] nimble/phy: Fix T_IFS on coded phy

### DIFF
--- a/hw/drivers/nimble/native/src/ble_phy.c
+++ b/hw/drivers/nimble/native/src/ble_phy.c
@@ -627,6 +627,6 @@ ble_phy_xcvr_state_get(void)
 #endif
 
 void
-ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
+ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs)
 {
 }

--- a/hw/drivers/nimble/nrf51/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf51/src/ble_phy.c
@@ -369,10 +369,11 @@ ble_phy_set_start_time(uint32_t cputime, uint8_t rem_usecs)
  * the received frame.
  *
  * @param txrx Flag denoting if this wfr is a txrx turn-around or not.
+ * @param tx_phy_mode phy mode for last TX (not used on nRF51)
  * @param wfr_usecs Amount of usecs to wait.
  */
 void
-ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs)
+ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs)
 {
     uint32_t end_time;
 
@@ -540,7 +541,7 @@ ble_phy_tx_end_isr(void)
         if (txlen && was_encrypted) {
             txlen += BLE_LL_DATA_MIC_LEN;
         }
-        ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_TXRX, 0);
+        ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_TXRX, 0, 0);
     } else {
         /*
          * XXX: not sure we need to stop the timer here all the time. Or that

--- a/hw/drivers/nimble/nrf52/include/ble/xcvr.h
+++ b/hw/drivers/nimble/nrf52/include/ble/xcvr.h
@@ -24,13 +24,16 @@
 extern "C" {
 #endif
 
+#define XCVR_RX_RADIO_RAMPUP_USECS  (40)
+#define XCVR_TX_RADIO_RAMPUP_USECS  (40)
+
 /*
  * NOTE: we have to account for the RTC output compare issue. We want it to be
  * 5 ticks.
  */
 #define XCVR_PROC_DELAY_USECS         (153)
-#define XCVR_RX_START_DELAY_USECS     (140)
-#define XCVR_TX_START_DELAY_USECS     (140)
+#define XCVR_RX_START_DELAY_USECS     (XCVR_RX_RADIO_RAMPUP_USECS)
+#define XCVR_TX_START_DELAY_USECS     (XCVR_TX_RADIO_RAMPUP_USECS)
 #define XCVR_TX_SCHED_DELAY_USECS     \
     (XCVR_TX_START_DELAY_USECS + XCVR_PROC_DELAY_USECS)
 #define XCVR_RX_SCHED_DELAY_USECS     \

--- a/hw/drivers/nimble/nrf52/src/ble_phy.c
+++ b/hw/drivers/nimble/nrf52/src/ble_phy.c
@@ -484,6 +484,17 @@ ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs)
         end_time += g_ble_phy_t_txenddelay[tx_phy_mode];
         /* Wait a bit longer due to allowed active clock accuracy */
         end_time += 2;
+#if MYNEWT_VAL(BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN) > 0
+        if ((phy == BLE_PHY_MODE_CODED_125KBPS) ||
+                                    (phy == BLE_PHY_MODE_CODED_500KBPS)) {
+            /*
+             * Some controllers exceed T_IFS when transmitting on coded phy
+             * so let's wait a bit longer to be able to talk to them if this
+             * workaround is enabled.
+             */
+            end_time += MYNEWT_VAL(BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN);
+        }
+#endif
     } else {
         /*
          * RX shall start no later than wfr_usecs after RX enabled.

--- a/hw/drivers/nimble/nrf52/syscfg.yml
+++ b/hw/drivers/nimble/nrf52/syscfg.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: hw/drivers/nimble/nrf52
+
+syscfg.defs:
+    BLE_PHY_DBG_TIME_TXRXEN_READY_PIN:
+        description: >
+            When set to proper GPIO pin number, this pin will be set
+            to high state when radio is enabled using PPI channels
+            20 or 21 and back to low state on radio EVENTS_READY.
+            This can be used to measure radio ram-up time.
+        value: -1
+
+    BLE_PHY_DBG_TIME_ADDRESS_END_PIN:
+        description: >
+            When set to proper GPIO pin number, this pin will be set
+            to high state on radio EVENTS_ADDRESS and back to low state
+            on radio EVENTS_END.
+            This can be used to measure radio pipeline delays.
+        value: -1
+
+    BLE_PHY_DBG_TIME_WFR_PIN:
+        description: >
+            When set to proper GPIO pin number, this pin will be set
+            to high state on radio EVENTS_RXREADY and back to low
+            state when wfr timer expires.
+            This can be used to check if wfr is calculated properly.
+        value: -1

--- a/hw/drivers/nimble/nrf52/syscfg.yml
+++ b/hw/drivers/nimble/nrf52/syscfg.yml
@@ -19,6 +19,16 @@
 # Package: hw/drivers/nimble/nrf52
 
 syscfg.defs:
+    BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN:
+        description: >
+            This defines additional margin for T_IFS tolerance while in
+            RX on coded phy to allow maintaining connections with some
+            controllers that exceed proper T_IFS (150 usecs) by more
+            than allowed 2 usecs.
+            This value shall be only used for debugging purposes. It is
+            strongly recommended to keep this settings at default value
+            to ensure compliance with specification.
+        value: 0
     BLE_PHY_DBG_TIME_TXRXEN_READY_PIN:
         description: >
             When set to proper GPIO pin number, this pin will be set

--- a/net/nimble/controller/include/controller/ble_phy.h
+++ b/net/nimble/controller/include/controller/ble_phy.h
@@ -134,7 +134,7 @@ void ble_phy_disable(void);
 #define BLE_PHY_WFR_ENABLE_TXRX     (1)
 
 void ble_phy_stop_usec_timer(void);
-void ble_phy_wfr_enable(int txrx, uint32_t wfr_usecs);
+void ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs);
 
 /* Starts rf clock */
 void ble_phy_rfclk_enable(void);

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -1533,7 +1533,7 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
              */
             usecs = connsm->slave_cur_tx_win_usecs + 61 +
                 (2 * connsm->slave_cur_window_widening);
-            ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_RX, usecs);
+            ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_RX, 0, usecs);
             /* Set next wakeup time to connection event end time */
             rc = BLE_LL_SCHED_STATE_RUNNING;
         }

--- a/net/nimble/controller/src/ble_ll_scan.c
+++ b/net/nimble/controller/src/ble_ll_scan.c
@@ -200,7 +200,7 @@ ble_ll_aux_scan_cb(struct ble_ll_sched_item *sch)
     }
 
     STATS_INC(ble_ll_stats, aux_fired_for_read);
-    ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_RX, BLE_LL_SCHED_ADV_MAX_USECS);
+    ble_phy_wfr_enable(BLE_PHY_WFR_ENABLE_RX, 0, BLE_LL_SCHED_ADV_MAX_USECS);
 
 done:
 


### PR DESCRIPTION
This changes T_IFS control from hardware to software. This is required in order to have proper T_IFS on LE Coded PHY since now we're ~16 usecs over the limit which means we can't maintain connection with other devices (except for another Mynewt).

Basically what's need to be done is to schedule TXEN/RXEN using TIMER0 exactly 150 usecs after end of TX/RX which is stored in CC[2]. It's a bit more complicated though as we need to take into account various delays in TX/RX pipeline which are not specified in nRF documentation so they were measured instead - code used to do this is also included as I think it can be useful for debugging purposes later.

The result is the same T_IFS on all phys: 150 +/- 1 usecs.

In addition, code to calculate wfr timer is upgraded to be more precise by including pipeline delays.