### PR TITLE
MYNEWT-881: SensorAPI: Add sensor_clear_high/low_thresh() API and LIS2DH12 set threshold cb fix

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -36,6 +36,8 @@
 #include <id/id.h>
 #include <os/os_time.h>
 #include <defs/error.h>
+#include <sensor/accel.h>
+#include <sensor/sensor.h>
 
 #if MYNEWT_VAL(BNO055_CLI)
 #include <bno055/bno055.h>
@@ -79,6 +81,10 @@ static const oc_handler_t sensor_oic_handler = {
 #include <services/gap/ble_svc_gap.h>
 /* Application-specified header. */
 #include "bleprph.h"
+
+struct sensor_type_traits stt;
+struct sensor_accel_data sad_low;
+struct sensor_accel_data sad_high;
 
 #if MYNEWT_VAL(SENSOR_OIC)
 static int sensor_oic_gap_event(struct ble_gap_event *event, void *arg);
@@ -271,6 +277,9 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
         BLEPRPH_LOG(INFO, "\n");
 
         oc_ble_coap_conn_del(event->disconnect.conn.conn_handle);
+
+        sensor_clear_low_thresh("lis2dh12_0", SENSOR_TYPE_ACCELEROMETER);
+        sensor_clear_high_thresh("lis2dh12_0", SENSOR_TYPE_ACCELEROMETER);
 
         /* Connection terminated; resume advertising. */
         sensor_oic_advertise();
@@ -524,6 +533,35 @@ main(int argc, char **argv)
 
     /* log reboot */
     reboot_start(hal_reset_cause());
+
+    stt = (struct sensor_type_traits) {
+        .stt_sensor_type     = SENSOR_TYPE_ACCELEROMETER,
+        .stt_low_thresh.sad = &sad_low,
+        .stt_high_thresh.sad = &sad_high,
+        .stt_algo            = SENSOR_THRESH_ALGO_WATERMARK
+    };
+
+    /* The thresholds are specified in m/s^2 */
+
+    sad_low = (struct sensor_accel_data) {
+        .sad_x = 0.6712,
+        .sad_x_is_valid = 1,
+        .sad_y = 0.6712,
+        .sad_y_is_valid = 1,
+        .sad_z = 0.6712,
+        .sad_z_is_valid = 1
+    };
+
+    sad_high = (struct sensor_accel_data) {
+        .sad_x = 0.6712,
+        .sad_x_is_valid = 1,
+        .sad_y = 0.6712,
+        .sad_y_is_valid = 1,
+        .sad_z = 0.6712,
+        .sad_z_is_valid = 1
+    };
+
+    sensor_set_thresh("lis2dh12_0", &stt);
 
     /*
      * As the last thing, process events from default event queue.

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -295,6 +295,24 @@ int
 lis2dh12_set_int2_duration(struct sensor_itf *itf, uint8_t dur);
 
 /**
+ * Disable interrupt 1
+ *
+ * @param the sensor interface
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_disable_int1(struct sensor_itf *itf);
+
+/**
+ * Disable interrupt 2
+ *
+ * @param the sensor interface
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_disable_int2(struct sensor_itf *itf);
+
+/**
  * Set high pass filter cfg
  *
  * @param the sensor interface

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -1297,7 +1297,6 @@ lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
     struct sensor_itf *itf;
     sensor_data_t low_thresh;
     sensor_data_t high_thresh;
-    struct sensor_read_ev_ctx *srec;
 
     itf = SENSOR_GET_ITF(sensor);
 
@@ -1369,12 +1368,10 @@ lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
 
         os_time_delay((OS_TICKS_PER_SEC * 100)/1000 + 1);
 
-        srec = malloc(sizeof(struct sensor_read_ev_ctx));
-        srec->srec_sensor = sensor;
-        srec->srec_type = type;
+        hal_gpio_irq_release(itf->si_low_pin);
 
-        hal_gpio_irq_init(itf->si_low_pin, lis2dh12_low_int1_irq_handler, srec,
-                          HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_NONE);
+        rc = hal_gpio_irq_init(itf->si_low_pin, lis2dh12_low_int1_irq_handler, stt,
+                               HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_NONE);
         if (rc) {
             goto err;
         }
@@ -1441,12 +1438,10 @@ lis2dh12_sensor_set_trigger_thresh(struct sensor *sensor,
 
         os_time_delay((OS_TICKS_PER_SEC * 100)/1000 + 1);
 
-        srec = malloc(sizeof(struct sensor_read_ev_ctx));
-        srec->srec_sensor = sensor;
-        srec->srec_type = type;
+        hal_gpio_irq_release(itf->si_high_pin);
 
-        hal_gpio_irq_init(itf->si_high_pin, lis2dh12_high_int2_irq_handler, srec,
-                          HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_NONE);
+        rc = hal_gpio_irq_init(itf->si_high_pin, lis2dh12_high_int2_irq_handler, stt,
+                               HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_NONE);
         if (rc) {
             goto err;
         }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -378,6 +378,17 @@ typedef int (*sensor_set_trigger_thresh_t)(struct sensor *, sensor_type_t,
                                            struct sensor_type_traits *stt);
 
 /**
+ * Clear the high/low threshold values for a specific sensor for the sensor
+ * type.
+ *
+ * @param ptr to the sensor
+ * @param type of sensor
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*sensor_clear_trigger_thresh_t)(struct sensor *, sensor_type_t);
+
+/**
  * Set the notification expectation for a targeted set of events for the
  * specific sensor. After this function returns successfully, the implementer
  * shall post corresponding event notifications to the sensor manager.
@@ -417,6 +428,8 @@ struct sensor_driver {
     sensor_get_config_func_t sd_get_config;
     sensor_set_config_func_t sd_set_config;
     sensor_set_trigger_thresh_t sd_set_trigger_thresh;
+    sensor_clear_trigger_thresh_t sd_clear_low_trigger_thresh;
+    sensor_clear_trigger_thresh_t sd_clear_high_trigger_thresh;
     sensor_set_notification_t sd_set_notification;
     sensor_unset_notification_t sd_unset_notification;
     sensor_handle_interrupt_t sd_handle_interrupt;
@@ -549,7 +562,7 @@ void sensor_unlock(struct sensor *);
 int sensor_register_listener(struct sensor *, struct sensor_listener *);
 
 /**
- * Un-register a sensor listener. This allows a calling application to unset
+ * Un-register a sensor listener. This allows a calling application to clear
  * callbacks for a given sensor object.
  *
  * @param The sensor object
@@ -818,6 +831,28 @@ sensor_get_type_traits_byname(char *, struct sensor_type_traits **,
  */
 int
 sensor_set_thresh(char *, struct sensor_type_traits *);
+
+/**
+ * Clears the low threshold for a sensor
+ *
+ * @param name of the sensor
+ * @param sensor type
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+sensor_clear_low_thresh(char *, sensor_type_t);
+
+/**
+ * Clears the high threshold for a sensor
+ *
+ * @param name of the sensor
+ * @param sensor type
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+sensor_clear_high_thresh(char *, sensor_type_t);
 
 /**
  * Set the watermark thresholds for a sensor

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -308,6 +308,8 @@ struct sensor_type_traits {
     oc_resource_t *stt_oic_res;
 #endif
 
+    struct sensor *stt_sensor;
+
     /* Next item in the sensor traits list.  The head of this list is
      * contained within the sensor object.
      */
@@ -319,13 +321,6 @@ struct sensor_notify_ev_ctx {
     struct sensor * snec_sensor;
     /* The event type */
     sensor_event_type_t snec_evtype;
-};
-
-struct sensor_read_ev_ctx {
-    /* The sensor for which the ev cb should be called */
-    struct sensor *srec_sensor;
-    /* The sensor type */
-    sensor_type_t srec_type;
 };
 
 /**

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -203,6 +203,13 @@ sensor_insert_type_trait(struct sensor *sensor, struct sensor_type_traits *stt)
     struct sensor_type_traits *cursor, *prev;
     int rc;
 
+    if (!sensor) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    stt->stt_sensor = sensor;
+
     rc = sensor_lock(sensor);
     if (rc != 0) {
         goto err;
@@ -1187,10 +1194,10 @@ static void
 sensor_read_ev_cb(struct os_event *ev)
 {
     int rc;
-    struct sensor_read_ev_ctx *srec;
+    struct sensor_type_traits *stt;
 
-    srec = ev->ev_arg;
-    rc = sensor_read(srec->srec_sensor, srec->srec_type, NULL, NULL,
+    stt = ev->ev_arg;
+    rc = sensor_read(stt->stt_sensor, stt->stt_sensor_type, NULL, NULL,
                      OS_TIMEOUT_NEVER);
     assert(rc == 0);
 }
@@ -1892,6 +1899,7 @@ sensor_set_thresh(char *devname, struct sensor_type_traits *stt)
         stt_tmp->stt_low_thresh = stt->stt_low_thresh;
         stt_tmp->stt_high_thresh = stt->stt_high_thresh;
         stt_tmp->stt_algo = stt->stt_algo;
+        stt_tmp->stt_sensor = sensor;
         sensor_unlock(sensor);
     } else {
         rc = SYS_EINVAL;


### PR DESCRIPTION
- There are two issues for calling lis2dh12_sensor_set_trigger_thresh() multiple times:

1. gpio irq was not being released before doing a re-initialization
2. srec was malloced and calling the function multiple times would have
malloced additional memory without freeing it.

Solution:
1. Release the gpio irq
2. Remove the malloc and add a ptr for the sensor in each type trait so
that a sensor read could be performed in the irq handler.

- Add sensor_clear_low_thresh() and sensor_clear_high_thresh() APIs