### PR TITLE
compiler: Define __MYNEWT__=1 for all builds

### DIFF
--- a/compiler/arc/compiler.yml
+++ b/compiler/arc/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arc-elf32-objdump
 compiler.path.objsize: arc-elf32-size
 compiler.path.objcopy: arc-elf32-objcopy
 
-compiler.flags.default: -mno-sdata -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections
+compiler.flags.default: -mno-sdata -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -D__MYNEWT__=1
 compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
 

--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.default: -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections
+compiler.flags.default: -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -D__MYNEWT__=1
 compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
 

--- a/compiler/arm-none-eabi-m3/compiler.yml
+++ b/compiler/arm-none-eabi-m3/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m3 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
+compiler.flags.base: -mcpu=cortex-m3 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.base, -Og -ggdb]

--- a/compiler/arm-none-eabi-m4/compiler.yml
+++ b/compiler/arm-none-eabi-m4/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m4 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
+compiler.flags.base: -mcpu=cortex-m4 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.base, -Og -ggdb]

--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m7 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
+compiler.flags.base: -mcpu=cortex-m7 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.base, -O0 -ggdb -fomit-frame-pointer]

--- a/compiler/mips/compiler.yml
+++ b/compiler/mips/compiler.yml
@@ -24,7 +24,7 @@ compiler.path.objdump: "mips-mti-elf-objdump"
 compiler.path.objsize: "mips-mti-elf-size"
 compiler.path.objcopy: "mips-mti-elf-objcopy"
 
-compiler.flags.base: -std=gnu11 -EL -mips32r2 -Wall -Werror
+compiler.flags.base: -std=gnu11 -EL -mips32r2 -Wall -Werror -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O2, -g]
 compiler.flags.optimized: [compiler.flags.base, -Os, -g]
 compiler.flags.debug: [compiler.flags.base, -g3]

--- a/compiler/riscv64/compiler.yml
+++ b/compiler/riscv64/compiler.yml
@@ -24,7 +24,7 @@ compiler.path.objdump: "riscv64-unknown-elf-objdump"
 compiler.path.objsize: "riscv64-unknown-elf-size"
 compiler.path.objcopy: "riscv64-unknown-elf-objcopy"
 
-compiler.flags.base: -std=gnu11 -Wall -Werror -Wno-format-truncation -ffunction-sections -fdata-sections -fno-builtin-printf
+compiler.flags.base: -std=gnu11 -Wall -Werror -Wno-format-truncation -ffunction-sections -fdata-sections -fno-builtin-printf -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.base, -O1 -ggdb]

--- a/compiler/sim-armv7/compiler.yml
+++ b/compiler/sim-armv7/compiler.yml
@@ -26,7 +26,7 @@ compiler.path.objdump: "objdump"
 compiler.path.objsize: "size"
 compiler.path.objcopy: "objcopy"
 compiler.flags.base: >
-    -Wall -Werror -ggdb -DARCH_sim
+    -Wall -Werror -ggdb -DARCH_sim  -D__MYNEWT__=1
 compiler.ld.resolve_circular_deps: true
 
 compiler.flags.default: [compiler.flags.base, -O1]

--- a/compiler/sim-mips/compiler.yml
+++ b/compiler/sim-mips/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: "mips-mti-linux-gnu-objdump"
 compiler.path.objsize: "mips-mti-linux-gnu-size"
 compiler.path.objcopy: "mips-mti-linux-gnu-objcopy"
 compiler.flags.base: >
-    -std=gnu11 -EL -mips32r2 -Wall -Werror -ggdb
+    -std=gnu11 -EL -mips32r2 -Wall -Werror -ggdb  -D__MYNEWT__=1
 compiler.ld.resolve_circular_deps: true
 
 compiler.flags.default: [compiler.flags.base, -O1]

--- a/compiler/sim/compiler.yml
+++ b/compiler/sim/compiler.yml
@@ -26,7 +26,7 @@ compiler.path.objdump: "objdump"
 compiler.path.objsize: "size"
 compiler.path.objcopy: "objcopy"
 compiler.flags.base: >
-    -m32 -Wall -Werror -ggdb
+    -m32 -Wall -Werror -ggdb  -D__MYNEWT__=1
 compiler.ld.resolve_circular_deps: true
 
 compiler.flags.default: [compiler.flags.base, -O1]

--- a/compiler/xc32/compiler.yml
+++ b/compiler/xc32/compiler.yml
@@ -24,7 +24,7 @@ compiler.path.objdump: "xc32-objdump"
 compiler.path.objsize: "xc32-size"
 compiler.path.objcopy: "xc32-objcopy"
 
-compiler.flags.base: -std=gnu11 -msmart-io=0
+compiler.flags.base: -std=gnu11 -msmart-io=0 -D__MYNEWT__=1
 compiler.flags.default: [compiler.flags.base, -O2, -g3]
 compiler.flags.optimized: [compiler.flags.base, -Os -g3]
 compiler.flags.debug: [compiler.flags.base, -g3]


### PR DESCRIPTION
This patch adds -D__MYNEWT__=1 for all compiler packages so we have
common symbol defined for all Mynewt builds. This will e.g. allow to
easily recognize Mynewt build when building external repositories.