### PR TITLE
apps/boot - Remove .OVERWRITE flag

### DIFF
--- a/apps/boot/pkg.yml
+++ b/apps/boot/pkg.yml
@@ -30,5 +30,5 @@ pkg.deps:
     - kernel/os
     - sys/console/stub
 
-pkg.deps.BOOT_SERIAL.OVERWRITE:
+pkg.deps.BOOT_SERIAL:
     - boot/boot_serial


### PR DESCRIPTION
apps/boot specified the .OVERWRITE flag when `BOOT_SERIAL` was set.  This flag should not be here, as the serial boot loader requires all the normal dependencies (boot/bootutil, kernel/os, and sys/console/stub).  These are required to satisfy other dependencies' API requirements.