### PR TITLE
BLE Host - Move HCI test util code into a new file

### DIFF
--- a/net/nimble/host/test/src/ble_att_svr_test.c
+++ b/net/nimble/host/test/src/ble_att_svr_test.c
@@ -1837,13 +1837,13 @@ TEST_CASE(ble_att_svr_test_prep_write_tmo)
     TEST_ASSERT(ticks_from_now == BLE_HS_ATT_SVR_QUEUED_WRITE_TMO);
 
     /* Allow the timer to expire. */
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
     os_time_advance(BLE_HS_ATT_SVR_QUEUED_WRITE_TMO);
     ticks_from_now = ble_hs_conn_timer();
     TEST_ASSERT(ticks_from_now == BLE_HS_FOREVER);
 
     /* Ensure connection was terminated. */
-    ble_hs_test_util_verify_tx_disconnect(2, BLE_ERR_REM_USER_CONN_TERM);
+    ble_hs_test_util_hci_verify_tx_disconnect(2, BLE_ERR_REM_USER_CONN_TERM);
 
     /* Free connection.  This is needed so that the prep write mbufs get
      * freed and no mbuf leak gets reported.

--- a/net/nimble/host/test/src/ble_gap_test.c
+++ b/net/nimble/host/test/src/ble_gap_test.c
@@ -158,7 +158,7 @@ ble_gap_test_util_verify_tx_clear_wl(void)
 {
     uint8_t param_len;
 
-    ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                    BLE_HCI_OCF_LE_CLEAR_WHITE_LIST,
                                    &param_len);
     TEST_ASSERT(param_len == 0);
@@ -171,7 +171,7 @@ ble_gap_test_util_verify_tx_add_wl(ble_addr_t *addr)
     uint8_t *param;
     int i;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_ADD_WHITE_LIST,
                                            &param_len);
     TEST_ASSERT(param_len == 7);
@@ -191,7 +191,7 @@ ble_gap_test_util_verify_tx_set_scan_params(uint8_t own_addr_type,
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_SET_SCAN_PARAMS,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_SET_SCAN_PARAM_LEN);
@@ -209,7 +209,7 @@ ble_gap_test_util_verify_tx_scan_enable(uint8_t enable,
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_SET_SCAN_ENABLE,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_SET_SCAN_ENABLE_LEN);
@@ -218,11 +218,11 @@ ble_gap_test_util_verify_tx_scan_enable(uint8_t enable,
 }
 
 static void
-ble_hs_test_util_verify_tx_create_conn_cancel(void)
+ble_hs_test_util_hci_verify_tx_create_conn_cancel(void)
 {
     uint8_t param_len;
 
-    ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                    BLE_HCI_OCF_LE_CREATE_CONN_CANCEL,
                                    &param_len);
     TEST_ASSERT(param_len == 0);
@@ -234,7 +234,7 @@ ble_gap_test_util_verify_tx_disconnect(void)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LINK_CTRL,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LINK_CTRL,
                                            BLE_HCI_OCF_DISCONNECT_CMD,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_DISCONNECT_CMD_LEN);
@@ -247,7 +247,7 @@ ble_gap_test_util_verify_tx_adv_params(void)
 {
     uint8_t param_len;
 
-    ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                    BLE_HCI_OCF_LE_SET_ADV_PARAMS,
                                    &param_len);
     TEST_ASSERT(param_len == BLE_HCI_SET_ADV_PARAM_LEN);
@@ -260,7 +260,7 @@ ble_gap_test_util_verify_tx_adv_data(void)
 {
     uint8_t param_len;
 
-    ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                    BLE_HCI_OCF_LE_SET_ADV_DATA,
                                    &param_len);
     /* Note: Content of message verified in ble_hs_adv_test.c. */
@@ -273,7 +273,7 @@ ble_gap_test_util_verify_tx_rsp_data(void)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_SET_SCAN_RSP_DATA,
                                            &param_len);
     (void)param; /* XXX: Verify other fields. */
@@ -286,7 +286,7 @@ ble_gap_test_util_verify_tx_adv_enable(int enabled)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_SET_ADV_ENABLE,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_SET_ADV_ENABLE_LEN);
@@ -299,7 +299,7 @@ ble_gap_test_util_verify_tx_update_conn(struct ble_gap_upd_params *params)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_CONN_UPDATE,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_CONN_UPDATE_LEN);
@@ -318,7 +318,7 @@ ble_gap_test_util_verify_tx_params_reply_pos(void)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_REM_CONN_PARAM_RR,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_CONN_PARAM_REPLY_LEN);
@@ -340,7 +340,7 @@ ble_gap_test_util_verify_tx_params_reply_neg(uint8_t reason)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_REM_CONN_PARAM_NRR,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_CONN_PARAM_NEG_REPLY_LEN);
@@ -395,7 +395,7 @@ ble_gap_test_util_rx_param_req(struct ble_gap_upd_params *params, int pos,
     }
     (*cmd_idx)++;
 
-    ble_hs_test_util_set_ack(opcode, hci_status);
+    ble_hs_test_util_hci_ack_set(opcode, hci_status);
     ble_gap_rx_param_req(&evt);
 
     return hci_status;
@@ -630,7 +630,8 @@ TEST_CASE(ble_gap_test_case_disc_good)
                     BLE_ADDR_PUBLIC);
         TEST_ASSERT(ble_gap_test_disc_desc.length_data == 3);
         TEST_ASSERT(ble_gap_test_disc_desc.rssi == 0);
-        TEST_ASSERT(memcmp(ble_gap_test_disc_desc.addr.val, desc.addr.val, 6) == 0);
+        TEST_ASSERT(memcmp(ble_gap_test_disc_desc.addr.val, desc.addr.val,
+                    6) == 0);
         TEST_ASSERT(ble_gap_test_disc_arg == NULL);
 
     }
@@ -781,7 +782,10 @@ TEST_CASE(ble_gap_test_case_disc_already)
 TEST_CASE(ble_gap_test_case_disc_busy)
 {
     static const struct ble_gap_disc_params disc_params = { 0 };
-    static const ble_addr_t peer_addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }};
+    static const ble_addr_t peer_addr = {
+        BLE_ADDR_PUBLIC,
+        { 1, 2, 3, 4, 5, 6 }
+    };
     int rc;
 
     ble_gap_test_util_init();
@@ -847,8 +851,9 @@ TEST_CASE(ble_gap_test_case_conn_gen_good)
     TEST_ASSERT(ble_gap_master_in_progress());
     TEST_ASSERT(ble_hs_atomic_conn_flags(2, NULL) == BLE_HS_ENOTCONN);
 
-    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony
+     * ack */
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive connection complete event. */
@@ -887,22 +892,27 @@ TEST_CASE(ble_gap_test_case_conn_gen_bad_args)
     TEST_ASSERT(!ble_gap_master_in_progress());
 
     /*** Connection already in progress. */
-    rc = ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
-                                  &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
-                                  0, NULL, ble_gap_test_util_connect_cb,
-                                  NULL, 0);
+    rc = ble_hs_test_util_connect(
+        BLE_OWN_ADDR_PUBLIC,
+        &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
+        0, NULL, ble_gap_test_util_connect_cb,
+        NULL, 0);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(ble_gap_master_in_progress());
 
-    rc = ble_gap_connect(BLE_OWN_ADDR_PUBLIC,
-                         &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
-                         0, NULL, ble_gap_test_util_connect_cb, NULL);
+    rc = ble_gap_connect(
+        BLE_OWN_ADDR_PUBLIC,
+        &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
+        0, NULL, ble_gap_test_util_connect_cb, NULL);
     TEST_ASSERT(rc == BLE_HS_EALREADY);
 }
 
 TEST_CASE(ble_gap_test_case_conn_gen_dflt_params)
 {
-    static const ble_addr_t peer_addr = { BLE_ADDR_PUBLIC, { 2, 3, 8, 6, 6, 1 }};
+    static const ble_addr_t peer_addr = {
+        BLE_ADDR_PUBLIC,
+        { 2, 3, 8, 6, 6, 1 }
+    };
     int rc;
 
     ble_gap_test_util_init();
@@ -916,7 +926,10 @@ TEST_CASE(ble_gap_test_case_conn_gen_dflt_params)
 TEST_CASE(ble_gap_test_case_conn_gen_already)
 {
     static const struct ble_gap_conn_params conn_params = { 0 };
-    static const ble_addr_t peer_addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }};
+    static const ble_addr_t peer_addr = {
+        BLE_ADDR_PUBLIC,
+        { 1, 2, 3, 4, 5, 6 }
+    };
     int rc;
 
     ble_gap_test_util_init();
@@ -935,14 +948,17 @@ TEST_CASE(ble_gap_test_case_conn_gen_already)
 TEST_CASE(ble_gap_test_case_conn_gen_done)
 {
     static const struct ble_gap_conn_params conn_params = { 0 };
-    static const ble_addr_t peer_addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }};
+    static const ble_addr_t peer_addr = {
+        BLE_ADDR_PUBLIC,
+        { 1, 2, 3, 4, 5, 6 }
+    };
     int rc;
 
     ble_gap_test_util_init();
 
     /* Successfully connect to the peer. */
-    ble_hs_test_util_create_conn(2, peer_addr.val, ble_gap_test_util_connect_cb,
-                                 NULL);
+    ble_hs_test_util_create_conn(2, peer_addr.val,
+                                 ble_gap_test_util_connect_cb, NULL);
 
     /* Ensure host indicates BLE_HS_EDONE if we try to connect to the same
      * peer.
@@ -956,7 +972,10 @@ TEST_CASE(ble_gap_test_case_conn_gen_busy)
 {
     static const struct ble_gap_disc_params disc_params = { 0 };
     static const struct ble_gap_conn_params conn_params = { 0 };
-    static const ble_addr_t peer_addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }};
+    static const ble_addr_t peer_addr = {
+        BLE_ADDR_PUBLIC,
+        { 1, 2, 3, 4, 5, 6 }
+    };
     int rc;
 
     ble_gap_test_util_init();
@@ -1029,7 +1048,7 @@ ble_gap_test_util_conn_cancel(uint8_t hci_status)
     TEST_ASSERT(rc == BLE_HS_HCI_ERR(hci_status));
 
     /* Verify tx of cancel create connection command. */
-    ble_hs_test_util_verify_tx_create_conn_cancel();
+    ble_hs_test_util_hci_verify_tx_create_conn_cancel();
     if (rc != 0) {
         return;
     }
@@ -1103,8 +1122,10 @@ TEST_CASE(ble_gap_test_case_conn_cancel_ctlr_fail)
      */
     TEST_ASSERT(ble_gap_test_event.type == 0xff);
 
-    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony
+     * ack
+     */
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Allow connection complete to succeed. */
@@ -1460,8 +1481,10 @@ ble_gap_test_util_adv(uint8_t own_addr_type,
                  * ble_gap_rx_conn_complete() will send extra HCI command, need
                  * phony ack
                  */
-                ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
-                                         BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
+                ble_hs_test_util_hci_ack_set(
+                    ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                                                BLE_HCI_OCF_LE_RD_REM_FEAT),
+                    0);
             }
 
             memset(&evt, 0, sizeof evt);
@@ -1516,9 +1539,10 @@ TEST_CASE(ble_gap_test_case_adv_bad_args)
     /*** Invalid peer address type with directed advertisable mode. */
     adv_params = ble_hs_test_util_adv_params;
     adv_params.conn_mode = BLE_GAP_CONN_MODE_DIR;
-    rc = ble_hs_test_util_adv_start(BLE_OWN_ADDR_PUBLIC,
-                                    &peer_addr_inv, &adv_params, BLE_HS_FOREVER,
-                                    ble_gap_test_util_connect_cb, NULL, 0, 0);
+    rc = ble_hs_test_util_adv_start(
+        BLE_OWN_ADDR_PUBLIC,
+        &peer_addr_inv, &adv_params, BLE_HS_FOREVER,
+        ble_gap_test_util_connect_cb, NULL, 0, 0);
     TEST_ASSERT(rc == BLE_HS_EINVAL);
     TEST_ASSERT(!ble_gap_adv_active());
 
