### PR TITLE
Extended Advertising API

### DIFF
--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -143,7 +143,6 @@ int btshell_ext_scan(uint8_t own_addr_type, uint16_t duration, uint16_t period,
                      const struct ble_gap_ext_disc_params *uncoded_params,
                      const struct ble_gap_ext_disc_params *coded_params);
 int btshell_scan_cancel(void);
-int btshell_set_adv_data(struct ble_hs_adv_fields *adv_fields);
 int btshell_update_conn(uint16_t conn_handle,
                          struct ble_gap_upd_params *params);
 void btshell_notify(uint16_t attr_handle);

--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -114,6 +114,11 @@ int btshell_write_long(uint16_t conn_handle, uint16_t attr_handle,
                        uint16_t offset, struct os_mbuf *om);
 int btshell_write_reliable(uint16_t conn_handle,
                            struct ble_gatt_attr *attrs, int num_attrs);
+#if MYNEWT_VAL(BLE_EXT_ADV)
+int btshell_ext_adv_configure(uint8_t instance,
+                              const struct ble_gap_ext_adv_params *params,
+                              int8_t *selected_tx_power);
+#endif
 int btshell_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
                       int32_t duration_ms,
                       const struct ble_gap_adv_params *params);

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1054,8 +1054,14 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
+#if MYNEWT_VAL(BLE_EXT_ADV)
+        console_printf("advertise complete; reason=%d, instance=%u, handle=%d\n",
+                       event->adv_complete.reason, event->adv_complete.instance,
+                       event->adv_complete.conn_handle);
+#else
         console_printf("advertise complete; reason=%d\n",
                        event->adv_complete.reason);
+#endif
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1561,15 +1561,6 @@ btshell_scan_cancel(void)
 }
 
 int
