### PR TITLE
net/lora: Fix MAC command issues

### DIFF
--- a/net/lora/node/include/node/mac/LoRaMac.h
+++ b/net/lora/node/include/node/mac/LoRaMac.h
@@ -429,6 +429,8 @@ typedef enum eLoRaMacMoteCmd
     MOTE_MAC_RX_TIMING_SETUP_ANS     = 0x08,
 }LoRaMacMoteCmd_t;
 
+#define LORA_MAC_MAX_MAC_CMD_CID    (MOTE_MAC_RX_TIMING_SETUP_ANS)
+
 /*!
  * LoRaMAC server MAC commands
  *

--- a/net/lora/node/src/lora_node.c
+++ b/net/lora/node/src/lora_node.c
@@ -62,6 +62,9 @@ uint8_t g_lora_app_eui[LORA_EUI_LEN];
 /* Application Key */
 uint8_t g_lora_app_key[LORA_KEY_LEN];
 
+/* Flag to denote if we last sent a mac command */
+uint8_t g_lora_node_last_tx_mac_cmd;
+
 #if !MYNEWT_VAL(LORA_NODE_CLI)
 LoRaMacPrimitives_t g_lora_primitives;
 #endif
@@ -369,14 +372,11 @@ lora_mac_proc_tx_q_event(struct os_event *ev)
     }
 
     /*
-     * XXX: there is a disconnect in the stack here.
-     * The LoRaMacQueryTxPossible() routine uses the Default channel rate
-     * to determine if the frame can be sent if ADR is not enabled. However,
-     * the stack can set the data it wants to send in the request. If these
-     * two are different there will be problems. Not sure why the app is even
-     * specifying data rate. But I guess we can leave it for now and hope
-     * that the app does not use a datarate that is different than the
-     * default.
+     * WWW: what I need to determine is what happens in the following case:
+     * a Mac command gets added to the buffer but we have nothing on the
+     * transmit queue. What do we do? I do not think we currently
+     * send the response until another frame is enqueued. Need to
+     * look at this. I think I should just send the response back
      */
 
     /*
@@ -388,6 +388,7 @@ lora_mac_proc_tx_q_event(struct os_event *ev)
         mp = STAILQ_FIRST(&g_lora_mac_data.lm_txq.mq_head);
         if (mp == NULL) {
             if (lora_mac_srv_ack_requested()) {
+                g_lora_node_last_tx_mac_cmd = 0;
                 goto send_empty_ack;
             }
             break;
@@ -395,6 +396,20 @@ lora_mac_proc_tx_q_event(struct os_event *ev)
 
         rc = LoRaMacQueryTxPossible(mp->omp_len, &txinfo);
         if (rc == LORAMAC_STATUS_MAC_CMD_LENGTH_ERROR) {
+            /*
+             * XXX: an ugly hack for now. If the server decides to send MAC
+             * commands all the time, it could be that we never send the
+             * data packet enqueued as we cannot add more data to it. For now,
+             * just alternate between sending the packet on the queue and
+             * a mac command. Yes, ugly.
+             */
+            if (g_lora_node_last_tx_mac_cmd) {
+                rc = LORAMAC_STATUS_OK;
+                goto send_from_txq;
+            }
+
+            g_lora_node_last_tx_mac_cmd = 1;
+
             /* Need to flush MAC commands. Send empty unconfirmed frame */
             STATS_INC(lora_mac_stats, tx_mac_flush);
             /* NOTE: no need to get a mbuf. */
@@ -405,11 +420,13 @@ send_empty_ack:
             req.Type = MCPS_UNCONFIRMED;
             rc = LORAMAC_STATUS_OK;
         } else {
+send_from_txq:
             om = os_mqueue_get(&g_lora_mac_data.lm_txq);
             assert(om != NULL);
             lpkt = LORA_PKT_INFO_PTR(om);
             req.om = om;
             req.Type = lpkt->pkt_type;
+            g_lora_node_last_tx_mac_cmd = 0;
         }
 
         if (rc != LORAMAC_STATUS_OK) {


### PR DESCRIPTION
There are two basic issues fixed with this commit: 1) If the
server sends MAC commands "constantly" the code would not
send any data until the MAC commands stopped being sent. Now, if
we cannot send any MAC commands because the application data is
too large, we will send a MAC commands, at most, every other
frame. 2) The code will now attempt to add as many MAC commands
as it can to each transmission. Prior code would either attempt
to add the entire MAC command buffer or do nothing.