@@ -1570,7 +1594,7 @@ ble_gap_test_util_adv_verify_dflt_params(uint8_t own_addr_type,
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure default parameters properly filled in. */
-    hci_buf = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    hci_buf = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                              BLE_HCI_OCF_LE_SET_ADV_PARAMS,
                                              &hci_param_len);
     TEST_ASSERT_FATAL(hci_buf != NULL);
@@ -1654,7 +1678,8 @@ TEST_CASE(ble_gap_test_case_adv_ctlr_fail)
     for (c = BLE_GAP_CONN_MODE_NON + 1; c < BLE_GAP_CONN_MODE_MAX; c++) {
         for (d = BLE_GAP_DISC_MODE_NON; d < BLE_GAP_DISC_MODE_MAX; d++) {
             ble_gap_test_util_adv(BLE_OWN_ADDR_PUBLIC,
-                                  &peer_addr, c, d, BLE_ERR_DIR_ADV_TMO, -1, 0);
+                                  &peer_addr, c, d, BLE_ERR_DIR_ADV_TMO,
+                                  -1, 0);
 
             TEST_ASSERT(!ble_gap_adv_active());
             TEST_ASSERT(ble_gap_test_event.type == BLE_GAP_EVENT_ADV_COMPLETE);
@@ -1984,7 +2009,7 @@ ble_gap_test_util_update_no_l2cap_tmo(struct ble_gap_upd_params *params,
     /* Timeout will result in a terminate HCI command being sent; schedule ack
      * from controller.
      */
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
 
     ble_gap_timer();
 
@@ -2061,7 +2086,7 @@ ble_gap_test_util_update_l2cap_tmo(struct ble_gap_upd_params *params,
     /* Timeout will result in a terminate HCI command being sent; schedule ack
      * from controller.
      */
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
 
     ble_gap_timer();
     ble_l2cap_sig_timer();
@@ -2443,10 +2468,12 @@ TEST_CASE(ble_gap_test_case_update_conn_l2cap)
     };
 
     /* Accepted L2CAP. */
-    ble_gap_test_util_update_l2cap(&params, BLE_L2CAP_SIG_UPDATE_RSP_RESULT_ACCEPT);
+    ble_gap_test_util_update_l2cap(&params,
+                                   BLE_L2CAP_SIG_UPDATE_RSP_RESULT_ACCEPT);
 
     /* Rejected L2CAP. */
-    ble_gap_test_util_update_l2cap(&params, BLE_L2CAP_SIG_UPDATE_RSP_RESULT_REJECT);
+    ble_gap_test_util_update_l2cap(&params,
+                                   BLE_L2CAP_SIG_UPDATE_RSP_RESULT_REJECT);
 }
 
 TEST_CASE(ble_gap_test_case_update_peer_good)
@@ -2679,11 +2706,12 @@ ble_gap_test_util_conn_forever(void)
     int32_t ticks_from_now;
 
     /* Initiate a connect procedure with no timeout. */
-    ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
-                             &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
-                             BLE_HS_FOREVER,
-                             NULL, ble_gap_test_util_connect_cb,
-                             NULL, 0);
+    ble_hs_test_util_connect(
+        BLE_OWN_ADDR_PUBLIC,
+        &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
+        BLE_HS_FOREVER,
+        NULL, ble_gap_test_util_connect_cb,
+        NULL, 0);
 
     /* Ensure no pending GAP event. */
     ticks_from_now = ble_gap_timer();
@@ -2707,11 +2735,12 @@ ble_gap_test_util_conn_timeout(int32_t duration_ms)
     TEST_ASSERT_FATAL(duration_ms != BLE_HS_FOREVER);
 
     /* Initiate a connect procedure with the specified timeout. */
-    ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
-                             &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
-                             duration_ms,
-                             NULL, ble_gap_test_util_connect_cb,
-                             NULL, 0);
+    ble_hs_test_util_connect(
+        BLE_OWN_ADDR_PUBLIC,
+        &((ble_addr_t) { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 }}),
+        duration_ms,
+        NULL, ble_gap_test_util_connect_cb,
+        NULL, 0);
 
     /* Ensure next GAP event is at the expected time. */
     rc = os_time_ms_to_ticks(duration_ms, &duration_ticks);
@@ -2724,7 +2753,7 @@ ble_gap_test_util_conn_timeout(int32_t duration_ms)
      */
     os_time_advance(duration_ms);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_CREATE_CONN_CANCEL),
         0);
@@ -2735,7 +2764,7 @@ ble_gap_test_util_conn_timeout(int32_t duration_ms)
     TEST_ASSERT(ticks_from_now == BLE_HS_FOREVER);
 
     /* Ensure cancel create connection command was sent. */
-    ble_hs_test_util_verify_tx_create_conn_cancel();
+    ble_hs_test_util_hci_verify_tx_create_conn_cancel();
 
     /* Ensure timer has been stopped. */
     ticks_from_now = ble_gap_timer();
@@ -2805,7 +2834,7 @@ ble_gap_test_util_disc_timeout(int32_t duration_ms)
     /* Advance duration ms; ensure timeout event was reported. */
     os_time_advance(duration_ms);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
         0);
@@ -3046,7 +3075,7 @@ TEST_CASE(ble_gap_test_case_set_cb_good)
     disconn_evt.connection_handle = 2;
     disconn_evt.status = 0;
     disconn_evt.reason = BLE_ERR_REM_USER_CONN_TERM;