-btshell_set_adv_data(struct ble_hs_adv_fields *adv_fields)
-{
-    int rc;
-
-    rc = ble_gap_adv_set_fields(adv_fields);
-    return rc;
-}
-
-int
 btshell_update_conn(uint16_t conn_handle, struct ble_gap_upd_params *params)
 {
     int rc;

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -1408,6 +1408,17 @@ btshell_write_reliable(uint16_t conn_handle,
     return rc;
 }
 
+#if MYNEWT_VAL(BLE_EXT_ADV)
+int
+btshell_ext_adv_configure(uint8_t instance,
+                          const struct ble_gap_ext_adv_params *params,
+                          int8_t *selected_tx_power)
+{
+    return ble_gap_ext_adv_configure(instance, params, selected_tx_power,
+                                     btshell_gap_event, NULL);
+}
+#endif
+
 int
 btshell_adv_stop(void)
 {

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -684,11 +684,6 @@ int ble_gap_adv_set_fields(const struct ble_hs_adv_fields *rsp_fields);
 int ble_gap_adv_rsp_set_fields(const struct ble_hs_adv_fields *rsp_fields);
 
 #if MYNEWT_VAL(BLE_EXT_ADV)
-int ble_gap_adv_set_tx_power(int8_t tx_power);
-int ble_gap_adv_set_phys(uint8_t primary_phy, uint8_t secondary_phy);
-#endif
-
-#if MYNEWT_VAL(BLE_EXT_ADV)
 struct ble_gap_ext_adv_params {
     unsigned int connectable:1;
     unsigned int scannable:1;

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -372,11 +372,19 @@ struct ble_gap_event {
             /**
              * The reason the advertise procedure stopped.  Typical reason
              * codes are:
-             *     o 0: Duration expired.
+             *     o 0: Terminated due to connection.
+             *     o BLE_HS_ETIMEOUT: Duration expired.
              *     o BLE_HS_EPREEMPTED: Host aborted procedure to configure a
              *       peer's identity.
              */
             int reason;
+
+#if MYNEWT_VAL(BLE_EXT_ADV)
+            /** Advertising instance */
+            uint8_t instance;
+            /** The handle of the relevant connection - valid if reason=0 */
+            uint16_t conn_handle;
+#endif
         } adv_complete;
 
         /**

--- a/net/nimble/host/include/host/ble_gap.h
+++ b/net/nimble/host/include/host/ble_gap.h
@@ -680,6 +680,41 @@ int ble_gap_adv_set_tx_power(int8_t tx_power);
 int ble_gap_adv_set_phys(uint8_t primary_phy, uint8_t secondary_phy);
 #endif
 
+#if MYNEWT_VAL(BLE_EXT_ADV)
+struct ble_gap_ext_adv_params {
+    unsigned int connectable:1;
+    unsigned int scannable:1;
+    unsigned int directed:1;
+    unsigned int high_duty_directed:1;
+    unsigned int legacy_pdu:1;
+    unsigned int anonymous:1;
+    unsigned int include_tx_power:1;
+    unsigned int scan_req_notif:1;
+
+    uint32_t itvl_min;
+    uint32_t itvl_max;
+    uint8_t channel_map;
+    uint8_t own_addr_type;
+    ble_addr_t peer;
+    uint8_t filter_policy;
+    uint8_t primary_phy;
+    uint8_t secondary_phy;
+    int8_t tx_power;
+    uint8_t sid;
+};
+
+int ble_gap_ext_adv_configure(uint8_t instance,
+                              const struct ble_gap_ext_adv_params *params,
+                              int8_t *selected_tx_power,
+                              ble_gap_event_fn *cb, void *cb_arg);
+int ble_gap_ext_adv_set_addr(uint8_t instance, const ble_addr_t *addr);
+int ble_gap_ext_adv_start(uint8_t instance, int duration, int max_events);
+int ble_gap_ext_adv_stop(uint8_t instance);
+int ble_gap_ext_adv_set_data(uint8_t instance, struct os_mbuf *data);
+int ble_gap_ext_adv_rsp_set_data(uint8_t instance, struct os_mbuf *data);
+int ble_gap_ext_adv_remove(uint8_t instance);
+#endif
+
 int ble_gap_disc(uint8_t own_addr_type, int32_t duration_ms,
                  const struct ble_gap_disc_params *disc_params,
                  ble_gap_event_fn *cb, void *cb_arg);

--- a/net/nimble/host/include/host/ble_hs_adv.h
+++ b/net/nimble/host/include/host/ble_hs_adv.h
@@ -158,6 +158,9 @@ struct ble_hs_adv_fields {
 
 #define BLE_HS_ADV_SVC_DATA_UUID128_MIN_LEN     16
 
+int ble_hs_adv_set_fields_mbuf(const struct ble_hs_adv_fields *adv_fields,
+                               struct os_mbuf *om);
+
 int ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
                           uint8_t *dst, uint8_t *dst_len, uint8_t max_len);
 

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -2519,6 +2519,52 @@ ble_gap_adv_set_phys(uint8_t primary_phy, uint8_t secondary_phy)
 
     return 0;
 }
+
+int
+ble_gap_ext_adv_configure(uint8_t instance,
+                          const struct ble_gap_ext_adv_params *params,
+                          int8_t *selected_tx_power,
+                          ble_gap_event_fn *cb, void *cb_arg)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_set_addr(uint8_t instance, const ble_addr_t *addr)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_start(uint8_t instance, int duration, int max_events)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_stop(uint8_t instance)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_set_data(uint8_t instance, struct os_mbuf *data)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_rsp_set_data(uint8_t instance, struct os_mbuf *data)
+{
+    return -1;
+}
+
+int
+ble_gap_ext_adv_remove(uint8_t instance)
+{
+    return -1;
+}
+
 #endif
 
 /*****************************************************************************

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -190,17 +190,11 @@ ble_gap_update_entry_remove(uint16_t conn_handle);
 static void
 ble_gap_update_l2cap_cb(uint16_t conn_handle, int status, void *arg);
 
-static int ble_gap_adv_enable_tx(int enable, bool directed);
+static int ble_gap_adv_enable_tx(int enable);
 static int ble_gap_conn_cancel_tx(void);
 
 #if NIMBLE_BLE_SCAN
 static int ble_gap_disc_enable_tx(int enable, int filter_duplicates);
-#endif
-
-#if MYNEWT_VAL(BLE_EXT_ADV)
-static uint8_t ext_adv_pri_phy = 0;
-static uint8_t ext_adv_sec_phy = 0;
-static int8_t ext_adv_tx_pwr = 127;
 #endif
 
 STATS_SECT_DECL(ble_gap_stats) ble_gap_stats;
@@ -1528,7 +1522,7 @@ ble_gap_slave_timer(void)
     /*** Timer expired; process event. */
 
     /* Stop advertising. */
-    rc = ble_gap_adv_enable_tx(0, false);
+    rc = ble_gap_adv_enable_tx(0);
     if (rc != 0) {
         /* Failed to stop advertising; try again in 100 ms. */
         return 100;
@@ -1756,34 +1750,14 @@ done:
  *****************************************************************************/
 
 static int
-ble_gap_adv_enable_tx(int enable, bool directed)
+ble_gap_adv_enable_tx(int enable)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    uint8_t buf[6];
-    struct hci_ext_adv_set set = {0, 0, 0};
-#else
     uint8_t buf[BLE_HCI_SET_ADV_ENABLE_LEN];
-#endif
     uint16_t opcode;
     int rc;
 
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_ENABLE);
-
-    if (enable && directed) {
-        set.duration = 128;
-    }
-
-    rc = ble_hs_hci_cmd_build_le_ext_adv_enable(!!enable, 1, &set, buf,
-                                                sizeof(buf));
-    if (rc != 0) {
-        return rc;
-    }
-
-#else
     opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_ENABLE);
     ble_hs_hci_cmd_build_le_set_adv_enable(!!enable, buf, sizeof buf);
-#endif
 
     rc = ble_hs_hci_cmd_tx_empty_ack(opcode, buf, sizeof(buf));
     if (rc != 0) {
@@ -1814,7 +1788,7 @@ ble_gap_adv_stop_no_lock(void)
 
     BLE_HS_LOG(INFO, "GAP procedure initiated: stop advertising.\n");
 
-    rc = ble_gap_adv_enable_tx(0, false);
+    rc = ble_gap_adv_enable_tx(0);
     if (rc != 0) {
         goto done;
     }
@@ -1844,7 +1818,7 @@ done:
 int
 ble_gap_adv_stop(void)
 {
-#if !NIMBLE_BLE_ADVERTISE
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
     return BLE_HS_ENOTSUP;
 #endif
 
@@ -1888,66 +1862,6 @@ ble_gap_adv_type(const struct ble_gap_adv_params *adv_params)
     }
 }
 
-#if MYNEWT_VAL(BLE_EXT_ADV)
-static uint16_t
-ble_gap_adv_type_to_props(int adv_type)
-{
-    uint16_t props = BLE_HCI_LE_SET_EXT_ADV_PROP_LEGACY;
-
-    switch(adv_type) {
-    case BLE_HCI_ADV_TYPE_ADV_IND:
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_CONNECTABLE;
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_SCANNABLE;
-        break;
-    case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD:
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_CONNECTABLE;
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_DIRECTED;
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_HD_DIRECTED;
-        break;
-    case BLE_HCI_ADV_TYPE_ADV_SCAN_IND:
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_SCANNABLE;
-        break;
-    case BLE_HCI_ADV_TYPE_ADV_NONCONN_IND:
-        break;
-    case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD:
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_CONNECTABLE;
-        props |= BLE_HCI_LE_SET_EXT_ADV_PROP_DIRECTED;
-        break;
-    default:
-        BLE_HS_DBG_ASSERT(0);
-        break;
-    }
-
-    return props;
-}
-
-static uint16_t
-ble_gap_ext_adv_prop(const struct ble_gap_adv_params *adv_params)
-{
-    uint16_t prop = 0;
-
-    switch (adv_params->conn_mode) {
-    case BLE_GAP_CONN_MODE_NON:
-        if (adv_params->disc_mode == BLE_GAP_DISC_MODE_NON) {
-            prop |= BLE_HCI_LE_SET_EXT_ADV_PROP_SCANNABLE;
-        }
-        break;
-    case BLE_GAP_CONN_MODE_UND:
-        prop |= BLE_HCI_LE_SET_EXT_ADV_PROP_CONNECTABLE;
-        break;
-    case BLE_GAP_CONN_MODE_DIR:
-        prop |= BLE_HCI_LE_SET_EXT_ADV_PROP_CONNECTABLE;
-        prop |= BLE_HCI_LE_SET_EXT_ADV_PROP_DIRECTED;
-        break;
-    default:
-        BLE_HS_DBG_ASSERT(0);
-        break;
-    }
-
-    return prop;
-}
-#endif
-
 static void
 ble_gap_adv_dflt_itvls(uint8_t conn_mode,
                        uint16_t *out_itvl_min, uint16_t *out_itvl_max)
@@ -1979,80 +1893,6 @@ ble_gap_adv_params_tx(uint8_t own_addr_type, const ble_addr_t *peer_addr,
                       const struct ble_gap_adv_params *adv_params)
 
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    struct hci_ext_adv_params hci_adv_params;
-    const ble_addr_t *peer_any = BLE_ADDR_ANY;
-    uint8_t buf[BLE_HCI_LE_SET_EXT_ADV_PARAM_LEN];
-    uint16_t min_int = 0, max_int = 0;
-    uint16_t props;
-    int rc;
-
-    if (peer_addr == NULL) {
-        peer_addr = peer_any;
-    }
-
-    hci_adv_params.own_addr_type = own_addr_type;
-    hci_adv_params.peer_addr_type = peer_addr->type;
-    memcpy(hci_adv_params.peer_addr, peer_addr->val,
-           sizeof hci_adv_params.peer_addr);
-
-    /* Fill optional fields if application did not specify them. */
-    if (adv_params->itvl_min == 0 && adv_params->itvl_max == 0) {
-        ble_gap_adv_dflt_itvls(adv_params->conn_mode, &min_int, &max_int);
-
-        /* TODO for now limited to legacy values*/
-        hci_adv_params.min_interval = min_int;
-        hci_adv_params.max_interval = max_int;
-
-    } else {
-        hci_adv_params.min_interval = adv_params->itvl_min;
-        hci_adv_params.max_interval = adv_params->itvl_max;
-    }
-    if (adv_params->channel_map == 0) {
-        hci_adv_params.chan_map = BLE_GAP_ADV_DFLT_CHANNEL_MAP;
-    } else {
-        hci_adv_params.chan_map = adv_params->channel_map;
-    }
-
-    /* Zero is the default value for filter policy and high duty cycle */
-    hci_adv_params.filter_policy = adv_params->filter_policy;
-    hci_adv_params.tx_power = ext_adv_tx_pwr;
-
-    /* if phy was not set this means legacy advertising PDUs */
-    if (ext_adv_pri_phy == 0) {
-        props = ble_gap_adv_type_to_props(ble_gap_adv_type(adv_params));
-
-        hci_adv_params.properties = props;
-        hci_adv_params.primary_phy = BLE_HCI_LE_PHY_1M;
-        hci_adv_params.secondary_phy = BLE_HCI_LE_PHY_1M;
-    } else {
-        /* allowed only for legacy PDUs */
-        if (adv_params->high_duty_cycle) {
-            return BLE_HS_EINVAL;
-        }
-
-        hci_adv_params.properties = ble_gap_ext_adv_prop(adv_params);
-        hci_adv_params.primary_phy = ext_adv_pri_phy;
-        hci_adv_params.secondary_phy = ext_adv_sec_phy;
-    }
-
-    hci_adv_params.max_skip = 0;
-    hci_adv_params.sid = 0;
-    hci_adv_params.scan_req_notif = 0;
-
-    rc = ble_hs_hci_cmd_build_le_ext_adv_params(0, &hci_adv_params,
-                                                buf, sizeof(buf));
-    if (rc != 0) {
-        return BLE_HS_EINVAL;
-    }
-
-    rc = ble_hs_hci_cmd_tx_empty_ack(
-        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_PARAM),
-        buf, sizeof(buf));
-    if (rc != 0) {
-        return rc;
-    }
-#else
     const ble_addr_t *peer_any = BLE_ADDR_ANY;
     struct hci_adv_params hci_adv_params;
     uint8_t buf[BLE_HCI_SET_ADV_PARAM_LEN];
@@ -2098,7 +1938,6 @@ ble_gap_adv_params_tx(uint8_t own_addr_type, const ble_addr_t *peer_addr,
     if (rc != 0) {
         return rc;
     }
-#endif
 
     return 0;
 }
@@ -2209,7 +2048,7 @@ ble_gap_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
                   const struct ble_gap_adv_params *adv_params,
                   ble_gap_event_fn *cb, void *cb_arg)
 {
-#if !NIMBLE_BLE_ADVERTISE
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
     return BLE_HS_ENOTSUP;
 #endif
 
@@ -2265,7 +2104,7 @@ ble_gap_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
 
     ble_gap_slave[0].op = BLE_GAP_OP_S_ADV;
 
-    rc = ble_gap_adv_enable_tx(1, direct_addr != NULL);
+    rc = ble_gap_adv_enable_tx(1);
     if (rc != 0) {
         ble_gap_slave_reset_state(0);
         goto done;
@@ -2299,11 +2138,11 @@ done:
 int
 ble_gap_adv_set_data(const uint8_t *data, int data_len)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    static uint8_t buf[4 + MYNEWT_VAL(BLE_EXT_ADV_MAX_SIZE)];
-#else
-    uint8_t buf[BLE_HCI_SET_ADV_DATA_LEN];
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
+    return BLE_HS_ENOTSUP;
 #endif
+
+    uint8_t buf[BLE_HCI_SET_ADV_DATA_LEN];
     uint16_t opcode;
     int rc;
 
@@ -2311,16 +2150,9 @@ ble_gap_adv_set_data(const uint8_t *data, int data_len)
 
     ble_hs_lock();
 
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_ADV_DATA);
-    rc = ble_hs_hci_cmd_build_le_ext_adv_data(0,
-                                    BLE_HCI_LE_SET_EXT_ADV_DATA_OPER_COMPLETE,
-                                    0, data, data_len, buf, sizeof(buf));
-#else
     opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_DATA);
     rc = ble_hs_hci_cmd_build_le_set_adv_data(data, data_len, buf,
                                               sizeof(buf));
