### PR TITLE
clicker/wifire: Fix SPI mode

### DIFF
--- a/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
+++ b/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
@@ -84,18 +84,6 @@ syscfg.defs:
         description: 'Whether to enable UART5'
         value:  1
 
-    SPI_1_MASTER:
-        description: 'SPI on J9 connector'
-        value:  1
-
-    SPI_2_MASTER:
-        description: 'SPI connected to microSD card'
-        value:  1
-
-    SPI_3_MASTER:
-        description: 'SPI connected to MRF24WG0MA'
-        value:  1
-
     I2C_3:
         description: 'I2C available on J6 connector'
         value:  1

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
@@ -131,18 +131,18 @@ hal_spi_config_master(int spi_num, struct hal_spi_settings *psettings)
 
     switch (psettings->data_mode) {
         case HAL_SPI_MODE0:
-            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
-            break;
-        case HAL_SPI_MODE1:
             SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK;
             SPIxCONSET(spi_num) = _SPI1CON_CKE_MASK;
             break;
+        case HAL_SPI_MODE1:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
         case HAL_SPI_MODE2:
-            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
-            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
             break;
         case HAL_SPI_MODE3:
-            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
             break;
         default:
             return -1;

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
@@ -159,18 +159,18 @@ hal_spi_config_master(int spi_num, struct hal_spi_settings *psettings)
 
     switch (psettings->data_mode) {
         case HAL_SPI_MODE0:
-            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
-            break;
-        case HAL_SPI_MODE1:
             SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK;
             SPIxCONSET(spi_num) = _SPI1CON_CKE_MASK;
             break;
+        case HAL_SPI_MODE1:
+            SPIxCONCLR(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            break;
         case HAL_SPI_MODE2:
-            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
-            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
             break;
         case HAL_SPI_MODE3:
-            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK;
+            SPIxCONCLR(spi_num) = _SPI1CON_CKE_MASK;
+            SPIxCONSET(spi_num) = _SPI1CON_CKP_MASK;
             break;
         default:
             return -1;


### PR DESCRIPTION
I found out that hal_spi was not setting the correct SPI mode since I used the sampling edge to deduce the values of CKP/CKE instead of the toggling edge. 
I also fixed the build for the wifire board: some defines concerning SPI_MASTER were left in the bsp.