-    ble_hs_test_util_rx_disconn_complete_event(&disconn_evt);
+    ble_hs_test_util_hci_rx_disconn_complete_event(&disconn_evt);
 
     TEST_ASSERT(event.type == BLE_GAP_EVENT_DISCONNECT);
     TEST_ASSERT(event.disconnect.reason ==

--- a/net/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/net/nimble/host/test/src/ble_gatt_conn_test.c
@@ -556,6 +556,7 @@ static void
 ble_gatt_conn_test_util_timeout(uint16_t conn_handle,
                                 struct ble_gatt_conn_test_arg *arg)
 {
+    struct hci_disconn_complete evt;
     int32_t ticks_from_now;
 
     ticks_from_now = ble_gattc_timer();
@@ -565,16 +566,16 @@ ble_gatt_conn_test_util_timeout(uint16_t conn_handle,
     ticks_from_now = ble_gattc_timer();
     TEST_ASSERT(ticks_from_now == 1 * OS_TICKS_PER_SEC);
 
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
     os_time_advance(1 * OS_TICKS_PER_SEC);
     ticks_from_now = ble_gattc_timer();
     TEST_ASSERT(ticks_from_now == BLE_HS_FOREVER);
 
     /* Ensure connection was terminated due to proecedure timeout. */
-    ble_hs_test_util_verify_tx_disconnect(conn_handle,
-                                          BLE_ERR_REM_USER_CONN_TERM);
-    ble_hs_test_util_rx_disconn_complete(conn_handle,
-                                         BLE_ERR_REM_USER_CONN_TERM);
+    evt.connection_handle = conn_handle;
+    evt.status = 0;
+    evt.reason = BLE_ERR_REM_USER_CONN_TERM;
+    ble_hs_test_util_hci_rx_disconn_complete_event(&evt);
 
     /* Ensure GATT callback was called with timeout status. */
     if (arg != NULL) {

--- a/net/nimble/host/test/src/ble_gatt_disc_s_test.c
+++ b/net/nimble/host/test/src/ble_gatt_disc_s_test.c
@@ -600,7 +600,7 @@ TEST_CASE(ble_gatt_disc_s_test_oom_timeout)
     /* Verify the procedure has timed out.  The connection should now be
      * in the process of being terminated.  XXX: Check this.
      */
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
     ble_gattc_timer();
 
     ticks_until = ble_gattc_timer();

--- a/net/nimble/host/test/src/ble_hs_adv_test.c
+++ b/net/nimble/host/test/src/ble_hs_adv_test.c
@@ -104,7 +104,7 @@ ble_hs_adv_test_misc_verify_tx_adv_data(struct ble_hs_adv_test_field *fields)
     int data_len;
     uint8_t *cmd;
 
-    cmd = ble_hs_test_util_get_last_hci_tx();
+    cmd = ble_hs_test_util_hci_out_last();
     TEST_ASSERT_FATAL(cmd != NULL);
 
     data_len = ble_hs_adv_test_misc_calc_data_len(fields);
@@ -121,7 +121,7 @@ ble_hs_adv_test_misc_verify_tx_rsp_data(struct ble_hs_adv_test_field *fields)
     int data_len;
     uint8_t *cmd;
 
-    cmd = ble_hs_test_util_get_last_hci_tx();
+    cmd = ble_hs_test_util_hci_out_last();
     TEST_ASSERT_FATAL(cmd != NULL);
 
     data_len = ble_hs_adv_test_misc_calc_data_len(fields);
@@ -163,7 +163,7 @@ ble_hs_adv_test_misc_tx_and_verify_data(
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Discard the adv-enable command. */
-    ble_hs_test_util_get_last_hci_tx();
+    ble_hs_test_util_hci_out_last();
 
     /* Ensure the same data gets sent on repeated advertise procedures. */
     rc = ble_hs_test_util_adv_stop(0);
@@ -174,7 +174,7 @@ ble_hs_adv_test_misc_tx_and_verify_data(
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Discard the adv-enable command. */
-    ble_hs_test_util_get_last_hci_tx();
+    ble_hs_test_util_hci_out_last();
 }
 
 TEST_CASE(ble_hs_adv_test_case_user)

--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -60,7 +60,7 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
     TEST_ASSERT(ble_gap_master_in_progress());
 
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive successful connection complete event. */
@@ -117,7 +117,7 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
     TEST_ASSERT(ble_gap_adv_active());
 
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive successful connection complete event. */
@@ -182,7 +182,7 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
     TEST_ASSERT(ble_gap_adv_active());
 
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive successful connection complete event. */

--- a/net/nimble/host/test/src/ble_hs_pvcy_test.c
+++ b/net/nimble/host/test/src/ble_hs_pvcy_test.c
@@ -36,12 +36,12 @@ ble_hs_pvcy_test_util_start_host(int num_expected_irks)
      */
     rc = ble_hs_test_util_set_our_irk((uint8_t[16]){0}, -1, 0);
     TEST_ASSERT_FATAL(rc == 0);
-    ble_hs_test_util_prev_hci_tx_clear();
+    ble_hs_test_util_hci_out_clear();
 
-    ble_hs_test_util_set_startup_acks();
+    ble_hs_test_util_hci_ack_set_startup();
 
     for (i = 0; i < num_expected_irks; i++) {
-        ble_hs_test_util_append_ack(
+        ble_hs_test_util_hci_ack_append(
             BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0); 
     }
 
@@ -49,7 +49,7 @@ ble_hs_pvcy_test_util_start_host(int num_expected_irks)
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Discard startup HCI commands. */
-    ble_hs_test_util_prev_tx_queue_adj(11);
+    ble_hs_test_util_hci_out_adj(11);
 }
 
 static void
@@ -57,22 +57,22 @@ ble_hs_pvcy_test_util_add_irk(const struct ble_store_value_sec *value_sec)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
-        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0); 
-    ble_hs_test_util_append_ack(
+    ble_hs_test_util_hci_ack_set(
+        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0);
+    ble_hs_test_util_hci_ack_append(
         BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE), 0);
 
     rc = ble_store_write_peer_sec(value_sec);
     TEST_ASSERT_FATAL(rc == 0);
 
-    ble_hs_test_util_verify_tx_add_irk(value_sec->peer_addr.type,
-                                       value_sec->peer_addr.val,
-                                       value_sec->irk,
-                                       ble_hs_pvcy_default_irk);
+    ble_hs_test_util_hci_verify_tx_add_irk(value_sec->peer_addr.type,
+                                           value_sec->peer_addr.val,
+                                           value_sec->irk,
+                                           ble_hs_pvcy_default_irk);
 
-    ble_hs_test_util_verify_tx_set_priv_mode(value_sec->peer_addr.type,
-                                             value_sec->peer_addr.val,
-                                             BLE_GAP_PRIVATE_MODE_DEVICE);
+    ble_hs_test_util_hci_verify_tx_set_priv_mode(value_sec->peer_addr.type,
+                                                 value_sec->peer_addr.val,
+                                                 BLE_GAP_PRIVATE_MODE_DEVICE);
 }
 
 TEST_CASE(ble_hs_pvcy_test_case_restore_irks)
@@ -100,10 +100,10 @@ TEST_CASE(ble_hs_pvcy_test_case_restore_irks)
 
     /* Ensure it gets added to list on startup. */
     ble_hs_pvcy_test_util_start_host(1);
-    ble_hs_test_util_verify_tx_add_irk(value_sec1.peer_addr.type,
-                                       value_sec1.peer_addr.val,
-                                       value_sec1.irk,
-                                       ble_hs_pvcy_default_irk);
+    ble_hs_test_util_hci_verify_tx_add_irk(value_sec1.peer_addr.type,
+                                           value_sec1.peer_addr.val,
+                                           value_sec1.irk,
+                                           ble_hs_pvcy_default_irk);
 
     /* Two persisted IRKs. */
     value_sec2 = (struct ble_store_value_sec) {
@@ -118,14 +118,14 @@ TEST_CASE(ble_hs_pvcy_test_case_restore_irks)
 
     /* Ensure both get added to list on startup. */
     ble_hs_pvcy_test_util_start_host(2);
-    ble_hs_test_util_verify_tx_add_irk(value_sec1.peer_addr.type,
-                                       value_sec1.peer_addr.val,
-                                       value_sec1.irk,
-                                       ble_hs_pvcy_default_irk);
-    ble_hs_test_util_verify_tx_add_irk(value_sec2.peer_addr.type,
-                                       value_sec2.peer_addr.val,
-                                       value_sec2.irk,
-                                       ble_hs_pvcy_default_irk);
+    ble_hs_test_util_hci_verify_tx_add_irk(value_sec1.peer_addr.type,
+                                           value_sec1.peer_addr.val,
+                                           value_sec1.irk,
+                                           ble_hs_pvcy_default_irk);
+    ble_hs_test_util_hci_verify_tx_add_irk(value_sec2.peer_addr.type,
+                                           value_sec2.peer_addr.val,
+                                           value_sec2.irk,
+                                           ble_hs_pvcy_default_irk);
 }
 
 TEST_SUITE(ble_hs_pvcy_test_suite_irk)

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -34,24 +34,12 @@
 /* Our global device address. */
 uint8_t g_dev_addr[BLE_DEV_ADDR_LEN];
 
-#define BLE_HS_TEST_UTIL_PUB_ADDR_VAL { 0x0a, 0x54, 0xab, 0x49, 0x7f, 0x06 }
-
-#define BLE_HS_TEST_UTIL_LE_OPCODE(ocf) \
-    ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE, (ocf))
-
 static STAILQ_HEAD(, os_mbuf_pkthdr) ble_hs_test_util_prev_tx_queue;
 struct os_mbuf *ble_hs_test_util_prev_tx_cur;
 
 int ble_sm_test_store_obj_type;
 union ble_store_key ble_sm_test_store_key;
 union ble_store_value ble_sm_test_store_value;
-
-#define BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT      64
-static uint8_t
-ble_hs_test_util_prev_hci_tx[BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT][260];
-int ble_hs_test_util_num_prev_hci_txes;
-
-uint8_t ble_hs_test_util_cur_hci_tx[260];
 
 const struct ble_gap_adv_params ble_hs_test_util_adv_params = {
     .conn_mode = BLE_GAP_CONN_MODE_UND,
@@ -179,290 +167,6 @@ ble_hs_test_util_prev_tx_queue_clear(void)
     }
 }
 
-void
-ble_hs_test_util_prev_tx_queue_adj(int count)
-{
-    TEST_ASSERT(ble_hs_test_util_num_prev_hci_txes >= count);
-
-    ble_hs_test_util_num_prev_hci_txes -= count;
-    if (ble_hs_test_util_num_prev_hci_txes > 0) {
-        memmove(
-            ble_hs_test_util_prev_hci_tx, ble_hs_test_util_prev_hci_tx + count,
-            sizeof ble_hs_test_util_prev_hci_tx[0] *
-            ble_hs_test_util_num_prev_hci_txes);
-    }
-}
-
-void *
-ble_hs_test_util_get_first_hci_tx(void)
-{
-    if (ble_hs_test_util_num_prev_hci_txes == 0) {
-        return NULL;
-    }
-
-    memcpy(ble_hs_test_util_cur_hci_tx, ble_hs_test_util_prev_hci_tx[0],
-           sizeof ble_hs_test_util_cur_hci_tx);
-
-    ble_hs_test_util_prev_tx_queue_adj(1);
-
-    return ble_hs_test_util_cur_hci_tx;
-}
-
-void *
-ble_hs_test_util_get_last_hci_tx(void)
-{
-    if (ble_hs_test_util_num_prev_hci_txes == 0) {
-        return NULL;
-    }
-
-    ble_hs_test_util_num_prev_hci_txes--;
-    memcpy(ble_hs_test_util_cur_hci_tx,
-           ble_hs_test_util_prev_hci_tx + ble_hs_test_util_num_prev_hci_txes,
-           sizeof ble_hs_test_util_cur_hci_tx);
-
-    return ble_hs_test_util_cur_hci_tx;
-}
-
-void
-ble_hs_test_util_enqueue_hci_tx(void *cmd)
-{
-    TEST_ASSERT_FATAL(ble_hs_test_util_num_prev_hci_txes <
-                      BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT);
-    memcpy(ble_hs_test_util_prev_hci_tx + ble_hs_test_util_num_prev_hci_txes,
-           cmd, 260);
-
-    ble_hs_test_util_num_prev_hci_txes++;
-}
-
-void
-ble_hs_test_util_prev_hci_tx_clear(void)
-{
-    ble_hs_test_util_num_prev_hci_txes = 0;
-}
-
-static void
-ble_hs_test_util_rx_hci_evt(uint8_t *evt)
-{
-    uint8_t *evbuf;
-    int totlen;
-    int rc;
-
-    totlen = BLE_HCI_EVENT_HDR_LEN + evt[1];
-    TEST_ASSERT_FATAL(totlen <= UINT8_MAX + BLE_HCI_EVENT_HDR_LEN);
-
-    evbuf = ble_hci_trans_buf_alloc(
-        BLE_HCI_TRANS_BUF_EVT_LO);
-    TEST_ASSERT_FATAL(evbuf != NULL);
-
-    memcpy(evbuf, evt, totlen);
-
-    if (os_started()) {
-        rc = ble_hci_trans_ll_evt_tx(evbuf);
-    } else {
-        rc = ble_hs_hci_evt_process(evbuf);
-    }
-
-    TEST_ASSERT_FATAL(rc == 0);
-}
-
-void
-ble_hs_test_util_build_cmd_complete(uint8_t *dst, int len,
-                                    uint8_t param_len, uint8_t num_pkts,
-                                    uint16_t opcode)
-{
-    TEST_ASSERT(len >= BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN);
-
-    dst[0] = BLE_HCI_EVCODE_COMMAND_COMPLETE;
-    dst[1] = 3 + param_len;
-    dst[2] = num_pkts;
-    put_le16(dst + 3, opcode);
-}
-
-void
-ble_hs_test_util_build_cmd_status(uint8_t *dst, int len,
-                                  uint8_t status, uint8_t num_pkts,
-                                  uint16_t opcode)
-{
-    TEST_ASSERT(len >= BLE_HCI_EVENT_CMD_STATUS_LEN);
-
-    dst[0] = BLE_HCI_EVCODE_COMMAND_STATUS;
-    dst[1] = BLE_HCI_EVENT_CMD_STATUS_LEN;
-    dst[2] = status;
-    dst[3] = num_pkts;
-    put_le16(dst + 4, opcode);
-}
-
-static struct ble_hs_test_util_phony_ack
-ble_hs_test_util_phony_acks[BLE_HS_TEST_UTIL_PHONY_ACK_MAX];
-static int ble_hs_test_util_num_phony_acks;
-
-static int
-ble_hs_test_util_phony_ack_cb(uint8_t *ack, int ack_buf_len)
-{
-    struct ble_hs_test_util_phony_ack *entry;
-
-    if (ble_hs_test_util_num_phony_acks == 0) {
-        return BLE_HS_ETIMEOUT_HCI;
-    }
-
-    entry = ble_hs_test_util_phony_acks;
-
-    ble_hs_test_util_build_cmd_complete(ack, 256,
-                                        entry->evt_params_len + 1, 1,
-                                        entry->opcode);
-    ack[BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN] = entry->status;
-    memcpy(ack + BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN + 1, entry->evt_params,
-           entry->evt_params_len);
-
-    ble_hs_test_util_num_phony_acks--;
-    if (ble_hs_test_util_num_phony_acks > 0) {
-        memmove(ble_hs_test_util_phony_acks, ble_hs_test_util_phony_acks + 1,
-                sizeof *entry * ble_hs_test_util_num_phony_acks);
-    }
-
-    return 0;
-}
-
-void
-ble_hs_test_util_build_ack_params(struct ble_hs_test_util_phony_ack *ack,
-                                  uint16_t opcode, uint8_t status,
-                                  void *params, uint8_t params_len)
-{
-    ack->opcode = opcode;
-    ack->status = status;
-
-    if (params == NULL || params_len == 0) {
-        ack->evt_params_len = 0;
-    } else {
-        memcpy(ack->evt_params, params, params_len);
-        ack->evt_params_len = params_len;
-    }
-}
-
-void
-ble_hs_test_util_set_ack_params(uint16_t opcode, uint8_t status, void *params,
-                                uint8_t params_len)
-{
-    struct ble_hs_test_util_phony_ack *ack;
-
-    ack = ble_hs_test_util_phony_acks + 0;
-    ble_hs_test_util_build_ack_params(ack, opcode, status, params, params_len);
-    ble_hs_test_util_num_phony_acks = 1;
-
-    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_phony_ack_cb);
-}
-
-void
-ble_hs_test_util_set_ack(uint16_t opcode, uint8_t status)
-{
-    ble_hs_test_util_set_ack_params(opcode, status, NULL, 0);
-}
-
-void
-ble_hs_test_util_append_ack_params(uint16_t opcode, uint8_t status,
-                                   void *params, uint8_t params_len)
-{
-    struct ble_hs_test_util_phony_ack *ack;
-
-    ack = ble_hs_test_util_phony_acks + ble_hs_test_util_num_phony_acks;
-    ble_hs_test_util_build_ack_params(ack, opcode, status, params, params_len);
-    ble_hs_test_util_num_phony_acks++;
-
-    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_phony_ack_cb);
-}
-
-void
-ble_hs_test_util_append_ack(uint16_t opcode, uint8_t status)
-{
-    ble_hs_test_util_append_ack_params(opcode, status, NULL, 0);
-}
-
-void
-ble_hs_test_util_set_ack_seq(struct ble_hs_test_util_phony_ack *acks)
-{
-    int i;
-
-    for (i = 0; acks[i].opcode != 0; i++) {
-        ble_hs_test_util_phony_acks[i] = acks[i];
-    }
-    ble_hs_test_util_num_phony_acks = i;
-
-    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_phony_ack_cb);
-}
-
-void
-ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
-                                 const uint8_t *our_rpa,
-                                 uint8_t peer_addr_type,
-                                 const uint8_t *peer_id_addr,
-                                 const uint8_t *peer_rpa,
-                                 uint8_t conn_features,
-                                 ble_gap_event_fn *cb, void *cb_arg)
-{
-    ble_addr_t addr;
-    struct hci_le_conn_complete evt;
-    struct hci_le_rd_rem_supp_feat_complete evt2;
-    int rc;
-
-    addr.type = peer_addr_type;
-    memcpy(addr.val, peer_id_addr, 6);
-
-    ble_hs_test_util_connect(own_addr_type, &addr,
-                             0, NULL, cb, cb_arg, 0);
-
-    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
-                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
-
-    memset(&evt, 0, sizeof evt);
-    evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
-    evt.status = BLE_ERR_SUCCESS;
-    evt.connection_handle = handle;
-    evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
-    evt.peer_addr_type = peer_addr_type;
-    memcpy(evt.peer_addr, peer_id_addr, 6);
-    evt.conn_itvl = BLE_GAP_INITIAL_CONN_ITVL_MAX;
-    evt.conn_latency = BLE_GAP_INITIAL_CONN_LATENCY;
-    evt.supervision_timeout = BLE_GAP_INITIAL_SUPERVISION_TIMEOUT;
-    memcpy(evt.local_rpa, our_rpa, 6);
-    memcpy(evt.peer_rpa, peer_rpa, 6);
-
-    rc = ble_gap_rx_conn_complete(&evt);
-    TEST_ASSERT(rc == 0);
-
-    evt2.subevent_code = BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT;
-    evt2.status = BLE_ERR_SUCCESS;
-    evt2.connection_handle = handle;
-    memcpy(evt2.features, ((uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }), 8);
-
-    ble_gap_rx_rd_rem_sup_feat_complete(&evt2);
-
-    ble_hs_test_util_prev_hci_tx_clear();
-}
-
-void
-ble_hs_test_util_create_conn(uint16_t handle, const uint8_t *peer_id_addr,
-                             ble_gap_event_fn *cb, void *cb_arg)
-{
-    static uint8_t null_addr[6];
-
-    ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
-                                     BLE_ADDR_PUBLIC, peer_id_addr,
-                                     null_addr, BLE_HS_TEST_CONN_FEAT_ALL,
-                                     cb, cb_arg);
-}
-
-void
-ble_hs_test_util_create_conn_feat(uint16_t handle, const uint8_t *peer_id_addr,
-                             uint8_t conn_features, ble_gap_event_fn *cb, void *cb_arg)
-{
-    static uint8_t null_addr[6];
-
-    ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
-                                     BLE_ADDR_PUBLIC, peer_id_addr,
-                                     null_addr, conn_features, cb, cb_arg);
-}
-
 static void
 ble_hs_test_util_conn_params_dflt(struct ble_gap_conn_params *conn_params)
 {
@@ -503,43 +207,77 @@ ble_hs_test_util_hcc_from_conn_params(
 }
 
 void
-ble_hs_test_util_verify_tx_disconnect(uint16_t handle, uint8_t reason)
+ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
+                                 const uint8_t *our_rpa,
+                                 uint8_t peer_addr_type,
+                                 const uint8_t *peer_id_addr,
+                                 const uint8_t *peer_rpa,
+                                 uint8_t conn_features,
+                                 ble_gap_event_fn *cb, void *cb_arg)
 {
-    uint8_t param_len;
-    uint8_t *param;
+    ble_addr_t addr;
+    struct hci_le_conn_complete evt;
+    struct hci_le_rd_rem_supp_feat_complete evt2;
+    int rc;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LINK_CTRL,
-                                           BLE_HCI_OCF_DISCONNECT_CMD,
-                                           &param_len);
-    TEST_ASSERT(param_len == BLE_HCI_DISCONNECT_CMD_LEN);
+    addr.type = peer_addr_type;
+    memcpy(addr.val, peer_id_addr, 6);
 