-#endif
     if (rc != 0) {
         goto done;
     }
@@ -2350,26 +2182,19 @@ done:
 int
 ble_gap_adv_rsp_set_data(const uint8_t *data, int data_len)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    static uint8_t buf[4 + MYNEWT_VAL(BLE_EXT_ADV_MAX_SIZE)];
-#else
-    uint8_t buf[BLE_HCI_SET_SCAN_RSP_DATA_LEN];
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
+    return BLE_HS_ENOTSUP;
 #endif
+
+    uint8_t buf[BLE_HCI_SET_SCAN_RSP_DATA_LEN];
     uint16_t opcode;
     int rc;
 
     ble_hs_lock();
 
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_EXT_SCAN_RSP_DATA);
-    rc = ble_hs_hci_cmd_build_le_ext_adv_scan_rsp(0,
-                                BLE_HCI_LE_SET_EXT_SCAN_RSP_DATA_OPER_COMPLETE,
-                                0, data, data_len, buf, sizeof(buf));
-#else
     opcode = BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_SCAN_RSP_DATA);
     rc = ble_hs_hci_cmd_build_le_set_scan_rsp_data(data, data_len,
                                                    buf, sizeof(buf));
-#endif
     if (rc != 0) {
         rc = BLE_HS_HCI_ERR(rc);
         goto done;
@@ -2402,11 +2227,11 @@ done:
 int
 ble_gap_adv_set_fields(const struct ble_hs_adv_fields *adv_fields)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    uint8_t buf[MYNEWT_VAL(BLE_EXT_ADV_MAX_SIZE)];
-#else
-    uint8_t buf[BLE_HS_ADV_MAX_SZ];
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
+    return BLE_HS_ENOTSUP;
 #endif
+
+    uint8_t buf[BLE_HS_ADV_MAX_SZ];
     uint8_t buf_sz;
     int rc;
 
@@ -2436,11 +2261,11 @@ ble_gap_adv_set_fields(const struct ble_hs_adv_fields *adv_fields)
 int
 ble_gap_adv_rsp_set_fields(const struct ble_hs_adv_fields *rsp_fields)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    uint8_t buf[MYNEWT_VAL(BLE_EXT_ADV_MAX_SIZE)];
-#else
-    uint8_t buf[BLE_HS_ADV_MAX_SZ];
+#if !NIMBLE_BLE_ADVERTISE || MYNEWT_VAL(BLE_EXT_ADV)
+    return BLE_HS_ENOTSUP;
 #endif
+
+    uint8_t buf[BLE_HS_ADV_MAX_SZ];
     uint8_t buf_sz;
     int rc;
 
@@ -2473,56 +2298,13 @@ ble_gap_adv_active(void)
 int
 ble_gap_adv_set_tx_power(int8_t tx_power)
 {
-    ble_hs_lock();
-
-    if (ble_gap_adv_active()) {
-        ble_hs_unlock();
-        return BLE_HS_EBUSY;
-    }
-
-    ext_adv_tx_pwr = tx_power;
-
-    ble_hs_unlock();
-
-    return 0;
+    return BLE_HS_ENOTSUP;
 }
 
 int
 ble_gap_adv_set_phys(uint8_t primary_phy, uint8_t secondary_phy)
 {
-    if (primary_phy) {
-        /* primary cannot be 2M */
-        if (primary_phy != BLE_HCI_LE_PHY_1M &&
-            primary_phy != BLE_HCI_LE_PHY_CODED) {
-            return BLE_HS_EINVAL;
-        }
-
-        /* if primary is not legacy then secondary must not be legacy as
-         * well
-         */
-        if (!secondary_phy || secondary_phy > BLE_HCI_LE_PHY_CODED) {
-            return BLE_HS_EINVAL;
-        }
-    } else {
-        /* if primary is legacy then secondary must be legacy as well */
-        if (secondary_phy) {
-            return BLE_HS_EINVAL;
-        }
-    }
-
-    ble_hs_lock();
-
-    if (ble_gap_adv_active()) {
-        ble_hs_unlock();
-        return BLE_HS_EBUSY;
-    }
-
-    ext_adv_pri_phy = primary_phy;
-    ext_adv_sec_phy = secondary_phy;
-
-    ble_hs_unlock();
-
-    return 0;
+    return BLE_HS_ENOTSUP;
 }
 
 static int

--- a/net/nimble/host/src/ble_gap.c
+++ b/net/nimble/host/src/ble_gap.c
@@ -2355,18 +2355,6 @@ ble_gap_adv_active(void)
 }
 
 #if MYNEWT_VAL(BLE_EXT_ADV)
