### PR TITLE
BLE Host - Honor controller's flow control

### DIFF
--- a/kernel/os/include/os/os_mbuf.h
+++ b/kernel/os/include/os/os_mbuf.h
@@ -285,8 +285,7 @@ int os_mbuf_free(struct os_mbuf *mb);
 int os_mbuf_free_chain(struct os_mbuf *om);
 
 void os_mbuf_adj(struct os_mbuf *mp, int req_len);
-int os_mbuf_cmpf(const struct os_mbuf *om, int off, const void *data,
-                   int len);
+int os_mbuf_cmpf(const struct os_mbuf *om, int off, const void *data, int len);
 int os_mbuf_cmpm(const struct os_mbuf *om1, uint16_t offset1,
                  const struct os_mbuf *om2, uint16_t offset2,
                  uint16_t len);

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -214,6 +214,76 @@ ble_hs_process_rx_data_queue(void)
     }
 }
 
+static int
+ble_hs_wakeup_tx_conn(struct ble_hs_conn *conn)
+{
+    struct os_mbuf_pkthdr *omp;
+    struct os_mbuf *om;
+    int rc;
+
+    while ((omp = STAILQ_FIRST(&conn->bhc_tx_q)) != NULL) {
+        STAILQ_REMOVE_HEAD(&conn->bhc_tx_q, omp_next);
+
+        om = OS_MBUF_PKTHDR_TO_MBUF(omp);
+        rc = ble_hs_hci_acl_tx_now(conn, &om);
+        if (rc == BLE_HS_EAGAIN) {
+            /* Controller is at capacity.  This packet will be the first to
+             * get transmitted next time around.
+             */
+            STAILQ_INSERT_HEAD(&conn->bhc_tx_q, OS_MBUF_PKTHDR(om),
+                               omp_next);
+            return BLE_HS_EAGAIN;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Schedules the transmission of all queued ACL data packets to the controller.
+ */
+void
+ble_hs_wakeup_tx(void)
+{
+    struct ble_hs_conn *conn;
+    int rc;
+
+    ble_hs_lock();
+
+    /* If there is a connection with a partially transmitted packet, it has to
+     * be serviced first.  The controller is waiting for the remainder so it
+     * can reassemble it.
+     */
+    for (conn = ble_hs_conn_first();
+         conn != NULL;
+         conn = SLIST_NEXT(conn, bhc_next)) {
+
+        if (conn->bhc_flags && BLE_HS_CONN_F_TX_FRAG) {
+            rc = ble_hs_wakeup_tx_conn(conn);
+            if (rc != 0) {
+                goto done;
+            }
+            break;
+        }
+    }
+
+    /* For each connection, transmit queued packets until there are no more
+     * packets to send or the controller's buffers are exhausted.
+     */
+    for (conn = ble_hs_conn_first();
+         conn != NULL;
+         conn = SLIST_NEXT(conn, bhc_next)) {
+
+        rc = ble_hs_wakeup_tx_conn(conn);
+        if (rc != 0) {
+            goto done;
+        }
+    }
+
+done:
+    ble_hs_unlock();
+}
+
 static void
 ble_hs_clear_data_queue(struct os_mqueue *mqueue)
 {

--- a/net/nimble/host/src/ble_hs_conn.c
+++ b/net/nimble/host/src/ble_hs_conn.c
@@ -177,6 +177,8 @@ ble_hs_conn_alloc(uint16_t conn_handle)
         goto err;
     }
 
+    STAILQ_INIT(&conn->bhc_tx_q);
+
     STATS_INC(ble_hs_stats, conn_create);
 
     return conn;

--- a/net/nimble/host/src/ble_hs_conn_priv.h
+++ b/net/nimble/host/src/ble_hs_conn_priv.h
@@ -36,6 +36,7 @@ typedef uint8_t ble_hs_conn_flags_t;
 
 #define BLE_HS_CONN_F_MASTER        0x01
 #define BLE_HS_CONN_F_TERMINATING   0x02
+#define BLE_HS_CONN_F_TX_FRAG       0x04 /* Cur ACL packet partially txed. */
 
 struct ble_hs_conn {
     SLIST_ENTRY(ble_hs_conn) bhc_next;
@@ -57,7 +58,15 @@ struct ble_hs_conn {
     struct ble_l2cap_chan_list bhc_channels;
     struct ble_l2cap_chan *bhc_rx_chan; /* Channel rxing current packet. */
     uint32_t bhc_rx_timeout;
-    uint16_t bhc_outstanding_pkts;
+
+    /**
+     * Count of packets sent over this connection that the controller has not
+     * transmitted or flushed yet.
+     */
+    uint8_t bhc_outstanding_pkts;
+
+    /** Queue of outgoing packets that could not be sent. */
+    STAILQ_HEAD(, os_mbuf_pkthdr) bhc_tx_q;
 
     struct ble_att_svr_conn bhc_att_svr;
     struct ble_gatts_conn bhc_gatt_svr;

--- a/net/nimble/host/src/ble_hs_conn_priv.h
+++ b/net/nimble/host/src/ble_hs_conn_priv.h
@@ -63,7 +63,7 @@ struct ble_hs_conn {
      * Count of packets sent over this connection that the controller has not
      * transmitted or flushed yet.
      */
-    uint8_t bhc_outstanding_pkts;
+    uint16_t bhc_outstanding_pkts;
 
     /** Queue of outgoing packets that could not be sent. */
     STAILQ_HEAD(, os_mbuf_pkthdr) bhc_tx_q;

--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -42,7 +42,7 @@ static uint32_t ble_hs_hci_sup_feat;
  * The number of available ACL transmit buffers on the controller.  This
  * variable must only be accessed while the host mutex is locked.
  */
-uint8_t ble_hs_hci_avail_pkts;
+uint16_t ble_hs_hci_avail_pkts;
 
 #if MYNEWT_VAL(BLE_HS_PHONY_HCI_ACKS)
 static ble_hs_hci_phony_ack_fn *ble_hs_hci_phony_ack_cb;
@@ -92,11 +92,11 @@ ble_hs_hci_set_buf_sz(uint16_t pktlen, uint16_t max_pkts)
  * Increases the count of available controller ACL buffers.
  */
 void
-ble_hs_hci_add_avail_pkts(uint8_t delta)
+ble_hs_hci_add_avail_pkts(uint16_t delta)
 {
     BLE_HS_DBG_ASSERT(ble_hs_locked_by_cur_task());
     
-    if (ble_hs_hci_avail_pkts + delta > UINT8_MAX) {
+    if (ble_hs_hci_avail_pkts + delta > UINT16_MAX) {
         ble_hs_sched_reset(BLE_HS_ECONTROLLER);
     } else {
         ble_hs_hci_avail_pkts += delta;

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -69,7 +69,7 @@ struct ble_hs_hci_ext_conn_params {
 };
 #endif
 
-extern uint8_t ble_hs_hci_avail_pkts;
+extern uint16_t ble_hs_hci_avail_pkts;
 
 int ble_hs_hci_cmd_tx(uint16_t opcode, void *cmd, uint8_t cmd_len,
                       void *evt_buf, uint8_t evt_buf_len,
@@ -161,7 +161,7 @@ int ble_hs_hci_cmd_le_conn_param_neg_reply(
 void ble_hs_hci_cmd_build_le_start_encrypt(const struct hci_start_encrypt *cmd,
                                            uint8_t *dst, int dst_len);
 int ble_hs_hci_set_buf_sz(uint16_t pktlen, uint16_t max_pkts);
-void ble_hs_hci_add_avail_pkts(uint8_t delta);
+void ble_hs_hci_add_avail_pkts(uint16_t delta);
 
 uint16_t ble_hs_hci_util_handle_pb_bc_join(uint16_t handle, uint8_t pb,
                                            uint8_t bc);

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -69,6 +69,8 @@ struct ble_hs_hci_ext_conn_params {
 };
 #endif
 
+extern uint8_t ble_hs_hci_avail_pkts;
+
 int ble_hs_hci_cmd_tx(uint16_t opcode, void *cmd, uint8_t cmd_len,
                       void *evt_buf, uint8_t evt_buf_len,
                       uint8_t *out_evt_buf_len);
@@ -158,12 +160,14 @@ int ble_hs_hci_cmd_le_conn_param_neg_reply(
     const struct hci_conn_param_neg_reply *hcn);
 void ble_hs_hci_cmd_build_le_start_encrypt(const struct hci_start_encrypt *cmd,
                                            uint8_t *dst, int dst_len);
-int ble_hs_hci_set_buf_sz(uint16_t pktlen, uint8_t max_pkts);
+int ble_hs_hci_set_buf_sz(uint16_t pktlen, uint16_t max_pkts);
+void ble_hs_hci_add_avail_pkts(uint8_t delta);
 
 uint16_t ble_hs_hci_util_handle_pb_bc_join(uint16_t handle, uint8_t pb,
                                            uint8_t bc);
 
-int ble_hs_hci_acl_tx(struct ble_hs_conn *connection, struct os_mbuf *txom);
+int ble_hs_hci_acl_tx_now(struct ble_hs_conn *conn, struct os_mbuf **om);
+int ble_hs_hci_acl_tx(struct ble_hs_conn *conn, struct os_mbuf **om);
 
 int ble_hs_hci_cmd_build_set_data_len(uint16_t connection_handle,
                                       uint16_t tx_octets, uint16_t tx_time,
@@ -263,7 +267,6 @@ int ble_hs_hci_cmd_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
 
 int ble_hs_hci_cmd_build_le_read_remote_feat(uint16_t handle, uint8_t *dst,
                                                                  int dst_len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -97,7 +97,6 @@ extern uint16_t ble_hs_max_attrs;
 extern uint16_t ble_hs_max_services;
 extern uint16_t ble_hs_max_client_configs;
 
-void ble_hs_process_tx_data_queue(void);
 void ble_hs_process_rx_data_queue(void);
 int ble_hs_tx_data(struct os_mbuf *om);
 void ble_hs_wakeup_tx(void);

--- a/net/nimble/host/src/ble_hs_priv.h
+++ b/net/nimble/host/src/ble_hs_priv.h
@@ -100,6 +100,7 @@ extern uint16_t ble_hs_max_client_configs;
 void ble_hs_process_tx_data_queue(void);
 void ble_hs_process_rx_data_queue(void);
 int ble_hs_tx_data(struct os_mbuf *om);
+void ble_hs_wakeup_tx(void);
 void ble_hs_enqueue_hci_event(uint8_t *hci_evt);
 void ble_hs_event_enqueue(struct os_event *ev);
 

--- a/net/nimble/host/src/ble_hs_startup.c
+++ b/net/nimble/host/src/ble_hs_startup.c
@@ -51,16 +51,14 @@ ble_hs_startup_le_read_sup_f_tx(void)
 }
 
 static int
-ble_hs_startup_le_read_buf_sz_tx(void)
+ble_hs_startup_le_read_buf_sz_tx(uint16_t *out_pktlen, uint8_t *out_max_pkts)
 {
-    uint16_t pktlen;
     uint8_t ack_params[BLE_HCI_RD_BUF_SIZE_RSPLEN];
     uint8_t ack_params_len;
-    uint8_t max_pkts;
     int rc;
 
     rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
-                                      BLE_HCI_OCF_LE_RD_BUF_SIZE),NULL, 0,
+                                      BLE_HCI_OCF_LE_RD_BUF_SIZE), NULL, 0,
                            ack_params, sizeof ack_params, &ack_params_len);
     if (rc != 0) {
         return rc;
@@ -70,8 +68,59 @@ ble_hs_startup_le_read_buf_sz_tx(void)
         return BLE_HS_ECONTROLLER;
     }
 
-    pktlen = get_le16(ack_params + 0);
-    max_pkts = ack_params[2];
+    *out_pktlen = get_le16(ack_params + 0);
+    *out_max_pkts = ack_params[2];
+
+    return 0;
+}
+
+static int
+ble_hs_startup_read_buf_sz_tx(uint16_t *out_pktlen, uint16_t *out_max_pkts)
+{
+    uint8_t ack_params[BLE_HCI_IP_RD_BUF_SIZE_RSPLEN];
+    uint8_t ack_params_len;
+    int rc;
+
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_INFO_PARAMS,
+                                      BLE_HCI_OCF_IP_RD_BUF_SIZE), NULL, 0,
+                           ack_params, sizeof ack_params, &ack_params_len);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (ack_params_len != BLE_HCI_IP_RD_BUF_SIZE_RSPLEN) {
+        return BLE_HS_ECONTROLLER;
+    }
+
+    *out_pktlen = get_le16(ack_params + 0);
+    *out_max_pkts = get_le16(ack_params + 3);
+
+    return 0;
+}
+
+static int
+ble_hs_startup_read_buf_sz(void)
+{
+    uint16_t le_pktlen;
+    uint16_t max_pkts;
+    uint16_t pktlen;
+    uint8_t le_max_pkts;
+    int rc;
+
+    rc = ble_hs_startup_le_read_buf_sz_tx(&le_pktlen, &le_max_pkts);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (le_pktlen != 0) {
+        pktlen = le_pktlen;
+        max_pkts = le_max_pkts;   
+    } else {
+        rc = ble_hs_startup_read_buf_sz_tx(&pktlen, &max_pkts);
+        if (rc != 0) {
+            return rc;
+        }
+    }
 
     rc = ble_hs_hci_set_buf_sz(pktlen, max_pkts);
     if (rc != 0) {
@@ -214,12 +263,10 @@ ble_hs_startup_go(void)
         return rc;
     }
 
-    rc = ble_hs_startup_le_read_buf_sz_tx();
+    rc = ble_hs_startup_read_buf_sz();
     if (rc != 0) {
         return rc;
     }
-
-    /* XXX: Read buffer size. */
 
     rc = ble_hs_startup_le_read_sup_f_tx();
     if (rc != 0) {

--- a/net/nimble/host/test/src/ble_att_clt_test.c
+++ b/net/nimble/host/test/src/ble_att_clt_test.c
@@ -175,14 +175,12 @@ ble_att_clt_test_case_tx_write_req_or_cmd(int is_req)
     /*** 5-byte write. */
     ble_att_clt_test_tx_write_req_or_cmd(conn_handle, 0x1234, value5,
                                          sizeof value5, is_req);
-    ble_hs_test_util_tx_all();
     ble_att_clt_test_misc_verify_tx_write(0x1234, value5, sizeof value5,
                                           is_req);
 
     /*** Overlong write; verify command truncated to ATT MTU. */
     ble_att_clt_test_tx_write_req_or_cmd(conn_handle, 0xab83, value300,
                                          sizeof value300, is_req);
-    ble_hs_test_util_tx_all();
     ble_att_clt_test_misc_verify_tx_write(0xab83, value300,
                                           BLE_ATT_MTU_DFLT - 3, is_req);
 }
@@ -203,7 +201,6 @@ ble_att_clt_test_misc_prep_good(uint16_t handle, uint16_t offset,
     rc = ble_att_clt_tx_prep_write(conn_handle, handle, offset, om);
     TEST_ASSERT(rc == 0);
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(om->om_len == BLE_ATT_PREP_WRITE_CMD_BASE_SZ + attr_data_len);
@@ -230,7 +227,6 @@ ble_att_clt_test_misc_exec_good(uint8_t flags)
     rc = ble_att_clt_tx_exec_write(conn_handle, flags);
     TEST_ASSERT(rc == 0);
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(om->om_len == BLE_ATT_EXEC_WRITE_REQ_SZ);
@@ -268,7 +264,6 @@ ble_att_clt_test_misc_tx_mtu(uint16_t conn_handle, uint16_t mtu, int status)
         ble_hs_test_util_verify_tx_mtu_cmd(1, mtu);
     }
 }
-
 
 TEST_CASE(ble_att_clt_test_tx_write)
 {
@@ -372,7 +367,6 @@ TEST_CASE(ble_att_clt_test_tx_read_mult)
     rc = ble_att_clt_tx_read_mult(conn_handle, ((uint16_t[]){ 1, 2 }), 2);
     TEST_ASSERT(rc == 0);
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(om->om_len == BLE_ATT_READ_MULT_REQ_BASE_SZ + 4);

--- a/net/nimble/host/test/src/ble_att_svr_test.c
+++ b/net/nimble/host/test/src/ble_att_svr_test.c
@@ -417,8 +417,6 @@ ble_att_svr_test_misc_verify_tx_read_mult_rsp(
     int off;
     int i;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue();
 
     rc = os_mbuf_copydata(om, 0, 1, &u8);
@@ -501,8 +499,6 @@ ble_att_svr_test_misc_verify_tx_find_type_value_rsp(
     int off;
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     off = 0;
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
@@ -552,8 +548,6 @@ ble_att_svr_test_misc_verify_tx_read_type_rsp(
     int off;
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT(om);
 
@@ -590,8 +584,6 @@ ble_att_svr_test_misc_verify_tx_prep_write_rsp(uint16_t attr_handle,
     uint8_t buf[1024];
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue();
 
     rc = os_mbuf_copydata(om, 0, OS_MBUF_PKTLEN(om), buf);
@@ -612,8 +604,6 @@ static void
 ble_att_svr_test_misc_verify_tx_exec_write_rsp(void)
 {
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT(om);
@@ -743,8 +733,6 @@ ble_att_svr_test_misc_verify_tx_indicate_rsp(void)
 {
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT(om);
 
@@ -788,7 +776,6 @@ ble_att_svr_test_misc_verify_indicate(uint16_t conn_handle,
         TEST_ASSERT(ble_att_svr_test_n_conn_handle == 0xffff);
         TEST_ASSERT(ble_att_svr_test_n_attr_handle == 0);
         TEST_ASSERT(ble_att_svr_test_attr_n_len == 0);
-        ble_hs_test_util_tx_all();
         TEST_ASSERT(ble_hs_test_util_prev_tx_queue_sz() == 0);
     }
 }
@@ -887,7 +874,6 @@ TEST_CASE(ble_att_svr_test_read)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure no response got sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /* Encrypt link; success. */
@@ -1068,7 +1054,6 @@ TEST_CASE(ble_att_svr_test_write)
     TEST_ASSERT(rc == 0);
 
     /* Ensure no response got sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /*** Successful write. */
@@ -1101,7 +1086,6 @@ TEST_CASE(ble_att_svr_test_write)
     TEST_ASSERT(rc == 0);
 
     /* Ensure no response got sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /* Encrypt link; success. */
@@ -1926,7 +1910,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure we were able to send a real response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_find_info_rsp(
         (struct ble_hs_test_util_att_info_entry[]) {
             { .handle = 1, .uuid = BLE_UUID16_DECLARE(BLE_ATT_UUID_PRIMARY_SERVICE) },
@@ -1942,7 +1925,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOMEM);
 
     /* Ensure we were able to send an error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_FIND_TYPE_VALUE_REQ, 1,
                                        BLE_ATT_ERR_INSUFFICIENT_RES);
 
@@ -1955,7 +1937,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOENT);
 
     /* Ensure we were able to send a non-OOM error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_READ_TYPE_REQ, 100,
                                        BLE_ATT_ERR_ATTR_NOT_FOUND);
 
@@ -1967,7 +1948,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure we were able to send a real response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_read_rsp(ble_att_svr_test_attr_w_1,
                                         ble_att_svr_test_attr_w_1_len);
 
@@ -1979,10 +1959,8 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure we were able to send a real response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_read_blob_rsp(ble_att_svr_test_attr_w_1,
                                              ble_att_svr_test_attr_w_1_len);
-
 
     /*** Read multiple. */
     ble_hs_test_util_prev_tx_dequeue();
@@ -1994,10 +1972,8 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOMEM);
 
     /* Ensure we were able to send an error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_READ_MULT_REQ, 0,
                                        BLE_ATT_ERR_INSUFFICIENT_RES);
-
 
     /***
      * Read by group type; always respond affirmatively, even when no
@@ -2011,7 +1987,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOENT);
 
     /* Ensure we were able to send a non-OOM error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_READ_GROUP_TYPE_REQ, 11,
                                        BLE_ATT_ERR_ATTR_NOT_FOUND);
 
@@ -2024,7 +1999,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOMEM);
 
     /* Ensure we were able to send an error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_WRITE_REQ, 1,
                                        BLE_ATT_ERR_INSUFFICIENT_RES);
 
@@ -2037,7 +2011,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure no response sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /*** Prepare write. */
@@ -2049,7 +2022,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOMEM);
 
     /* Ensure we were able to send an error response. */
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_verify_tx_err_rsp(BLE_ATT_OP_PREP_WRITE_REQ, 1,
                                        BLE_ATT_ERR_INSUFFICIENT_RES);
 
@@ -2062,7 +2034,6 @@ TEST_CASE(ble_att_svr_test_oom)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure no response sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /*** Indicate. */

--- a/net/nimble/host/test/src/ble_gap_test.c
+++ b/net/nimble/host/test/src/ble_gap_test.c
@@ -1292,7 +1292,6 @@ TEST_CASE(ble_gap_test_case_conn_find)
                                      ble_gap_test_util_connect_cb,
                                      NULL);
 
-
     rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, pub_addr, NULL);
     TEST_ASSERT_FATAL(rc == 0);
 
@@ -3035,7 +3034,6 @@ TEST_CASE(ble_gap_test_case_set_cb_good)
 
     ble_hs_test_util_create_conn(2, peer_addr, ble_gap_test_util_connect_cb,
                                  NULL);
-
 
     /* Reconfigure the callback. */
     rc = ble_gap_set_event_cb(2, ble_gap_test_util_set_cb_event, &event);

--- a/net/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/net/nimble/host/test/src/ble_gatt_conn_test.c
@@ -489,7 +489,6 @@ TEST_CASE(ble_gatt_conn_test_disconnect)
     TEST_ASSERT_FATAL(rc == 0);
 
     /*** Start the procedures. */
-    ble_hs_test_util_tx_all();
 
     /*** Break the connections; verify proper callbacks got called. */
     /* Connection 1. */

--- a/net/nimble/host/test/src/ble_gatt_disc_c_test.c
+++ b/net/nimble/host/test/src/ble_gatt_disc_c_test.c
@@ -60,7 +60,6 @@ ble_gatt_disc_c_test_misc_rx_rsp_once(
     int i;
 
     /* Send the pending ATT Read By Type Request. */
-    ble_hs_test_util_tx_all();
 
     if (chars[0].uuid->type == BLE_UUID_TYPE_16) {
        rsp.batp_length = BLE_ATT_READ_TYPE_ADATA_BASE_SZ +
@@ -141,7 +140,6 @@ ble_gatt_disc_c_test_misc_rx_rsp(uint16_t conn_handle,
 
     if (chars[idx - 1].def_handle != end_handle) {
         /* Send the pending ATT Request. */
-        ble_hs_test_util_tx_all();
         ble_hs_test_util_rx_att_err_rsp(conn_handle, BLE_ATT_OP_READ_TYPE_REQ,
                                         BLE_ATT_ERR_ATTR_NOT_FOUND,
                                         chars[idx - 1].def_handle);
@@ -581,7 +579,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -595,8 +592,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_all)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
     ble_gatt_disc_c_test_misc_rx_rsp_once(1, chrs + num_chrs);
@@ -605,7 +600,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -618,8 +612,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_all)
 
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_TYPE_REQ,
@@ -674,7 +666,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_uuid)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -687,8 +678,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_uuid)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
     ble_gatt_disc_c_test_misc_rx_rsp_once(1, chrs + num_chrs);
@@ -697,7 +686,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_uuid)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -709,8 +697,6 @@ TEST_CASE(ble_gatt_disc_c_test_oom_uuid)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_TYPE_REQ,

--- a/net/nimble/host/test/src/ble_gatt_disc_d_test.c
+++ b/net/nimble/host/test/src/ble_gatt_disc_d_test.c
@@ -59,7 +59,6 @@ ble_gatt_disc_d_test_misc_rx_rsp_once(
     int i;
 
     /* Send the pending ATT Read By Type Request. */
-    ble_hs_test_util_tx_all();
 
     if (dscs[0].dsc_uuid.u.type == BLE_UUID_TYPE_16) {
         rsp.bafp_format = BLE_ATT_FIND_INFO_RSP_FORMAT_16BIT;
@@ -131,7 +130,6 @@ ble_gatt_disc_d_test_misc_rx_rsp(uint16_t conn_handle,
 
     if (dscs[idx - 1].dsc_handle != end_handle) {
         /* Send the pending ATT Request. */
-        ble_hs_test_util_tx_all();
         ble_hs_test_util_rx_att_err_rsp(conn_handle, BLE_ATT_OP_FIND_INFO_REQ,
                                         BLE_ATT_ERR_ATTR_NOT_FOUND,
                                         end_handle);
@@ -398,7 +396,6 @@ TEST_CASE(ble_gatt_disc_d_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -411,8 +408,6 @@ TEST_CASE(ble_gatt_disc_d_test_oom_all)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
     ble_gatt_disc_d_test_misc_rx_rsp_once(1, dscs + num_dscs);
@@ -421,7 +416,6 @@ TEST_CASE(ble_gatt_disc_d_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -433,8 +427,6 @@ TEST_CASE(ble_gatt_disc_d_test_oom_all)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_TYPE_REQ,

--- a/net/nimble/host/test/src/ble_gatt_disc_s_test.c
+++ b/net/nimble/host/test/src/ble_gatt_disc_s_test.c
@@ -66,7 +66,6 @@ ble_gatt_disc_s_test_misc_rx_all_rsp_once(
     int i;
 
     /* Send the pending ATT Read By Group Type Request. */
-    ble_hs_test_util_tx_all();
 
     rsp.bagp_length = ble_gatt_disc_s_test_misc_svc_length(services);
     ble_att_read_group_type_rsp_write(buf, BLE_ATT_READ_GROUP_TYPE_RSP_BASE_SZ,
@@ -134,7 +133,6 @@ ble_gatt_disc_s_test_misc_rx_all_rsp(
 
     if (services[idx - 1].end_handle != 0xffff) {
         /* Send the pending ATT Request. */
-        ble_hs_test_util_tx_all();
         ble_hs_test_util_rx_att_err_rsp(conn_handle,
                                         BLE_ATT_OP_READ_GROUP_TYPE_REQ,
                                         BLE_ATT_ERR_ATTR_NOT_FOUND,
@@ -152,7 +150,6 @@ ble_gatt_disc_s_test_misc_rx_uuid_rsp_once(
     int i;
 
     /* Send the pending ATT Find By Type Value Request. */
-    ble_hs_test_util_tx_all();
 
     buf[0] = BLE_ATT_OP_FIND_TYPE_VALUE_RSP;
     off = BLE_ATT_FIND_TYPE_VALUE_RSP_BASE_SZ;
@@ -199,7 +196,6 @@ ble_gatt_disc_s_test_misc_rx_uuid_rsp(
 
     if (services[idx - 1].end_handle != 0xffff) {
         /* Send the pending ATT Request. */
-        ble_hs_test_util_tx_all();
         ble_hs_test_util_rx_att_err_rsp(conn_handle,
                                         BLE_ATT_OP_FIND_TYPE_VALUE_REQ,
                                         BLE_ATT_ERR_ATTR_NOT_FOUND,
@@ -434,7 +430,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -455,7 +450,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_all)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -466,8 +460,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_all)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_GROUP_TYPE_REQ,
@@ -515,7 +507,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_uuid)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -527,7 +518,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_uuid)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-    ble_hs_test_util_tx_all();
 
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
@@ -537,7 +527,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_uuid)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -549,8 +538,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_uuid)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_GROUP_TYPE_REQ,
@@ -594,7 +581,6 @@ TEST_CASE(ble_gatt_disc_s_test_oom_timeout)
          * sent due to mbuf exhaustion.
          */
         ble_hs_test_util_prev_tx_queue_clear();
-        ble_hs_test_util_tx_all();
         TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
         oms_temp = ble_hs_test_util_mbuf_alloc_all_but(0);

--- a/net/nimble/host/test/src/ble_gatt_find_s_test.c
+++ b/net/nimble/host/test/src/ble_gatt_find_s_test.c
@@ -172,8 +172,6 @@ ble_gatt_find_s_test_misc_verify_tx_read_type(uint16_t start_handle,
     struct os_mbuf *om;
     uint16_t uuid16;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
 
@@ -191,8 +189,6 @@ ble_gatt_find_s_test_misc_verify_tx_read(uint16_t handle)
 {
     struct ble_att_read_req req;
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
@@ -387,7 +383,6 @@ TEST_CASE(ble_gatt_find_s_test_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -400,15 +395,12 @@ TEST_CASE(ble_gatt_find_s_test_oom)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* We can't cause a memory exhaustion error on the follow up request.  The
      * GATT client frees the read response immediately before sending the
      * follow-up request, so there is always an mbuf available.
      */
     /* XXX: Find a way to test this. */
     ble_gatt_find_s_test_misc_rx_read(1, incs[0].uuid);
-    ble_hs_test_util_tx_all();
 
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
@@ -421,7 +413,6 @@ TEST_CASE(ble_gatt_find_s_test_oom)
     ble_gattc_timer();
 
     ble_gatt_find_s_test_misc_rx_read(1, incs[1].uuid);
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(1,
                                     BLE_ATT_OP_READ_TYPE_REQ,

--- a/net/nimble/host/test/src/ble_gatt_read_test.c
+++ b/net/nimble/host/test/src/ble_gatt_read_test.c
@@ -170,7 +170,6 @@ ble_gatt_read_test_misc_rx_rsp_good_raw(uint16_t conn_handle,
     TEST_ASSERT_FATAL(data_len <= sizeof buf);
 
     /* Send the pending ATT Read Request. */
-    ble_hs_test_util_tx_all();
 
     buf[0] = att_op;
     memcpy(buf + 1, data, data_len);
@@ -194,7 +193,6 @@ ble_gatt_read_test_misc_rx_rsp_bad(uint16_t conn_handle,
                                    uint8_t att_error, uint16_t err_handle)
 {
     /* Send the pending ATT Read Request. */
-    ble_hs_test_util_tx_all();
 
     ble_hs_test_util_rx_att_err_rsp(conn_handle, BLE_ATT_OP_READ_REQ,
                                     att_error, err_handle);
@@ -216,7 +214,6 @@ ble_gatt_read_test_misc_uuid_rx_rsp_good(
     }
 
     /* Send the pending ATT Read By Type Request. */
-    ble_hs_test_util_tx_all();
 
     rsp.batp_length = 2 + attrs[0].value_len;
     ble_att_read_type_rsp_write(buf, sizeof buf, &rsp);
@@ -312,7 +309,6 @@ ble_gatt_read_test_misc_uuid_verify_good(
     while (1) {
         num_read = ble_gatt_read_test_misc_uuid_rx_rsp_good(2, attrs + idx);
         if (num_read == 0) {
-            ble_hs_test_util_tx_all();
             ble_hs_test_util_rx_att_err_rsp(2, BLE_ATT_OP_READ_TYPE_REQ,
                                             BLE_ATT_ERR_ATTR_NOT_FOUND,
                                             start_handle);
@@ -855,7 +851,6 @@ TEST_CASE(ble_gatt_read_test_long_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -867,7 +862,6 @@ TEST_CASE(ble_gatt_read_test_long_oom)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-    ble_hs_test_util_tx_all();
 
     /* Exhaust the msys pool.  Leave one mbuf for the forthcoming response. */
     oms = ble_hs_test_util_mbuf_alloc_all_but(1);
@@ -880,7 +874,6 @@ TEST_CASE(ble_gatt_read_test_long_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -892,8 +885,6 @@ TEST_CASE(ble_gatt_read_test_long_oom)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-
-    ble_hs_test_util_tx_all();
 
     chunk_sz = attr.value_len - off;
     ble_gatt_read_test_misc_rx_rsp_good_raw(2, BLE_ATT_OP_READ_RSP,

--- a/net/nimble/host/test/src/ble_gatt_write_test.c
+++ b/net/nimble/host/test/src/ble_gatt_write_test.c
@@ -164,7 +164,6 @@ ble_gatt_write_test_misc_long_good(int attr_len)
     ble_hs_test_util_verify_tx_exec_write(BLE_ATT_EXEC_WRITE_F_EXECUTE);
 
     /* Receive Exec Write response. */
-    ble_hs_test_util_tx_all();
     ble_gatt_write_test_rx_exec_rsp(2);
 
     /* Verify callback got called. */
@@ -354,7 +353,6 @@ ble_gatt_write_test_misc_reliable_good(
     ble_hs_test_util_verify_tx_exec_write(BLE_ATT_EXEC_WRITE_F_EXECUTE);
 
     /* Receive Exec Write response. */
-    ble_hs_test_util_tx_all();
     ble_gatt_write_test_rx_exec_rsp(2);
 
     /* Verify callback got called. */
@@ -383,7 +381,6 @@ TEST_CASE(ble_gatt_write_test_no_rsp)
     TEST_ASSERT(rc == 0);
 
     /* Send the pending ATT Write Command. */
-    ble_hs_test_util_tx_all();
 
     /* No response expected; verify callback not called. */
     TEST_ASSERT(!ble_gatt_write_test_cb_called);
@@ -404,7 +401,6 @@ TEST_CASE(ble_gatt_write_test_rsp)
                                      &attr_len);
 
     /* Send the pending ATT Write Command. */
-    ble_hs_test_util_tx_all();
 
     /* Response not received yet; verify callback not called. */
     TEST_ASSERT(!ble_gatt_write_test_cb_called);
@@ -582,7 +578,6 @@ TEST_CASE(ble_gatt_write_test_long_queue_full)
     off = 0;
     for (i = 0; i < 2; i++) {
         /* Verify prep write request was sent. */
-        ble_hs_test_util_tx_all();
         TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() != NULL);
 
         /* Receive Prep Write response. */
@@ -597,7 +592,6 @@ TEST_CASE(ble_gatt_write_test_long_queue_full)
     }
 
     /* Verify prep write request was sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() != NULL);
 
     /* Receive queue full error. */
@@ -657,7 +651,6 @@ TEST_CASE(ble_gatt_write_test_long_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -669,7 +662,6 @@ TEST_CASE(ble_gatt_write_test_long_oom)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-    ble_hs_test_util_tx_all();
 
     chunk_sz = attr.value_len - off;
     ble_hs_test_util_verify_tx_prep_write(attr.handle, off,
@@ -685,7 +677,6 @@ TEST_CASE(ble_gatt_write_test_long_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -698,13 +689,10 @@ TEST_CASE(ble_gatt_write_test_long_oom)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* Verify execute write request sent. */
     ble_hs_test_util_verify_tx_exec_write(BLE_ATT_EXEC_WRITE_F_EXECUTE);
 
     /* Receive Exec Write response. */
-    ble_hs_test_util_tx_all();
     ble_gatt_write_test_rx_exec_rsp(2);
 
     /* Verify callback got called. */
@@ -757,7 +745,6 @@ TEST_CASE(ble_gatt_write_test_reliable_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -769,7 +756,6 @@ TEST_CASE(ble_gatt_write_test_reliable_oom)
     TEST_ASSERT_FATAL(rc == 0);
     os_time_advance(ticks_until);
     ble_gattc_timer();
-    ble_hs_test_util_tx_all();
 
     chunk_sz = attr.value_len - off;
     ble_hs_test_util_verify_tx_prep_write(attr.handle, off,
@@ -785,7 +771,6 @@ TEST_CASE(ble_gatt_write_test_reliable_oom)
      * due to mbuf exhaustion.
      */
     ble_hs_test_util_prev_tx_queue_clear();
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue_pullup() == NULL);
 
     /* Verify that we will resume the stalled GATT procedure in one second. */
@@ -798,13 +783,10 @@ TEST_CASE(ble_gatt_write_test_reliable_oom)
     os_time_advance(ticks_until);
     ble_gattc_timer();
 
-    ble_hs_test_util_tx_all();
-
     /* Verify execute write request sent. */
     ble_hs_test_util_verify_tx_exec_write(BLE_ATT_EXEC_WRITE_F_EXECUTE);
 
     /* Receive Exec Write response. */
-    ble_hs_test_util_tx_all();
     ble_gatt_write_test_rx_exec_rsp(2);
 
     /* Verify callback got called. */

--- a/net/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/net/nimble/host/test/src/ble_gatts_notify_test.c
@@ -61,7 +61,6 @@ static const struct ble_gatt_svc_def ble_gatts_notify_test_svcs[] = { {
     0
 } };
 
-
 static uint16_t ble_gatts_notify_test_chr_1_def_handle;
 static uint8_t ble_gatts_notify_test_chr_1_val[1024];
 static int ble_gatts_notify_test_chr_1_len;
@@ -113,8 +112,6 @@ ble_gatts_notify_test_misc_read_notify(uint16_t conn_handle,
     rc = ble_hs_test_util_l2cap_rx_payload_flat(conn_handle, BLE_L2CAP_CID_ATT,
                                                 buf, sizeof buf);
     TEST_ASSERT(rc == 0);
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
@@ -427,7 +424,6 @@ ble_gatts_notify_test_misc_rx_indicate_rsp(uint16_t conn_handle,
     ble_gatts_notify_test_util_verify_ack_event(conn_handle, attr_handle);
 }
 
-
 static void
 ble_gatts_notify_test_misc_verify_tx_n(uint16_t conn_handle,
                                        uint16_t attr_handle,
@@ -436,8 +432,6 @@ ble_gatts_notify_test_misc_verify_tx_n(uint16_t conn_handle,
     struct ble_att_notify_req req;
     struct os_mbuf *om;
     int i;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
@@ -461,8 +455,6 @@ ble_gatts_notify_test_misc_verify_tx_i(uint16_t conn_handle,
     struct ble_att_indicate_req req;
     struct os_mbuf *om;
     int i;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
@@ -556,7 +548,6 @@ ble_gatts_notify_test_restore_bonding(uint16_t conn_handle,
     if (chr1_tx) {
         ble_gatts_notify_test_misc_verify_tx_gen(conn_handle, 1, chr1_flags);
     }
-
 
     if (chr2_flags != 0) {
         ble_gatts_notify_test_util_verify_sub_event(
@@ -719,7 +710,6 @@ TEST_CASE(ble_gatts_notify_test_i)
     /* Verify the second indication doesn't get sent until the first is
      * confirmed.
      */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_queue_sz() == 0);
 
     /* Receive the confirmation for the first indication. */
@@ -728,7 +718,6 @@ TEST_CASE(ble_gatts_notify_test_i)
         ble_gatts_notify_test_chr_1_def_handle + 1);
 
     /* Verify indication sent properly. */
-    ble_hs_test_util_tx_all();
     ble_gatts_notify_test_misc_verify_tx_i(
         conn_handle,
         ble_gatts_notify_test_chr_2_def_handle + 1,
@@ -896,7 +885,6 @@ TEST_CASE(ble_gatts_notify_test_bonded_i)
     /* Verify the second indication doesn't get sent until the first is
      * confirmed.
      */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_queue_sz() == 0);
 
     /* Receive the confirmation for the first indication. */
@@ -905,7 +893,6 @@ TEST_CASE(ble_gatts_notify_test_bonded_i)
         ble_gatts_notify_test_chr_1_def_handle + 1);
 
     /* Verify indication sent properly. */
-    ble_hs_test_util_tx_all();
     ble_gatts_notify_test_misc_verify_tx_i(
         conn_handle,
         ble_gatts_notify_test_chr_2_def_handle + 1,
@@ -949,7 +936,6 @@ TEST_CASE(ble_gatts_notify_test_bonded_i_no_ack)
     ble_gatts_chr_updated(ble_gatts_notify_test_chr_1_def_handle + 1);
 
     /* Verify indication sent properly. */
-    ble_hs_test_util_tx_all();
     ble_gatts_notify_test_misc_verify_tx_i(
         conn_handle,
         ble_gatts_notify_test_chr_1_def_handle + 1,

--- a/net/nimble/host/test/src/ble_gatts_read_test.c
+++ b/net/nimble/host/test/src/ble_gatts_read_test.c
@@ -62,7 +62,6 @@ static const struct ble_gatt_svc_def ble_gatts_read_test_svcs[] = { {
     0
 } };
 
-
 static uint16_t ble_gatts_read_test_chr_1_def_handle;
 static uint16_t ble_gatts_read_test_chr_1_val_handle;
 static uint8_t ble_gatts_read_test_chr_1_val[1024];

--- a/net/nimble/host/test/src/ble_gatts_reg_test.c
+++ b/net/nimble/host/test/src/ble_gatts_reg_test.c
@@ -504,7 +504,6 @@ TEST_CASE(ble_gatts_reg_test_svc_cb)
         0
     } });
 
-
     /*** 1 primary, 1 secondary. */
     ble_gatts_reg_test_misc_svcs((struct ble_gatt_svc_def[]) { {
         .type = BLE_GATT_SVC_TYPE_PRIMARY,

--- a/net/nimble/host/test/src/ble_hs_hci_test.c
+++ b/net/nimble/host/test/src/ble_hs_hci_test.c
@@ -83,12 +83,258 @@ TEST_CASE(ble_hs_hci_test_rssi)
     TEST_ASSERT(rc == BLE_HS_ECONTROLLER);
 }
 
+TEST_CASE(ble_hs_hci_acl_one_conn)
+{
+    struct ble_hs_test_util_num_completed_pkts_entry ncpe[2] = { 0 };
+    uint8_t peer_addr[6] = { 1, 2, 3, 4, 5, 6 };
+    uint8_t data[256];
+    int rc;
+    int i;
+
+    for (i = 0; i < sizeof data; i++) {
+        data[i] = i;
+    }
+
+    ble_hs_test_util_init();
+
+    /* The controller has room for five 20-byte payloads (+ 4-byte header). */
+    rc = ble_hs_hci_set_buf_sz(24, 5);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
+
+    ble_hs_test_util_create_conn(1, peer_addr, NULL, NULL);
+
+    /* Ensure the ATT doesn't truncate our data packets. */
+    ble_hs_test_util_set_att_mtu(1, 256);
+
+    /* Send two 3-byte data packets. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 3);
+    TEST_ASSERT_FATAL(rc == 0);
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 3);
+    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 3);
+
+    /* Send fragmented packet (two fragments). */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 25);
+    TEST_ASSERT_FATAL(rc == 0);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
+
+    ble_hs_test_util_prev_tx_queue_clear();
+
+    /* Receive a number-of-completed-packets event.  Ensure available buffer
+     * count increases.
+     */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 3;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 4);
+
+    /* Use all remaining buffers (four fragments). */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 70);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+
+    /* Attempt to transmit eight more fragments. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 160);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+
+    /* Receive number-of-completed-packets: 5. */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 5;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+
+    /* Receive number-of-completed-packets: 4. */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 5;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+    ble_hs_test_util_tx_all();
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
+
+    /* Ensure the stalled fragments were sent in the expected order. */
+    ble_hs_test_util_verify_tx_write_cmd(100, data, 70);
+    ble_hs_test_util_verify_tx_write_cmd(100, data, 160);
+
+    /* Receive a disconnection-complete event. Ensure available buffer count
+     * increases.
+     */
+    ble_hs_test_util_rx_disconn_complete(1, 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
+}
+
+TEST_CASE(ble_hs_hci_acl_two_conn)
+{
+    struct ble_hs_test_util_num_completed_pkts_entry ncpe[2] = { 0 };
+    const struct ble_hs_conn *conn1;
+    const struct ble_hs_conn *conn2;
+    uint8_t peer_addr1[6] = { 1, 2, 3, 4, 5, 6 };
+    uint8_t peer_addr2[6] = { 2, 3, 4, 5, 6, 7 };
+    uint8_t data[256];
+    int rc;
+    int i;
+
+    for (i = 0; i < sizeof data; i++) {
+        data[i] = i;
+    }
+
+    ble_hs_test_util_init();
+
+    /* The controller has room for five 20-byte payloads (+ 4-byte header). */
+    rc = ble_hs_hci_set_buf_sz(24, 5);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
+
+    ble_hs_test_util_create_conn(1, peer_addr1, NULL, NULL);
+    ble_hs_test_util_create_conn(2, peer_addr2, NULL, NULL);
+
+    /* This test inspects the connection objects after unlocking the host
+     * mutex.  It is not OK for real code to do this, but this test can assume
+     * the connection list is unchanging.
+     */
+    ble_hs_lock();
+    conn1 = ble_hs_conn_find_assert(1);
+    conn2 = ble_hs_conn_find_assert(2);
+    ble_hs_unlock();
+
+    /* Ensure the ATT doesn't truncate our data packets. */
+    ble_hs_test_util_set_att_mtu(1, 256);
+    ble_hs_test_util_set_att_mtu(2, 256);
+
+    /* Tx two fragments over connection 1. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 25);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 3);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /* Tx two fragments over connection 2. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(2, 100, data + 10, 25);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /* Tx four fragments over connection 2. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(2, 100, data + 20, 70);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG);
+
+    /* Tx four fragments over connection 1. */
+    rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data + 30, 70);
+    TEST_ASSERT_FATAL(rc == 0);
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /**
+     * controller: (11 222)
+     *     conn 1: 1111
+     *     conn 2: 222
+     */
+
+    /* Receive number-of-completed-packets: conn=2, num-pkts=1. */
+    ncpe[0].handle_id = 2;
+    ncpe[0].num_pkts = 1;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: (11 222)
+     *     conn 1: 1111
+     *     conn 2: 22
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+    TEST_ASSERT_FATAL(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG);
+
+    /* Receive number-of-completed-packets: conn=1, num-pkts=1. */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 1;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: (1 2222)
+     *     conn 1: 1111
+     *     conn 2: 2
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+    TEST_ASSERT_FATAL(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG);
+
+    /* Receive number-of-completed-packets: conn=1, num-pkts=1. */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 1;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: (22222)
+     *     conn 1: 1111
+     *     conn 2: -
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+    TEST_ASSERT_FATAL(!(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /* Receive number-of-completed-packets: conn=2, num-pkts=3. */
+    ncpe[0].handle_id = 2;
+    ncpe[0].num_pkts = 3;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: (11122)
+     *     conn 1: 1
+     *     conn 2: -
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
+    TEST_ASSERT_FATAL(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG);
+    TEST_ASSERT_FATAL(!(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /* Receive number-of-completed-packets: conn=2, num-pkts=2. */
+    ncpe[0].handle_id = 2;
+    ncpe[0].num_pkts = 2;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: (1111)
+     *     conn 1: -
+     *     conn 2: -
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+    TEST_ASSERT_FATAL(!(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /* Receive number-of-completed-packets: conn=1, num-pkts=4. */
+    ncpe[0].handle_id = 1;
+    ncpe[0].num_pkts = 4;
+    ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
+
+    /**
+     * controller: ()
+     *     conn 1: -
+     *     conn 2: -
+     */
+    TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
+    TEST_ASSERT_FATAL(!(conn1->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+    TEST_ASSERT_FATAL(!(conn2->bhc_flags & BLE_HS_CONN_F_TX_FRAG));
+
+    /*** Verify payloads. */
+    ble_hs_test_util_verify_tx_write_cmd(100, data, 25);
+    ble_hs_test_util_verify_tx_write_cmd(100, data + 10, 25);
+    ble_hs_test_util_verify_tx_write_cmd(100, data + 20, 70);
+    ble_hs_test_util_verify_tx_write_cmd(100, data + 30, 70);
+}
+
 TEST_SUITE(ble_hs_hci_suite)
 {
     tu_suite_set_post_test_cb(ble_hs_test_util_post_test, NULL);
 
     ble_hs_hci_test_event_bad();
     ble_hs_hci_test_rssi();
+    ble_hs_hci_acl_one_conn();
+    ble_hs_hci_acl_two_conn();
 }
 
 int

--- a/net/nimble/host/test/src/ble_hs_hci_test.c
+++ b/net/nimble/host/test/src/ble_hs_hci_test.c
@@ -112,13 +112,11 @@ TEST_CASE(ble_hs_hci_acl_one_conn)
     TEST_ASSERT_FATAL(rc == 0);
     rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 3);
     TEST_ASSERT_FATAL(rc == 0);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 3);
 
     /* Send fragmented packet (two fragments). */
     rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 25);
     TEST_ASSERT_FATAL(rc == 0);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
 
     ble_hs_test_util_prev_tx_queue_clear();
@@ -133,13 +131,11 @@ TEST_CASE(ble_hs_hci_acl_one_conn)
 
     /* Use all remaining buffers (four fragments). */
     rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 70);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
 
     /* Attempt to transmit eight more fragments. */
     rc = ble_hs_test_util_gatt_write_no_rsp_flat(1, 100, data, 160);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
 
@@ -147,14 +143,12 @@ TEST_CASE(ble_hs_hci_acl_one_conn)
     ncpe[0].handle_id = 1;
     ncpe[0].num_pkts = 5;
     ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 0);
 
     /* Receive number-of-completed-packets: 4. */
     ncpe[0].handle_id = 1;
     ncpe[0].num_pkts = 5;
     ble_hs_test_util_rx_num_completed_pkts_event(ncpe);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 1);
 
     /* Ensure the stalled fragments were sent in the expected order. */

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -174,7 +174,6 @@ ble_hs_test_util_prev_tx_queue_sz(void)
 void
 ble_hs_test_util_prev_tx_queue_clear(void)
 {
-    ble_hs_test_util_tx_all();
     while (!STAILQ_EMPTY(&ble_hs_test_util_prev_tx_queue)) {
         ble_hs_test_util_prev_tx_dequeue();
     }
@@ -1585,19 +1584,12 @@ ble_hs_test_util_verify_tx_hci(uint8_t ogf, uint16_t ocf,
 }
 
 void
-ble_hs_test_util_tx_all(void)
-{
-    ble_hs_process_tx_data_queue();
-}
-
-void
 ble_hs_test_util_verify_tx_prep_write(uint16_t attr_handle, uint16_t offset,
                                       const void *data, int data_len)
 {
     struct ble_att_prep_write_cmd req;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(OS_MBUF_PKTLEN(om) ==
@@ -1619,7 +1611,6 @@ ble_hs_test_util_verify_tx_exec_write(uint8_t expected_flags)
     struct ble_att_exec_write_req req;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(om->om_len == BLE_ATT_EXEC_WRITE_REQ_SZ);
@@ -1638,7 +1629,6 @@ ble_hs_test_util_verify_tx_find_type_value(uint16_t start_handle,
     struct ble_att_find_type_value_req req;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
     TEST_ASSERT(om->om_len == BLE_ATT_FIND_TYPE_VALUE_REQ_BASE_SZ + value_len);
@@ -1671,8 +1661,6 @@ ble_hs_test_util_verify_tx_read_rsp_gen(uint8_t att_op,
     uint8_t u8;
     int rc;
     int i;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue();
 
@@ -1711,8 +1699,6 @@ ble_hs_test_util_verify_tx_write_rsp(void)
     uint8_t u8;
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue();
 
     rc = os_mbuf_copydata(om, 0, 1, &u8);
@@ -1725,8 +1711,6 @@ ble_hs_test_util_verify_tx_mtu_cmd(int is_req, uint16_t mtu)
 {
     struct ble_att_mtu_cmd cmd;
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om != NULL);
@@ -1752,8 +1736,6 @@ ble_hs_test_util_verify_tx_find_info_rsp(
     ble_uuid_any_t uuid;
     int off;
     int rc;
-
-    ble_hs_test_util_tx_all();
 
     off = 0;
 
@@ -1809,8 +1791,6 @@ ble_hs_test_util_verify_tx_read_group_type_rsp(
     int off;
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue_pullup();
     TEST_ASSERT_FATAL(om);
 
@@ -1863,8 +1843,6 @@ ble_hs_test_util_verify_tx_err_rsp(uint8_t req_op, uint16_t handle,
     uint8_t buf[BLE_ATT_ERROR_RSP_SZ];
     int rc;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_prev_tx_dequeue();
 
     rc = os_mbuf_copydata(om, 0, sizeof buf, buf);
@@ -1885,8 +1863,6 @@ ble_hs_test_util_verify_tx_write_cmd(uint16_t handle, const void *data,
     struct os_mbuf *om;
     uint8_t buf[BLE_ATT_WRITE_CMD_BASE_SZ];
     int rc;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue();
 
@@ -1963,8 +1939,6 @@ ble_hs_test_util_verify_tx_l2cap_sig(uint16_t opcode, void *cmd,
     struct ble_l2cap_sig_hdr hdr;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_hs_test_util_verify_tx_l2cap_sig_hdr(opcode, 0, cmd_size, &hdr);
     om = os_mbuf_pullup(om, cmd_size);
 
@@ -1978,8 +1952,6 @@ void
 ble_hs_test_util_verify_tx_l2cap(struct os_mbuf *txom)
 {
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_prev_tx_dequeue();
     TEST_ASSERT_FATAL(om != NULL);
@@ -2032,8 +2004,6 @@ ble_hs_test_util_verify_tx_l2cap_update_req(
     struct ble_l2cap_sig_update_req req;
     struct ble_l2cap_sig_hdr hdr;
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_hs_test_util_verify_tx_l2cap_sig_hdr(BLE_L2CAP_SIG_OP_UPDATE_REQ,
                                                   0,
@@ -2304,7 +2274,6 @@ ble_hs_test_util_mbuf_count(const struct ble_hs_test_util_mbuf_params *params)
     int count;
     int i;
 
-    ble_hs_process_tx_data_queue();
     ble_hs_process_rx_data_queue();
 
     count = os_msys_num_free();

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -252,7 +252,6 @@ void ble_hs_test_util_rx_disconn_complete_event(
     struct hci_disconn_complete *evt);
 uint8_t *ble_hs_test_util_verify_tx_hci(uint8_t ogf, uint16_t ocf,
                                         uint8_t *out_param_len);
-void ble_hs_test_util_tx_all(void);
 void ble_hs_test_util_verify_tx_prep_write(uint16_t attr_handle,
                                            uint16_t offset,
                                            const void *data, int data_len);

--- a/net/nimble/host/test/src/ble_hs_test_util.h
+++ b/net/nimble/host/test/src/ble_hs_test_util.h
@@ -274,6 +274,9 @@ void ble_hs_test_util_verify_tx_read_group_type_rsp(
     struct ble_hs_test_util_att_group_type_entry *entries);
 void ble_hs_test_util_verify_tx_err_rsp(uint8_t req_op, uint16_t handle,
                                         uint8_t error_code);
+void ble_hs_test_util_verify_tx_write_cmd(uint16_t handle, const void *data,
+                                          uint16_t data_len);
+
 uint8_t ble_hs_test_util_verify_tx_l2cap_update_req(
     struct ble_l2cap_sig_update_params *params);
 int ble_hs_test_util_rx_l2cap_update_rsp(uint16_t conn_handle,

--- a/net/nimble/host/test/src/ble_l2cap_test.c
+++ b/net/nimble/host/test/src/ble_l2cap_test.c
@@ -293,7 +293,6 @@ TEST_CASE(ble_l2cap_test_case_bad_handle)
     TEST_ASSERT(rc == BLE_HS_ENOTCONN);
 
     /* Ensure we did not send anything in return. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_test_util_prev_tx_dequeue() == NULL);
 }
 
@@ -464,7 +463,6 @@ TEST_CASE(ble_l2cap_test_case_sig_unsol_rsp)
     TEST_ASSERT(rc == 0);
 
     /* Ensure we did not send anything in return. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT_FATAL(ble_hs_test_util_prev_tx_dequeue() == NULL);
 }
 
@@ -506,7 +504,6 @@ ble_l2cap_test_util_peer_updates(int accept)
     ble_l2cap_test_util_rx_update_req(2, 1, &l2cap_params);
 
     /* Ensure an update response command got sent. */
-    ble_hs_process_tx_data_queue();
     ble_hs_test_util_verify_tx_l2cap_update_rsp(1, !accept);
 
     if (accept) {
@@ -552,8 +549,6 @@ ble_l2cap_test_util_we_update(int peer_accepts)
     params.timeout_multiplier = 0x100;
     rc = ble_l2cap_sig_update(2, &params, ble_l2cap_test_util_update_cb, NULL);
     TEST_ASSERT_FATAL(rc == 0);
-
-    ble_hs_test_util_tx_all();
 
     /* Ensure an update request got sent. */
     id = ble_hs_test_util_verify_tx_l2cap_update_req(&params);
@@ -609,7 +604,6 @@ TEST_CASE(ble_l2cap_test_case_sig_update_init_fail_master)
     TEST_ASSERT_FATAL(rc == BLE_HS_EINVAL);
 
     /* Ensure callback never called. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_l2cap_test_update_status == -1);
 }
 
@@ -633,8 +627,6 @@ TEST_CASE(ble_l2cap_test_case_sig_update_init_fail_bad_id)
     params.timeout_multiplier = 0x100;
     rc = ble_l2cap_sig_update(2, &params, ble_l2cap_test_util_update_cb, NULL);
     TEST_ASSERT_FATAL(rc == 0);
-
-    ble_hs_test_util_tx_all();
 
     /* Ensure an update request got sent. */
     id = ble_hs_test_util_verify_tx_l2cap_update_req(&params);
@@ -755,8 +747,6 @@ ble_l2cap_test_coc_connect(struct test_data *t)
         return;
     }
 
-    ble_hs_test_util_tx_all();
-
     req.credits = htole16((t->mtu + (BLE_L2CAP_COC_MTU - 1) / 2) /
                                                         BLE_L2CAP_COC_MTU);
     req.mps = htole16(BLE_L2CAP_COC_MTU);
@@ -797,8 +787,6 @@ ble_l2cap_test_coc_connect_by_peer(struct test_data *t)
 
     ble_l2cap_test_util_create_conn(2, ((uint8_t[]){1,2,3,4,5,6}),
                                     ble_l2cap_test_util_conn_cb, NULL);
-
-    ble_hs_test_util_tx_all();
 
     /* Use some different parameters for peer */
     req.credits = htole16(30);
@@ -854,8 +842,6 @@ ble_l2cap_test_coc_disc(struct test_data *t)
     rc = ble_l2cap_sig_disconnect(t->chan);
     TEST_ASSERT_FATAL(rc == 0);
 
-    ble_hs_test_util_tx_all();
-
     req.dcid = htole16(t->chan->dcid);
     req.scid = htole16(t->chan->scid);
 
@@ -879,8 +865,6 @@ ble_l2cap_test_coc_disc_by_peer(struct test_data *t)
     struct event *ev = &t->event[t->event_iter++];
     uint8_t id = 10;
     int rc;
-
-    ble_hs_test_util_tx_all();
 
     /* Receive disconnect request from peer. Note that source cid
      * and destination cid are from peer perspective */
@@ -908,8 +892,6 @@ ble_l2cap_test_coc_invalid_disc_by_peer(struct test_data *t)
     uint8_t id = 10;
     int rc;
     struct event *ev = &t->event[t->event_iter++];
-
-    ble_hs_test_util_tx_all();
 
     /* Receive disconnect request from peer. Note that source cid
      * and destination cid are from peer perspective */

--- a/net/nimble/host/test/src/ble_os_test.c
+++ b/net/nimble/host/test/src/ble_os_test.c
@@ -278,7 +278,6 @@ ble_gap_terminate_cb(struct ble_gap_event *event, void *arg)
     return 0;
 }
 
-
 static void
 ble_gap_terminate_test_task_handler(void *arg)
 {

--- a/net/nimble/host/test/src/ble_sm_test.c
+++ b/net/nimble/host/test/src/ble_sm_test.c
@@ -303,8 +303,6 @@ TEST_CASE(ble_sm_test_case_peer_sec_req_inval)
     ble_sm_test_util_rx_sec_req(
         2, &sec_req, BLE_HS_SM_US_ERR(BLE_SM_ERR_CMD_NOT_SUPP));
 
-    ble_hs_test_util_tx_all();
-
     fail.reason = BLE_SM_ERR_CMD_NOT_SUPP;
     ble_sm_test_util_verify_tx_pair_fail(&fail);
 
@@ -312,11 +310,9 @@ TEST_CASE(ble_sm_test_case_peer_sec_req_inval)
     ble_hs_atomic_conn_set_flags(2, BLE_HS_CONN_F_MASTER, 1);
     rc = ble_sm_pair_initiate(2);
     TEST_ASSERT_FATAL(rc == 0);
-    ble_hs_test_util_tx_all();
     ble_hs_test_util_prev_tx_queue_clear();
 
     ble_sm_test_util_rx_sec_req(2, &sec_req, BLE_HS_EALREADY);
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_queue_sz() == 0);
 }
 

--- a/net/nimble/host/test/src/ble_sm_test_util.c
+++ b/net/nimble/host/test/src/ble_sm_test_util.c
@@ -1103,8 +1103,6 @@ ble_sm_test_util_verify_tx_public_key(
     struct ble_sm_public_key cmd;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
-
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_PAIR_PUBLIC_KEY,
                                         sizeof(struct ble_sm_public_key));
     ble_sm_public_key_parse(om->om_data, om->om_len, &cmd);
@@ -1133,7 +1131,6 @@ ble_sm_test_util_verify_tx_enc_info(struct ble_sm_enc_info *exp_cmd)
     struct ble_sm_enc_info cmd;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_ENC_INFO,
                                         sizeof(struct ble_sm_enc_info));
     ble_sm_enc_info_parse(om->om_data, om->om_len, &cmd);
@@ -1150,7 +1147,6 @@ ble_sm_test_util_verify_tx_master_id(struct ble_sm_master_id *exp_cmd)
     struct ble_sm_master_id cmd;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_MASTER_ID,
                                         sizeof(struct ble_sm_master_id));
     ble_sm_master_id_parse(om->om_data, om->om_len, &cmd);
@@ -1165,7 +1161,6 @@ ble_sm_test_util_verify_tx_id_info(struct ble_sm_id_info *exp_cmd)
     struct ble_sm_id_info cmd;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_IDENTITY_INFO,
                                         sizeof(struct ble_sm_id_info));
     ble_sm_id_info_parse(om->om_data, om->om_len, &cmd);
@@ -1190,7 +1185,6 @@ ble_sm_test_util_verify_tx_id_addr_info(struct ble_sm_id_addr_info *exp_cmd)
 
     TEST_ASSERT_FATAL(rc == 0);
 
-    ble_hs_test_util_tx_all();
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_IDENTITY_ADDR_INFO,
                                         sizeof(struct ble_sm_id_addr_info));
     ble_sm_id_addr_info_parse(om->om_data, om->om_len, &cmd);
@@ -1206,7 +1200,6 @@ ble_sm_test_util_verify_tx_sign_info(struct ble_sm_sign_info *exp_cmd)
     struct ble_sm_sign_info cmd;
     struct os_mbuf *om;
 
-    ble_hs_test_util_tx_all();
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_SIGN_INFO,
                                         sizeof(struct ble_sm_sign_info));
     ble_sm_sign_info_parse(om->om_data, om->om_len, &cmd);
@@ -1222,8 +1215,6 @@ ble_sm_test_util_verify_tx_sec_req(struct ble_sm_sec_req *exp_cmd)
 {
     struct ble_sm_sec_req cmd;
     struct os_mbuf *om;
-
-    ble_hs_test_util_tx_all();
 
     om = ble_sm_test_util_verify_tx_hdr(BLE_SM_OP_SEC_REQ, sizeof(struct ble_sm_sec_req));
     ble_sm_sec_req_parse(om->om_data, om->om_len, &cmd);
@@ -1473,7 +1464,6 @@ ble_sm_test_util_io_check_post(struct ble_sm_test_passkey_info *passkey_info,
     }
 
     /* Ensure response not sent until user performs IO. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_queue_sz() == 0);
 
     rc = ble_sm_inject_io(2, &passkey_info->passkey);
@@ -1774,7 +1764,6 @@ ble_sm_test_util_us_bonding_good(int send_enc_req, uint8_t our_addr_type,
     }
 
     /* Ensure we sent the expected start encryption command. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_start_enc(2, rand_num, ediv, ltk);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -1840,7 +1829,6 @@ ble_sm_test_util_peer_fail_inval(
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
     /* Ensure we sent the expected pair fail. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_fail(pair_fail);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 0);
@@ -1901,7 +1889,6 @@ ble_sm_test_util_peer_lgcy_fail_confirm(
     ble_sm_test_util_io_inject_bad(2, BLE_SM_IOACT_NONE);
 
     /* Ensure we sent the expected pair response. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_rsp(pair_rsp);
     TEST_ASSERT(ble_sm_num_procs() == 1);
     ble_sm_test_util_io_inject_bad(2, BLE_SM_IOACT_NONE);
@@ -1912,7 +1899,6 @@ ble_sm_test_util_peer_lgcy_fail_confirm(
     ble_sm_test_util_io_inject_bad(2, BLE_SM_IOACT_NONE);
 
     /* Ensure we sent the expected pair confirm. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_confirm(confirm_rsp);
     TEST_ASSERT(ble_sm_num_procs() == 1);
     ble_sm_test_util_io_inject_bad(2, BLE_SM_IOACT_NONE);
@@ -1922,7 +1908,6 @@ ble_sm_test_util_peer_lgcy_fail_confirm(
         2, random_req, BLE_HS_SM_US_ERR(BLE_SM_ERR_CONFIRM_MISMATCH));
 
     /* Ensure we sent the expected pair fail. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_fail(fail_rsp);
 
     /* The proc should now be freed. */
@@ -2138,7 +2123,6 @@ ble_sm_test_util_us_lgcy_good_once_no_init(
     }
 
     /* Ensure we sent the expected pair request. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_req(our_entity->pair_cmd);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2154,7 +2138,6 @@ ble_sm_test_util_us_lgcy_good_once_no_init(
                                BLE_SM_PROC_STATE_CONFIRM);
 
     /* Ensure we sent the expected pair confirm. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_confirm(our_entity->confirms);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2167,7 +2150,6 @@ ble_sm_test_util_us_lgcy_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected pair random. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_random(our_entity->randoms);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2180,7 +2162,6 @@ ble_sm_test_util_us_lgcy_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected start encryption command. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_start_enc(2, 0, 0, params->stk);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2284,7 +2265,6 @@ ble_sm_test_util_peer_lgcy_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected pair response. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_rsp(our_entity->pair_cmd);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2303,7 +2283,6 @@ ble_sm_test_util_peer_lgcy_good_once_no_init(
                                    BLE_SM_PROC_STATE_CONFIRM);
 
     /* Ensure we sent the expected pair confirm. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_confirm(our_entity->confirms);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2316,7 +2295,6 @@ ble_sm_test_util_peer_lgcy_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected pair random. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_random(our_entity->randoms);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2450,7 +2428,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
     }
 
     /* Ensure we sent the expected pair request. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_req(our_entity->pair_cmd);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2463,7 +2440,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected public key. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_public_key(our_entity->public_key);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2498,7 +2474,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
             }
 
             /* Ensure we sent the expected pair confirm. */
-            ble_hs_test_util_tx_all();
             ble_sm_test_util_verify_tx_pair_confirm(our_entity->confirms + i);
             TEST_ASSERT(!conn->bhc_sec_state.encrypted);
             TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2513,7 +2488,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
         ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
         /* Ensure we sent the expected pair random. */
-        ble_hs_test_util_tx_all();
         ble_sm_test_util_verify_tx_pair_random(our_entity->randoms + i);
         TEST_ASSERT(!conn->bhc_sec_state.encrypted);
         TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2530,7 +2504,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
                                BLE_SM_PROC_STATE_DHKEY_CHECK);
 
     /* Ensure we sent the expected dhkey check. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_dhkey_check(our_entity->dhkey_check);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2543,7 +2516,6 @@ ble_sm_test_util_us_sc_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected start encryption command. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_start_enc(2, 0, 0, params->ltk);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2652,7 +2624,6 @@ ble_sm_test_util_peer_sc_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected pair response. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_rsp(our_entity->pair_cmd);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2665,7 +2636,6 @@ ble_sm_test_util_peer_sc_good_once_no_init(
     ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
     /* Ensure we sent the expected public key. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_public_key(our_entity->public_key);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2707,7 +2677,6 @@ ble_sm_test_util_peer_sc_good_once_no_init(
         }
 
         /* Ensure we sent the expected pair confirm. */
-        ble_hs_test_util_tx_all();
         ble_sm_test_util_verify_tx_pair_confirm(our_entity->confirms + i);
         TEST_ASSERT(!conn->bhc_sec_state.encrypted);
         TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2720,7 +2689,6 @@ ble_sm_test_util_peer_sc_good_once_no_init(
         ble_sm_test_util_io_inject_bad(2, params->passkey_info.passkey.action);
 
         /* Ensure we sent the expected pair random. */
-        ble_hs_test_util_tx_all();
         ble_sm_test_util_verify_tx_pair_random(our_entity->randoms + i);
         TEST_ASSERT(!conn->bhc_sec_state.encrypted);
         TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2741,7 +2709,6 @@ ble_sm_test_util_peer_sc_good_once_no_init(
                                    BLE_SM_PROC_STATE_DHKEY_CHECK);
 
     /* Ensure we sent the expected dhkey check. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_dhkey_check(our_entity->dhkey_check);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2881,7 +2848,6 @@ ble_sm_test_util_us_fail_inval(struct ble_sm_test_params *params)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure we sent the expected pair request. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_req(&params->pair_req);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -2894,7 +2860,6 @@ ble_sm_test_util_us_fail_inval(struct ble_sm_test_params *params)
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
     /* Ensure we sent the expected pair fail. */
-    ble_hs_test_util_tx_all();
     ble_sm_test_util_verify_tx_pair_fail(&params->pair_fail);
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 0);
@@ -2948,7 +2913,6 @@ ble_sm_test_util_repeat_pairing(struct ble_sm_test_params *params, int sc)
 
     /* Receive a pair request from the peer. */
     ble_sm_test_util_rx_pair_req(2, peer_entity.pair_cmd, BLE_HS_EALREADY);
-    ble_hs_test_util_tx_all();
 
     /* Verify repeat pairing event got reported twice. */
     TEST_ASSERT(ble_sm_test_repeat_pairing.num_calls == 2);
@@ -2957,7 +2921,6 @@ ble_sm_test_util_repeat_pairing(struct ble_sm_test_params *params, int sc)
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
     /* Verify no SM messages were sent. */
-    ble_hs_test_util_tx_all();
     TEST_ASSERT(ble_hs_test_util_prev_tx_dequeue() == NULL);
 
     /*** Receive another pairing request. */

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -78,6 +78,7 @@ extern "C" {
 #define BLE_HCI_OCF_IP_RD_LOCAL_VER         (0x0001)
 #define BLE_HCI_OCF_IP_RD_LOC_SUPP_CMD      (0x0002)
 #define BLE_HCI_OCF_IP_RD_LOC_SUPP_FEAT     (0x0003)
+#define BLE_HCI_OCF_IP_RD_BUF_SIZE          (0x0005)
 #define BLE_HCI_OCF_IP_RD_BD_ADDR           (0x0009)
 
 /* List of OCF for Status parameters commands (OGF = 0x05) */
@@ -174,6 +175,10 @@ extern "C" {
 
 /* --- Read BD_ADDR (OGF 0x04, OCF 0x0009 --- */
 #define BLE_HCI_IP_RD_BD_ADDR_ACK_PARAM_LEN (6)
+
+/* --- Read buffer size (OGF 0x04, OCF 0x0005) --- */
+#define BLE_HCI_IP_RD_BUF_SIZE_LEN          (0)
+#define BLE_HCI_IP_RD_BUF_SIZE_RSPLEN       (7) /* No status byte. */
 
 /* --- Read/Write authenticated payload timeout (ocf 0x007B/0x007C) */
 #define BLE_HCI_RD_AUTH_PYLD_TMO_LEN        (4)


### PR DESCRIPTION
Prior to this commit, the host ignored any "Number of Completed Packets" events from the controller.  If the host had any data to send, it would always send it, even if the controller had no free buffers.

Now, the host only sends an ACL packet if the controller has a buffer to hold it:
* When the controller cannot accept more data, the host enqueues outgoing data to the appropriate connection's transmit queue.

* If the host has queued data and the controller indicates that it has freed up buffers, the host attempts to send all its queued data.
* If a disconnect occurs, all outstanding packets associated with the connection are considered flushed.