### PR TITLE
apps/bleprph: Add simple support for non-1M LE PHYs

### DIFF
--- a/apps/bleprph/src/bleprph.h
+++ b/apps/bleprph/src/bleprph.h
@@ -20,6 +20,7 @@
 #ifndef H_BLEPRPH_
 #define H_BLEPRPH_
 
+#include <stdbool.h>
 #include "log/log.h"
 #include "nimble/ble.h"
 #ifdef __cplusplus
@@ -48,6 +49,15 @@ extern struct log bleprph_log;
 
 void gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg);
 int gatt_svr_init(void);
+
+/* PHY support */
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+#define CONN_HANDLE_INVALID     0xffff
+
+void phy_init(void);
+void phy_conn_changed(uint16_t handle);
+void phy_update(uint8_t phy);
+#endif
 
 /** Misc. */
 void print_bytes(const uint8_t *bytes, int len);

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -168,6 +168,10 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
             rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
             assert(rc == 0);
             bleprph_print_conn_desc(&desc);
+
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+            phy_conn_changed(event->connect.conn_handle);
+#endif
         }
         BLEPRPH_LOG(INFO, "\n");
 
@@ -181,6 +185,10 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         BLEPRPH_LOG(INFO, "disconnect; reason=%d ", event->disconnect.reason);
         bleprph_print_conn_desc(&event->disconnect.conn);
         BLEPRPH_LOG(INFO, "\n");
+
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+        phy_conn_changed(CONN_HANDLE_INVALID);
+#endif
 
         /* Connection terminated; resume advertising. */
         bleprph_advertise();
@@ -240,6 +248,13 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
          * continue with the pairing operation.
          */
         return BLE_GAP_REPEAT_PAIRING_RETRY;
+
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+    case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
+        /* XXX: assume symmetric phy for now */
+        phy_update(event->phy_updated.tx_phy);
+        return 0;
+#endif
     }
 
     return 0;
@@ -295,6 +310,10 @@ main(void)
     /* Set the default device name. */
     rc = ble_svc_gap_device_name_set("nimble-bleprph");
     assert(rc == 0);
+
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+    phy_init();
+#endif
 
     conf_load();
 

