### PR TITLE
kernel/os_mempool: Fix for incorrect check on os_mempool_init

### DIFF
--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -90,7 +90,7 @@ os_mempool_init(struct os_mempool *mp, int blocks, int block_size,
     struct os_memblock *block_ptr;
 
     /* Check for valid parameters */
-    if (!mp || (blocks < 0) || (block_size <= sizeof(struct os_memblock))) {
+    if (!mp || (blocks < 0) || (block_size <= 0)) {
         return OS_INVALID_PARM;
     }
 


### PR DESCRIPTION
This is regression from abd8c4598b as it was changing API incorretly.
Documentation says that 'block_size' parameter in os_mempool_init() is
"Minimum size of an individual element in pool"

It does not required from the user to take into account of 'block_size'
an internal overhead which is sizeof(struct os_memblock).

The only requirement on user is to make sure that provided 'membuf' has
enough bytes which can be calculated using OS_MEMPOOL_BYTES() macro.

Without this patch we have assert when creating mempool with block_size=4