### PR TITLE
BLE Host - Delay sync callback after IRK restore

### DIFF
--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -405,6 +405,11 @@ blecent_gap_event(struct ble_gap_event *event, void *arg)
         blecent_scan();
         return 0;
 
+    case BLE_GAP_EVENT_DISC_COMPLETE:
+        BLECENT_LOG(INFO, "discovery complete; reason=%d\n",
+                    event->disc_complete.reason);
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         BLECENT_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -204,6 +204,12 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         BLEPRPH_LOG(INFO, "\n");
         return 0;
 
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        BLEPRPH_LOG(INFO, "advertise complete; reason=%d",
+                    event->adv_complete.reason);
+        bleprph_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         BLEPRPH_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -214,6 +214,12 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         BLEPRPH_LOG(INFO, "\n");
         return 0;
 
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        BLEPRPH_LOG(INFO, "advertise complete; reason=%d\n",
+                    event->adv_complete.reason);
+        bleprph_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         BLEPRPH_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/blesplit/src/main.c
+++ b/apps/blesplit/src/main.c
@@ -196,6 +196,13 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
         BLESPLIT_LOG(INFO, "\n");
         return 0;
 
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        BLESPLIT_LOG(INFO, "advertise complete; reason=%d\n",
+                     event->adv_complete.reason);
+        blesplit_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         BLESPLIT_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -1023,14 +1023,6 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
 
         return 0;
 
-    case BLE_GAP_EVENT_DISC_COMPLETE:
-        console_printf("scanning finished\n");
-        return 0;
-
-    case BLE_GAP_EVENT_ADV_COMPLETE:
-        console_printf("advertising complete.\n");
-        return 0;
-
     case BLE_GAP_EVENT_CONN_UPDATE:
         console_printf("connection updated; status=%d ",
                        event->conn_update.status);
@@ -1044,7 +1036,7 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
         *event->conn_update_req.self_params =
             *event->conn_update_req.peer_params;
         return 0;
-
+ 
     case BLE_GAP_EVENT_PASSKEY_ACTION:
         console_printf("passkey action event; action=%d",
                        event->passkey.params.action);
@@ -1053,6 +1045,16 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
                            (unsigned long)event->passkey.params.numcmp);
         }
         console_printf("\n");
+        return 0;
+
+    case BLE_GAP_EVENT_DISC_COMPLETE:
+        console_printf("discovery complete; reason=%d\n",
+                       event->disc_complete.reason);
+        return 0;
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        console_printf("advertise complete; reason=%d\n",
+                       event->adv_complete.reason);
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:

--- a/apps/bleuart/src/main.c
+++ b/apps/bleuart/src/main.c
@@ -160,6 +160,12 @@ bleuart_gap_event(struct ble_gap_event *event, void *arg)
         bleuart_advertise();
         return 0;
 
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        /* Advertising terminated; resume advertising. */
+        bleuart_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_REPEAT_PAIRING:
         /* We already have a bond with the peer, but it is attempting to
          * establish a new secure link.  This app sacrifices security for

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1023,14 +1023,6 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
 
         return 0;
 
-    case BLE_GAP_EVENT_DISC_COMPLETE:
-        console_printf("scanning finished\n");
-        return 0;
-
-    case BLE_GAP_EVENT_ADV_COMPLETE:
-        console_printf("advertising complete.\n");
-        return 0;
-
     case BLE_GAP_EVENT_CONN_UPDATE:
         console_printf("connection updated; status=%d ",
                        event->conn_update.status);
@@ -1053,6 +1045,17 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
                            (unsigned long)event->passkey.params.numcmp);
         }
         console_printf("\n");
+        return 0;
+
+
+    case BLE_GAP_EVENT_DISC_COMPLETE:
+        console_printf("discovery complete; reason=%d\n",
+                       event->disc_complete.reason);
+        return 0;
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        console_printf("advertise complete; reason=%d\n",
+                       event->adv_complete.reason);
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:

--- a/apps/ocf_sample/src/ocf_ble.c
+++ b/apps/ocf_sample/src/ocf_ble.c
@@ -219,6 +219,12 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
         OCF_BLE_LOG(INFO, "\n");
         return 0;
 
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        OCF_BLE_LOG(INFO, "advertise complete; reason=%d\n",
+                    event->adv_complete.reason);
+        ocf_ble_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         OCF_BLE_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -279,6 +279,18 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
         BLEPRPH_LOG(INFO, "\n");
         return 0;
 
+
+    case BLE_GAP_EVENT_DISC_COMPLETE:
+        BLEPRPH_LOG(INFO, "discovery complete; reason=%d\n",
+                    event->disc_complete.reason);
+        return 0;
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        BLEPRPH_LOG(INFO, "advertise complete; reason=%d\n",
+                    event->adv_complete.reason);
+        sensor_oic_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         BLEPRPH_LOG(INFO, "encryption change event; status=%d ",

--- a/apps/testbench/src/tbb.c
+++ b/apps/testbench/src/tbb.c
@@ -219,6 +219,12 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
         TBB_LOG(INFO, "\n");
         return 0;
 
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        TBB_LOG(INFO, "advertise complete; reason=%d\n",
+                event->adv_complete.reason);
+        tbb_advertise();
+        return 0;
+
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
         TBB_LOG(INFO, "encryption change event; status=%d ",

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -306,9 +306,6 @@ ble_hs_sync(void)
     rc = ble_hs_startup_go();
     if (rc == 0) {
         ble_hs_sync_state = BLE_HS_SYNC_STATE_GOOD;
-        if (ble_hs_cfg.sync_cb != NULL) {
-            ble_hs_cfg.sync_cb();
-        }
     } else {
         ble_hs_sync_state = BLE_HS_SYNC_STATE_BAD;
     }
@@ -316,6 +313,13 @@ ble_hs_sync(void)
     ble_hs_timer_sched(BLE_HS_SYNC_RETRY_RATE);
 
     if (rc == 0) {
+        rc = ble_hs_misc_restore_irks();
+        assert(rc == 0);
+
+        if (ble_hs_cfg.sync_cb != NULL) {
+            ble_hs_cfg.sync_cb();
+        }
+
         STATS_INC(ble_hs_stats, sync);
     }
 
@@ -555,9 +559,6 @@ ble_hs_start(void)
     }
 
     ble_hs_sync();
-
-    rc = ble_hs_misc_restore_irks();
-    assert(rc == 0);
 
     return 0;
 }


### PR DESCRIPTION
#### Prior to commit

On startup, the host executes the following steps:

1. HCI startup sequence
2. Call sync callback
3. Restore IRKs from flash

The problem is that step 3 (IRK restoration) causes a GAP preemption if
there are any persisted IRKs.  If the application initiates a GAP
procedure during the sync callback, it will be immediately preempted.
This happens in the bleprph app, for example.

#### After commit

Don't call the sync callback until after IRK restoration is complete.