### PR TITLE
Removing use of undefined TASKS_START behavior

### DIFF
--- a/hw/drivers/nimble/nrf52/src/ble_hw.c
+++ b/hw/drivers/nimble/nrf52/src/ble_hw.c
@@ -344,13 +344,11 @@ ble_hw_rng_start(void)
 
     /* No need for interrupt if there is no callback */
     OS_ENTER_CRITICAL(sr);
-    if (NRF_RNG->TASKS_START == 0) {
-        NRF_RNG->EVENTS_VALRDY = 0;
-        if (g_ble_rng_isr_cb) {
-            NRF_RNG->INTENSET = 1;
-        }
-        NRF_RNG->TASKS_START = 1;
+    NRF_RNG->EVENTS_VALRDY = 0;
+    if (g_ble_rng_isr_cb) {
+        NRF_RNG->INTENSET = 1;
     }
+    NRF_RNG->TASKS_START = 1;
     OS_EXIT_CRITICAL(sr);
 
     return 0;


### PR DESCRIPTION
Tested using the bleprph app. Seems to be working the same as before. Happy to help testing further!

The problem was that the behavior of the RNG TASKS_START is defined to be write only. Reading from it is undefined and though it might have worked up until now doesn't mean it'll constantly work. I was only able to catch on to this using an emulator.