-int
-ble_gap_adv_set_tx_power(int8_t tx_power)
-{
-    return BLE_HS_ENOTSUP;
-}
-
-int
-ble_gap_adv_set_phys(uint8_t primary_phy, uint8_t secondary_phy)
-{
-    return BLE_HS_ENOTSUP;
-}
-
 static int
 ble_gap_ext_adv_params_tx(uint8_t instance,
                           const struct ble_gap_ext_adv_params *params,

--- a/net/nimble/host/src/ble_gap_priv.h
+++ b/net/nimble/host/src/ble_gap_priv.h
@@ -77,10 +77,11 @@ extern STATS_SECT_DECL(ble_gap_stats) ble_gap_stats;
 
 #if MYNEWT_VAL(BLE_EXT_ADV)
 void ble_gap_rx_ext_adv_report(struct ble_gap_ext_disc_desc *desc);
+void ble_gap_rx_adv_set_terminated(struct hci_le_adv_set_terminated *evt);
 #endif
 void ble_gap_rx_adv_report(struct ble_gap_disc_desc *desc);
 void ble_gap_rx_rd_rem_sup_feat_complete(struct hci_le_rd_rem_supp_feat_complete *evt);
-int ble_gap_rx_conn_complete(struct hci_le_conn_complete *evt);
+int ble_gap_rx_conn_complete(struct hci_le_conn_complete *evt, uint8_t instance);
 void ble_gap_rx_disconn_complete(struct hci_disconn_complete *evt);
 void ble_gap_rx_update_complete(struct hci_le_conn_upd_complete *evt);
 void ble_gap_rx_param_req(struct hci_le_conn_param_req *evt);

--- a/net/nimble/host/src/ble_hs_adv.c
+++ b/net/nimble/host/src/ble_hs_adv.c
@@ -34,8 +34,21 @@ static ble_uuid128_t ble_hs_adv_uuids128[BLE_HS_ADV_MAX_FIELD_SZ / 16];
 
 static int
 ble_hs_adv_set_hdr(uint8_t type, uint8_t data_len, uint8_t max_len,
-                   uint8_t *dst, uint8_t *dst_len)
+                   uint8_t *dst, uint8_t *dst_len, struct os_mbuf *om)
 {
+    int rc;
+
+    if (om ) {
+        data_len++;
+        rc = os_mbuf_append(om, &data_len, sizeof(data_len));
+        if (rc) {
+            return rc;
+        }
+
+        return os_mbuf_append(om, &type, sizeof(type));
+    }
+
+
     if (*dst_len + 2 + data_len > max_len) {
         return BLE_HS_EMSGSIZE;
     }
@@ -48,21 +61,22 @@ ble_hs_adv_set_hdr(uint8_t type, uint8_t data_len, uint8_t max_len,
     return 0;
 }
 
-int
-ble_hs_adv_set_flat(uint8_t type, int data_len, const void *data,
-                    uint8_t *dst, uint8_t *dst_len, uint8_t max_len)
+static int
+ble_hs_adv_set_flat_mbuf(uint8_t type, int data_len, const void *data,
+                    uint8_t *dst, uint8_t *dst_len, uint8_t max_len,
+                    struct os_mbuf *om)
 {
-#if !NIMBLE_BLE_ADVERTISE
-    return BLE_HS_ENOTSUP;
-#endif
-
     int rc;
 
     BLE_HS_DBG_ASSERT(data_len > 0);
 
-    rc = ble_hs_adv_set_hdr(type, data_len, max_len, dst, dst_len);
+    rc = ble_hs_adv_set_hdr(type, data_len, max_len, dst, dst_len, om);
     if (rc != 0) {
         return rc;
+    }
+
+    if (om) {
+        return os_mbuf_append(om, data, data_len);
     }
 
     memcpy(dst + *dst_len, data, data_len);
@@ -71,23 +85,43 @@ ble_hs_adv_set_flat(uint8_t type, int data_len, const void *data,
     return 0;
 }
 
+int
+ble_hs_adv_set_flat(uint8_t type, int data_len, const void *data,
+                    uint8_t *dst, uint8_t *dst_len, uint8_t max_len)
+{
+#if !NIMBLE_BLE_ADVERTISE
+    return BLE_HS_ENOTSUP;
+#endif
+
+    return ble_hs_adv_set_flat_mbuf(type, data_len, data, dst, dst_len, max_len,
+                                    NULL);
+}
+
 static int
 ble_hs_adv_set_array_uuid16(uint8_t type, uint8_t num_elems,
                             const ble_uuid16_t *elems, uint8_t *dst,
-                            uint8_t *dst_len, uint8_t max_len)
+                            uint8_t *dst_len, uint8_t max_len,
+                            struct os_mbuf *om)
 {
     int rc;
     int i;
 
     rc = ble_hs_adv_set_hdr(type, num_elems * 2, max_len, dst,
-                            dst_len);
+                            dst_len, om);
     if (rc != 0) {
         return rc;
     }
 
     for (i = 0; i < num_elems; i++) {
-        ble_uuid_flat(&elems[i].u, dst + *dst_len);
-        *dst_len += 2;
+        if (om) {
+            rc = ble_uuid_to_mbuf(&elems[i].u, om);
+            if (rc) {
+                return rc;
+            }
+        } else {
+            ble_uuid_flat(&elems[i].u, dst + *dst_len);
+            *dst_len += 2;
+        }
     }
 
     return 0;
@@ -96,13 +130,15 @@ ble_hs_adv_set_array_uuid16(uint8_t type, uint8_t num_elems,
 static int
 ble_hs_adv_set_array_uuid32(uint8_t type, uint8_t num_elems,
                             const ble_uuid32_t *elems, uint8_t *dst,
-                            uint8_t *dst_len, uint8_t max_len)
+                            uint8_t *dst_len, uint8_t max_len,
+                            struct os_mbuf *om)
 {
+    uint32_t uuid_le;
     int rc;
     int i;
 
     rc = ble_hs_adv_set_hdr(type, num_elems * 4, max_len, dst,
-                            dst_len);
+                            dst_len, om);
     if (rc != 0) {
         return rc;
     }
@@ -112,8 +148,16 @@ ble_hs_adv_set_array_uuid32(uint8_t type, uint8_t num_elems,
          * 128-bit as ATT requires. In AD, 32-bit UUID shall be written as an
          * actual 32-bit value.
          */
-        put_le32(dst + *dst_len, elems[i].value);
-        *dst_len += 4;
+        if (om) {
+            uuid_le = htole32(elems[i].value);
+            rc = os_mbuf_append(om, &uuid_le, sizeof(uuid_le));
+            if (rc) {
+                return rc;
+            }
+        } else {
+            put_le32(dst + *dst_len, elems[i].value);
+            *dst_len += 4;
+        }
     }
 
     return 0;
@@ -122,20 +166,28 @@ ble_hs_adv_set_array_uuid32(uint8_t type, uint8_t num_elems,
 static int
 ble_hs_adv_set_array_uuid128(uint8_t type, uint8_t num_elems,
                              const ble_uuid128_t *elems, uint8_t *dst,
-                             uint8_t *dst_len, uint8_t max_len)
+                             uint8_t *dst_len, uint8_t max_len,
+                             struct os_mbuf *om)
 {
     int rc;
     int i;
 
     rc = ble_hs_adv_set_hdr(type, num_elems * 16, max_len, dst,
-                            dst_len);
+                            dst_len, om);
     if (rc != 0) {
         return rc;
     }
 
     for (i = 0; i < num_elems; i++) {
-        ble_uuid_flat(&elems[i].u, dst + *dst_len);
-        *dst_len += 16;
+        if (om) {
+            rc = ble_uuid_to_mbuf(&elems[i].u, om);
+            if (rc) {
+                return rc;
+            }
+        } else {
+            ble_uuid_flat(&elems[i].u, dst + *dst_len);
+            *dst_len += 16;
+        }
     }
 
     return 0;
@@ -143,33 +195,39 @@ ble_hs_adv_set_array_uuid128(uint8_t type, uint8_t num_elems,
 
 static int
 ble_hs_adv_set_array16(uint8_t type, uint8_t num_elems, const uint16_t *elems,
-                       uint8_t *dst, uint8_t *dst_len, uint8_t max_len)
+                       uint8_t *dst, uint8_t *dst_len, uint8_t max_len,
+                       struct os_mbuf *om)
 {
+    uint16_t tmp;
     int rc;
     int i;
 
     rc = ble_hs_adv_set_hdr(type, num_elems * sizeof *elems, max_len, dst,
-                            dst_len);
+                            dst_len, om);
     if (rc != 0) {
         return rc;
     }
 
     for (i = 0; i < num_elems; i++) {
-        put_le16(dst + *dst_len, elems[i]);
-        *dst_len += sizeof elems[i];
+        if (om) {
+            tmp = htole16(elems[i]);
+            rc = os_mbuf_append(om, &tmp, sizeof(tmp));
+            if (rc) {
+                return rc;
+            }
+        } else {
+            put_le16(dst + *dst_len, elems[i]);
+            *dst_len += sizeof elems[i];
+        }
     }
 
     return 0;
 }
 
