### PR TITLE
BLE socket transport - don't drop large frames.

### DIFF
--- a/net/nimble/transport/socket/src/ble_hci_socket.c
+++ b/net/nimble/transport/socket/src/ble_hci_socket.c
@@ -167,7 +167,7 @@ static struct ble_hci_sock_state {
     struct os_event ev;
     struct os_callout timer;
 
-    uint8_t rx_off;
+    uint16_t rx_off;
     uint8_t rx_data[512];
 } ble_hci_sock_state;
 


### PR DESCRIPTION
For large incoming ACL packets, the "current offset" field was rolling over, making it look like the packet was being dropped.  The fix is to change the offset member from `uint8_t` to `uint16_t`.