### PR TITLE
MYNEWT-879: OS scheduler issues with TAILQ_INSERT_TAIL

### DIFF
--- a/kernel/os/src/os_sched.c
+++ b/kernel/os/src/os_sched.c
@@ -65,7 +65,7 @@ os_sched_insert(struct os_task *t)
     entry = NULL;
     OS_ENTER_CRITICAL(sr);
 
-    /* If sleep list empty, add to front */
+    /* If run list empty, add to front */
     if (TAILQ_EMPTY(&g_os_run_list)) {
         TAILQ_INSERT_HEAD(&g_os_run_list, t, t_os_list);
     } else {


### PR DESCRIPTION
kernel/os: fix errors in os_sched.c related to TAILQ_INSERT_TAIL

The code needs to check if the list is empty before calling TAILQ_INSERT_TAIL as that macro does not set the first element in the list if the list is empty.