-    TEST_ASSERT(get_le16(param + 0) == handle);
-    TEST_ASSERT(param[2] == reason);
+    ble_hs_test_util_connect(own_addr_type, &addr, 0, NULL, cb, cb_arg, 0);
+
+    /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+                             BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
+
+    memset(&evt, 0, sizeof evt);
+    evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
+    evt.status = BLE_ERR_SUCCESS;
+    evt.connection_handle = handle;
+    evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
+    evt.peer_addr_type = peer_addr_type;
+    memcpy(evt.peer_addr, peer_id_addr, 6);
+    evt.conn_itvl = BLE_GAP_INITIAL_CONN_ITVL_MAX;
+    evt.conn_latency = BLE_GAP_INITIAL_CONN_LATENCY;
+    evt.supervision_timeout = BLE_GAP_INITIAL_SUPERVISION_TIMEOUT;
+    memcpy(evt.local_rpa, our_rpa, 6);
+    memcpy(evt.peer_rpa, peer_rpa, 6);
+
+    rc = ble_gap_rx_conn_complete(&evt);
+    TEST_ASSERT(rc == 0);
+
+    evt2.subevent_code = BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT;
+    evt2.status = BLE_ERR_SUCCESS;
+    evt2.connection_handle = handle;
+    memcpy(evt2.features, ((uint8_t[]){ conn_features, 0, 0, 0, 0, 0, 0, 0 }),
+           8);
+
+    ble_gap_rx_rd_rem_sup_feat_complete(&evt2);
+
+    ble_hs_test_util_hci_out_clear();
 }
 
 void
-ble_hs_test_util_verify_tx_create_conn(const struct hci_create_conn *exp)
+ble_hs_test_util_create_conn(uint16_t handle, const uint8_t *peer_id_addr,
+                             ble_gap_event_fn *cb, void *cb_arg)
 {
-    uint8_t param_len;
-    uint8_t *param;
+    static uint8_t null_addr[6];
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
-                                           BLE_HCI_OCF_LE_CREATE_CONN,
-                                           &param_len);
-    TEST_ASSERT(param_len == BLE_HCI_CREATE_CONN_LEN);
+    ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
+                                     BLE_ADDR_PUBLIC, peer_id_addr,
+                                     null_addr, BLE_HS_TEST_CONN_FEAT_ALL,
+                                     cb, cb_arg);
+}
 
-    TEST_ASSERT(get_le16(param + 0) == exp->scan_itvl);
-    TEST_ASSERT(get_le16(param + 2) == exp->scan_window);
-    TEST_ASSERT(param[4] == exp->filter_policy);
-    TEST_ASSERT(param[5] == exp->peer_addr_type);
-    TEST_ASSERT(memcmp(param + 6, exp->peer_addr, 6) == 0);
-    TEST_ASSERT(param[12] == exp->own_addr_type);
-    TEST_ASSERT(get_le16(param + 13) == exp->conn_itvl_min);
-    TEST_ASSERT(get_le16(param + 15) == exp->conn_itvl_max);
-    TEST_ASSERT(get_le16(param + 17) == exp->conn_latency);
-    TEST_ASSERT(get_le16(param + 19) == exp->supervision_timeout);
-    TEST_ASSERT(get_le16(param + 21) == exp->min_ce_len);
-    TEST_ASSERT(get_le16(param + 23) == exp->max_ce_len);
+void
+ble_hs_test_util_create_conn_feat(uint16_t handle, const uint8_t *peer_id_addr,
+                                  uint8_t conn_features, ble_gap_event_fn *cb,
+                                  void *cb_arg)
+{
+    static uint8_t null_addr[6];
+
+    ble_hs_test_util_create_rpa_conn(handle, BLE_OWN_ADDR_PUBLIC, null_addr,
+                                     BLE_ADDR_PUBLIC, peer_id_addr,
+                                     null_addr, conn_features, cb, cb_arg);
 }
 
 int
@@ -557,9 +295,9 @@ ble_hs_test_util_connect(uint8_t own_addr_type, const ble_addr_t *peer_addr,
      * create connection command.  If the current test case has unverified HCI
      * commands, assume we are not interested in them and clear the queue.
      */
-    ble_hs_test_util_prev_hci_tx_clear();
+    ble_hs_test_util_hci_out_clear();
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_CREATE_CONN),
         ack_status);
@@ -576,7 +314,7 @@ ble_hs_test_util_connect(uint8_t own_addr_type, const ble_addr_t *peer_addr,
 
     ble_hs_test_util_hcc_from_conn_params(&hcc, own_addr_type, peer_addr,
                                           params);
-    ble_hs_test_util_verify_tx_create_conn(&hcc);
+    ble_hs_test_util_hci_verify_tx_create_conn(&hcc);
 
     return rc;
 }
@@ -586,7 +324,7 @@ ble_hs_test_util_conn_cancel(uint8_t ack_status)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_CREATE_CONN_CANCEL),
         ack_status);
@@ -598,27 +336,8 @@ ble_hs_test_util_conn_cancel(uint8_t ack_status)
 void
 ble_hs_test_util_conn_cancel_full(void)
 {
-    struct hci_le_conn_complete evt;
-    int rc;
-
     ble_hs_test_util_conn_cancel(0);
-
-    memset(&evt, 0, sizeof evt);
-    evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
-    evt.status = BLE_ERR_UNK_CONN_ID;
-    evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
-
-    rc = ble_gap_rx_conn_complete(&evt);
-    TEST_ASSERT_FATAL(rc == 0);
-}
-
-void
-ble_hs_test_util_set_ack_disconnect(uint8_t hci_status)
-{
-    ble_hs_test_util_set_ack(
-        ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LINK_CTRL,
-                                    BLE_HCI_OCF_DISCONNECT_CMD),
-        hci_status);
+    ble_hs_test_util_hci_rx_conn_cancel_evt();
 }
 
 int
@@ -626,45 +345,25 @@ ble_hs_test_util_conn_terminate(uint16_t conn_handle, uint8_t hci_status)
 {
     int rc;
 
-    ble_hs_test_util_set_ack_disconnect(hci_status);
+    ble_hs_test_util_hci_ack_set_disconnect(hci_status);
     rc = ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
     return rc;
 }
 
 void
-ble_hs_test_util_rx_disconn_complete(uint16_t conn_handle, uint8_t reason)
-{
-    uint8_t buf[BLE_HCI_EVENT_HDR_LEN + BLE_HCI_EVENT_DISCONN_COMPLETE_LEN];
-
-    buf[0] = BLE_HCI_EVCODE_DISCONN_CMP;
-    buf[1] = BLE_HCI_EVENT_DISCONN_COMPLETE_LEN;
-    buf[2] = 0;
-    put_le16(buf + 3, conn_handle);
-    buf[5] = reason;
-
-    ble_hs_test_util_rx_hci_evt(buf);
-}
-
-void
 ble_hs_test_util_conn_disconnect(uint16_t conn_handle)
 {
+    struct hci_disconn_complete evt;
     int rc;
 
     rc = ble_hs_test_util_conn_terminate(conn_handle, 0);
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Receive disconnection complete event. */
-    ble_hs_test_util_rx_disconn_complete(conn_handle, BLE_ERR_CONN_TERM_LOCAL);
-}
-
-int
-ble_hs_test_util_exp_hci_status(int cmd_idx, int fail_idx, uint8_t fail_status)
-{
-    if (cmd_idx == fail_idx) {
-        return BLE_HS_HCI_ERR(fail_status);
-    } else {
-        return 0;
-    }
+    evt.connection_handle = conn_handle;
+    evt.status = 0;
+    evt.reason = BLE_ERR_CONN_TERM_LOCAL;
+    ble_hs_test_util_hci_rx_disconn_complete_event(&evt);
 }
 
 int
@@ -673,49 +372,9 @@ ble_hs_test_util_disc(uint8_t own_addr_type, int32_t duration_ms,
                       ble_gap_event_fn *cb, void *cb_arg, int fail_idx,
                       uint8_t fail_status)
 {
-    static bool privacy_enabled;
     int rc;
 
-    /*
-     * SET_RPA_TMO should be expected only when test uses RPA and privacy has
-     * not yet been enabled. The Bluetooth stack remembers that privacy is
-     * enabled and does not send SET_RPA_TMO every time. For test purpose
-     * let's track privacy state in here.
-     */
-    if ((own_addr_type == BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT ||
-         own_addr_type == BLE_OWN_ADDR_RPA_RANDOM_DEFAULT) && !privacy_enabled) {
-        privacy_enabled = true;
-        ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
-            {
-                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_RPA_TMO),
-                ble_hs_test_util_exp_hci_status(0, fail_idx, fail_status),
-            },
-            {
-                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_PARAMS),
-                ble_hs_test_util_exp_hci_status(1, fail_idx, fail_status),
-            },
-            {
-                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
-                ble_hs_test_util_exp_hci_status(2, fail_idx, fail_status),
-            },
-
-            { 0 }
-        }));
-    } else {
-        ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
-            {
-                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_PARAMS),
-                ble_hs_test_util_exp_hci_status(0, fail_idx, fail_status),
-            },
-            {
-                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
-                ble_hs_test_util_exp_hci_status(1, fail_idx, fail_status),
-            },
-
-            { 0 }
-        }));
-    }
-
+    ble_hs_test_util_hci_ack_set_disc(own_addr_type, fail_idx, fail_status);
     rc = ble_gap_disc(own_addr_type, duration_ms, disc_params,
                       cb, cb_arg);
     return rc;
