### PR TITLE
Add new semaphore API + some nimble/os fixes

### DIFF
--- a/kernel/os/include/os/os_sem.h
+++ b/kernel/os/include/os/os_sem.h
@@ -63,4 +63,4 @@ static inline uint16_t os_sem_get_count(struct os_sem *sem)
 }
 #endif
 
-#endif  /* _OS_MUTEX_H_ */
+#endif  /* _OS_SEM_H_ */

--- a/kernel/os/include/os/os_sem.h
+++ b/kernel/os/include/os/os_sem.h
@@ -53,6 +53,12 @@ os_error_t os_sem_release(struct os_sem *sem);
 /* Pend (wait) for a semaphore */
 os_error_t os_sem_pend(struct os_sem *sem, uint32_t timeout);
 
+/* Get current semaphore's count */
+static inline uint16_t os_sem_get_count(struct os_sem *sem)
+{
+    return sem->sem_tokens;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_mbuf.c
+++ b/kernel/os/src/os_mbuf.c
@@ -927,6 +927,9 @@ os_mbuf_cmpm(const struct os_mbuf *om1, uint16_t offset1,
     uint16_t om2_off;
     int rc;
 
+    om1_off = 0;
+    om2_off = 0;
+
     cur1 = os_mbuf_off(om1, offset1, &om1_off);
     cur2 = os_mbuf_off(om2, offset2, &om2_off);
 

--- a/net/nimble/host/services/ias/src/ble_svc_ias.c
+++ b/net/nimble/host/services/ias/src/ble_svc_ias.c
@@ -44,10 +44,10 @@ static const struct ble_gatt_svc_def ble_svc_ias_defs[] = {
     {
         /*** Service: Immediate Alert Service (IAS). */
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
-        .uuid = BLE_UUID16(BLE_SVC_IAS_UUID16),
+        .uuid = BLE_UUID16_DECLARE(BLE_SVC_IAS_UUID16),
         .characteristics = (struct ble_gatt_chr_def[]) { {
             /*** Characteristic: Alert Level. */
-            .uuid = BLE_UUID16(BLE_SVC_IAS_CHR_UUID16_ALERT_LEVEL),
+            .uuid = BLE_UUID16_DECLARE(BLE_SVC_IAS_CHR_UUID16_ALERT_LEVEL),
             .access_cb = ble_svc_ias_access,
             .flags = BLE_GATT_CHR_F_WRITE_NO_RSP,
         }, {

--- a/net/nimble/host/src/ble_att.c
+++ b/net/nimble/host/src/ble_att.c
@@ -19,7 +19,6 @@
 
 #include <stddef.h>
 #include <errno.h>
-#include "bsp/bsp.h"
 #include "ble_hs_priv.h"
 
 static uint16_t ble_att_preferred_mtu_val;

--- a/net/nimble/host/src/ble_att_svr.c
+++ b/net/nimble/host/src/ble_att_svr.c
@@ -19,7 +19,6 @@
 
 #include <string.h>
 #include <errno.h>
-#include "bsp/bsp.h"
 #include "os/os.h"
 #include "nimble/ble.h"
 #include "host/ble_uuid.h"

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
-#include "bsp/bsp.h"
 #include "stats/stats.h"
 #include "os/os.h"
 #include "console/console.h"

--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -124,20 +124,20 @@ ble_hs_evq_set(struct os_eventq *evq)
     ble_hs_evq = evq;
 }
 
+#if MYNEWT_VAL(BLE_HS_DEBUG)
 int
 ble_hs_locked_by_cur_task(void)
 {
     struct os_task *owner;
 
-#if MYNEWT_VAL(BLE_HS_DEBUG)
     if (!os_started()) {
         return ble_hs_dbg_mutex_locked;
     }
-#endif
 
     owner = ble_hs_mutex.mu_owner;
     return owner != NULL && owner == os_sched_get_current_task();
 }
+#endif
 
 /**
  * Indicates whether the host's parent task is currently running.

--- a/net/nimble/host/src/ble_hs_hci.c
+++ b/net/nimble/host/src/ble_hs_hci.c
@@ -338,7 +338,7 @@ ble_hs_hci_cmd_tx_empty_ack(uint16_t opcode, void *cmd, uint8_t cmd_len)
 void
 ble_hs_hci_rx_ack(uint8_t *ack_ev)
 {
-    if (ble_hs_hci_sem.sem_tokens != 0) {
+    if (os_sem_get_count(&ble_hs_hci_sem) > 0) {
         /* This ack is unexpected; ignore it. */
         ble_hci_trans_buf_free(ack_ev);
         return;

--- a/net/nimble/host/src/ble_monitor.c
+++ b/net/nimble/host/src/ble_monitor.c
@@ -25,6 +25,7 @@
 #error "Cannot enable monitor over UART and RTT at the same time!"
 #endif
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <inttypes.h>
 #include "os/os.h"


### PR DESCRIPTION
Main addition is new os_sem_get_count() API - it is then used in nimble where applicable.

+ some random fixes inside nimble and os code.