### PR TITLE
net/oic BLE; was not able to receive small requests.

### DIFF
--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -229,8 +229,8 @@ oc_ble_reass(struct os_mbuf *om1, uint16_t conn_handle, uint8_t srv_idx)
         oe_ble->conn_handle = conn_handle;
         pkt2 = OS_MBUF_PKTHDR(om2);
 
-        if (os_mbuf_copydata(om2, 0, sizeof(hdr), hdr) ||
-          coap_tcp_msg_size(hdr, sizeof(hdr)) > pkt2->omp_len) {
+        os_mbuf_copydata(om2, 0, sizeof(hdr), hdr);
+        if (coap_tcp_msg_size(hdr, sizeof(hdr)) > pkt2->omp_len) {
             STAILQ_INSERT_TAIL(&oc_ble_reass_q, pkt2, omp_next);
         } else {
             STATS_INC(oc_ble_stats, iframe);


### PR DESCRIPTION
because here the header size is < 6 bytes. We erroneously are checking return code from os_mbuf_copydata() and asking it to copy less bytes than there are in the packet.