### PR TITLE
BLE Host - Populate resolving list with persisted IRKs at startup

### DIFF
--- a/net/nimble/host/include/host/ble_hs_test.h
+++ b/net/nimble/host/include/host/ble_hs_test.h
@@ -46,6 +46,7 @@ int ble_hs_hci_test_all(void);
 int ble_hs_id_test_all(void);
 int ble_l2cap_test_all(void);
 int ble_os_test_all(void);
+int ble_hs_pvcy_test_all(void);
 int ble_sm_lgcy_test_suite(void);
 int ble_sm_sc_test_suite(void);
 int ble_sm_test_all(void);

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -103,6 +103,8 @@ STATS_NAME_START(ble_hs_stats)
     STATS_NAME(ble_hs_stats, hci_timeout)
     STATS_NAME(ble_hs_stats, reset)
     STATS_NAME(ble_hs_stats, sync)
+    STATS_NAME(ble_hs_stats, pvcy_add_entry)
+    STATS_NAME(ble_hs_stats, pvcy_add_entry_fail)
 STATS_NAME_END(ble_hs_stats)
 
 struct os_eventq *
@@ -500,6 +502,9 @@ ble_hs_start(void)
     }
 
     ble_hs_sync();
+
+    rc = ble_hs_misc_restore_irks();
+    assert(rc == 0);
 
     return 0;
 }

--- a/net/nimble/host/src/ble_hs_misc.c
+++ b/net/nimble/host/src/ble_hs_misc.c
@@ -94,3 +94,35 @@ ble_hs_misc_addr_type_to_id(uint8_t own_addr_type)
         return BLE_ADDR_PUBLIC;
     }
 }
+
+static int
+ble_hs_misc_restore_one_irk(int obj_type, union ble_store_value *val,
+                            void *cookie)
+{
+    const struct ble_store_value_sec *sec;
+    int rc;
+
+    BLE_HS_DBG_ASSERT(obj_type == BLE_STORE_OBJ_TYPE_PEER_SEC);
+
+    sec = &val->sec;
+    if (sec->irk_present) {
+        rc = ble_hs_pvcy_add_entry(sec->peer_addr.val, sec->peer_addr.type,
+                                   sec->irk);
+        if (rc != 0) {
+            BLE_HS_LOG(ERROR, "failed to configure restored IRK\n");
+        }
+    }
+
+    return 0;
+}
+
+int
+ble_hs_misc_restore_irks(void)
+{
+    int rc;
+
+    rc = ble_store_iterate(BLE_STORE_OBJ_TYPE_PEER_SEC,
+                           ble_hs_misc_restore_one_irk,
+                           NULL);
+    return rc;
+}

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -83,6 +83,8 @@ STATS_SECT_START(ble_hs_stats)
     STATS_SECT_ENTRY(hci_timeout)
     STATS_SECT_ENTRY(reset)
     STATS_SECT_ENTRY(sync)
+    STATS_SECT_ENTRY(pvcy_add_entry)
+    STATS_SECT_ENTRY(pvcy_add_entry_fail)
 STATS_SECT_END
 extern STATS_SECT_DECL(ble_hs_stats) ble_hs_stats;
 
@@ -111,6 +113,7 @@ void ble_hs_misc_conn_chan_find_reqd(uint16_t conn_handle, uint16_t cid,
                                      struct ble_hs_conn **out_conn,
                                      struct ble_l2cap_chan **out_chan);
 uint8_t ble_hs_misc_addr_type_to_id(uint8_t addr_type);
+int ble_hs_misc_restore_irks(void);
 
 int ble_hs_locked_by_cur_task(void);
 int ble_hs_is_parent_task(void);

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -25,7 +25,7 @@ static uint8_t ble_hs_pvcy_started;
 uint8_t ble_hs_pvcy_irk[16];
 
 /** Use this as a default IRK if none gets set. */
