### PR TITLE
Remove inclusion of bsp.h

### DIFF
--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -18,7 +18,6 @@
  */
 #include <inttypes.h>
 #include <assert.h>
-#include <bsp/bsp.h>
 
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash.h"


### PR DESCRIPTION
bsp.h is unused here and causes a circular dependency when hw/bsp/* depends on this.