### PR TITLE
nimble/ll: Do not initiate features xchg as a slave

### DIFF
--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -2511,10 +2511,17 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2) == 1)
             ble_ll_hci_ev_le_csa(connsm);
 #endif
-        }
 
-        /* Initiate features exchange */
-        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_FEATURE_XCHG);
+            /*
+             * Initiate features exchange
+             *
+             * XXX we do this only as a master as it was observed that sending
+             * LL_SLAVE_FEATURE_REQ after connection breaks some recent iPhone
+             * models; for slave just assume master will initiate features xchg
+             * if it has some additional features to use.
+             */
+            ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_FEATURE_XCHG);
+        }
     }
 
     return rc;


### PR DESCRIPTION
This patch removes initial feature xchg from controller when connected
as a slave due to observed problems with recent iPhones (8 and X).