### PR TITLE
oic/ble_adapter: Fix build errors build for oc_client configuration

### DIFF
--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -327,6 +327,7 @@ oc_connectivity_shutdown_gatt(void)
     /* there is not unregister for BLE */
 }
 
+#if (MYNEWT_VAL(OC_SERVER) == 1)
 static int
 oc_ble_frag(struct os_mbuf *m, uint16_t mtu)
 {
@@ -369,25 +370,28 @@ err:
     };
     return -1;
 }
+#endif
 
 void
 oc_send_buffer_gatt(struct os_mbuf *m)
 {
+#if (MYNEWT_VAL(OC_SERVER) == 1)
     struct oc_endpoint *oe;
     struct os_mbuf_pkthdr *pkt;
     uint16_t mtu;
     uint16_t conn_handle;
     uint16_t attr_handle;
-
-    assert(OS_MBUF_USRHDR_LEN(m) >= sizeof(struct oc_endpoint_ble));
-    oe = OC_MBUF_ENDPOINT(m);
-    conn_handle = oe->oe_ble.conn_handle;
+#endif
 
 #if (MYNEWT_VAL(OC_CLIENT) == 1)
     OC_LOG_ERROR("oc_gatt send not supported on client");
 #endif
 
 #if (MYNEWT_VAL(OC_SERVER) == 1)
+
+    assert(OS_MBUF_USRHDR_LEN(m) >= sizeof(struct oc_endpoint_ble));
+    oe = OC_MBUF_ENDPOINT(m);
+    conn_handle = oe->oe_ble.conn_handle;
 
     STATS_INC(oc_ble_stats, oframe);
     STATS_INCN(oc_ble_stats, obytes, OS_MBUF_PKTLEN(m));


### PR DESCRIPTION
Error: repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:
In function 'oc_send_buffer_gatt':
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:380:14:
error: unused variable 'attr_handle' [-Werror=unused-variable]
     uint16_t attr_handle;
              ^
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:379:14:
error: variable 'conn_handle' set but not used
[-Werror=unused-but-set-variable]
     uint16_t conn_handle;
              ^
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:378:14:
error: unused variable 'mtu' [-Werror=unused-variable]
     uint16_t mtu;
              ^
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:377:28:
error: unused variable 'pkt' [-Werror=unused-variable]
     struct os_mbuf_pkthdr *pkt;
                            ^
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c: At top
level:
repos/apache-mynewt-core/net/oic/src/port/mynewt/ble_adaptor.c:331:1:
error: 'oc_ble_frag' defined but not used [-Werror=unused-function]
 oc_ble_frag(struct os_mbuf *m, uint16_t mtu)
 ^
cc1: all warnings being treated as errors