### PR TITLE
sys/flash_map; add flash_area_getnext_sector().

### DIFF
--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -88,6 +88,12 @@ uint8_t flash_area_align(const struct flash_area *);
  */
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
+/*
+ * Get-next interface for obtaining info about sectors.
+ * To start the get-next walk, call with *sec_id set to -1.
+ */
+int flash_area_getnext_sector(int id, int *sec_id, struct flash_area *ret);
+
 int flash_area_id_from_image_slot(int slot);
 int flash_area_id_to_image_slot(int area_id);
 

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -186,7 +186,7 @@ flash_area_is_empty(const struct flash_area *fa, bool *empty)
     uint8_t i;
     int rc;
 
-    while(data_off < fa->fa_size) {
+    while (data_off < fa->fa_size) {
         bytes_to_read = min(64, fa->fa_size - data_off);
         rc = flash_area_read(fa, data_off, data, bytes_to_read);
         if (rc) {
@@ -197,7 +197,7 @@ flash_area_is_empty(const struct flash_area *fa, bool *empty)
             goto not_empty;
           }
         }
-        data_off+=bytes_to_read;
+        data_off += bytes_to_read;
     }
     *empty = true;
     return 0;

--- a/sys/flash_map/test/src/flash_map_test.c
+++ b/sys/flash_map/test/src/flash_map_test.c
@@ -40,11 +40,13 @@ struct flash_area *fa_sectors;
 
 TEST_CASE_DECL(flash_map_test_case_1)
 TEST_CASE_DECL(flash_map_test_case_2)
+TEST_CASE_DECL(flash_map_test_case_3)
 
 TEST_SUITE(flash_map_test_suite)
 {
     flash_map_test_case_1();
     flash_map_test_case_2();
+    flash_map_test_case_3();
 }
 
 #if MYNEWT_VAL(SELFTEST)

--- a/sys/flash_map/test/src/testcases/flash_map_test_case3.c
+++ b/sys/flash_map/test/src/testcases/flash_map_test_case3.c
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "flash_map_test.h"
+
+extern struct flash_area *fa_sectors;
+
+/*
+ * Test flash_area_to_sectors() vs flash_area_getnext_sector()
+ */
+TEST_CASE(flash_map_test_case_3)
+{
+    int areas[] = {
+        FLASH_AREA_BOOTLOADER,
+        FLASH_AREA_IMAGE_0,
+        FLASH_AREA_IMAGE_1,
+        FLASH_AREA_IMAGE_SCRATCH,
+        FLASH_AREA_REBOOT_LOG,
+        FLASH_AREA_NFFS
+    };
+    int i;
+    int sec_cnt;
+    int aid;
+    int sec_idx;
+    int j;
+    int rc;
+    struct flash_area ret;
+
+    for (i = 0; i < sizeof(areas) / sizeof(areas[0]); i++) {
+        aid = areas[i];
+        rc = flash_area_to_sectors(aid, &sec_cnt, fa_sectors);
+        TEST_ASSERT_FATAL(rc == 0, "flash_area_to_sectors failed");
+
+        sec_idx = -1;
+        j = 0;
+        while (1) {
+            rc = flash_area_getnext_sector(aid, &sec_idx, &ret);
+            if (rc == 0) {
+                TEST_ASSERT(fa_sectors[j].fa_device_id == ret.fa_device_id);
+                TEST_ASSERT(fa_sectors[j].fa_id == ret.fa_id);
+                TEST_ASSERT(fa_sectors[j].fa_off == ret.fa_off);
+                TEST_ASSERT(fa_sectors[j].fa_size == ret.fa_size);
+                j++;
+            } else {
+                TEST_ASSERT(sec_cnt == j);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows user to query info about sectors within area without
having to allocate a (possibly big) array of struct flash_areas.