### PR TITLE
apps: Fix symbol names for ext advertising data

### DIFF
--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -934,14 +934,14 @@ bletiny_decode_event_type(struct ble_gap_ext_disc_desc *desc)
     }
 
     switch(desc->data_status) {
-    case BLE_HCI_ADV_COMPLETED:
-        console_printf("completed");
+    case BLE_HCI_ADV_DATA_STATUS_COMPLETE:
+        console_printf("complete");
         break;
-    case BLE_HCI_ADV_INCOMPLETE:
-        console_printf("incompleted");
+    case BLE_HCI_ADV_DATA_STATUS_INCOMPLETE:
+        console_printf("incomplete");
         break;
-    case BLE_HCI_ADV_CORRUPTED:
-        console_printf("corrupted");
+    case BLE_HCI_ADV_DATA_STATUS_TRUNCATED:
+        console_printf("truncated");
         break;
     default:
         console_printf("reserved %d", desc->data_status);

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -934,14 +934,14 @@ btshell_decode_event_type(struct ble_gap_ext_disc_desc *desc)
     }
 
     switch(desc->data_status) {
-    case BLE_HCI_ADV_COMPLETED:
-        console_printf("completed");
+    case BLE_HCI_ADV_DATA_STATUS_COMPLETE:
+        console_printf("complete");
         break;
-    case BLE_HCI_ADV_INCOMPLETE:
-        console_printf("incompleted");
+    case BLE_HCI_ADV_DATA_STATUS_INCOMPLETE:
+        console_printf("incomplete");
         break;
-    case BLE_HCI_ADV_CORRUPTED:
-        console_printf("corrupted");
+    case BLE_HCI_ADV_DATA_STATUS_TRUNCATED:
+        console_printf("truncated");
         break;
     default:
         console_printf("reserved %d", desc->data_status);


### PR DESCRIPTION
Symbols for data status in extended advertising reports were changed in
a1000b8d6 so we need to adjust them in apps... or they won't build ;)