### PR TITLE
mesh: Fix compilation with GCC 7.1

### DIFF
--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -80,7 +80,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
     console_printf("SET UNACK\n");
 }
 
-static const struct bt_mesh_model_op const gen_onoff_op[] = {
+static const struct bt_mesh_model_op gen_onoff_op[] = {
     { BT_MESH_MODEL_OP_2(0x82, 0x01), 0, gen_onoff_get },
     { BT_MESH_MODEL_OP_2(0x82, 0x02), 2, gen_onoff_set },
     { BT_MESH_MODEL_OP_2(0x82, 0x03), 2, gen_onoff_set_unack },
@@ -129,7 +129,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 {
 }
 
-static const struct bt_mesh_model_op const gen_level_op[] = {
+static const struct bt_mesh_model_op gen_level_op[] = {
     { BT_MESH_MODEL_OP_2(0x82, 0x05), 0, gen_level_get },
     { BT_MESH_MODEL_OP_2(0x82, 0x06), 3, gen_level_set },
     { BT_MESH_MODEL_OP_2(0x82, 0x07), 3, gen_level_set_unack },

--- a/net/nimble/host/mesh/src/access.c
+++ b/net/nimble/host/mesh/src/access.c
@@ -29,7 +29,7 @@ static u16_t dev_primary_addr;
 static const struct {
 	const u16_t id;
 	int (*const init)(struct bt_mesh_model *model, bool primary);
-} const model_init[] = {
+} model_init[] = {
 	{ BT_MESH_MODEL_ID_CFG_SRV, bt_mesh_conf_init },
 	{ BT_MESH_MODEL_ID_HEALTH_SRV, bt_mesh_health_init },
 };


### PR DESCRIPTION
Fix following error emitted by GCC 7.1:

Error: repos/apache-mynewt-core/apps/blemesh/src/main.c:83:38: error:
 duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
 static const struct bt_mesh_model_op const gen_onoff_op[] = {
                                      ^~~~~
repos/apache-mynewt-core/apps/blemesh/src/main.c:132:38: error:
 duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
 static const struct bt_mesh_model_op const gen_level_op[] = {
                                      ^~~~~
cc1: all warnings being treated as errors