### PR TITLE
nimble/controller: Remove misleading TODO

### DIFF
--- a/net/nimble/controller/src/ble_ll_adv.c
+++ b/net/nimble/controller/src/ble_ll_adv.c
@@ -956,7 +956,6 @@ ble_ll_adv_secondary_tx_start_cb(struct ble_ll_sched_item *sch)
     }
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION) == 1)
-    /* XXX: automatically do this in the phy based on channel? */
     ble_phy_encrypt_disable();
 #endif
 


### PR DESCRIPTION
This comment is no longer valid as with Extended Advertising all
channels are used for advertising.