### PR TITLE
nimble: Don't hardcode TinyCrypt rand function

### DIFF
--- a/crypto/tinycrypt/include/tinycrypt/ecc_platform_specific.h
+++ b/crypto/tinycrypt/include/tinycrypt/ecc_platform_specific.h
@@ -74,7 +74,7 @@
  * for some platforms, such as Unix and Linux. For other platforms, you may need
  * to provide another PRNG function.
 */
-#define default_RNG_defined 1
+#define default_RNG_defined 0
 
 int default_CSPRNG(uint8_t *dest, unsigned int size);
 

--- a/net/nimble/host/mesh/src/mesh.c
+++ b/net/nimble/host/mesh/src/mesh.c
@@ -164,6 +164,9 @@ bt_mesh_init(uint8_t own_addr_type, const struct bt_mesh_prov *prov,
 
     g_mesh_addr_type = own_addr_type;
 
+    /* initialize SM alg ECC subsystem (it is used directly from mesh code) */
+    ble_sm_alg_ecc_init();
+
     err = bt_mesh_comp_register(comp);
     if (err) {
         return err;

--- a/net/nimble/host/src/ble_sm_alg.c
+++ b/net/nimble/host/src/ble_sm_alg.c
@@ -470,14 +470,20 @@ ble_sm_alg_gen_key_pair(uint8_t *pub, uint8_t *priv)
 }
 
 /* used by uECC to get random data */
-int
-default_CSPRNG(uint8_t *dst, unsigned int size)
+static int
+ble_sm_alg_rand(uint8_t *dst, unsigned int size)
 {
     if (ble_hs_hci_util_rand(dst, size)) {
         return 0;
     }
 
     return 1;
+}
+
+void
+ble_sm_alg_ecc_init(void)
+{
+    uECC_set_rng(ble_sm_alg_rand);
 }
 
 #endif

--- a/net/nimble/host/src/ble_sm_priv.h
+++ b/net/nimble/host/src/ble_sm_priv.h
@@ -327,6 +327,7 @@ int ble_sm_alg_f6(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
 int ble_sm_alg_gen_dhkey(uint8_t *peer_pub_key_x, uint8_t *peer_pub_key_y,
                          uint8_t *our_priv_key, uint8_t *out_dhkey);
 int ble_sm_alg_gen_key_pair(uint8_t *pub, uint8_t *priv);
+void ble_sm_alg_ecc_init(void);
 
 void ble_sm_enc_change_rx(struct hci_encrypt_change *evt);
 void ble_sm_enc_key_refresh_rx(struct hci_encrypt_key_refresh *evt);

--- a/net/nimble/host/src/ble_sm_sc.c
+++ b/net/nimble/host/src/ble_sm_sc.c
@@ -784,6 +784,7 @@ ble_sm_sc_dhkey_check_rx(uint16_t conn_handle, struct os_mbuf **om,
 void
 ble_sm_sc_init(void)
 {
+    ble_sm_alg_ecc_init();
     ble_sm_sc_keys_generated = 0;
 }
 


### PR DESCRIPTION
TinyCrypt requires rand function to be implemented by user. Instead of
hardcoding it, user is required to provide own implementation by
uECC_set_rng. This allows to provide different implementations
depending on supported features (eg BLE controller).