### PR TITLE
mesh: Fix and clean up iv update procedure

### DIFF
--- a/net/nimble/host/mesh/src/net.c
+++ b/net/nimble/host/mesh/src/net.c
@@ -556,35 +556,50 @@ void bt_mesh_iv_update(u32_t iv_index, bool iv_update)
 {
 	int i;
 
-	if (iv_index < bt_mesh.iv_index || iv_index > bt_mesh.iv_index + 42) {
-		BT_ERR("IV Index completely out of sync: 0x%08x != 0x%08x",
-			iv_index, bt_mesh.iv_index);
-		return;
-	}
-
-	if (iv_index > bt_mesh.iv_index + 1) {
-		BT_WARN("Performing IV Index Recovery");
-		memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
-		bt_mesh.iv_index = iv_index;
-		bt_mesh.seq = 0;
-		goto do_update;
-	}
-
-	if (iv_update == bt_mesh.iv_update) {
-		if (iv_index != bt_mesh.iv_index) {
-			BT_WARN("No update, but IV Index 0x%08x != 0x%08x",
-				iv_index, bt_mesh.iv_index);
-		}
-		return;
-	}
-
 	if (bt_mesh.iv_update) {
+		/* We're currently in IV Update mode */
+
 		if (iv_index != bt_mesh.iv_index) {
 			BT_WARN("IV Index mismatch: 0x%08x != 0x%08x",
 				iv_index, bt_mesh.iv_index);
 			return;
 		}
-	} else {
+
+		if (iv_update) {
+			/* Nothing to do */
+			BT_DBG("Already in IV Update in Progress state");
+			return;
+		}
+	} else  {
+		/* We're currently in Normal mode */
+
+		if (iv_index < bt_mesh.iv_index ||
+		    iv_index > bt_mesh.iv_index + 42) {
+			BT_ERR("IV Index out of sync: " "0x%08x != 0x%08x",
+			       iv_index, bt_mesh.iv_index);
+			return;
+		}
+
+		if (iv_index > bt_mesh.iv_index + 1) {
+			BT_WARN("Performing IV Index Recovery");
+			memset(bt_mesh.rpl, 0, sizeof(bt_mesh.rpl));
+			bt_mesh.iv_index = iv_index;
+			bt_mesh.seq = 0;
+			goto do_update;
+		}
+
+		if (iv_index == bt_mesh.iv_index + 1 && !iv_update) {
+			BT_WARN("Ignoring new index in normal mode",
+				iv_index, bt_mesh.iv_index);
+			return;
+		}
+
+		if (!iv_update) {
+			/* Nothing to do */
+			BT_DBG("Already in Normal mode");
+			return;
+		}
+
 		if (iv_index != bt_mesh.iv_index + 1) {
 			BT_WARN("Wrong new IV Index: 0x%08x != 0x%08x + 1",
 				iv_index, bt_mesh.iv_index);


### PR DESCRIPTION
This patch fixes issue when receiving iv index greater than current
index + 42 in update mode. According to Specification when node is in update
state it should only accept iv index equal to the current iv index. When
node is in normal mode it should ignore index that is greater than current
index + 42.

This allows to pass MESH/NODE/IVU/BI-02-C.

Also this patch cleans up the iv update procedure, to make it easier to
read.