### PR TITLE
mesh: Fail init on keys generation error

### DIFF
--- a/net/nimble/host/mesh/src/mesh.c
+++ b/net/nimble/host/mesh/src/mesh.c
@@ -173,7 +173,11 @@ bt_mesh_init(uint8_t own_addr_type, const struct bt_mesh_prov *prov,
     }
 
     if (MYNEWT_VAL(BLE_MESH_PROV)) {
-        bt_mesh_prov_init(prov);
+        err = bt_mesh_prov_init(prov);
+        if (err) {
+            return err;
+        }
+
     }
 
 #if (MYNEWT_VAL(BLE_MESH_PROXY))

--- a/net/nimble/host/mesh/src/prov.c
+++ b/net/nimble/host/mesh/src/prov.c
@@ -1502,8 +1502,9 @@ bool bt_prov_active(void)
 	return atomic_test_bit(link.flags, LINK_ACTIVE);
 }
 
-void bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
+int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 {
+	int err;
 	static struct bt_pub_key_cb pub_key_cb = {
 		.func = pub_key_ready,
 	};
@@ -1512,8 +1513,10 @@ void bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 
 #endif
 
-	if (bt_pub_key_gen(&pub_key_cb)) {
-		BT_ERR("Failed to generate public key");
+	err = bt_pub_key_gen(&pub_key_cb);
+	if (err) {
+		BT_ERR("Failed to generate public key (%d)", err);
+		return err;
 	}
 
 	prov = prov_info;
@@ -1530,6 +1533,8 @@ void bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 #endif
 
 #endif /* MYNEWT_VAL(BLE_MESH_PB_ADV) */
+
+	return 0;
 }
 
 void bt_mesh_prov_reset_link(void) {

--- a/net/nimble/host/mesh/src/prov.h
+++ b/net/nimble/host/mesh/src/prov.h
@@ -29,7 +29,7 @@ bt_mesh_pb_gatt_recv(uint16_t conn_handle, struct os_mbuf *buf);
 const u8_t *
 bt_mesh_prov_get_uuid(void);
 
-void
+int
 bt_mesh_prov_init(const struct bt_mesh_prov *prov);
 
 void


### PR DESCRIPTION
Fail on Mesh initialization if provisioning is enabled and keys were
not generated. This make it simpler to debug misconfigured devices.

Ported from Zephyr PR #4691