@@ -726,7 +385,7 @@ ble_hs_test_util_disc_cancel(uint8_t ack_status)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
         ack_status);
@@ -740,55 +399,17 @@ ble_hs_test_util_verify_tx_rd_pwr(void)
 {
     uint8_t param_len;
 
-    ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                    BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR,
                                    &param_len);
     TEST_ASSERT(param_len == 0);
-}
-
-void
-ble_hs_test_util_verify_tx_add_irk(uint8_t addr_type,
-                                   const uint8_t *addr,
-                                   const uint8_t *peer_irk,
-                                   const uint8_t *local_irk)
-{
-    uint8_t param_len;
-    uint8_t *param;
-
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
-                                           BLE_HCI_OCF_LE_ADD_RESOLV_LIST,
-                                           &param_len);
-    TEST_ASSERT(param_len == BLE_HCI_ADD_TO_RESOLV_LIST_LEN);
-
-    TEST_ASSERT(param[0] == addr_type);
-    TEST_ASSERT(memcmp(param + 1, addr, 6) == 0);
-    TEST_ASSERT(memcmp(param + 7, peer_irk, 16) == 0);
-    TEST_ASSERT(memcmp(param + 23, local_irk, 16) == 0);
-}
-
-void
-ble_hs_test_util_verify_tx_set_priv_mode(uint8_t addr_type,
-                                         const uint8_t *addr,
-                                         uint8_t priv_mode)
-{
-    uint8_t param_len;
-    uint8_t *param;
-
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
-                                           BLE_HCI_OCF_LE_SET_PRIVACY_MODE,
-                                           &param_len);
-    TEST_ASSERT(param_len == BLE_HCI_LE_SET_PRIVACY_MODE_LEN);
-
-    TEST_ASSERT(param[0] == addr_type);
-    TEST_ASSERT(memcmp(param + 1, addr, 6) == 0);
-    TEST_ASSERT(param[7] == priv_mode);
 }
 
 int
 ble_hs_test_util_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
                                 int cmd_fail_idx, uint8_t hci_status)
 {
-    struct ble_hs_test_util_phony_ack acks[3];
+    struct ble_hs_test_util_hci_ack acks[3];
     int auto_pwr;
     int rc;
     int i;
@@ -798,23 +419,23 @@ ble_hs_test_util_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     i = 0;
     if (auto_pwr) {
-        acks[i] = (struct ble_hs_test_util_phony_ack) {
+        acks[i] = (struct ble_hs_test_util_hci_ack) {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR),
-            ble_hs_test_util_exp_hci_status(i, cmd_fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(i, cmd_fail_idx, hci_status),
             {0},
             1,
         };
         i++;
     }
 
-    acks[i] = (struct ble_hs_test_util_phony_ack) {
+    acks[i] = (struct ble_hs_test_util_hci_ack) {
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADV_DATA),
-        ble_hs_test_util_exp_hci_status(i, cmd_fail_idx, hci_status),
+        ble_hs_test_util_hci_misc_exp_status(i, cmd_fail_idx, hci_status),
     };
     i++;
 
     memset(acks + i, 0, sizeof acks[i]);
-    ble_hs_test_util_set_ack_seq(acks);
+    ble_hs_test_util_hci_ack_set_seq(acks);
 
     rc = ble_gap_adv_set_fields(adv_fields);
     if (rc == 0 && auto_pwr) {
@@ -829,7 +450,7 @@ int
 ble_hs_test_util_adv_rsp_set_fields(const struct ble_hs_adv_fields *adv_fields,
                                     int cmd_fail_idx, uint8_t hci_status)
 {
-    struct ble_hs_test_util_phony_ack acks[3];
+    struct ble_hs_test_util_hci_ack acks[3];
     int auto_pwr;
     int rc;
     int i;
@@ -839,23 +460,23 @@ ble_hs_test_util_adv_rsp_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     i = 0;
     if (auto_pwr) {
-        acks[i] = (struct ble_hs_test_util_phony_ack) {
+        acks[i] = (struct ble_hs_test_util_hci_ack) {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_RD_ADV_CHAN_TXPWR),
-            ble_hs_test_util_exp_hci_status(i, cmd_fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(i, cmd_fail_idx, hci_status),
             {0},
             1,
         };
         i++;
     }
 
-    acks[i] = (struct ble_hs_test_util_phony_ack) {
+    acks[i] = (struct ble_hs_test_util_hci_ack) {
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_RSP_DATA),
-        ble_hs_test_util_exp_hci_status(i, cmd_fail_idx, hci_status),
+        ble_hs_test_util_hci_misc_exp_status(i, cmd_fail_idx, hci_status),
     };
     i++;
 
     memset(acks + i, 0, sizeof acks[i]);
-    ble_hs_test_util_set_ack_seq(acks);
+    ble_hs_test_util_hci_ack_set_seq(acks);
 
     rc = ble_gap_adv_rsp_set_fields(adv_fields);
     if (rc == 0 && auto_pwr) {
@@ -873,27 +494,27 @@ ble_hs_test_util_adv_start(uint8_t own_addr_type, const ble_addr_t *peer_addr,
                            ble_gap_event_fn *cb, void *cb_arg,
                            int fail_idx, uint8_t fail_status)
 {
-    struct ble_hs_test_util_phony_ack acks[6];
+    struct ble_hs_test_util_hci_ack acks[6];
     int rc;
     int i;
 
     i = 0;
 
-    acks[i] = (struct ble_hs_test_util_phony_ack) {
+    acks[i] = (struct ble_hs_test_util_hci_ack) {
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADV_PARAMS),
         fail_idx == i ? fail_status : 0,
     };
     i++;
 
-    acks[i] = (struct ble_hs_test_util_phony_ack) {
+    acks[i] = (struct ble_hs_test_util_hci_ack) {
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADV_ENABLE),
-        ble_hs_test_util_exp_hci_status(i, fail_idx, fail_status),
+        ble_hs_test_util_hci_misc_exp_status(i, fail_idx, fail_status),
     };
     i++;
 
     memset(acks + i, 0, sizeof acks[i]);
 
-    ble_hs_test_util_set_ack_seq(acks);
+    ble_hs_test_util_hci_ack_set_seq(acks);
     
     rc = ble_gap_adv_start(own_addr_type, peer_addr,
                            duration_ms, adv_params, cb, cb_arg);
@@ -906,7 +527,7 @@ ble_hs_test_util_adv_stop(uint8_t hci_status)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADV_ENABLE),
         hci_status);
 
@@ -918,7 +539,7 @@ int
 ble_hs_test_util_wl_set(ble_addr_t *addrs, uint8_t addrs_count,
                         int fail_idx, uint8_t fail_status)
 {
-    struct ble_hs_test_util_phony_ack acks[64];
+    struct ble_hs_test_util_hci_ack acks[64];
     int cmd_idx;
     int rc;
     int i;
@@ -926,23 +547,23 @@ ble_hs_test_util_wl_set(ble_addr_t *addrs, uint8_t addrs_count,
     TEST_ASSERT_FATAL(addrs_count < 63);
 
     cmd_idx = 0;
-    acks[cmd_idx] = (struct ble_hs_test_util_phony_ack) {
+    acks[cmd_idx] = (struct ble_hs_test_util_hci_ack) {
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_CLEAR_WHITE_LIST),
-        ble_hs_test_util_exp_hci_status(cmd_idx, fail_idx, fail_status),
+        ble_hs_test_util_hci_misc_exp_status(cmd_idx, fail_idx, fail_status),
     };
     cmd_idx++;
 
     for (i = 0; i < addrs_count; i++) {
-        acks[cmd_idx] = (struct ble_hs_test_util_phony_ack) {
+        acks[cmd_idx] = (struct ble_hs_test_util_hci_ack) {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_ADD_WHITE_LIST),
-            ble_hs_test_util_exp_hci_status(cmd_idx, fail_idx, fail_status),
+            ble_hs_test_util_hci_misc_exp_status(cmd_idx, fail_idx, fail_status),
         };
 
         cmd_idx++;
     }
     memset(acks + cmd_idx, 0, sizeof acks[cmd_idx]);
 
-    ble_hs_test_util_set_ack_seq(acks);
+    ble_hs_test_util_hci_ack_set_seq(acks);
     rc = ble_gap_wl_set(addrs, addrs_count);
     return rc;
 }
@@ -959,7 +580,7 @@ ble_hs_test_util_conn_update(uint16_t conn_handle,
      * be triggered - in this case we don't need phony ack.
      */
     if (hci_status != 0xFF) {
-        ble_hs_test_util_set_ack(
+        ble_hs_test_util_hci_ack_set(
                 BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_CONN_UPDATE),
                 hci_status);
     }
@@ -974,22 +595,26 @@ ble_hs_test_util_set_our_irk(const uint8_t *irk, int fail_idx,
 {
     int rc;
 
-    ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
+    ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
         {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
-            ble_hs_test_util_exp_hci_status(0, fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(0, fail_idx, hci_status),
         },
         {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_CLR_RESOLV_LIST),
-            ble_hs_test_util_exp_hci_status(1, fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(1, fail_idx, hci_status),
         },
         {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
-            ble_hs_test_util_exp_hci_status(2, fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(2, fail_idx, hci_status),
         },
         {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
-            ble_hs_test_util_exp_hci_status(3, fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(3, fail_idx, hci_status),
+        },
+        {
+            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
+            ble_hs_test_util_hci_misc_exp_status(4, fail_idx, hci_status),
         },
         {
             0
@@ -1005,7 +630,7 @@ ble_hs_test_util_security_initiate(uint16_t conn_handle, uint8_t hci_status)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_START_ENCRYPT), hci_status);
 
     rc = ble_gap_security_initiate(conn_handle);
@@ -1447,140 +1072,6 @@ ble_hs_test_util_rx_att_err_rsp(uint16_t conn_handle, uint8_t req_op,
     rc = ble_hs_test_util_l2cap_rx_payload_flat(conn_handle, BLE_L2CAP_CID_ATT,
                                                 buf, sizeof buf);
     TEST_ASSERT(rc == 0);
-}
-
-void
-ble_hs_test_util_set_startup_acks(void)
-{
-    /* Receive acknowledgements for the startup sequence.  We sent the
-     * corresponding requests when the host task was started.
-     */
-    ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
-        {
-            .opcode = ble_hs_hci_util_opcode_join(BLE_HCI_OGF_CTLR_BASEBAND,
-                                                  BLE_HCI_OCF_CB_RESET),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_SET_EVENT_MASK),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_SET_EVENT_MASK2),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EVENT_MASK),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_BUF_SIZE),
-            /* Use a very low buffer size (20) to test fragmentation. 
-             * Use a large num-pkts (200) to prevent controller buf exhaustion.
-             */
-            .evt_params = { 0x14, 0x00, 200 },
-            .evt_params_len = 3,
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_LOC_SUPP_FEAT),
-            .evt_params = { 0 },
-            .evt_params_len = 8,
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_INFO_PARAMS, BLE_HCI_OCF_IP_RD_BD_ADDR),
-            .evt_params = BLE_HS_TEST_UTIL_PUB_ADDR_VAL,
-            .evt_params_len = 6,
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CLR_RESOLV_LIST),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
-        },
-        {
-            .opcode = ble_hs_hci_util_opcode_join(
-                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
-        },
-        { 0 }
-    }));
-}
-
-void
-ble_hs_test_util_rx_num_completed_pkts_event(
-    struct ble_hs_test_util_num_completed_pkts_entry *entries)
-{
-    struct ble_hs_test_util_num_completed_pkts_entry *entry;
-    uint8_t buf[1024];
-    int num_entries;
-    int off;
-    int i;
-
-    /* Count number of entries. */
-    num_entries = 0;
-    for (entry = entries; entry->handle_id != 0; entry++) {
-        num_entries++;
-    }
-    TEST_ASSERT_FATAL(num_entries <= UINT8_MAX);
-
-    buf[0] = BLE_HCI_EVCODE_NUM_COMP_PKTS;
-    buf[2] = num_entries;
-
-    off = 3;
-    for (i = 0; i < num_entries; i++) {
-        put_le16(buf + off, entries[i].handle_id);
-        off += 2;
-    }
-    for (i = 0; i < num_entries; i++) {
-        put_le16(buf + off, entries[i].num_pkts);
-        off += 2;
-    }
-
-    buf[1] = off - 2;
-
-    ble_hs_test_util_rx_hci_evt(buf);
-}
-
-void
-ble_hs_test_util_rx_disconn_complete_event(struct hci_disconn_complete *evt)
-{
-    uint8_t buf[BLE_HCI_EVENT_HDR_LEN + BLE_HCI_EVENT_DISCONN_COMPLETE_LEN];
-
-    buf[0] = BLE_HCI_EVCODE_DISCONN_CMP;
-    buf[1] = BLE_HCI_EVENT_DISCONN_COMPLETE_LEN;
-    buf[2] = evt->status;
-    put_le16(buf + 3, evt->connection_handle);
-    buf[5] = evt->reason;
-
-    ble_hs_test_util_rx_hci_evt(buf);
-}
-
-uint8_t *
-ble_hs_test_util_verify_tx_hci(uint8_t ogf, uint16_t ocf,
-                               uint8_t *out_param_len)
-{
-    uint16_t opcode;
-    uint8_t *cmd;
-
-    cmd = ble_hs_test_util_get_first_hci_tx();
-    TEST_ASSERT_FATAL(cmd != NULL);
-
-    opcode = get_le16(cmd);
-    TEST_ASSERT(BLE_HCI_OGF(opcode) == ogf);
-    TEST_ASSERT(BLE_HCI_OCF(opcode) == ocf);
-
-    if (out_param_len != NULL) {
-        *out_param_len = cmd[2];
-    }
-
-    return cmd + 3;
 }
 
 void
@@ -2075,13 +1566,13 @@ ble_hs_test_util_set_static_rnd_addr(const uint8_t *addr)
 {
     int rc;
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_RAND_ADDR), 0);
 
     rc = ble_hs_id_set_rnd(addr);
     TEST_ASSERT_FATAL(rc == 0);
 
-    ble_hs_test_util_get_first_hci_tx();
+    ble_hs_test_util_hci_out_first();
 }
 
 struct os_mbuf *
