### PR TITLE
nimble/host: Fix build issue

### DIFF
--- a/net/nimble/host/src/ble_hs_startup.c
+++ b/net/nimble/host/src/ble_hs_startup.c
@@ -101,10 +101,10 @@ ble_hs_startup_read_buf_sz_tx(uint16_t *out_pktlen, uint16_t *out_max_pkts)
 static int
 ble_hs_startup_read_buf_sz(void)
 {
-    uint16_t le_pktlen;
-    uint16_t max_pkts;
-    uint16_t pktlen;
-    uint8_t le_max_pkts;
+    uint16_t le_pktlen = 0;
+    uint16_t max_pkts = 0;
+    uint16_t pktlen = 0;
+    uint8_t le_max_pkts = 0;
     int rc;
 
     rc = ble_hs_startup_le_read_buf_sz_tx(&le_pktlen, &le_max_pkts);
@@ -114,7 +114,7 @@ ble_hs_startup_read_buf_sz(void)
 
     if (le_pktlen != 0) {
         pktlen = le_pktlen;
-        max_pkts = le_max_pkts;   
+        max_pkts = le_max_pkts;
     } else {
         rc = ble_hs_startup_read_buf_sz_tx(&pktlen, &max_pkts);
         if (rc != 0) {


### PR DESCRIPTION
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:125:8:
error: 'pktlen' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
     rc = ble_hs_hci_set_buf_sz(pktlen, max_pkts);
        ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:106:14:
note: 'pktlen' was declared here
     uint16_t pktlen;
              ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:125:8:
error: 'max_pkts' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
     rc = ble_hs_hci_set_buf_sz(pktlen, max_pkts);
        ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:105:14:
note: 'max_pkts' was declared here
     uint16_t max_pkts;
              ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:117:18:
error: 'le_max_pkts' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
         max_pkts = le_max_pkts;
                  ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:107:13:
note: 'le_max_pkts' was declared here
     uint8_t le_max_pkts;
             ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:115:8:
error: 'le_pktlen' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
     if (le_pktlen != 0) {
        ^
repos/apache-mynewt-core/net/nimble/host/src/ble_hs_startup.c:104:14:
note: 'le_pktlen' was declared here
     uint16_t le_pktlen;
              ^
cc1: all warnings being treated as errors