### PR TITLE
mesh: Fix revoking app keys

### DIFF
--- a/net/nimble/host/mesh/src/cfg.c
+++ b/net/nimble/host/mesh/src/cfg.c
@@ -2649,7 +2649,7 @@ static void krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	} else if ((sub->kr_phase == BT_MESH_KR_PHASE_1 ||
 		    sub->kr_phase == BT_MESH_KR_PHASE_2) &&
 		   phase == BT_MESH_KR_PHASE_3) {
-		memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
+		bt_mesh_net_revoke_keys(sub);
 		if ((MYNEWT_VAL(BLE_MESH_LOW_POWER)) ||
 		    (MYNEWT_VAL(BLE_MESH_FRIEND))) {
 			bt_mesh_friend_cred_refresh(ctx->net_idx);

--- a/net/nimble/host/mesh/src/net.c
+++ b/net/nimble/host/mesh/src/net.c
@@ -468,6 +468,26 @@ int bt_mesh_net_create(u16_t idx, u8_t flags, const u8_t key[16],
 	return 0;
 }
 
+void bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub)
+{
+	int i;
+
+	BT_DBG("idx 0x%04x", sub->net_idx);
+
+	memcpy(&sub->keys[0], &sub->keys[1], sizeof(sub->keys[0]));
+
+	for (i = 0; i < ARRAY_SIZE(bt_mesh.app_keys); i++) {
+		struct bt_mesh_app_key *key = &bt_mesh.app_keys[i];
+
+		if (key->net_idx != sub->net_idx || !key->updated) {
+			continue;
+		}
+
+		memcpy(&key->keys[0], &key->keys[1], sizeof(key->keys[0]));
+		key->updated = false;
+	}
+}
+
 bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, u8_t new_kr, bool new_key)
 {
 	if (new_kr != sub->kr_flag && sub->kr_phase == BT_MESH_KR_NORMAL) {
@@ -499,8 +519,7 @@ bool bt_mesh_kr_update(struct bt_mesh_subnet *sub, u8_t new_kr, bool new_key)
 		 */
 		case BT_MESH_KR_PHASE_2:
 			BT_DBG("KR Phase 0x%02x -> Normal", sub->kr_phase);
-			memcpy(&sub->keys[0], &sub->keys[1],
-			       sizeof(sub->keys[0]));
+			bt_mesh_net_revoke_keys(sub);
 			if ((MYNEWT_VAL(BLE_MESH_LOW_POWER)) ||
 			    (MYNEWT_VAL(BLE_MESH_FRIEND))) {
 				bt_mesh_friend_cred_refresh(sub->net_idx);

--- a/net/nimble/host/mesh/src/net.h
+++ b/net/nimble/host/mesh/src/net.h
@@ -263,6 +263,9 @@ bt_mesh_friend_cred_del(u16_t net_idx, u16_t addr);
 bool
 bt_mesh_kr_update(struct bt_mesh_subnet *sub, u8_t new_kr, bool new_key);
 
+void
+bt_mesh_net_revoke_keys(struct bt_mesh_subnet *sub);
+
 int
 bt_mesh_net_beacon_update(struct bt_mesh_subnet *sub);
 


### PR DESCRIPTION
The needed code for taking updated app keys into use and revoking the
old ones was missing.

Ported from https://github.com/zephyrproject-rtos/zephyr/pull/4198/