### PR TITLE
net/lora: display transmit power in dbm

### DIFF
--- a/apps/lora_app_shell/src/main.c
+++ b/apps/lora_app_shell/src/main.c
@@ -51,7 +51,7 @@ lora_app_shell_txd_func(uint8_t port, LoRaMacEventInfoStatus_t status,
 
     lpkt = LORA_PKT_INFO_PTR(om);
     console_printf("\tdr:%u\n", lpkt->txdinfo.datarate);
-    console_printf("\ttxpower:%d\n", lpkt->txdinfo.txpower);
+    console_printf("\ttxpower (dbm):%d\n", lpkt->txdinfo.txpower);
     console_printf("\ttries:%u\n", lpkt->txdinfo.retries);
     console_printf("\tack_rxd:%u\n", lpkt->txdinfo.ack_rxd);
     console_printf("\ttx_time_on_air:%lu\n", lpkt->txdinfo.tx_time_on_air);

--- a/net/lora/node/src/mac/LoRaMac.c
+++ b/net/lora/node/src/mac/LoRaMac.c
@@ -3416,7 +3416,7 @@ SendFrameOnChannel( ChannelParams_t channel )
 
     /* Set MCPS confirm information */
     McpsConfirm.Datarate = LoRaMacParams.ChannelsDatarate;
-    McpsConfirm.TxPower = txPowerIndex;
+    McpsConfirm.TxPower = txPower;
     McpsConfirm.UpLinkFrequency = channel.Frequency;
 
     Radio.SetChannel( channel.Frequency );


### PR DESCRIPTION
Got tired of seeing an index instead of actual transmit power in dbm.