### PR TITLE
nimble/controller: Make sure random address is set correctly

### DIFF
--- a/net/nimble/controller/src/ble_ll_hci.c
+++ b/net/nimble/controller/src/ble_ll_hci.c
@@ -678,6 +678,13 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen)
         break;
     case BLE_HCI_OCF_LE_SET_RAND_ADDR:
         rc = ble_ll_set_random_addr(cmdbuf);
+#if MYNEWT_VAL(BLE_EXT_ADV)
+        if (rc != BLE_ERR_SUCCESS) {
+            break;
+        }
+        /* For instance 0 we need same address */
+        rc = ble_ll_adv_set_random_addr(cmdbuf, 0);
+#endif
         break;
     case BLE_HCI_OCF_LE_SET_ADV_PARAMS:
         rc = ble_ll_adv_set_adv_params(cmdbuf);


### PR DESCRIPTION
When host sets random address when advertising extensions are enabled,
we need to make sure that same address is used for instance 0 which is
legacy advertising instance