### PR TITLE
mesh: Reset Heartbeat Publication timer before sending message

### DIFF
--- a/net/nimble/host/mesh/src/cfg_srv.c
+++ b/net/nimble/host/mesh/src/cfg_srv.c
@@ -3081,19 +3081,19 @@ static void hb_publish(struct os_event *work)
 		return;
 	}
 
-	hb_send(model);
-
 	if (cfg->hb_pub.count == 0) {
 		return;
-	}
-
-	if (cfg->hb_pub.count != 0xffff) {
-		cfg->hb_pub.count--;
 	}
 
 	period_ms = hb_pwr2(cfg->hb_pub.period, 1) * 1000;
 	if (period_ms) {
 		k_delayed_work_submit(&cfg->hb_pub.timer, period_ms);
+	}
+
+	hb_send(model);
+
+	if (cfg->hb_pub.count != 0xffff) {
+		cfg->hb_pub.count--;
 	}
 }
 

--- a/net/nimble/host/mesh/src/cfg_srv.c
+++ b/net/nimble/host/mesh/src/cfg_srv.c
@@ -3086,7 +3086,7 @@ static void hb_publish(struct os_event *work)
 	}
 
 	period_ms = hb_pwr2(cfg->hb_pub.period, 1) * 1000;
-	if (period_ms) {
+	if (period_ms && cfg->hb_pub.count > 1) {
 		k_delayed_work_submit(&cfg->hb_pub.timer, period_ms);
 	}
 


### PR DESCRIPTION
The timer should be reset before sending to ensure correct publication period.

This patch allows to pass MESH/NODE/CFG/HBP/BV-02-C.