### PR TITLE
mesh: Fix dropping valid proxy configuration messages

### DIFF
--- a/net/nimble/host/mesh/src/net.c
+++ b/net/nimble/host/mesh/src/net.c
@@ -1133,7 +1133,8 @@ int bt_mesh_net_decode(struct os_mbuf *data, enum bt_mesh_net_if net_if,
 	BT_DBG("Decryption successful. Payload len %u: %s", buf->om_len,
 		   bt_hex(buf->om_data, buf->om_len));
 
-	if (rx->dst == BT_MESH_ADDR_UNASSIGNED) {
+	if (net_if != BT_MESH_NET_IF_PROXY_CFG &&
+	    rx->dst == BT_MESH_ADDR_UNASSIGNED) {
 		BT_ERR("Destination address is unassigned; dropping packet");
 		return -EBADMSG;
 	}


### PR DESCRIPTION
Proxy configuration messages are allowed (in fact required) to use
unassigned addresses, so they should be exempt from this check.

Ported from Zephyr