### PR TITLE
nimble/blemesh: Use valid company id

### DIFF
--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -34,8 +34,8 @@
 
 #define BT_DBG_ENABLED (MYNEWT_VAL(BLE_MESH_DEBUG))
 
-/* Company ID*/
-#define CID_VENDOR 0xFFFF
+/* Company ID */
+#define CID_VENDOR 0x05C3
 #define STANDARD_TEST_ID 0x00
 #define TEST_ID 0x01
 static int recent_test_id = STANDARD_TEST_ID;


### PR DESCRIPTION
To avoid issues with implementation which does not support testing
company id 0xffff, lets use valid one.