### PR TITLE
imgmgr; imgmr_erase() and imgr_upload() had shared code regarding

### DIFF
--- a/mgmt/imgmgr/include/imgmgr/imgmgr.h
+++ b/mgmt/imgmgr/include/imgmgr/imgmgr.h
@@ -73,6 +73,7 @@ uint8_t imgmgr_state_flags(int query_slot);
 int imgmgr_state_slot_in_use(int slot);
 int imgmgr_state_set_pending(int slot, int permanent);
 int imgmgr_state_confirm(void);
+int imgmgr_find_best_area_id(void);
 
 #ifdef __cplusplus
 }

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -328,10 +328,6 @@ imgr_erase(struct mgmt_cbuf *cb)
         return MGMT_ERR_ENOMEM;
     }
 
-    if (!imgr_state.upload.fa) {
-        return MGMT_ERR_EINVAL;
-    }
-
     g_err |= cbor_encode_text_stringz(&cb->encoder, "rc");
     g_err |= cbor_encode_int(&cb->encoder, MGMT_ERR_EOK);
 

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -264,15 +264,13 @@ imgr_find_by_hash(uint8_t *find, struct image_version *ver)
     return -1;
 }
 
-static int
-imgr_erase(struct mgmt_cbuf *cb)
+int
+imgmgr_find_best_area_id(void)
 {
     struct image_version ver;
-    int area_id;
     int best = -1;
-    int rc;
     int i;
-    CborError g_err = CborNoError;
+    int rc;
 
     for (i = 0; i < 2; i++) {
         rc = imgr_read_info(i, &ver, NULL, NULL);
@@ -282,7 +280,7 @@ imgr_erase(struct mgmt_cbuf *cb)
         if (rc == 0) {
             /* Image in slot is ok. */
             if (imgmgr_state_slot_in_use(i)) {
-                /* Slot is in use; can't erase to this. */
+                /* Slot is in use; can't use this. */
                 continue;
             } else {
                 /*
@@ -297,7 +295,20 @@ imgr_erase(struct mgmt_cbuf *cb)
         break;
     }
     if (best >= 0) {
-        area_id = flash_area_id_from_image_slot(best);
+        best = flash_area_id_from_image_slot(best);
+    }
+    return best;
+}
+
+static int
+imgr_erase(struct mgmt_cbuf *cb)
+{
+    int area_id;
+    int rc;
+    CborError g_err = CborNoError;
+
+    area_id = imgmgr_find_best_area_id();
+    if (area_id >= 0) {
         if (imgr_state.upload.fa) {
             flash_area_close(imgr_state.upload.fa);
             imgr_state.upload.fa = NULL;
@@ -359,12 +370,9 @@ imgr_upload(struct mgmt_cbuf *cb)
         },
         [3] = { 0 },
     };
-    struct image_version ver;
     struct image_header *hdr;
     int area_id;
-    int best;
     int rc;
-    int i;
     bool empty = false;
     CborError g_err = CborNoError;
 
@@ -390,32 +398,9 @@ imgr_upload(struct mgmt_cbuf *cb)
          */
         imgr_state.upload.off = 0;
         imgr_state.upload.size = size;
-        best = -1;
 
-        for (i = 0; i < 2; i++) {
-            rc = imgr_read_info(i, &ver, NULL, NULL);
-            if (rc < 0) {
-                continue;
-            }
-            if (rc == 0) {
-                /* Image in slot is ok. */
-                if (imgmgr_state_slot_in_use(i)) {
-                    /* Slot is in use; can't upload to this. */
-                    continue;
-                } else {
-                    /*
-                     * Not active slot, but image is ok. Use it if there are
-                     * no better candidates.
-                     */
-                    best = i;
-                }
-                continue;
-            }
-            best = i;
-            break;
-        }
-        if (best >= 0) {
-            area_id = flash_area_id_from_image_slot(best);
+        area_id = imgmgr_find_best_area_id();
+        if (area_id >= 0) {
             if (imgr_state.upload.fa) {
                 flash_area_close(imgr_state.upload.fa);
                 imgr_state.upload.fa = NULL;


### PR DESCRIPTION
find target slot to operate in. Separate that into a function.