### PR TITLE
apollo2 - Ensure OS tick timer is running.

### DIFF
--- a/hw/mcu/ambiq/apollo2/src/hal_os_tick.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_os_tick.c
@@ -114,6 +114,8 @@ os_tick_idle(os_time_t ticks)
 void
 os_tick_init(uint32_t os_ticks_per_sec, int prio)
 {
+    os_sr_t sr;
+
     /* Reset the timer to 0. */
     am_hal_stimer_counter_clear();
 
@@ -131,4 +133,9 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
     NVIC_SetPriority(APOLLO2_OS_TICK_IRQ, prio);
     NVIC_SetVector(APOLLO2_OS_TICK_IRQ, (uint32_t)apollo2_os_tick_handler);
     NVIC_EnableIRQ(APOLLO2_OS_TICK_IRQ);
+
+    /* Schedule timer to interrupt at the next tick. */
+    OS_ENTER_CRITICAL(sr);
+    apollo2_os_tick_set_timer(1);
+    OS_EXIT_CRITICAL(sr);
 }

--- a/hw/mcu/ambiq/apollo2/src/hal_timer.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_timer.c
@@ -206,35 +206,33 @@ apollo2_timer_sdk_cfg(const struct apollo2_timer_cfg *cfg, uint32_t freq_hz,
         entry = apollo2_timer_tbl_find(apollo2_timer_tbl_hfrc, freq_hz);
         *out_actual_hz = entry->freq;
         *out_cfg = entry->cfg;
-        break;
+        return 0;
 
     case APOLLO2_TIMER_SOURCE_XT:
         entry = apollo2_timer_tbl_find(apollo2_timer_tbl_xt, freq_hz);
         *out_actual_hz = entry->freq;
         *out_cfg = entry->cfg;
-        break;
+        return 0;
 
     case APOLLO2_TIMER_SOURCE_LFRC:
         entry = apollo2_timer_tbl_find(apollo2_timer_tbl_lfrc, freq_hz);
         *out_actual_hz = entry->freq;
         *out_cfg = entry->cfg;
-        break;
+        return 0;
 
     case APOLLO2_TIMER_SOURCE_RTC:
         *out_actual_hz = 100;
         *out_cfg = AM_HAL_CTIMER_RTC_100HZ;
-        break;
+        return 0;
 
     case APOLLO2_TIMER_SOURCE_HCLK:
         *out_actual_hz = 48000000;
         *out_cfg = AM_HAL_CTIMER_HCLK;
-        break;
+        return 0;
 
     default:
         return SYS_EINVAL;
     }
-
-    return 0;
 }
 
 /**

--- a/hw/mcu/ambiq/apollo2/src/hal_timer.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_timer.c
@@ -779,8 +779,7 @@ hal_timer_stop(struct hal_timer *timer)
     if (reset_ocmp) {
         timer = TAILQ_FIRST(&bsp_timer->hal_timer_q);
         if (timer != NULL) {
-            TAILQ_REMOVE(&bsp_timer->hal_timer_q, timer, link);
-            hal_timer_start_at(timer, timer->expiry);
+            apollo2_timer_set_ocmp_at(bsp_timer, timer->expiry);
         } else {
             apollo2_timer_clear_ocmp(bsp_timer);
         }


### PR DESCRIPTION
The code assumes that when it does not reschedule the OS tick timer (STIMER), it will expire on the next OS tick.  This assumption failed on the first tick after startup, as the ISR hadn't run yet.  Consequently, the idle task would never terminate if a scheduling event occurred on the first tick.

The fix is to set the STIMER to expire on the next OS tick at init time.

I also snuck in a few minor fixes (second and third commits).