### PR TITLE
BLE Host - Don't crash if no store package.

### DIFF
--- a/net/nimble/host/src/ble_hs.c
+++ b/net/nimble/host/src/ble_hs.c
@@ -313,7 +313,10 @@ ble_hs_sync(void)
 
     if (rc == 0) {
         rc = ble_hs_misc_restore_irks();
-        assert(rc == 0);
+        if (rc != 0) {
+            BLE_HS_LOG(INFO, "Failed to restore IRKs from store; status=%d",
+                       rc);
+        }
 
         if (ble_hs_cfg.sync_cb != NULL) {
             ble_hs_cfg.sync_cb();


### PR DESCRIPTION
Prior to this change: the host asserted that IRK restoration succeeds at sync time.

After change: If IRK restoration at startup fails because there is no store package present, don't crash.