### PR TITLE
net/lora: Fix assumption of flat buffers

### DIFF
--- a/net/lora/node/include/node/mac/LoRaMac.h
+++ b/net/lora/node/include/node/mac/LoRaMac.h
@@ -718,14 +718,6 @@ typedef struct sMcpsReqUnconfirmed
      */
     uint8_t fPort;
     /*!
-     * Pointer to the buffer of the frame payload
-     */
-    void *fBuffer;
-    /*!
-     * Size of the frame payload
-     */
-    uint16_t fBufferSize;
-    /*!
      * Uplink datarate, if ADR is off
      */
     int8_t Datarate;
@@ -743,14 +735,6 @@ typedef struct sMcpsReqConfirmed
      * LoRaWAN Specification V1.0.1, chapter 4.3.2
      */
     uint8_t fPort;
-    /*!
-     * Pointer to the buffer of the frame payload
-     */
-    void *fBuffer;
-    /*!
-     * Size of the frame payload
-     */
-    uint16_t fBufferSize;
     /*!
      * Uplink datarate, if ADR is off
      */
@@ -783,14 +767,6 @@ typedef struct sMcpsReqConfirmed
  */
 typedef struct sMcpsReqProprietary
 {
-    /*!
-     * Pointer to the buffer of the frame payload
-     */
-    void *fBuffer;
-    /*!
-     * Size of the frame payload
-     */
-    uint16_t fBufferSize;
     /*!
      * Uplink datarate, if ADR is off
      */

--- a/net/lora/node/src/lora_app.c
+++ b/net/lora/node/src/lora_app.c
@@ -277,12 +277,10 @@ lora_app_port_send(uint8_t port, Mcps_t pkt_type, struct os_mbuf *om)
     struct lora_pkt_info *lpkt;
 
     /* If no buffer to send, fine. */
-    if (om == NULL) {
-        return LORA_APP_STATUS_OK;
+    if ((om == NULL) || (OS_MBUF_PKTLEN(om) == 0)) {
+        return LORA_APP_STATUS_INVALID_PARAM;
     }
     assert(OS_MBUF_USRHDR_LEN(om) >= sizeof(struct lora_pkt_info));
-
-    /* XXX: TODO: support multicast */
 
     /* Check valid packet type. Only confirmed and unconfirmed for now. */
     if ((pkt_type != MCPS_UNCONFIRMED) && (pkt_type != MCPS_CONFIRMED)) {

--- a/net/lora/node/src/lora_node.c
+++ b/net/lora/node/src/lora_node.c
@@ -427,21 +427,13 @@ send_empty_ack:
         case MCPS_UNCONFIRMED:
             if (lpkt) {
                 req.Req.Unconfirmed.fPort = lpkt->port;
-                req.Req.Unconfirmed.fBuffer = om->om_data;
-                req.Req.Unconfirmed.fBufferSize = OS_MBUF_PKTLEN(om);
             }
             evstatus = LORAMAC_EVENT_INFO_STATUS_OK;
             break;
         case MCPS_CONFIRMED:
             req.Req.Confirmed.fPort = lpkt->port;
-            req.Req.Confirmed.fBuffer = om->om_data;
-            req.Req.Confirmed.fBufferSize = OS_MBUF_PKTLEN(om);
             req.Req.Confirmed.NbTrials = lpkt->txdinfo.retries;
             evstatus = LORAMAC_EVENT_INFO_STATUS_OK;
-            break;
-        case MCPS_MULTICAST:
-            /* XXX: implement */
-            evstatus = LORAMAC_EVENT_INFO_STATUS_ERROR;
             break;
         case MCPS_PROPRIETARY:
             /* XXX: not allowed */


### PR DESCRIPTION
The code was not fully modified to deal with mbufs. The previous
code assumes flat buffers and while some of the changes were
made to support mbufs, the code still assumed that all data
was contiguous in one mbuf and that mbufs were not chained.
This new code should now copy data from the mbuf into the
global lora mac buffer.