### PR TITLE
STM32F4 HAL: Enable timer module

### DIFF
--- a/hw/bsp/nucleo-f401re/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f401re/include/bsp/stm32f4xx_hal_conf.h
@@ -99,6 +99,7 @@
 #define HAL_RCC_MODULE_ENABLED
 #define HAL_SPI_MODULE_ENABLED
 #define HAL_CORTEX_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
 #endif
 
 /* ########################## HSE/HSI Values adaptation ##################### */


### PR DESCRIPTION
Required for the compilation of /hw/mcu/stm/stm32f4xx/src/hal_timer.c