### PR TITLE
Remove dynamic memory allocation from hal_uart.

### DIFF
--- a/hw/drivers/uart/uart_hal/src/uart_hal.c
+++ b/hw/drivers/uart/uart_hal/src/uart_hal.c
@@ -29,64 +29,67 @@
 
 #include "uart_hal/uart_hal.h"
 
-struct uart_hal_priv {
-    int unit;
-};
+inline static int
+uart_hal_dev_get_id(struct uart_dev *dev)
+{
+    return (int)(dev->ud_priv) - 1;
+}
+
+inline static void
+uart_hal_dev_set_id(struct uart_dev *dev, int id)
+{
+    dev->ud_priv = (void *)(id + 1);
+}
 
 static void
 uart_hal_start_tx(struct uart_dev *dev)
 {
-    struct uart_hal_priv *priv;
+    assert(dev->ud_priv);
 
-    priv = dev->ud_priv;
-    assert(priv);
-
-    hal_uart_start_tx(priv->unit);
+    hal_uart_start_tx(uart_hal_dev_get_id(dev));
 }
 
 static void
 uart_hal_start_rx(struct uart_dev *dev)
 {
-    struct uart_hal_priv *priv;
+    assert(dev->ud_priv);
 
-    priv = dev->ud_priv;
-
-    hal_uart_start_rx(priv->unit);
+    hal_uart_start_rx(uart_hal_dev_get_id(dev));
 }
 
 static void
 uart_hal_blocking_tx(struct uart_dev *dev, uint8_t byte)
 {
-    struct uart_hal_priv *priv;
+    assert(dev->ud_priv);
 
-    priv = dev->ud_priv;
-
-    hal_uart_blocking_tx(priv->unit, byte);
+    hal_uart_blocking_tx(uart_hal_dev_get_id(dev), byte);
 }
 
 static int
 uart_hal_open(struct os_dev *odev, uint32_t wait, void *arg)
 {
-    struct uart_hal_priv *priv;
     struct uart_conf *uc;
+    struct uart_dev *dev;
     int rc;
 
-    priv = ((struct uart_dev *)odev)->ud_priv;
-
+    dev = (struct uart_dev *)odev;
     uc = (struct uart_conf *)arg;
+
+    assert(dev->ud_priv);
+
     if (!uc) {
         return OS_EINVAL;
     }
     if (odev->od_flags & OS_DEV_F_STATUS_OPEN) {
         return OS_EBUSY;
     }
-    rc = hal_uart_init_cbs(priv->unit, uc->uc_tx_char, uc->uc_tx_done,
+    rc = hal_uart_init_cbs(uart_hal_dev_get_id(dev), uc->uc_tx_char, uc->uc_tx_done,
                            uc->uc_rx_char, uc->uc_cb_arg);
     if (rc) {
         return OS_EINVAL;
     }
 
-    rc = hal_uart_config(priv->unit, uc->uc_speed, uc->uc_databits,
+    rc = hal_uart_config(uart_hal_dev_get_id(dev), uc->uc_speed, uc->uc_databits,
       uc->uc_stopbits, (enum hal_uart_parity)uc->uc_parity, (enum hal_uart_flow_ctl)uc->uc_flow_ctl);
     if (rc) {
         return OS_EINVAL;
@@ -97,12 +100,11 @@ uart_hal_open(struct os_dev *odev, uint32_t wait, void *arg)
 static int
 uart_hal_close(struct os_dev *odev)
 {
-    struct uart_hal_priv *priv;
+    struct uart_dev *dev;
     int rc;
 
-    priv = ((struct uart_dev *)odev)->ud_priv;
-
-    rc = hal_uart_close(priv->unit);
+    dev = (struct uart_dev *)odev;
+    rc = hal_uart_close(uart_hal_dev_get_id(dev));
     if (rc) {
         return OS_EINVAL;
     }
@@ -116,32 +118,23 @@ int
 uart_hal_init(struct os_dev *odev, void *arg)
 {
     struct uart_dev *dev;
-    struct uart_hal_priv *priv;
     char ch;
 
-    priv = os_malloc(sizeof(struct uart_hal_priv));
-    if (!priv) {
-        return OS_ENOMEM;
-    }
-    priv->unit = -1;
+    dev = (struct uart_dev *)odev;
 
     ch = odev->od_name[strlen(odev->od_name) - 1];
     if (!isdigit((int) ch)) {
-        os_free(priv);
         return OS_EINVAL;
     }
-    priv->unit = ch - '0';
-
-    dev = (struct uart_dev *)odev;
+    uart_hal_dev_set_id(dev, ch - '0');
 
     OS_DEV_SETHANDLERS(odev, uart_hal_open, uart_hal_close);
 
     dev->ud_funcs.uf_start_tx = uart_hal_start_tx;
     dev->ud_funcs.uf_start_rx = uart_hal_start_rx;
     dev->ud_funcs.uf_blocking_tx = uart_hal_blocking_tx;
-    dev->ud_priv = priv;
 
-    hal_uart_init(priv->unit, arg);
+    hal_uart_init(uart_hal_dev_get_id(dev), arg);
 
     return OS_OK;
 }

--- a/hw/drivers/uart/uart_hal/src/uart_hal.c
+++ b/hw/drivers/uart/uart_hal/src/uart_hal.c
@@ -32,13 +32,13 @@
 inline static int
 uart_hal_dev_get_id(struct uart_dev *dev)
 {
-    return (int)(dev->ud_priv) - 1;
+    return (intptr_t)(dev->ud_priv) - 1;
 }
 
 inline static void
 uart_hal_dev_set_id(struct uart_dev *dev, int id)
 {
-    dev->ud_priv = (void *)(id + 1);
+    dev->ud_priv = (void *)((intptr_t)(id + 1));
 }
 
 static void


### PR DESCRIPTION
The current implementation allocates a structure with a single integer to store the ID of the uart. This PR uses the memory space of the opaque pointer to store said integer value directly and thus removes the dependency on dynamic memory allocation.

The stored ID is artificially incremented by 1 in order to distinguish between a not initialized device ID and uart "0".

Application size of a simple app using the console with the original implementation:

```
Size of Application Image: app
  FLASH   CCRAM    SRAM 
     63       0     410 *fill*
    841       0     649 apps_rfcomm.a
    874       0     112 hw_bsp_nucleo-f303k8.a
     72       0       0 hw_cmsis-core.a
    260       0       0 hw_drivers_uart_uart_hal.a
    148       0       0 hw_hal.a
   4662       0     200 hw_mcu_stm_stm32f3xx.a
   4880       0    8229 kernel_os.a
   1936       0      44 libc_baselibc.a
   2199       0     103 sys_console_full.a
    326       0     128 sys_flash_map.a
    364       0      12 sys_mfg.a
     30       0       5 sys_sysinit.a
     48       0       0 util_mem.a
     92       0       0 rfcomm-sysinit-app.a
  11170       0    2292 libg.a
   4632       0       0 libgcc.a

objsize
   text	   data	    bss	    dec	    hex	filename
  32568	   2404	   9780	  44752	   aed0	/home/markus/projects/vrc/android-rfcomm-robot/newt/bin/targets/rfcomm/app/apps/rfcomm/rfcomm.elf
```

And the same application compiled with this PR

```
Size of Application Image: app
  FLASH   CCRAM    SRAM 
     57       0     414 *fill*
    841       0     649 apps_rfcomm.a
    874       0     112 hw_bsp_nucleo-f303k8.a
     72       0       0 hw_cmsis-core.a
    280       0       0 hw_drivers_uart_uart_hal.a
    148       0       0 hw_hal.a
   4662       0     200 hw_mcu_stm_stm32f3xx.a
   4752       0    8217 kernel_os.a
   1530       0      12 libc_baselibc.a
   2199       0     103 sys_console_full.a
    326       0     128 sys_flash_map.a
    364       0      12 sys_mfg.a
     30       0       5 sys_sysinit.a
     48       0       0 util_mem.a
     92       0       0 rfcomm-sysinit-app.a
  11170       0    2292 libg.a
   4632       0       0 libgcc.a

objsize
   text	   data	    bss	    dec	    hex	filename
  32048	   2372	   9772	  44192	   aca0	/home/markus/projects/vrc/android-rfcomm-robot/newt/bin/targets/rfcomm/app/apps/rfcomm/rfcomm.elf
```

Note that the in addition to the bigger size and memory requirement of the original implementation it also requires additional memory for the dynamically allocated struct.