### PR TITLE
MYNEWT-861: Sensor per type polling

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -495,6 +495,25 @@ main(int argc, char **argv)
     /* Initialize BLE OIC GATT Server */
     sensor_ble_oic_server_init();
 
+    sensor_set_poll_rate_ms("ms5837_0", 60);
+
+    struct sensor_type_traits stt_temp;
+    struct sensor_type_traits stt_press;
+
+    stt_temp = (struct sensor_type_traits) {
+        .stt_sensor_type = SENSOR_TYPE_AMBIENT_TEMPERATURE,
+        .stt_poll_n      = 2
+    };
+
+    sensor_set_n_poll_rate("ms5837_0", &stt_temp);
+
+    stt_press = (struct sensor_type_traits) {
+        .stt_sensor_type = SENSOR_TYPE_PRESSURE,
+        .stt_poll_n      = 5
+    };
+
+    sensor_set_n_poll_rate("ms5837_0", &stt_press);
+
     /* log reboot */
     reboot_start(hal_reset_cause());
 

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -495,25 +495,6 @@ main(int argc, char **argv)
     /* Initialize BLE OIC GATT Server */
     sensor_ble_oic_server_init();
 
-    sensor_set_poll_rate_ms("ms5837_0", 60);
-
-    struct sensor_type_traits stt_temp;
-    struct sensor_type_traits stt_press;
-
-    stt_temp = (struct sensor_type_traits) {
-        .stt_sensor_type = SENSOR_TYPE_AMBIENT_TEMPERATURE,
-        .stt_poll_n      = 2
-    };
-
-    sensor_set_n_poll_rate("ms5837_0", &stt_temp);
-
-    stt_press = (struct sensor_type_traits) {
-        .stt_sensor_type = SENSOR_TYPE_PRESSURE,
-        .stt_poll_n      = 5
-    };
-
-    sensor_set_n_poll_rate("ms5837_0", &stt_press);
-
     /* log reboot */
     reboot_start(hal_reset_cause());
 

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -685,9 +685,9 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
                    uint8_t len)
 {
     int rc;
-    uint8_t payload[20] = { addr, 0, 0, 0, 0, 0, 0, 0,
+    uint8_t payload[24] = { addr, 0, 0, 0, 0, 0, 0, 0,
                               0, 0, 0, 0, 0, 0, 0, 0,
-                              0, 0, 0, 0};
+                              0, 0, 0, 0, 0 ,0 ,0, 0};
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -254,11 +254,9 @@ struct sensor_type_traits {
 
     uint16_t stt_polls_left;
 
-    uint32_t ts_buff[100];
-
-    uint32_t ts_buff_idx;
-
+#if MYNEWT_VAL(SENSOR_POLL_TEST_LOG)
     os_time_t prev_now;
+#endif
 
     /* function ptr for setting comparison algo */
     sensor_trigger_cmp_func_t stt_trigger_cmp_algo;

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -249,6 +249,11 @@ struct sensor_type_traits {
     /* field for selecting algorithm */
     uint8_t stt_algo;
 
+    /* Poll rate multiple */
+    uint16_t stt_poll_n;
+
+    os_time_t stt_next_run;
+
     /* function ptr for setting comparison algo */
     sensor_trigger_cmp_func_t stt_trigger_cmp_algo;
 
@@ -617,6 +622,16 @@ int sensor_mgr_match_bytype(struct sensor *, void *);
  */
 int
 sensor_set_poll_rate_ms(char *, uint32_t);
+
+/**
+ * Set the sensor poll rate multiple based on the device name, sensor type
+ *
+ * @param The devname
+ * @param The sensor type trait
+ * @param The multiple of the poll rate
+ */
+int
+sensor_set_n_poll_rate(char *devname, struct sensor_type_traits *stt);
 
 /**
  * Transmit OIC trigger

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -252,7 +252,13 @@ struct sensor_type_traits {
     /* Poll rate multiple */
     uint16_t stt_poll_n;
 
-    os_time_t stt_next_run;
+    uint16_t stt_polls_left;
+
+    uint32_t ts_buff[100];
+
+    uint32_t ts_buff_idx;
+
+    os_time_t prev_now;
 
     /* function ptr for setting comparison algo */
     sensor_trigger_cmp_func_t stt_trigger_cmp_algo;
@@ -545,8 +551,6 @@ sensor_get_config(struct sensor *sensor, sensor_type_t type,
  * polling has been configured more frequently than this, it will
  * be triggered instead.
  */
-#define SENSOR_MGR_WAKEUP_TICKS (MYNEWT_VAL(SENSOR_MGR_WAKEUP_RATE) * \
-    OS_TICKS_PER_SEC) / 1000
 
 int sensor_mgr_lock(void);
 void sensor_mgr_unlock(void);
@@ -631,7 +635,7 @@ sensor_set_poll_rate_ms(char *, uint32_t);
  * @param The multiple of the poll rate
  */
 int
-sensor_set_n_poll_rate(char *devname, struct sensor_type_traits *stt);
+sensor_set_n_poll_rate(char *, struct sensor_type_traits *);
 
 /**
  * Transmit OIC trigger

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -43,6 +43,7 @@
 #include "sensor/gyro.h"
 #include "console/console.h"
 
+#if MYNEWT_VAL(SENSOR_POLL_TEST_LOG)
 uint32_t test_log_idx;
 uint32_t smgr_wakeup_idx;
 
@@ -56,6 +57,7 @@ struct test_log {
 }test_log[100];
 
 os_time_t smgr_wakeup[500];
+#endif
 
 struct {
     struct os_mutex mgr_lock;
@@ -306,7 +308,7 @@ sensor_calc_nextrun_delta(struct sensor *sensor, os_time_t now)
 
     sensor_lock(sensor);
 
-    delta = (int32_t)(now - sensor->s_next_run);
+    delta = (int32_t)(sensor->s_next_run - now);
     if (delta < 0) {
         /* This fires the callout right away */
         sensor_ticks = 0;
@@ -319,11 +321,10 @@ sensor_calc_nextrun_delta(struct sensor *sensor, os_time_t now)
     return sensor_ticks;
 }
 
-static os_time_t
-sensor_find_min_nextrun(os_time_t now)
+static struct sensor *
+sensor_find_min_nextrun_sensor(os_time_t now, os_time_t *min_nextrun)
 {
     struct sensor *head;
-    os_time_t next_wakeup;
 
     head = NULL;
 
@@ -331,18 +332,21 @@ sensor_find_min_nextrun(os_time_t now)
 
     head = SLIST_FIRST(&sensor_mgr.mgr_sensor_list);
 
-    next_wakeup = sensor_calc_nextrun_delta(head, now);
+    *min_nextrun = sensor_calc_nextrun_delta(head, now);
 
     sensor_mgr_unlock();
 
-    return next_wakeup;
+    return head;
 
 }
 
 static void
-sensor_update_nextrun(struct sensor *sensor, os_time_t now,
-                      os_time_t next_wakeup)
+sensor_update_nextrun(struct sensor *sensor, os_time_t now)
 {
+    os_time_t sensor_ticks;
+
+    os_time_ms_to_ticks(sensor->s_poll_rate, &sensor_ticks);
+
     sensor_lock(sensor);
 
     /* Remove the sensor from the sensor list for insert. */
@@ -351,7 +355,7 @@ sensor_update_nextrun(struct sensor *sensor, os_time_t now,
     /* Set next wakeup, and insert the sensor back into the
      * list.
      */
-    sensor->s_next_run = next_wakeup + now;
+    sensor->s_next_run = sensor_ticks + now;
 
     /* Re-insert the sensor manager, with the new wakeup time. */
     sensor_mgr_insert(sensor);
@@ -389,11 +393,11 @@ sensor_set_poll_rate_ms(char *devname, uint32_t poll_rate)
 
     sensor_update_poll_rate(sensor, poll_rate);
 
-    sensor_update_nextrun(sensor, now, next_wakeup);
+    sensor_update_nextrun(sensor, now);
 
     sensor_unlock(sensor);
 
-    next_wakeup = sensor_find_min_nextrun(now);
+    sensor = sensor_find_min_nextrun_sensor(now, &next_wakeup);
 
     os_callout_reset(&sensor_mgr.mgr_wakeup_callout, next_wakeup);
 
@@ -440,18 +444,10 @@ err:
  * run," and re-inserts it into the list
  */
 static void
-sensor_mgr_poll_one(struct sensor *sensor, sensor_type_t type,
-                    struct sensor_type_traits *stt,
-                    os_time_t now, os_time_t next_wakeup)
+sensor_mgr_poll_bytype(struct sensor *sensor, sensor_type_t type,
+                       struct sensor_type_traits *stt, os_time_t now)
 {
     if (!stt || !stt->stt_polls_left) {
-#if 0
-        console_printf("%c%c n: %u now: %u delta_now(ms): %d, s_next_run: %u polls_left: %u\n",
-                 sensor->s_dev->od_name[0],
-                 type == 1 ? 'a' : type == 32 ? 't' : type == 64 ? 'p' : 'x' ,
-                 (unsigned int)stt->stt_poll_n, (unsigned int)now, ((int)(now - ((stt != NULL)? stt->prev_now : 0))),
-                 (unsigned int)sensor->s_next_run, stt->stt_polls_left);
-#endif
         /* Sensor read results. Every time a sensor is read, all of its
          * listeners are called by default. Specify NULL as a callback,
          * because we just want to run all the listeners.
@@ -466,6 +462,7 @@ sensor_mgr_poll_one(struct sensor *sensor, sensor_type_t type,
                 stt->stt_polls_left = stt->stt_poll_n;
                 stt->stt_polls_left--;
             }
+#if MYNEWT_VAL(SENSOR_POLL_TEST_LOG)
             test_log[test_log_idx].delta = (uint32_t)(now - stt->prev_now);
             test_log[test_log_idx].polls_left = stt->stt_polls_left;
             test_log[test_log_idx].now = now;
@@ -476,6 +473,7 @@ sensor_mgr_poll_one(struct sensor *sensor, sensor_type_t type,
             test_log_idx++;
             test_log_idx %= 100;
             stt->prev_now = now;
+#endif
         }
 
         /* Unlock the sensor to allow other access */
@@ -484,6 +482,39 @@ sensor_mgr_poll_one(struct sensor *sensor, sensor_type_t type,
     } else {
         stt->stt_polls_left--;
     }
+}
+
+static uint8_t
+sensor_type_traits_empty(struct sensor *sensor)
+{
+    return SLIST_EMPTY(&sensor->s_type_traits_list);
+}
+
+static void
+sensor_poll_per_type_trait(struct sensor *sensor, os_time_t now,
+                           os_time_t next_wakeup)
+{
+    struct sensor_type_traits *stt;
+
+    /* Lock the sensor */
+    sensor_lock(sensor);
+
+    SLIST_FOREACH(stt, &sensor->s_type_traits_list, stt_next) {
+
+        /* poll multiple is one if no multiple is specified,
+         * as a result, the sensor would get polled at the
+         * poll rate if no multiple is specified
+         *
+         * If a multiple is specified, the sensor would get polled
+         * at the poll multiple
+         */
+
+        sensor_mgr_poll_bytype(sensor, stt->stt_sensor_type, stt,
+                               now);
+    }
+
+    /* Unlock the sensor to allow other access */
+    sensor_unlock(sensor);
 }
 
 /**
@@ -496,78 +527,49 @@ static void
 sensor_mgr_wakeup_event(struct os_event *ev)
 {
     struct sensor *cursor;
-    struct sensor_type_traits *stt;
     os_time_t now;
     os_time_t next_wakeup;
-    os_time_t sensor_ticks;
 
     now = os_time_get();
 
+#if MYNEWT_VAL(SENSOR_POLL_TEST_LOG)
     smgr_wakeup[smgr_wakeup_idx++%500] = now;
+#endif
 
     sensor_mgr_lock();
 
     cursor = NULL;
     while (1) {
 
-        cursor = SLIST_FIRST(&sensor_mgr.mgr_sensor_list);
+        cursor = sensor_find_min_nextrun_sensor(now, &next_wakeup);
 
+        sensor_lock(cursor);
         /* Sensors that are not periodic are inserted at the end of the sensor
          * list.
          */
         if (!cursor->s_poll_rate) {
+            sensor_unlock(cursor);
             sensor_mgr_unlock();
             return;
         }
 
-        next_wakeup = sensor_calc_nextrun_delta(cursor, now);
-
-        os_time_ms_to_ticks(cursor->s_poll_rate, &sensor_ticks);
-
         /* List is sorted by what runs first.  If we reached the first element that
          * doesn't run, break out.
          */
-        if (OS_TIME_TICK_LT(now, cursor->s_next_run)) {
+        if (next_wakeup > 0) {
             break;
         }
 
-        if (SLIST_EMPTY(&cursor->s_type_traits_list)) {
+        if (sensor_type_traits_empty(cursor)) {
 
-            sensor_mgr_poll_one(cursor, cursor->s_mask, NULL,
-                                now, next_wakeup);
-
-            sensor_update_nextrun(cursor, now, sensor_ticks);
-
-            break;
+            sensor_mgr_poll_bytype(cursor, cursor->s_mask, NULL, now);
+        } else {
+            sensor_poll_per_type_trait(cursor, now, next_wakeup);
         }
 
-        /* Lock the sensor */
-        sensor_lock(cursor);
+        sensor_update_nextrun(cursor, now);
 
-        /* Remove the sensor from the sensor list for insert. */
-        sensor_mgr_remove(cursor);
-
-        SLIST_FOREACH(stt, &cursor->s_type_traits_list, stt_next) {
-
-            /* poll multiple is one if no multiple is specified,
-             * as a result, the sensor would get polled at the
-             * poll rate if no multiple is specified
-             *
-             * If a multiple is specified, the sensor would get polled
-             * at the poll multiple
-             */
-
-            sensor_mgr_poll_one(cursor, stt->stt_sensor_type, stt,
-                                now, next_wakeup);
-        }
-
-        cursor->s_next_run = sensor_ticks + now;
-
-        /* Unlock the sensor to allow other access */
         sensor_unlock(cursor);
-
-        /* Re-insert the sensor manager, with the new wakeup time. */
-        sensor_mgr_insert(cursor);
     }
 
     sensor_mgr_unlock();

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -44,3 +44,7 @@ syscfg.defs:
     SENSOR_OIC_PERIODIC:
         description: 'Sensor polling is periodic'
         value: 0
+
+    SENSOR_POLL_TEST_LOG:
+        description: 'Sensor poller log'
+        value: '0'

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -19,10 +19,6 @@
 # Package: hw/sensor
 
 syscfg.defs:
-    SENSOR_MGR_WAKEUP_RATE:
-        description: 'The default wakeup rate of the sensor manager in ms'
-        value: 2000
-
     SENSOR_CLI:
         description: 'Whether or not to enable the sensor shell support'
         value: 1

--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -64,6 +64,7 @@ extern "C" {
 #endif
 
 typedef uint32_t os_time_t;
+typedef int32_t os_stime_t;
 #define OS_TIME_MAX UINT32_MAX
  
 /* Used to wait forever for events and mutexs */
@@ -73,9 +74,9 @@ os_time_t os_time_get(void);
 void os_time_advance(int ticks);
 void os_time_delay(int32_t osticks);
 
-#define OS_TIME_TICK_LT(__t1, __t2) ((int32_t) ((__t1) - (__t2)) < 0)
-#define OS_TIME_TICK_GT(__t1, __t2) ((int32_t) ((__t1) - (__t2)) > 0)
-#define OS_TIME_TICK_GEQ(__t1, __t2) ((int32_t) ((__t1) - (__t2)) >= 0)
+#define OS_TIME_TICK_LT(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) < 0)
+#define OS_TIME_TICK_GT(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) > 0)
+#define OS_TIME_TICK_GEQ(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) >= 0)
 
 struct os_timeval {
     int64_t tv_sec;         /* seconds since Jan 1 1970 */


### PR DESCRIPTION
- Support per type polling
- Fix os_time macros by using typedef for signed os_time_t
- Fix stack overflow with bmp280 driver
- Clean and reorganize some parts of the code
- Fix poll rate for multiple sensors
- Adding a poller ram test log which is conditional based on SENSOR_POLL_TEST_LOG

Configuration example:

     struct sensor_type_traits stt_ms_temp;
     struct sensor_type_traits stt_ms_press;
     struct sensor_type_traits stt_bmp_temp;
     struct sensor_type_traits stt_bmp_press;
 
     /* Poll rates for MS5837 */
 
     sensor_set_poll_rate_ms("ms5837_0", 60);
 
     stt_ms_temp = (struct sensor_type_traits) {
         .stt_sensor_type = SENSOR_TYPE_AMBIENT_TEMPERATURE,
         .stt_poll_n      = 2
     };
 
     sensor_set_n_poll_rate("ms5837_0", &stt_ms_temp);
 
     stt_ms_press = (struct sensor_type_traits) {
         .stt_sensor_type = SENSOR_TYPE_PRESSURE,
         .stt_poll_n      = 4
     };
 
     sensor_set_n_poll_rate("ms5837_0", &stt_ms_press);
 
     /* Poll rates for BMP280 */
 
     sensor_set_poll_rate_ms("bmp280_0", 120);
 
     stt_bmp_temp = (struct sensor_type_traits) {
         .stt_sensor_type = SENSOR_TYPE_AMBIENT_TEMPERATURE,
         .stt_poll_n      = 2
     };

     sensor_set_n_poll_rate("bmp280_0", &stt_bmp_temp);
 
     stt_bmp_press = (struct sensor_type_traits) {
         .stt_sensor_type = SENSOR_TYPE_PRESSURE,
         .stt_poll_n      = 4
     };
 
     sensor_set_n_poll_rate("bmp280_0", &stt_bmp_press);
 
     /* Poll rates for Accelerometer */
 
     sensor_set_poll_rate_ms("bma253_0", 180);

Jira Ticket: https://issues.apache.org/jira/browse/MYNEWT-861