### PR TITLE
adc driver impl: correct incoming arg check

### DIFF
--- a/hw/drivers/adc/src/adc.c
+++ b/hw/drivers/adc/src/adc.c
@@ -36,7 +36,7 @@ adc_chan_config(struct adc_dev *dev, uint8_t cnum, void *data)
 {
     assert(dev->ad_funcs.af_configure_channel != NULL);
 
-    if (cnum > dev->ad_chan_count) {
+    if (cnum >= dev->ad_chan_count) {
         return (EINVAL);
     }
 
@@ -57,7 +57,7 @@ adc_chan_read(struct adc_dev *dev, uint8_t cnum, int *result)
 {
     assert(dev->ad_funcs.af_read_channel != NULL);
 
-    if (cnum > dev->ad_chan_count) {
+    if (cnum >= dev->ad_chan_count) {
         return (EINVAL);
     }
 


### PR DESCRIPTION
I noticed this while working on the nrfx drivers. This check was actually off by one I beleive