-const uint8_t default_irk[16] = {
+const uint8_t ble_hs_pvcy_default_irk[16] = {
     0xef, 0x8d, 0xe2, 0x16, 0x4f, 0xec, 0x43, 0x0d,
     0xbf, 0x5b, 0xdd, 0x34, 0xc0, 0x53, 0x1e, 0xb8,
 };
@@ -165,7 +165,7 @@ ble_hs_pvcy_set_our_irk(const uint8_t *irk)
     if (irk != NULL) {
         memcpy(new_irk, irk, 16);
     } else {
-        memcpy(new_irk, default_irk, 16);
+        memcpy(new_irk, ble_hs_pvcy_default_irk, 16);
     }
 
     /* Clear the resolving list if this is a new IRK. */

--- a/net/nimble/host/src/ble_hs_pvcy_priv.h
+++ b/net/nimble/host/src/ble_hs_pvcy_priv.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+extern const uint8_t ble_hs_pvcy_default_irk[16];
+
 int ble_hs_pvcy_set_our_irk(const uint8_t *irk);
 int ble_hs_pvcy_our_irk(const uint8_t **out_irk);
 int ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr);

--- a/net/nimble/host/src/ble_store.c
+++ b/net/nimble/host/src/ble_store.c
@@ -245,10 +245,10 @@ ble_store_write_peer_sec(const struct ble_store_value_sec *value_sec)
             return rc;
         }
 
-        /* FIXME Controller is BT5.0 and default privacy mode is network which can
-         * cause problems for apps which are not aware of it. We need to sort it
-         * out somehow. For now we set device mode for all of the peer devices and
-         * application should change it to network if needed
+        /* FIXME Controller is BT5.0 and default privacy mode is network which
+         * can cause problems for apps which are not aware of it. We need to
+         * sort it out somehow. For now we set device mode for all of the peer
+         * devices and application should change it to network if needed
          */
         rc = ble_hs_pvcy_set_mode(&value_sec->peer_addr,
                                   BLE_GAP_PRIVATE_MODE_DEVICE);

--- a/net/nimble/host/test/src/ble_hs_pvcy_test.c
+++ b/net/nimble/host/test/src/ble_hs_pvcy_test.c
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stddef.h>
+#include <errno.h>
+#include <string.h>
+#include "testutil/testutil.h"
+#include "host/ble_hs_test.h"
+#include "ble_hs_test_util.h"
+
+static void
+ble_hs_pvcy_test_util_start_host(int num_expected_irks)
+{
+    int rc;
+    int i;
+
+    /* Clear our IRK.  This ensures the full startup sequence, including
+     * setting the default IRK, takes place.  We need this so that we can plan
+     * which HCI acks to fake.
+     */
+    rc = ble_hs_test_util_set_our_irk((uint8_t[16]){0}, -1, 0);
+    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_prev_hci_tx_clear();
+
+    ble_hs_test_util_set_startup_acks();
+
+    for (i = 0; i < num_expected_irks; i++) {
+        ble_hs_test_util_append_ack(
+            BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0); 
+    }
+
+    rc = ble_hs_start();
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Discard startup HCI commands. */
+    ble_hs_test_util_prev_tx_queue_adj(11);
+}
+
+static void
+ble_hs_pvcy_test_util_add_irk(const struct ble_store_value_sec *value_sec)
+{
+    int rc;
+
+    ble_hs_test_util_set_ack(
+        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0); 
+    ble_hs_test_util_append_ack(
+        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE), 0);
+
+    rc = ble_store_write_peer_sec(value_sec);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    ble_hs_test_util_verify_tx_add_irk(value_sec->peer_addr.type,
+                                       value_sec->peer_addr.val,
+                                       value_sec->irk,
+                                       ble_hs_pvcy_default_irk);
+
+    ble_hs_test_util_verify_tx_set_priv_mode(value_sec->peer_addr.type,
+                                             value_sec->peer_addr.val,
+                                             BLE_GAP_PRIVATE_MODE_DEVICE);
+}
+
+TEST_CASE(ble_hs_pvcy_test_case_restore_irks)
+{
+    struct ble_store_value_sec value_sec1;
+    struct ble_store_value_sec value_sec2;
+
+    ble_hs_test_util_init();
+
+    /*** No persisted IRKs. */
+    ble_hs_pvcy_test_util_start_host(0);
+
+    /*** One persisted IRK. */
+
+    /* Persist IRK; ensure it automatically gets added to the list. */
+    value_sec1 = (struct ble_store_value_sec) {
+        .peer_addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 } },
+        .key_size = 16,
+        .ediv = 1,
+        .rand_num = 2,
+        .irk = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 },
+        .irk_present = 1,
+    };
+    ble_hs_pvcy_test_util_add_irk(&value_sec1);
+
+    /* Ensure it gets added to list on startup. */
+    ble_hs_pvcy_test_util_start_host(1);
+    ble_hs_test_util_verify_tx_add_irk(value_sec1.peer_addr.type,
+                                       value_sec1.peer_addr.val,
+                                       value_sec1.irk,
+                                       ble_hs_pvcy_default_irk);
+
+    /* Two persisted IRKs. */
+    value_sec2 = (struct ble_store_value_sec) {
+        .peer_addr = { BLE_ADDR_PUBLIC, { 2, 3, 4, 5, 6, 7 } },
+        .key_size = 16,
+        .ediv = 12,
+        .rand_num = 20,
+        .irk = { 4, 4, 4, 4, 5, 5, 5, 6, 6, 6, 9, 9, 9, 9, 9, 10 },
+        .irk_present = 1,
+    };
+    ble_hs_pvcy_test_util_add_irk(&value_sec2);
+
+    /* Ensure both get added to list on startup. */
+    ble_hs_pvcy_test_util_start_host(2);
+    ble_hs_test_util_verify_tx_add_irk(value_sec1.peer_addr.type,
+                                       value_sec1.peer_addr.val,
+                                       value_sec1.irk,
+                                       ble_hs_pvcy_default_irk);
+    ble_hs_test_util_verify_tx_add_irk(value_sec2.peer_addr.type,
+                                       value_sec2.peer_addr.val,
+                                       value_sec2.irk,
+                                       ble_hs_pvcy_default_irk);
+}
+
+TEST_SUITE(ble_hs_pvcy_test_suite_irk)
+{
+    tu_suite_set_post_test_cb(ble_hs_test_util_post_test, NULL);
+
+    ble_hs_pvcy_test_case_restore_irks();
+}
+
+int
+ble_hs_pvcy_test_all(void)
+{
+    ble_hs_pvcy_test_suite_irk();
+
+    return tu_any_failed;
+}