@@ -2346,7 +1837,7 @@ ble_hs_test_util_pkt_txed(struct os_mbuf *om, void *arg)
 static int
 ble_hs_test_util_hci_txed(uint8_t *cmdbuf, void *arg)
 {
-    ble_hs_test_util_enqueue_hci_tx(cmdbuf);
+    ble_hs_test_util_hci_out_enqueue(cmdbuf);
     ble_hci_trans_buf_free(cmdbuf);
     return 0;
 }
@@ -2493,13 +1984,13 @@ ble_hs_test_util_init_no_start(void)
     ble_hci_trans_cfg_ll(ble_hs_test_util_hci_txed, NULL,
                          ble_hs_test_util_pkt_txed, NULL);
 
-    ble_hs_test_util_set_startup_acks();
+    ble_hs_test_util_hci_ack_set_startup();
 
     ble_hs_max_services = 16;
     ble_hs_max_client_configs = 32;
     ble_hs_max_attrs = 64;
 
-    ble_hs_test_util_prev_hci_tx_clear();
+    ble_hs_test_util_hci_out_clear();
 
     ble_hs_cfg.store_read_cb = ble_hs_test_util_store_read;
     ble_hs_cfg.store_write_cb = ble_hs_test_util_store_write;
@@ -2518,7 +2009,7 @@ ble_hs_test_util_init(void)
     rc = ble_hs_start();
     TEST_ASSERT_FATAL(rc == 0);
 
-    ble_hs_test_util_prev_hci_tx_clear();
+    ble_hs_test_util_hci_out_clear();
 
     /* Clear random address. */
     ble_hs_test_util_set_static_rnd_addr((uint8_t[6]){ 0, 0, 0, 0, 0, 0 });