--- a/apps/bleprph/src/phy.c
+++ b/apps/bleprph/src/phy.c
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "bsp/bsp.h"
+#include "hal/hal_gpio.h"
+#include "host/ble_gap.h"
+#include "os/os_eventq.h"
+#include "syscfg/syscfg.h"
+#include "bleprph.h"
+
+#if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
+
+static const int button_gpio[4] = MYNEWT_VAL(BLEPRPH_LE_PHY_BUTTON_GPIO);
+static const int led_gpio[3] = MYNEWT_VAL(BLEPRPH_LE_PHY_LED_GPIO);
+
+#define PHY_TO_PTR(_mask, _opts) (void *)(((_opts) << 16) | ((_mask)))
+#define PTR_TO_PHY_MASK(_ptr) (uint8_t)(((int)_ptr) & 0x0ff)
+#define PTR_TO_PHY_OPTS(_ptr) (uint8_t)(((int)_ptr) >> 16)
+
+static struct os_event gpio_event;
+
+static uint16_t conn_handle = CONN_HANDLE_INVALID;
+
+static void
+gpio_irq_handler(void *arg)
+{
+    gpio_event.ev_arg = arg;
+    os_eventq_put(os_eventq_dflt_get(), &gpio_event);
+}
+
+static void
+gpio_event_handler(struct os_event *ev)
+{
+    uint8_t phy_mask;
+    uint8_t phy_opts;
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+    phy_mask = PTR_TO_PHY_MASK(ev->ev_arg);
+    phy_opts = PTR_TO_PHY_OPTS(ev->ev_arg);
+    OS_EXIT_CRITICAL(sr);
+
+    if (conn_handle != CONN_HANDLE_INVALID) {
+        ble_gap_set_prefered_le_phy(conn_handle, phy_mask, phy_mask, phy_opts);
+    }
+}
+
+static void
+setup_button_gpio(int button, uint8_t phy_mask, uint8_t phy_opts)
+{
+    if (button < 0) {
+        return;
+    }
+
+    hal_gpio_irq_init(button, gpio_irq_handler, PHY_TO_PTR(phy_mask, phy_opts),
+                      HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_UP);
+    hal_gpio_irq_enable(button);
+}
+
+void
+phy_init(void)
+{
+    gpio_event.ev_cb = gpio_event_handler;
+
+    /*
+     * XXX: we could make this configurable, but for now assume all pins are
+     * valid, buttons gpio pins are pulled-up and LEDs are active-low - this
+     * is valid for nRF52840 PDK.
+     */
+    setup_button_gpio(button_gpio[0], BLE_GAP_LE_PHY_1M_MASK,
+                      BLE_GAP_LE_PHY_CODED_ANY);
+    setup_button_gpio(button_gpio[1], BLE_GAP_LE_PHY_2M_MASK,
+                      BLE_GAP_LE_PHY_CODED_ANY);
+    setup_button_gpio(button_gpio[2], BLE_GAP_LE_PHY_CODED_MASK,
+                      BLE_GAP_LE_PHY_CODED_S2);
+    setup_button_gpio(button_gpio[3], BLE_GAP_LE_PHY_CODED_MASK,
+                      BLE_GAP_LE_PHY_CODED_S8);
+
+    hal_gpio_init_out(led_gpio[0], 1);
+    hal_gpio_init_out(led_gpio[1], 1);
+    hal_gpio_init_out(led_gpio[2], 1);
+}
+
+void
+phy_conn_changed(uint16_t handle)
+{
+    uint8_t phy = 0;
+
+    conn_handle = handle;
+
+    if (handle != CONN_HANDLE_INVALID) {
+        /* XXX: assume symmetric phy for now */
+        ble_gap_read_le_phy(handle, &phy, &phy);
+    }
+
+    phy_update(phy);
+}
+
+void
+phy_update(uint8_t phy)
+{
+    if (conn_handle == CONN_HANDLE_INVALID) {
+        hal_gpio_write(led_gpio[0], 1);
+        hal_gpio_write(led_gpio[1], 1);
+        hal_gpio_write(led_gpio[2], 1);
+    } else {
+        hal_gpio_write(led_gpio[0], !(phy == BLE_GAP_LE_PHY_1M));
+        hal_gpio_write(led_gpio[1], !(phy == BLE_GAP_LE_PHY_2M));
+        hal_gpio_write(led_gpio[2], !(phy == BLE_GAP_LE_PHY_CODED));
+    }
+}
+
+#endif

--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -18,6 +18,27 @@
 
 # Package: apps/bleprph
 
+syscfg.defs:
+    BLEPRPH_LE_PHY_SUPPORT:
+        description: >
+            Enable support for changing PHY preference on active connection.
+            PHY preference change is triggered by configured GPIO pins.
+            Current PHY is indicated using LEDs connected to configured
+            GPIO pins.
+        value: 0
+    BLEPRPH_LE_PHY_BUTTON_GPIO:
+        description: >
+            GPIO pins for changing PHY preference on active connection. This
+            is an array of 4 GPIO pin numbers for 1M, 2M, LE Coded S=2 and
+            LE Coded S=8 respectively.
+        value: "(int[]){ BUTTON_1, BUTTON_2, BUTTON_3, BUTTON_4 }"
+    BLEPRPH_LE_PHY_LED_GPIO:
+        description: >
+            GPIO pins for indicating current PHY on active connection. This
+            is an array of 3 GPIO pin numbers for 1M, 2M and LE Coded
+            respectively.
+        value: "(int[]){ LED_1, LED_2, LED_3 }"
+
 syscfg.vals:
     # Disable central and observer roles.
     BLE_ROLE_BROADCASTER: 1


### PR DESCRIPTION
PHY support can be enabled using BLEPRPH_LE_PHY_SUPPORT syscfg val.

Once enabled, we have 4 buttons and 3 LEDs to work with:
- buttons 1-4 change phy preference to 1M, 2M, Coded S=2 or Coded S=8
  respectively,
- LEDs 1-3 display current phy on active connection as 1M, 2M or Coded
  respectively.

For now we just assume symmetric phy on link.

This works ootb on nRF52840 PDK, for other BSPs GPIO pins may need
to be adjusted using syscfg vals.