--- a/net/nimble/host/test/src/ble_hs_test.c
+++ b/net/nimble/host/test/src/ble_hs_test.c
@@ -49,6 +49,7 @@ main(int argc, char **argv)
     ble_hs_conn_test_all();
     ble_hs_hci_test_all();
     ble_hs_id_test_all();
+    ble_hs_pvcy_test_all();
     ble_l2cap_test_all();
     ble_os_test_all();
     ble_sm_test_all();

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -90,7 +90,11 @@ void ble_hs_test_util_prev_tx_queue_clear(void);
 void ble_hs_test_util_set_ack_params(uint16_t opcode, uint8_t status,
                                      void *params, uint8_t params_len);
 void ble_hs_test_util_set_ack(uint16_t opcode, uint8_t status);
+void ble_hs_test_util_append_ack_params(uint16_t opcode, uint8_t status,
+                                        void *params, uint8_t params_len);
+void ble_hs_test_util_append_ack(uint16_t opcode, uint8_t status);
 void ble_hs_test_util_set_ack_seq(struct ble_hs_test_util_phony_ack *acks);
+void ble_hs_test_util_prev_tx_queue_adj(int count);
 void *ble_hs_test_util_get_first_hci_tx(void);
 void *ble_hs_test_util_get_last_hci_tx(void);
 void ble_hs_test_util_enqueue_hci_tx(void *cmd);
@@ -134,6 +138,13 @@ int ble_hs_test_util_disc(uint8_t own_addr_type, int32_t duration_ms,
                           ble_gap_event_fn *cb, void *cb_arg, int fail_idx,
                           uint8_t fail_status);
 int ble_hs_test_util_disc_cancel(uint8_t ack_status);
+void ble_hs_test_util_verify_tx_add_irk(uint8_t addr_type,
+                                        const uint8_t *addr,
+                                        const uint8_t *peer_irk,
+                                        const uint8_t *local_irk);
+void ble_hs_test_util_verify_tx_set_priv_mode(uint8_t addr_type,
+                                              const uint8_t *addr,
+                                              uint8_t priv_mode);
 void ble_hs_test_util_verify_tx_disconnect(uint16_t handle, uint8_t reason);
 void ble_hs_test_util_verify_tx_create_conn(const struct hci_create_conn *exp);
 int ble_hs_test_util_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,


### PR DESCRIPTION
(Jira ticket: https://issues.apache.org/jira/browse/MYNEWT-841)

### Prior to this commit:
Identity information gets persisted during pairing, but it is never restored after a reboot.

### After commit:
At startup and on stack reset, the host populates the resolving list with the persisted entries.