--- a/net/nimble/host/test/src/ble_hs_test_util_hci.c
+++ b/net/nimble/host/test/src/ble_hs_test_util_hci.c
@@ -1,0 +1,555 @@
+#include "testutil/testutil.h"
+#include "nimble/ble.h"
+#include "nimble/hci_common.h"
+#include "transport/ram/ble_hci_ram.h"
+#include "ble_hs_test_util.h"
+
+#define BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT      64
+
+static uint8_t
+ble_hs_test_util_hci_out_queue[BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT][260];
+static int ble_hs_test_util_hci_out_queue_sz;
+static uint8_t ble_hs_test_util_hci_out_cur[260];
+
+static struct ble_hs_test_util_hci_ack
+ble_hs_test_util_hci_acks[BLE_HS_TEST_UTIL_PHONY_ACK_MAX];
+static int ble_hs_test_util_hci_num_acks;
+
+/*****************************************************************************
+ * $tx queue                                                                 *
+ *****************************************************************************/
+
+void
+ble_hs_test_util_hci_out_adj(int count)
+{
+    if (count >= 0) {
+        TEST_ASSERT(ble_hs_test_util_hci_out_queue_sz >= count);
+
+        ble_hs_test_util_hci_out_queue_sz -= count;
+        if (ble_hs_test_util_hci_out_queue_sz > 0) {
+            memmove(
+                ble_hs_test_util_hci_out_queue,
+                ble_hs_test_util_hci_out_queue + count,
+                sizeof ble_hs_test_util_hci_out_queue[0] *
+                ble_hs_test_util_hci_out_queue_sz);
+        }
+    } else {
+        TEST_ASSERT(ble_hs_test_util_hci_out_queue_sz >= -count);
+
+        ble_hs_test_util_hci_out_adj(
+            ble_hs_test_util_hci_out_queue_sz + count);
+    }
+}
+
+void *
+ble_hs_test_util_hci_out_first(void)
+{
+    if (ble_hs_test_util_hci_out_queue_sz == 0) {
+        return NULL;
+    }
+
+    memcpy(ble_hs_test_util_hci_out_cur, ble_hs_test_util_hci_out_queue[0],
+           sizeof ble_hs_test_util_hci_out_cur);
+
+    ble_hs_test_util_hci_out_adj(1);
+
+    return ble_hs_test_util_hci_out_cur;
+}
+
+void *
+ble_hs_test_util_hci_out_last(void)
+{
+    if (ble_hs_test_util_hci_out_queue_sz == 0) {
+        return NULL;
+    }
+
+    ble_hs_test_util_hci_out_queue_sz--;
+    memcpy(ble_hs_test_util_hci_out_cur,
+           ble_hs_test_util_hci_out_queue + ble_hs_test_util_hci_out_queue_sz,
+           sizeof ble_hs_test_util_hci_out_cur);
+
+    return ble_hs_test_util_hci_out_cur;
+}
+
+void
+ble_hs_test_util_hci_out_enqueue(void *cmd)
+{
+    TEST_ASSERT_FATAL(ble_hs_test_util_hci_out_queue_sz <
+                      BLE_HS_TEST_UTIL_PREV_HCI_TX_CNT);
+    memcpy(ble_hs_test_util_hci_out_queue + ble_hs_test_util_hci_out_queue_sz,
+           cmd, 260);
+
+    ble_hs_test_util_hci_out_queue_sz++;
+}
+
+void
+ble_hs_test_util_hci_out_clear(void)
+{
+    ble_hs_test_util_hci_out_queue_sz = 0;
+}
+
+/*****************************************************************************
+ * $build                                                                    *
+ *****************************************************************************/
+
+void
+ble_hs_test_util_hci_build_cmd_complete(uint8_t *dst, int len,
+                                    uint8_t param_len, uint8_t num_pkts,
+                                    uint16_t opcode)
+{
+    TEST_ASSERT(len >= BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN);
+
+    dst[0] = BLE_HCI_EVCODE_COMMAND_COMPLETE;
+    dst[1] = 3 + param_len;
+    dst[2] = num_pkts;
+    put_le16(dst + 3, opcode);
+}
+
+void
+ble_hs_test_util_hci_build_cmd_status(uint8_t *dst, int len,
+                                  uint8_t status, uint8_t num_pkts,
+                                  uint16_t opcode)
+{
+    TEST_ASSERT(len >= BLE_HCI_EVENT_CMD_STATUS_LEN);
+
+    dst[0] = BLE_HCI_EVCODE_COMMAND_STATUS;
+    dst[1] = BLE_HCI_EVENT_CMD_STATUS_LEN;
+    dst[2] = status;
+    dst[3] = num_pkts;
+    put_le16(dst + 4, opcode);
+}
+
+static void
+ble_hs_test_util_hci_build_ack_params(
+    struct ble_hs_test_util_hci_ack *ack,
+    uint16_t opcode, uint8_t status, void *params, uint8_t params_len)
+{
+    ack->opcode = opcode;
+    ack->status = status;
+
+    if (params == NULL || params_len == 0) {
+        ack->evt_params_len = 0;
+    } else {
+        memcpy(ack->evt_params, params, params_len);
+        ack->evt_params_len = params_len;
+    }
+}
+
+/*****************************************************************************
+ * $ack                                                                      *
+ *****************************************************************************/
+
+static int
+ble_hs_test_util_hci_ack_cb(uint8_t *ack, int ack_buf_len)
+{
+    struct ble_hs_test_util_hci_ack *entry;
+
+    if (ble_hs_test_util_hci_num_acks == 0) {
+        return BLE_HS_ETIMEOUT_HCI;
+    }
+
+    entry = ble_hs_test_util_hci_acks;
+
+    ble_hs_test_util_hci_build_cmd_complete(ack, 256,
+                                        entry->evt_params_len + 1, 1,
+                                        entry->opcode);
+    ack[BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN] = entry->status;
+    memcpy(ack + BLE_HCI_EVENT_CMD_COMPLETE_HDR_LEN + 1, entry->evt_params,
+           entry->evt_params_len);
+
+    ble_hs_test_util_hci_num_acks--;
+    if (ble_hs_test_util_hci_num_acks > 0) {
+        memmove(ble_hs_test_util_hci_acks,
+                ble_hs_test_util_hci_acks + 1,
+                sizeof *entry * ble_hs_test_util_hci_num_acks);
+    }
+
+    return 0;
+}
+
+void
+ble_hs_test_util_hci_ack_set_params(uint16_t opcode, uint8_t status,
+                                    void *params, uint8_t params_len)
+{
+    struct ble_hs_test_util_hci_ack *ack;
+
+    ack = ble_hs_test_util_hci_acks + 0;
+    ble_hs_test_util_hci_build_ack_params(ack, opcode, status, params,
+                                          params_len);
+    ble_hs_test_util_hci_num_acks = 1;
+
+    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_hci_ack_cb);
+}
+
+void
+ble_hs_test_util_hci_ack_set(uint16_t opcode, uint8_t status)
+{
+    ble_hs_test_util_hci_ack_set_params(opcode, status, NULL, 0);
+}
+
+void
+ble_hs_test_util_hci_ack_append_params(uint16_t opcode, uint8_t status,
+                                   void *params, uint8_t params_len)
+{
+    struct ble_hs_test_util_hci_ack *ack;
+
+    ack = ble_hs_test_util_hci_acks + ble_hs_test_util_hci_num_acks;
+    ble_hs_test_util_hci_build_ack_params(ack, opcode, status, params,
+                                          params_len);
+    ble_hs_test_util_hci_num_acks++;
+
+    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_hci_ack_cb);
+}
+
+void
+ble_hs_test_util_hci_ack_append(uint16_t opcode, uint8_t status)
+{
+    ble_hs_test_util_hci_ack_append_params(opcode, status, NULL, 0);
+}
+
+void
+ble_hs_test_util_hci_ack_set_seq(struct ble_hs_test_util_hci_ack *acks)
+{
+    int i;
+
+    for (i = 0; acks[i].opcode != 0; i++) {
+        ble_hs_test_util_hci_acks[i] = acks[i];
+    }
+    ble_hs_test_util_hci_num_acks = i;
+
+    ble_hs_hci_set_phony_ack_cb(ble_hs_test_util_hci_ack_cb);
+}
+
+void
+ble_hs_test_util_hci_ack_set_startup(void)
+{
+    /* Receive acknowledgements for the startup sequence.  We sent the
+     * corresponding requests when the host task was started.
+     */
+    ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
+        {
+            .opcode = ble_hs_hci_util_opcode_join(BLE_HCI_OGF_CTLR_BASEBAND,
+                                                  BLE_HCI_OCF_CB_RESET),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_SET_EVENT_MASK),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_CTLR_BASEBAND, BLE_HCI_OCF_CB_SET_EVENT_MASK2),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EVENT_MASK),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_BUF_SIZE),
+            /* Use a very low buffer size (20) to test fragmentation.
+             * Use a large num-pkts (200) to prevent controller buf exhaustion.
+             */
+            .evt_params = { 0x14, 0x00, 200 },
+            .evt_params_len = 3,
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_RD_LOC_SUPP_FEAT),
+            .evt_params = { 0 },
+            .evt_params_len = 8,
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_INFO_PARAMS, BLE_HCI_OCF_IP_RD_BD_ADDR),
+            .evt_params = BLE_HS_TEST_UTIL_PUB_ADDR_VAL,
+            .evt_params_len = 6,
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_CLR_RESOLV_LIST),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADDR_RES_EN),
+        },
+        {
+            .opcode = ble_hs_hci_util_opcode_join(
+                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
+        },
+        { 0 }
+    }));
+}
+
+void
+ble_hs_test_util_hci_ack_set_disc(uint8_t own_addr_type,
+                               int fail_idx, uint8_t fail_status)
+{
+    static bool privacy_enabled;
+
+    /*
+     * SET_RPA_TMO should be expected only when test uses RPA and privacy has
+     * not yet been enabled. The Bluetooth stack remembers that privacy is
+     * enabled and does not send SET_RPA_TMO every time. For test purpose
+     * let's track privacy state in here.
+     */
+    if ((own_addr_type == BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT ||
+         own_addr_type == BLE_OWN_ADDR_RPA_RANDOM_DEFAULT) &&
+        !privacy_enabled) {
+
+        privacy_enabled = true;
+        ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
+            {
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_RPA_TMO),
+                ble_hs_test_util_hci_misc_exp_status(0, fail_idx, fail_status),
+            },
+            {
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_PARAMS),
+                ble_hs_test_util_hci_misc_exp_status(1, fail_idx, fail_status),
+            },
+            {
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
+                ble_hs_test_util_hci_misc_exp_status(2, fail_idx, fail_status),
+            },
+
+            { 0 }
+        }));
+    } else {
+        ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
+            {
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_PARAMS),
+                ble_hs_test_util_hci_misc_exp_status(0, fail_idx, fail_status),
+            },
+            {
+                BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
+                ble_hs_test_util_hci_misc_exp_status(1, fail_idx, fail_status),
+            },
+
+            { 0 }
+        }));
+    }
+}
+
+void
+ble_hs_test_util_hci_ack_set_disconnect(uint8_t hci_status)
+{
+    ble_hs_test_util_hci_ack_set(
+        ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LINK_CTRL,
+                                    BLE_HCI_OCF_DISCONNECT_CMD),
+        hci_status);
+}
+
+/*****************************************************************************
+ * $verify tx                                                                *
+ *****************************************************************************/
+
+void
+ble_hs_test_util_hci_verify_tx_add_irk(uint8_t addr_type,
+                                       const uint8_t *addr,
+                                       const uint8_t *peer_irk,
+                                       const uint8_t *local_irk)
+{
+    uint8_t param_len;
+    uint8_t *param;
+
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
+                                           BLE_HCI_OCF_LE_ADD_RESOLV_LIST,
+                                           &param_len);
+    TEST_ASSERT(param_len == BLE_HCI_ADD_TO_RESOLV_LIST_LEN);
+
+    TEST_ASSERT(param[0] == addr_type);
+    TEST_ASSERT(memcmp(param + 1, addr, 6) == 0);
+    TEST_ASSERT(memcmp(param + 7, peer_irk, 16) == 0);
+    TEST_ASSERT(memcmp(param + 23, local_irk, 16) == 0);
+}
+
+void
+ble_hs_test_util_hci_verify_tx_set_priv_mode(uint8_t addr_type,
+                                             const uint8_t *addr,
+                                             uint8_t priv_mode)
+{
+    uint8_t param_len;
+    uint8_t *param;
+
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
+                                           BLE_HCI_OCF_LE_SET_PRIVACY_MODE,
+                                           &param_len);
+    TEST_ASSERT(param_len == BLE_HCI_LE_SET_PRIVACY_MODE_LEN);
+
+    TEST_ASSERT(param[0] == addr_type);
+    TEST_ASSERT(memcmp(param + 1, addr, 6) == 0);
+    TEST_ASSERT(param[7] == priv_mode);
+}
+
+void
+ble_hs_test_util_hci_verify_tx_disconnect(uint16_t handle, uint8_t reason)
+{
+    uint8_t param_len;
+    uint8_t *param;
+
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LINK_CTRL,
+                                           BLE_HCI_OCF_DISCONNECT_CMD,
+                                           &param_len);
+    TEST_ASSERT(param_len == BLE_HCI_DISCONNECT_CMD_LEN);
+
+    TEST_ASSERT(get_le16(param + 0) == handle);
+    TEST_ASSERT(param[2] == reason);
+}
+
+void
+ble_hs_test_util_hci_verify_tx_create_conn(const struct hci_create_conn *exp)
+{
+    uint8_t param_len;
+    uint8_t *param;
+
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
+                                           BLE_HCI_OCF_LE_CREATE_CONN,
+                                           &param_len);
+    TEST_ASSERT(param_len == BLE_HCI_CREATE_CONN_LEN);
+
+    TEST_ASSERT(get_le16(param + 0) == exp->scan_itvl);
+    TEST_ASSERT(get_le16(param + 2) == exp->scan_window);
+    TEST_ASSERT(param[4] == exp->filter_policy);
+    TEST_ASSERT(param[5] == exp->peer_addr_type);
+    TEST_ASSERT(memcmp(param + 6, exp->peer_addr, 6) == 0);
+    TEST_ASSERT(param[12] == exp->own_addr_type);
+    TEST_ASSERT(get_le16(param + 13) == exp->conn_itvl_min);
+    TEST_ASSERT(get_le16(param + 15) == exp->conn_itvl_max);
+    TEST_ASSERT(get_le16(param + 17) == exp->conn_latency);
+    TEST_ASSERT(get_le16(param + 19) == exp->supervision_timeout);
+    TEST_ASSERT(get_le16(param + 21) == exp->min_ce_len);
+    TEST_ASSERT(get_le16(param + 23) == exp->max_ce_len);
+}
+
+uint8_t *
+ble_hs_test_util_hci_verify_tx(uint8_t ogf, uint16_t ocf,
+                               uint8_t *out_param_len)
+{
+    uint16_t opcode;
+    uint8_t *cmd;
+
+    cmd = ble_hs_test_util_hci_out_first();
+    TEST_ASSERT_FATAL(cmd != NULL);
+
+    opcode = get_le16(cmd);
+    TEST_ASSERT(BLE_HCI_OGF(opcode) == ogf);
+    TEST_ASSERT(BLE_HCI_OCF(opcode) == ocf);
+
+    if (out_param_len != NULL) {
+        *out_param_len = cmd[2];
+    }
+
+    return cmd + 3;
+}
+
+/*****************************************************************************
+ * $rx                                                                       *
+ *****************************************************************************/
+
+static void
+ble_hs_test_util_hci_rx_evt(uint8_t *evt)
+{
+    uint8_t *evbuf;
+    int totlen;
+    int rc;
+
+    totlen = BLE_HCI_EVENT_HDR_LEN + evt[1];
+    TEST_ASSERT_FATAL(totlen <= UINT8_MAX + BLE_HCI_EVENT_HDR_LEN);
+
+    evbuf = ble_hci_trans_buf_alloc(
+        BLE_HCI_TRANS_BUF_EVT_LO);
+    TEST_ASSERT_FATAL(evbuf != NULL);
+
+    memcpy(evbuf, evt, totlen);
+
+    if (os_started()) {
+        rc = ble_hci_trans_ll_evt_tx(evbuf);
+    } else {
+        rc = ble_hs_hci_evt_process(evbuf);
+    }
+
+    TEST_ASSERT_FATAL(rc == 0);
+}
+
+void
+ble_hs_test_util_hci_rx_num_completed_pkts_event(
+    struct ble_hs_test_util_hci_num_completed_pkts_entry *entries)
+{
+    struct ble_hs_test_util_hci_num_completed_pkts_entry *entry;
+    uint8_t buf[1024];
+    int num_entries;
+    int off;
+    int i;
+
+    /* Count number of entries. */
+    num_entries = 0;
+    for (entry = entries; entry->handle_id != 0; entry++) {
+        num_entries++;
+    }
+    TEST_ASSERT_FATAL(num_entries <= UINT8_MAX);
+
+    buf[0] = BLE_HCI_EVCODE_NUM_COMP_PKTS;
+    buf[2] = num_entries;
+
+    off = 3;
+    for (i = 0; i < num_entries; i++) {
+        put_le16(buf + off, entries[i].handle_id);
+        off += 2;
+    }
+    for (i = 0; i < num_entries; i++) {
+        put_le16(buf + off, entries[i].num_pkts);
+        off += 2;
+    }
+
+    buf[1] = off - 2;
+
+    ble_hs_test_util_hci_rx_evt(buf);
+}
+
+void
+ble_hs_test_util_hci_rx_disconn_complete_event(
+    struct hci_disconn_complete *evt)
+{
+    uint8_t buf[BLE_HCI_EVENT_HDR_LEN + BLE_HCI_EVENT_DISCONN_COMPLETE_LEN];
+
+    buf[0] = BLE_HCI_EVCODE_DISCONN_CMP;
+    buf[1] = BLE_HCI_EVENT_DISCONN_COMPLETE_LEN;
+    buf[2] = evt->status;
+    put_le16(buf + 3, evt->connection_handle);
+    buf[5] = evt->reason;
+
+    ble_hs_test_util_hci_rx_evt(buf);
+}
+
+void
+ble_hs_test_util_hci_rx_conn_cancel_evt(void)
+{
+    struct hci_le_conn_complete evt;
+    int rc;
+
+    memset(&evt, 0, sizeof evt);
+    evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
+    evt.status = BLE_ERR_UNK_CONN_ID;
+    evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
+
+    rc = ble_gap_rx_conn_complete(&evt);
+    TEST_ASSERT_FATAL(rc == 0);
+}
+
+/*****************************************************************************
+ * $misc                                                                     *
+ *****************************************************************************/
+
+int
+ble_hs_test_util_hci_misc_exp_status(int cmd_idx, int fail_idx,
+                                     uint8_t fail_status)
+{
+    if (cmd_idx == fail_idx) {
+        return BLE_HS_HCI_ERR(fail_status);
+    } else {
+        return 0;
+    }
+}

