### PR TITLE
nimble/ll: Fix consecutive bits detection in AA

### DIFF
--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -549,7 +549,7 @@ ble_ll_conn_calc_access_addr(void)
 
         /* Cannot have more than 24 transitions */
         transitions = 0;
-        consecutive = 0;
+        consecutive = 1;
         ones = 0;
         mask = 0x00000001;
         while (mask < 0x80000000) {
@@ -558,7 +558,7 @@ ble_ll_conn_calc_access_addr(void)
             if (mask & aa) {
                 if (prev_bit == 0) {
                     ++transitions;
-                    consecutive = 0;
+                    consecutive = 1;
                 } else {
                     ++consecutive;
                 }
@@ -567,7 +567,7 @@ ble_ll_conn_calc_access_addr(void)
                     ++consecutive;
                 } else {
                     ++transitions;
-                    consecutive = 0;
+                    consecutive = 1;
                 }
             }
 
@@ -587,6 +587,8 @@ ble_ll_conn_calc_access_addr(void)
 
             /* This is invalid! */
             if (consecutive > 6) {
+                /* Make sure we always detect invalid sequence below */
+                mask = 0;
                 break;
             }
         }


### PR DESCRIPTION
Initial value for number of consecutive bits should be 1, i.e. single
bit is "1 consecutive bit".

With this set to 0 we calculate number of consecutive bits 1 less than
we should and thus allow for 7 consecutive bits in AA which is invalid.

Also, in case 7 msb have the same value, we would detect this at the
last iteration of loop which means mask value is already set to final
value so invalid sequence won't be detected. To make this simple, let's
just set mask value to 0 in case consecutive bits violation is detected
so it is always properly detected as invalid sequence.