### PR TITLE
nimble: Fixes for privacy

### DIFF
--- a/net/nimble/controller/include/controller/ble_ll_scan.h
+++ b/net/nimble/controller/include/controller/ble_ll_scan.h
@@ -119,6 +119,10 @@ struct ble_ll_scan_sm
     uint8_t scan_rsp_cons_ok;
     int8_t scan_rpa_index;
     uint8_t scan_peer_rpa[BLE_DEV_ADDR_LEN];
+#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY) == 1)
+    uint32_t scan_nrpa_timer;
+    uint8_t scan_nrpa[BLE_DEV_ADDR_LEN];
+#endif
 
     /* XXX: Shall we count backoff per phy? */
     uint16_t upper_limit;

--- a/net/nimble/controller/src/ble_ll_conn.c
+++ b/net/nimble/controller/src/ble_ll_conn.c
@@ -2728,6 +2728,11 @@ ble_ll_conn_req_pdu_update(struct os_mbuf *m, uint8_t *adva, uint8_t addr_type,
             }
         }
 
+        /*
+         * If peer in on resolving list, we use RPA generated with Local IRK
+         * from resolving list entry. In other case, we need to use our identity
+         * address (see  Core 5.0, Vol 6, Part B, section 6.4).
+         */
         if (rl) {
             hdr |= BLE_ADV_PDU_HDR_TXADD_RAND;
             ble_ll_resolv_gen_priv_addr(rl, 1, dptr);

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -229,12 +229,16 @@ ble_hs_pvcy_set_our_irk(const uint8_t *irk)
             return rc;
         }
 
-        /* Push a null address identity to the controller.  The controller uses
-         * this entry to generate an RPA when we do advertising with
-         * own-addr-type = rpa.
+        /*
+         * Add local IRK entry with 00:00:00:00:00:00 address. This entry will
+         * be used to generate RPA for non-directed advertising if own_addr_type
+         * is set to rpa_pub since we use all-zero address as peer addres in
+         * such case. Peer IRK should be left all-zero since this is not for an
+         * actual peer.
          */
         memset(tmp_addr, 0, 6);
-        rc = ble_hs_pvcy_add_entry(tmp_addr, 0, ble_hs_pvcy_irk);
+        memset(new_irk, 0, 16);
+        rc = ble_hs_pvcy_add_entry(tmp_addr, 0, new_irk);
         if (rc != 0) {
             return rc;
         }

--- a/net/nimble/host/src/ble_hs_pvcy.c
+++ b/net/nimble/host/src/ble_hs_pvcy.c
@@ -202,8 +202,6 @@ ble_hs_pvcy_set_our_irk(const uint8_t *irk)
     uint8_t new_irk[16];
     int rc;
 
-    memset(new_irk, 0, sizeof(new_irk));
-
     if (irk != NULL) {
         memcpy(new_irk, irk, 16);
     } else {


### PR DESCRIPTION
Few fixes for privacy.

Apparently, in some cases we need to use our identity address even when using privacy. This happens if other device is not on our resolving list so we do not have entry with local IRK to generate RPA.

- for non-directed advertising host specifies peer address as 00:00:00:00:00:00 and assuming there is corresponding entry in resolving list we use this local IRK to generate RPA for AdvA (already works like this, had to fix RPA refreshing though)
- for scanning a device which is not in our resolving list we do not have local IRK to generate RPA for ScanA, but we are allowed to use NRPA so we can safely scan anything in the vicinity (fixed here)
- for initiating with a device which is not in our resolving list we do not have local IRK to generate RPA for InitA and we also cannot use NRPA thus we need to use identity address (just added a note to make this clear)