--- a/net/nimble/host/test/src/ble_hs_test_util_hci.h
+++ b/net/nimble/host/test/src/ble_hs_test_util_hci.h
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_HS_TEST_UTIL_HCI_
+#define H_BLE_HS_TEST_UTIL_HCI_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLE_HS_TEST_UTIL_PHONY_ACK_MAX  64
+struct ble_hs_test_util_hci_ack {
+    uint16_t opcode;
+    uint8_t status;
+    uint8_t evt_params[256];
+    uint8_t evt_params_len;
+};
+
+struct ble_hs_test_util_hci_num_completed_pkts_entry {
+    uint16_t handle_id; /* 0 for terminating entry in array. */
+    uint16_t num_pkts;
+};
+
+/* $out queue */
+void ble_hs_test_util_hci_out_adj(int count);
+void *ble_hs_test_util_hci_out_first(void);
+void *ble_hs_test_util_hci_out_last(void);
+void ble_hs_test_util_hci_out_enqueue(void *cmd);
+void ble_hs_test_util_hci_out_clear(void);
+
+/* $build */
+void ble_hs_test_util_hci_build_cmd_complete(uint8_t *dst, int len,
+                                             uint8_t param_len,
+                                             uint8_t num_pkts,
+                                             uint16_t opcode);
+void ble_hs_test_util_hci_build_cmd_status(uint8_t *dst, int len,
+                                           uint8_t status, uint8_t num_pkts,
+                                           uint16_t opcode);
+
+/* $ack */
+void ble_hs_test_util_hci_ack_set_params(uint16_t opcode, uint8_t status,
+                                         void *params, uint8_t params_len);
+void ble_hs_test_util_hci_ack_set(uint16_t opcode, uint8_t status);
+void ble_hs_test_util_hci_ack_append_params(uint16_t opcode, uint8_t status,
+                                            void *params, uint8_t params_len);
+void ble_hs_test_util_hci_ack_append(uint16_t opcode, uint8_t status);
+void ble_hs_test_util_hci_ack_set_seq(struct ble_hs_test_util_hci_ack *acks);
+void ble_hs_test_util_hci_ack_set_startup(void);
+void ble_hs_test_util_hci_ack_set_disc(uint8_t own_addr_type,
+                                       int fail_idx, uint8_t fail_status);
+void ble_hs_test_util_hci_ack_set_disconnect(uint8_t hci_status);
+
+/* $verify tx */
+void ble_hs_test_util_hci_verify_tx_add_irk(uint8_t addr_type,
+                                            const uint8_t *addr,
+                                            const uint8_t *peer_irk,
+                                            const uint8_t *local_irk);
+void ble_hs_test_util_hci_verify_tx_set_priv_mode(uint8_t addr_type,
+                                                  const uint8_t *addr,
+                                                  uint8_t priv_mode);
+void ble_hs_test_util_hci_verify_tx_disconnect(uint16_t handle,
+                                               uint8_t reason);
+void ble_hs_test_util_hci_verify_tx_create_conn(
+    const struct hci_create_conn *exp);
+uint8_t *ble_hs_test_util_hci_verify_tx(uint8_t ogf, uint16_t ocf,
+                                        uint8_t *out_param_len);
+
+/* $rx */
+void ble_hs_test_util_hci_rx_num_completed_pkts_event(
+    struct ble_hs_test_util_hci_num_completed_pkts_entry *entries);
+void ble_hs_test_util_hci_rx_disconn_complete_event(
+    struct hci_disconn_complete *evt);
+void ble_hs_test_util_hci_rx_conn_cancel_evt(void);
+
+/* $misc */
+int ble_hs_test_util_hci_misc_exp_status(int cmd_idx, int fail_idx,
+                                         uint8_t fail_status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/net/nimble/host/test/src/ble_l2cap_test.c
+++ b/net/nimble/host/test/src/ble_l2cap_test.c
@@ -93,7 +93,7 @@ ble_l2cap_test_util_rx_update_req(uint16_t conn_handle, uint8_t id,
     req->slave_latency = htole16(params->slave_latency);
     req->timeout_multiplier = htole16(params->timeout_multiplier);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_CONN_UPDATE), 0);
     rc = ble_hs_test_util_l2cap_rx_first_frag(conn_handle, BLE_L2CAP_CID_SIG,
@@ -108,7 +108,7 @@ ble_l2cap_test_util_verify_tx_update_conn(
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_CONN_UPDATE,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_CONN_UPDATE_LEN);
@@ -150,7 +150,7 @@ ble_l2cap_test_util_create_conn(uint16_t conn_handle, uint8_t *addr,
 
     ble_hs_conn_chan_insert(conn, chan);
 
-    ble_hs_test_util_prev_hci_tx_clear();
+    ble_hs_test_util_hci_out_clear();
 
     ble_hs_unlock();
 }
@@ -436,13 +436,13 @@ TEST_CASE(ble_l2cap_test_case_frag_timeout)
     TEST_ASSERT(ticks_from_now == MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT));
 
     /* Allow the timer to expire. */
-    ble_hs_test_util_set_ack_disconnect(0);
+    ble_hs_test_util_hci_ack_set_disconnect(0);
     os_time_advance(MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT));
     ticks_from_now = ble_hs_conn_timer();
     TEST_ASSERT(ticks_from_now == BLE_HS_FOREVER);
 
     /* Ensure connection was terminated. */
-    ble_hs_test_util_verify_tx_disconnect(2, BLE_ERR_REM_USER_CONN_TERM);
+    ble_hs_test_util_hci_verify_tx_disconnect(2, BLE_ERR_REM_USER_CONN_TERM);
 }
 
 /*****************************************************************************

--- a/net/nimble/host/test/src/ble_os_test.c
+++ b/net/nimble/host/test/src/ble_os_test.c
@@ -74,7 +74,7 @@ ble_os_test_misc_init(void)
     /* Receive acknowledgements for the startup sequence.  We sent the
      * corresponding requests when the host task was started.
      */
-    ble_hs_test_util_set_startup_acks();
+    ble_hs_test_util_hci_ack_set_startup();
 
     ble_os_test_init_app_task();
 }
@@ -145,7 +145,7 @@ ble_gap_direct_connect_test_task_handler(void *arg)
     TEST_ASSERT(!cb_called);
 
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
 
     /* Receive an HCI connection-complete event. */
@@ -200,7 +200,7 @@ ble_os_disc_test_task_handler(void *arg)
     /* Receive acknowledgements for the startup sequence.  We sent the
      * corresponding requests when the host task was started.
      */
-    ble_hs_test_util_set_startup_acks();
+    ble_hs_test_util_hci_ack_set_startup();
 
     /* Set the connect callback so we can verify that it gets called with the
      * proper arguments.
@@ -236,7 +236,7 @@ ble_os_disc_test_task_handler(void *arg)
     TEST_ASSERT(ble_gap_master_in_progress());
     TEST_ASSERT(!cb_called);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_SET_SCAN_ENABLE),
         0);
@@ -291,7 +291,7 @@ ble_gap_terminate_test_task_handler(void *arg)
     /* Receive acknowledgements for the startup sequence.  We sent the
      * corresponding requests when the host task was started.
      */
-    ble_hs_test_util_set_startup_acks();
+    ble_hs_test_util_hci_ack_set_startup();
 
     /* Set the connect callback so we can verify that it gets called with the
      * proper arguments.
@@ -309,7 +309,7 @@ ble_gap_terminate_test_task_handler(void *arg)
                              &addr1, 0, NULL, ble_gap_terminate_cb,
                              &disconn_handle, 0);
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
     memset(&conn_evt, 0, sizeof conn_evt);
     conn_evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
@@ -323,7 +323,7 @@ ble_gap_terminate_test_task_handler(void *arg)
                              &addr2, 0, NULL, ble_gap_terminate_cb,
                              &disconn_handle, 0);
     /* ble_gap_rx_conn_complete() will send extra HCI command, need phony ack */
-    ble_hs_test_util_set_ack(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
+    ble_hs_test_util_hci_ack_set(ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                              BLE_HCI_OCF_LE_RD_REM_FEAT), 0);
     memset(&conn_evt, 0, sizeof conn_evt);
     conn_evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
@@ -342,7 +342,7 @@ ble_gap_terminate_test_task_handler(void *arg)
     disconn_evt.connection_handle = 1;
     disconn_evt.status = 0;
     disconn_evt.reason = BLE_ERR_REM_USER_CONN_TERM;
-    ble_hs_test_util_rx_disconn_complete_event(&disconn_evt);
+    ble_hs_test_util_hci_rx_disconn_complete_event(&disconn_evt);
     TEST_ASSERT(ble_os_test_gap_event_type == BLE_GAP_EVENT_DISCONNECT);
     TEST_ASSERT(disconn_handle == 1);
     TEST_ASSERT_FATAL(!ble_os_test_misc_conn_exists(1));
@@ -354,7 +354,7 @@ ble_gap_terminate_test_task_handler(void *arg)
     disconn_evt.connection_handle = 2;
     disconn_evt.status = 0;
     disconn_evt.reason = BLE_ERR_REM_USER_CONN_TERM;
-    ble_hs_test_util_rx_disconn_complete_event(&disconn_evt);
+    ble_hs_test_util_hci_rx_disconn_complete_event(&disconn_evt);
     TEST_ASSERT(ble_os_test_gap_event_type == BLE_GAP_EVENT_DISCONNECT);
     TEST_ASSERT(disconn_handle == 2);
     TEST_ASSERT_FATAL(!ble_os_test_misc_conn_exists(1));

--- a/net/nimble/host/test/src/ble_sm_test_util.c
+++ b/net/nimble/host/test/src/ble_sm_test_util.c
@@ -1257,7 +1257,7 @@ ble_sm_test_util_verify_tx_lt_key_req_reply(uint16_t conn_handle, uint8_t *stk)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_LT_KEY_REQ_REPLY,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_LT_KEY_REQ_REPLY_LEN);
@@ -1271,7 +1271,7 @@ ble_sm_test_util_verify_tx_lt_key_req_neg_reply(uint16_t conn_handle)
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_LT_KEY_REQ_NEG_REPLY,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_LT_KEY_REQ_NEG_REPLY_LEN);
@@ -1285,7 +1285,7 @@ ble_sm_test_util_set_lt_key_req_neg_reply_ack(uint8_t status,
     static uint8_t params[BLE_HCI_LT_KEY_REQ_NEG_REPLY_ACK_PARAM_LEN];
 
     put_le16(params, conn_handle);
-    ble_hs_test_util_set_ack_params(
+    ble_hs_test_util_hci_ack_set_params(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_LT_KEY_REQ_NEG_REPLY),
         status, params, sizeof params);
@@ -1297,7 +1297,7 @@ ble_sm_test_util_set_lt_key_req_reply_ack(uint8_t status, uint16_t conn_handle)
     static uint8_t params[BLE_HCI_LT_KEY_REQ_REPLY_ACK_PARAM_LEN];
 
     put_le16(params, conn_handle);
-    ble_hs_test_util_set_ack_params(
+    ble_hs_test_util_hci_ack_set_params(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_LT_KEY_REQ_REPLY),
         status, params, sizeof params);
@@ -1325,7 +1325,7 @@ ble_sm_test_util_verify_tx_start_enc(uint16_t conn_handle,
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_START_ENCRYPT,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_LE_START_ENCRYPT_LEN);
@@ -1344,7 +1344,7 @@ ble_sm_test_util_verify_tx_add_resolve_list(uint8_t peer_id_addr_type,
     uint8_t param_len;
     uint8_t *param;
 
-    param = ble_hs_test_util_verify_tx_hci(BLE_HCI_OGF_LE,
+    param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_ADD_RESOLV_LIST,
                                            &param_len);
     TEST_ASSERT(param_len == BLE_HCI_ADD_TO_RESOLV_LIST_LEN);
@@ -1747,7 +1747,7 @@ ble_sm_test_util_us_bonding_good(int send_enc_req, uint8_t our_addr_type,
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_START_ENCRYPT),
         0);
@@ -2035,7 +2035,7 @@ ble_sm_test_util_rx_keys(struct ble_sm_test_params *params,
     }
     if (peer_key_dist & BLE_SM_PAIR_KEY_DIST_ID) {
 
-        ble_hs_test_util_set_ack_seq(((struct ble_hs_test_util_phony_ack[]) {
+        ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
             {
                 .opcode = ble_hs_hci_util_opcode_join(
                                 BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
@@ -2111,7 +2111,7 @@ ble_sm_test_util_us_lgcy_good_once_no_init(
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_START_ENCRYPT), 0);
     if (params->sec_req.authreq != 0) {
@@ -2416,7 +2416,7 @@ ble_sm_test_util_us_sc_good_once_no_init(
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 0);
 
-    ble_hs_test_util_set_ack(
+    ble_hs_test_util_hci_ack_set(
         ble_hs_hci_util_opcode_join(BLE_HCI_OGF_LE,
                                     BLE_HCI_OCF_LE_START_ENCRYPT), 0);
     if (params->sec_req.authreq != 0) {


### PR DESCRIPTION
The BLE host test code was getting out of hand, and this is a small step towards making it manageable again.  This commit moves all the HCI-related test utility functions into a new file:
`net/nimble/host/test/src/ble_hs_test_util_hci.c`.  Furthermore, all the functions in this file have been renamed to use the common prefix `ble_hs_test_util_hci_`.