-/**
- * Converts a high-level set of fields to a byte buffer.
- *
- * @return                      0 on success; nonzero on failure.
- */
-int
-ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
-                      uint8_t *dst, uint8_t *dst_len, uint8_t max_len)
+static int
+adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
+                      uint8_t *dst, uint8_t *dst_len, uint8_t max_len,
+                      struct os_mbuf *om)
 {
 #if !NIMBLE_BLE_ADVERTISE
     return BLE_HS_ENOTSUP;
@@ -179,7 +237,9 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     int8_t tx_pwr_lvl;
     int rc;
 
-    *dst_len = 0;
+    if (dst_len) {
+        *dst_len = 0;
+    }
 
     /*** 0x01 - Flags. */
     /* The application has two options concerning the flags field:
@@ -190,8 +250,9 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
      * of specifying option 1 vs. 2 is sound.
      */
     if (adv_fields->flags != 0) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_FLAGS, 1, &adv_fields->flags,
-                                 dst, dst_len, max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_FLAGS, 1,
+                                      &adv_fields->flags, dst, dst_len,
+                                      max_len, om);
 
         if (rc != 0) {
             return rc;
@@ -208,7 +269,7 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
         rc = ble_hs_adv_set_array_uuid16(type, adv_fields->num_uuids16,
                                          adv_fields->uuids16, dst, dst_len,
-                                         max_len);
+                                         max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -224,7 +285,7 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
         rc = ble_hs_adv_set_array_uuid32(type, adv_fields->num_uuids32,
                                          adv_fields->uuids32, dst, dst_len,
-                                         max_len);
+                                         max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -240,7 +301,7 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
         rc = ble_hs_adv_set_array_uuid128(type, adv_fields->num_uuids128,
                                           adv_fields->uuids128, dst, dst_len,
-                                          max_len);
+                                          max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -254,8 +315,9 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
             type = BLE_HS_ADV_TYPE_INCOMP_NAME;
         }
 
