### PR TITLE
BLE Host - Remove BLE_GAP_EVENT_CONN_CANCEL

### DIFF
--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -1031,10 +1031,6 @@ bletiny_gap_event(struct ble_gap_event *event, void *arg)
         console_printf("advertising complete.\n");
         return 0;
 
-    case BLE_GAP_EVENT_CONN_CANCEL:
-        console_printf("connection procedure cancelled.\n");
-        return 0;
-
     case BLE_GAP_EVENT_CONN_UPDATE:
         console_printf("connection updated; status=%d ",
                        event->conn_update.status);

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1031,10 +1031,6 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
         console_printf("advertising complete.\n");
         return 0;
 
-    case BLE_GAP_EVENT_CONN_CANCEL:
-        console_printf("connection procedure cancelled.\n");
-        return 0;
-
     case BLE_GAP_EVENT_CONN_UPDATE:
         console_printf("connection updated; status=%d ",
                        event->conn_update.status);

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -98,7 +98,7 @@ struct hci_conn_update;
 
 #define BLE_GAP_EVENT_CONNECT               0
 #define BLE_GAP_EVENT_DISCONNECT            1
-#define BLE_GAP_EVENT_CONN_CANCEL           2
+/* Reserved                                 2 */
 #define BLE_GAP_EVENT_CONN_UPDATE           3
 #define BLE_GAP_EVENT_CONN_UPDATE_REQ       4
 #define BLE_GAP_EVENT_L2CAP_UPDATE_REQ      5

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -725,18 +725,15 @@ ble_gap_master_connect_cancelled(void)
 
     ble_gap_master_extract_state(&state, 1);
     if (state.cb != NULL) {
-        /* The GAP event type depends on whether 1) the application manually
-         * cancelled the connect procedure or 2) the connect procedure timed
-         * out.
-         */
         memset(&event, 0, sizeof event);
+        event.type = BLE_GAP_EVENT_CONNECT;
+        event.connect.conn_handle = BLE_HS_CONN_HANDLE_NONE;
         if (state.conn.cancel) {
-            event.type = BLE_GAP_EVENT_CONN_CANCEL;
+            /* Connect procedure successfully cancelled. */
+            event.connect.status = BLE_HS_EAPP;
         } else {
-            event.type = BLE_GAP_EVENT_CONNECT;
+            /* Connect procedure timed out. */
             event.connect.status = BLE_HS_ETIMEOUT;
-            event.connect.conn_handle = BLE_HS_CONN_HANDLE_NONE;
-
         }
         state.cb(&event, state.cb_arg);
     }

--- a/net/nimble/host/test/src/ble_gap_test.c
+++ b/net/nimble/host/test/src/ble_gap_test.c
@@ -104,9 +104,6 @@ ble_gap_test_util_connect_cb(struct ble_gap_event *event, void *arg)
         TEST_ASSERT_FATAL(ret == 0);
         break;
 
-    case BLE_GAP_EVENT_CONN_CANCEL:
-        break;
-
     case BLE_GAP_EVENT_TERM_FAILURE:
         ble_gap_test_conn_status = event->term_failure.status;
         ret = ble_gap_conn_find(event->term_failure.conn_handle,
@@ -1062,7 +1059,8 @@ ble_gap_test_util_conn_cancel(uint8_t hci_status)
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!ble_gap_master_in_progress());
 
-    TEST_ASSERT(ble_gap_test_event.type == BLE_GAP_EVENT_CONN_CANCEL);
+    TEST_ASSERT(ble_gap_test_event.type == BLE_GAP_EVENT_CONNECT);
+    TEST_ASSERT(ble_gap_test_event.connect.status == BLE_HS_EAPP);
 }
 
 static void
@@ -1104,7 +1102,8 @@ TEST_CASE(ble_gap_test_case_conn_cancel_good)
 
     ble_gap_test_util_conn_and_cancel(peer_addr, 0);
 
-    TEST_ASSERT(ble_gap_test_event.type == BLE_GAP_EVENT_CONN_CANCEL);
+    TEST_ASSERT(ble_gap_test_event.type == BLE_GAP_EVENT_CONNECT);
+    TEST_ASSERT(ble_gap_test_event.connect.status == BLE_HS_EAPP);
     TEST_ASSERT(ble_gap_test_conn_desc.conn_handle == BLE_HS_CONN_HANDLE_NONE);
 }
 


### PR DESCRIPTION
Cancelled connect procedures are reported as:
* event.type: `BLE_GAP_EVENT_CONNECT`
* event.connect.status: `BLE_HS_EAPP`

Discussion regarding this change can be found here:
https://lists.apache.org/thread.html/6575cbf8faef793381845aaa99bea7c4c053926af43928c82f62e236@%3Cdev.mynewt.apache.org%3E