### PR TITLE
net/lora  Add config variable for antenna switch

### DIFF
--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -85,6 +85,7 @@ syscfg.vals:
     SX1276_SPI_CS_PIN: 22
     XTAL_32768: 1
     BOOT_SERIAL_DETECT_PIN: 12
+    SX1276_HAS_ANT_SW: 1
 
 syscfg.vals.BLE_LP_CLOCK:
     OS_CPUTIME_FREQ: 32768

--- a/hw/drivers/lora/sx1276/src/sx1276-board.c
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.c
@@ -19,10 +19,12 @@ Maintainer: Miguel Luis and Gregory Cristian
 #include "sx1276.h"
 #include "sx1276-board.h"
 
+#if MYNEWT_VAL(SX1276_HAS_ANT_SW)
 /*!
  * Flag used to set the RF switch control pins in low power mode when the radio is not active.
  */
 static bool RadioIsActive = false;
+#endif
 
 /*!
  * Radio driver structure initialization
@@ -58,8 +60,10 @@ void SX1276IoInit( void )
     struct hal_spi_settings spi_settings;
     int rc;
 
+#if MYNEWT_VAL(SX1276_HAS_ANT_SW)
     rc = hal_gpio_init_out(SX1276_RXTX, 1);
     assert(rc == 0);
+#endif
 
     rc = hal_gpio_init_out(RADIO_NSS, 1);
     assert(rc == 0);
@@ -135,6 +139,7 @@ uint8_t SX1276GetPaSelect( uint32_t channel )
     }
 }
 
+#if MYNEWT_VAL(SX1276_HAS_ANT_SW)
 void SX1276SetAntSwLowPower( bool status )
 {
     if( RadioIsActive != status )
@@ -174,6 +179,7 @@ void SX1276SetAntSw( uint8_t rxTx )
         hal_gpio_write(SX1276_RXTX, 0);
     }
 }
+#endif
 
 bool SX1276CheckRfFrequency( uint32_t frequency )
 {

--- a/hw/drivers/lora/sx1276/src/sx1276-board.h
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.h
@@ -81,6 +81,7 @@ void SX1276SetRfTxPower( int8_t power );
  */
 uint8_t SX1276GetPaSelect( uint32_t channel );
 
+#if MYNEWT_VAL(SX1276_HAS_ANT_SW)
 /*!
  * \brief Set the RF Switch I/Os pins in Low Power mode
  *
@@ -108,6 +109,7 @@ void SX1276AntSwDeInit( void );
  * \param [IN] opMode Current radio operating mode
  */
 void SX1276SetAntSw( uint8_t opMode );
+#endif
 
 /*!
  * \brief Checks if the given RF frequency is supported by the hardware

--- a/hw/drivers/lora/sx1276/src/sx1276.c
+++ b/hw/drivers/lora/sx1276/src/sx1276.c
@@ -1272,6 +1272,7 @@ void SX1276Reset( void )
 
 void SX1276SetOpMode( uint8_t opMode )
 {
+#if MYNEWT_VAL(SX1276_HAS_ANT_SW)
     if( opMode == RF_OPMODE_SLEEP )
     {
         SX1276SetAntSwLowPower( true );
@@ -1288,6 +1289,7 @@ void SX1276SetOpMode( uint8_t opMode )
             SX1276SetAntSw( 0 );
         }
     }
+#endif
     SX1276Write( REG_OPMODE, ( SX1276Read( REG_OPMODE ) & RF_OPMODE_MASK ) | opMode );
 }
 

--- a/hw/drivers/lora/sx1276/syscfg.yml
+++ b/hw/drivers/lora/sx1276/syscfg.yml
@@ -29,3 +29,8 @@ syscfg.defs:
     SX1276_SPI_BAUDRATE:
         description:
         value: 500
+
+    SX1276_HAS_ANT_SW:
+        description: 'Set to 1 if board has an antenna switch'
+        value: 0
+


### PR DESCRIPTION
Not all boards will have an antenna switch. Add a mynewt variable
(defined in hw/drivers/lora/sx1276) called SX1276_HAS_ANT_SW to
distinguish boards with/without antenna switches. Note that the value should be set in the bsp (default is 0).