### PR TITLE
mesh: Fix build issue

### DIFF
--- a/net/nimble/host/mesh/src/health_cli.c
+++ b/net/nimble/host/mesh/src/health_cli.c
@@ -21,6 +21,7 @@
 #include "transport.h"
 #include "access.h"
 #include "foundation.h"
+#include "mesh/health_cli.h"
 
 static s32_t msg_timeout = K_SECONDS(2);
 


### PR DESCRIPTION
repos/apache-mynewt-core/net/nimble/host/mesh/src/health_cli.c:49:16:
error: dereferencing pointer to incomplete type 'struct
bt_mesh_health_cli'
  if (health_cli->op_pending != OP_HEALTH_FAULT_STATUS) {