-        rc = ble_hs_adv_set_flat(type, adv_fields->name_len, adv_fields->name,
-                                 dst, dst_len, max_len);
+        rc = ble_hs_adv_set_flat_mbuf(type, adv_fields->name_len,
+                                      adv_fields->name, dst, dst_len, max_len,
+                                      om);
         if (rc != 0) {
             return rc;
         }
@@ -275,8 +337,8 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
             tx_pwr_lvl = adv_fields->tx_pwr_lvl;
         }
 
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_TX_PWR_LVL, 1, &tx_pwr_lvl,
-                                 dst, dst_len, max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_TX_PWR_LVL, 1,
+                                      &tx_pwr_lvl, dst, dst_len, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -284,10 +346,10 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x12 - Slave connection interval range. */
     if (adv_fields->slave_itvl_range != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE,
-                                 BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN,
-                                 adv_fields->slave_itvl_range, dst, dst_len,
-                                 max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE,
+                                      BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN,
+                                      adv_fields->slave_itvl_range, dst,
+                                      dst_len, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -295,10 +357,10 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x16 - Service data - 16-bit UUID. */
     if (adv_fields->svc_data_uuid16 != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_SVC_DATA_UUID16,
-                                 adv_fields->svc_data_uuid16_len,
-                                 adv_fields->svc_data_uuid16, dst, dst_len,
-                                 max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID16,
+                                      adv_fields->svc_data_uuid16_len,
+                                      adv_fields->svc_data_uuid16, dst, dst_len,
+                                      max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -308,11 +370,11 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     if (adv_fields->public_tgt_addr != NULL &&
         adv_fields->num_public_tgt_addrs != 0) {
 
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_PUBLIC_TGT_ADDR,
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_PUBLIC_TGT_ADDR,
                                  BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN *
                                      adv_fields->num_public_tgt_addrs,
                                  adv_fields->public_tgt_addr, dst, dst_len,
-                                 max_len);
+                                 max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -320,10 +382,10 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x19 - Appearance. */
     if (adv_fields->appearance_is_present) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_APPEARANCE,
-                                 BLE_HS_ADV_APPEARANCE_LEN,
-                                 &adv_fields->appearance, dst, dst_len,
-                                 max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_APPEARANCE,
+                                      BLE_HS_ADV_APPEARANCE_LEN,
+                                      &adv_fields->appearance, dst, dst_len,
+                                      max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -333,7 +395,7 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     if (adv_fields->adv_itvl_is_present) {
         rc = ble_hs_adv_set_array16(BLE_HS_ADV_TYPE_ADV_ITVL, 1,
                                     &adv_fields->adv_itvl, dst, dst_len,
-                                    max_len);
+                                    max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -341,10 +403,10 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x20 - Service data - 32-bit UUID. */
     if (adv_fields->svc_data_uuid32 != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_SVC_DATA_UUID32,
-                                 adv_fields->svc_data_uuid32_len,
-                                 adv_fields->svc_data_uuid32, dst, dst_len,
-                                 max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID32,
+                                     adv_fields->svc_data_uuid32_len,
+                                     adv_fields->svc_data_uuid32, dst, dst_len,
+                                     max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -352,10 +414,10 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x21 - Service data - 128-bit UUID. */
     if (adv_fields->svc_data_uuid128 != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_SVC_DATA_UUID128,
-                                 adv_fields->svc_data_uuid128_len,
-                                 adv_fields->svc_data_uuid128, dst, dst_len,
-                                 max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID128,
+                                      adv_fields->svc_data_uuid128_len,
+                                      adv_fields->svc_data_uuid128, dst,
+                                      dst_len, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -363,8 +425,9 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0x24 - URI. */
     if (adv_fields->uri != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_URI, adv_fields->uri_len,
-                                 adv_fields->uri, dst, dst_len, max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_URI, adv_fields->uri_len,
+                                      adv_fields->uri, dst, dst_len, max_len,
+                                      om);
         if (rc != 0) {
             return rc;
         }
@@ -372,15 +435,42 @@ ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     /*** 0xff - Manufacturer specific data. */
     if (adv_fields->mfg_data != NULL) {
-        rc = ble_hs_adv_set_flat(BLE_HS_ADV_TYPE_MFG_DATA,
-                                 adv_fields->mfg_data_len,
-                                 adv_fields->mfg_data, dst, dst_len, max_len);
+        rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_MFG_DATA,
+                                      adv_fields->mfg_data_len,
+                                      adv_fields->mfg_data,
+                                      dst, dst_len, max_len, om);
         if (rc != 0) {
             return rc;
         }
     }
 
     return 0;
+}
+
+/**
+ * Converts a high-level set of fields to a byte buffer.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int
+ble_hs_adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
+                      uint8_t *dst, uint8_t *dst_len, uint8_t max_len)
+{
+#if !NIMBLE_BLE_ADVERTISE
+    return BLE_HS_ENOTSUP;
+#endif
+
+    return adv_set_fields(adv_fields, dst, dst_len, max_len, NULL);
+}
+
+int
+ble_hs_adv_set_fields_mbuf(const struct ble_hs_adv_fields *adv_fields,
+                           struct os_mbuf *om)
+{
+#if !NIMBLE_BLE_ADVERTISE
+    return BLE_HS_ENOTSUP;
+#endif
+    return adv_set_fields(adv_fields, NULL, NULL, 0, om);
 }
 
 static int

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -1471,8 +1471,8 @@ ble_hs_hci_cmd_build_le_ext_adv_set_random_addr(uint8_t handle,
 
 int
 ble_hs_hci_cmd_build_le_ext_adv_data(uint8_t handle, uint8_t operation,
-                                     uint8_t frag_pref,
-                                     const uint8_t *data, uint8_t data_len,
+                                     uint8_t frag_pref, struct os_mbuf *data,
+                                     uint8_t data_len,
                                      uint8_t *cmd, int cmd_len)
 {
     BLE_HS_DBG_ASSERT(cmd_len >= 4 + data_len);
@@ -1481,24 +1481,7 @@ ble_hs_hci_cmd_build_le_ext_adv_data(uint8_t handle, uint8_t operation,
     cmd[1] = operation;
     cmd[2] = frag_pref;
     cmd[3] = data_len;
-    memcpy(cmd + 4, data, data_len);
-
-    return 0;
-}
-
-int
-ble_hs_hci_cmd_build_le_ext_adv_scan_rsp(uint8_t handle, uint8_t operation,
-                                         uint8_t frag_pref,
-                                         const uint8_t *data, uint8_t data_len,
-                                         uint8_t *cmd, int cmd_len)
-{
-    BLE_HS_DBG_ASSERT(cmd_len >= 4 + data_len);
-
-    cmd[0] = handle;
-    cmd[1] = operation;
-    cmd[2] = frag_pref;
-    cmd[3] = data_len;
-    memcpy(cmd + 4, data, data_len);
+    os_mbuf_copydata(data, 0, data_len, cmd + 4);
 
     return 0;
 }

--- a/net/nimble/host/src/ble_hs_hci_cmd.c
+++ b/net/nimble/host/src/ble_hs_hci_cmd.c
@@ -1560,6 +1560,16 @@ ble_hs_hci_cmd_build_le_ext_adv_params(uint8_t handle,
 
     return 0;
 }
+int
+ble_hs_hci_cmd_build_le_ext_adv_remove(uint8_t handle,
+                                       uint8_t *cmd, int cmd_len)
+{
+    BLE_HS_DBG_ASSERT(cmd_len >= BLE_HCI_LE_REMOVE_ADV_SET_LEN);
+
+    cmd[0] = handle;
+
+    return 0;
+}
 #endif
 
 static int

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -212,19 +212,11 @@ ble_hs_hci_cmd_build_le_ext_adv_set_random_addr(uint8_t handle,
                                                 const uint8_t *addr,
                                                 uint8_t *cmd, int cmd_len);
 
-
-
 int
 ble_hs_hci_cmd_build_le_ext_adv_data(uint8_t handle, uint8_t operation,
-                                     uint8_t frag_pref,
-                                     const uint8_t *data, uint8_t data_len,
+                                     uint8_t frag_pref, struct os_mbuf *data,
+                                     uint8_t data_len,
                                      uint8_t *cmd, int cmd_len);
-
-int
-ble_hs_hci_cmd_build_le_ext_adv_scan_rsp(uint8_t handle, uint8_t operation,
-                                         uint8_t frag_pref,
-                                         const uint8_t *data, uint8_t data_len,
-                                         uint8_t *cmd, int cmd_len);
 
 int
 ble_hs_hci_cmd_build_le_ext_adv_enable(uint8_t enable, uint8_t sets_num,

--- a/net/nimble/host/src/ble_hs_hci_priv.h
+++ b/net/nimble/host/src/ble_hs_hci_priv.h
@@ -235,6 +235,10 @@ int
 ble_hs_hci_cmd_build_le_ext_adv_params(uint8_t handle,
                                        const struct hci_ext_adv_params *params,
                                        uint8_t *cmd, int cmd_len);
+
+int
+ble_hs_hci_cmd_build_le_ext_adv_remove(uint8_t handle,
+                                       uint8_t *cmd, int cmd_len);
 #endif
 
 int ble_hs_hci_cmd_build_le_enh_recv_test(uint8_t rx_chan, uint8_t phy,

--- a/net/nimble/host/src/ble_hs_hci_util.c
+++ b/net/nimble/host/src/ble_hs_hci_util.c
@@ -126,12 +126,7 @@ ble_hs_hci_util_read_rssi(uint16_t conn_handle, int8_t *out_rssi)
 int
 ble_hs_hci_util_set_random_addr(const uint8_t *addr)
 {
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    /* this buffer is larger and can handle both commands */
-    uint8_t buf[BLE_HCI_LE_SET_ADV_SET_RND_ADDR_LEN];
-#else
     uint8_t buf[BLE_HCI_SET_RAND_ADDR_LEN];
-#endif
     int rc;
 
     /* set the address in the controller */
@@ -147,25 +142,6 @@ ble_hs_hci_util_set_random_addr(const uint8_t *addr)
     if (rc != 0) {
         return rc;
     }
-
-#if MYNEWT_VAL(BLE_EXT_ADV)
-    /* TODO
-     * Since we currently support only 1 instance we can set random address
-     * here. For now advertising handle is hardcoded.
-     */
-    rc = ble_hs_hci_cmd_build_le_ext_adv_set_random_addr(0, addr, buf,
-                                                         sizeof(buf));
-    if (rc != 0) {
-        return rc;
-    }
-
-    rc = ble_hs_hci_cmd_tx_empty_ack(BLE_HCI_OP(BLE_HCI_OGF_LE,
-                                           BLE_HCI_OCF_LE_SET_ADV_SET_RND_ADDR),
-                                     buf, sizeof(buf));
-    if (rc != 0) {
-        return rc;
-    }
-#endif
 
     return 0;
 }

--- a/net/nimble/host/test/src/ble_gap_test.c
+++ b/net/nimble/host/test/src/ble_gap_test.c
@@ -860,7 +860,7 @@ TEST_CASE(ble_gap_test_case_conn_gen_good)
     evt.connection_handle = 2;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
     memcpy(evt.peer_addr, peer_addr.val, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
 
     TEST_ASSERT(!ble_gap_master_in_progress());
@@ -1008,7 +1008,7 @@ TEST_CASE(ble_gap_test_case_conn_gen_fail_evt)
     evt.status = BLE_ERR_CONN_ACCEPT_TMO;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
 
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure failed connect was reported to application. */
@@ -1055,7 +1055,7 @@ ble_gap_test_util_conn_cancel(uint8_t hci_status)
     memset(&evt, 0, sizeof evt);
     evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
     evt.status = BLE_ERR_UNK_CONN_ID;
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!ble_gap_master_in_progress());
 
@@ -1134,7 +1134,7 @@ TEST_CASE(ble_gap_test_case_conn_cancel_ctlr_fail)
     evt.connection_handle = 2;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
     memcpy(evt.peer_addr, peer_addr, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
 
     TEST_ASSERT(!ble_gap_master_in_progress());
@@ -1492,7 +1492,7 @@ ble_gap_test_util_adv(uint8_t own_addr_type,
             evt.connection_handle = 2;
             evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_SLAVE;
             memcpy(evt.peer_addr, peer_addr->val, 6);
-            rc = ble_gap_rx_conn_complete(&evt);
+            rc = ble_gap_rx_conn_complete(&evt, 0);
             TEST_ASSERT(rc == 0);
 
             if (connect_status == 0 ||
@@ -2773,7 +2773,7 @@ ble_gap_test_util_conn_timeout(int32_t duration_ms)
     memset(&evt, 0, sizeof evt);
     evt.subevent_code = BLE_HCI_LE_SUBEV_CONN_COMPLETE;
     evt.status = BLE_ERR_UNK_CONN_ID;
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT_FATAL(rc == 0);
 
     /* Ensure the GAP event was triggered. */

--- a/net/nimble/host/test/src/ble_hs_conn_test.c
+++ b/net/nimble/host/test/src/ble_hs_conn_test.c
@@ -70,7 +70,7 @@ TEST_CASE(ble_hs_conn_test_direct_connect_success)
     evt.connection_handle = 2;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
     memcpy(evt.peer_addr, addr.val, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!ble_gap_master_in_progress());
 
@@ -127,7 +127,7 @@ TEST_CASE(ble_hs_conn_test_direct_connectable_success)
     evt.connection_handle = 2;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_SLAVE;
     memcpy(evt.peer_addr, addr.val, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!ble_gap_master_in_progress());
     TEST_ASSERT(!ble_gap_adv_active());
@@ -192,7 +192,7 @@ TEST_CASE(ble_hs_conn_test_undirect_connectable_success)
     evt.connection_handle = 2;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_SLAVE;
     memcpy(evt.peer_addr, addr.val, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!ble_gap_master_in_progress());
     TEST_ASSERT(!ble_gap_adv_active());

--- a/net/nimble/host/test/src/ble_hs_test_util.c
+++ b/net/nimble/host/test/src/ble_hs_test_util.c
@@ -242,7 +242,7 @@ ble_hs_test_util_create_rpa_conn(uint16_t handle, uint8_t own_addr_type,
     memcpy(evt.local_rpa, our_rpa, 6);
     memcpy(evt.peer_rpa, peer_rpa, 6);
 
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
 
     evt2.subevent_code = BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT;

--- a/net/nimble/host/test/src/ble_hs_test_util_hci.c
+++ b/net/nimble/host/test/src/ble_hs_test_util_hci.c
@@ -539,7 +539,7 @@ ble_hs_test_util_hci_rx_conn_cancel_evt(void)
     evt.status = BLE_ERR_UNK_CONN_ID;
     evt.role = BLE_HCI_LE_CONN_COMPLETE_ROLE_MASTER;
 
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT_FATAL(rc == 0);
 }
 

--- a/net/nimble/host/test/src/ble_os_test.c
+++ b/net/nimble/host/test/src/ble_os_test.c
@@ -154,7 +154,7 @@ ble_gap_direct_connect_test_task_handler(void *arg)
     evt.status = BLE_ERR_SUCCESS;
     evt.connection_handle = 2;
     memcpy(evt.peer_addr, addr.val, 6);
-    rc = ble_gap_rx_conn_complete(&evt);
+    rc = ble_gap_rx_conn_complete(&evt, 0);
     TEST_ASSERT(rc == 0);
 
     /* The connection should now be created. */
@@ -316,7 +316,7 @@ ble_gap_terminate_test_task_handler(void *arg)
     conn_evt.status = BLE_ERR_SUCCESS;
     conn_evt.connection_handle = 1;
     memcpy(conn_evt.peer_addr, addr1.val, 6);
-    rc = ble_gap_rx_conn_complete(&conn_evt);
+    rc = ble_gap_rx_conn_complete(&conn_evt, 0);
     TEST_ASSERT(rc == 0);
 
     ble_hs_test_util_connect(BLE_OWN_ADDR_PUBLIC,
@@ -330,7 +330,7 @@ ble_gap_terminate_test_task_handler(void *arg)
     conn_evt.status = BLE_ERR_SUCCESS;
     conn_evt.connection_handle = 2;
     memcpy(conn_evt.peer_addr, addr2.val, 6);
-    rc = ble_gap_rx_conn_complete(&conn_evt);
+    rc = ble_gap_rx_conn_complete(&conn_evt, 0);
     TEST_ASSERT(rc == 0);
 
     TEST_ASSERT_FATAL(ble_os_test_misc_conn_exists(1));

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -1046,6 +1046,16 @@ struct hci_le_phy_upd_complete
     uint8_t rx_phy;
 };
 
+/* LE Advertising Set Terminated subevent*/
+struct hci_le_adv_set_terminated
+{
+    uint8_t subevent_code;
+    uint8_t status;
+    uint8_t adv_handle;
+    uint16_t conn_handle;
+    uint8_t completed_events;
+};
+
 #define BLE_HCI_DATA_HDR_SZ                 4
 #define BLE_HCI_DATA_HANDLE(handle_pb_bc)   (((handle_pb_bc) & 0x0fff) >> 0)
 #define BLE_HCI_DATA_PB(handle_pb_bc)       (((handle_pb_bc) & 0x3000) >> 12)

--- a/net/nimble/include/nimble/hci_common.h
+++ b/net/nimble/include/nimble/hci_common.h
@@ -491,6 +491,9 @@ extern "C" {
 #define BLE_HCI_LE_SET_EXT_ADV_PROP_LEGACY_NONCONN  (0x0010)
 
 /* --- LE set extended advertising data (OCF 0x0037) */
+#define BLE_HCI_MAX_EXT_ADV_DATA_LEN                (251)
+#define BLE_HCI_SET_EXT_ADV_DATA_HDR_LEN            (4)
+
 #define BLE_HCI_LE_SET_EXT_ADV_DATA_LEN             BLE_HCI_VARIABLE_LEN
 #define BLE_HCI_LE_SET_EXT_ADV_DATA_OPER_INT        (0)
 #define BLE_HCI_LE_SET_EXT_ADV_DATA_OPER_FIRST      (1)
@@ -499,6 +502,9 @@ extern "C" {
 #define BLE_HCI_LE_SET_EXT_ADV_DATA_OPER_UNCHANGED  (4)
 
 /* --- LE set extended scan response data (OCF 0x0038) */
+#define BLE_HCI_MAX_EXT_SCAN_RSP_DATA_LEN           (251)
+#define BLE_HCI_SET_EXT_SCAN_RSP_DATA_HDR_LEN       (4)
+
 #define BLE_HCI_LE_SET_EXT_SCAN_RSP_DATA_LEN        BLE_HCI_VARIABLE_LEN
 #define BLE_HCI_LE_SET_EXT_SCAN_RSP_DATA_OPER_INT        (0)
 #define BLE_HCI_LE_SET_EXT_SCAN_RSP_DATA_OPER_FIRST      (1)


### PR DESCRIPTION
This adds host GAP support for all features provided by Extended Advertising:
 - multiple advertising instances
 - advertising TX power configuration
 - alternate PHYs configuration
 - large advertising data

Applications are now able to control multiple advertising instances and configure them separately.
btshell application is also extended with support for all new functionalities.
