### PR TITLE
nimble/ll: Fix BLE_LL_CONN_INIT_MIN_WIN_OFFSET

### DIFF
--- a/net/nimble/controller/src/ble_ll_sched.c
+++ b/net/nimble/controller/src/ble_ll_sched.c
@@ -402,6 +402,8 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             assert(0);
         }
     }
+    earliest_start += MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) *
+                      BLE_LL_SCHED_32KHZ_TICKS_PER_SLOT;
     itvl_t = connsm->conn_itvl_ticks;
 
     /* We have to find a place for this schedule */
@@ -630,6 +632,8 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             assert(0);
         }
     }
+    earliest_start += MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) *
+                      BLE_LL_SCHED_32KHZ_TICKS_PER_SLOT;
     earliest_end = earliest_start + dur;
     itvl_t = connsm->conn_itvl_ticks;
 


### PR DESCRIPTION
The code which calculates earliest connection event start does not take
BLE_LL_CONN_INIT_MIN_WIN_OFFSET into account, but we still update tx
windows offset in state machine with its value. As a result when this
setting is set to non-zero value we schedule first connection event
earlier than what slave calculates from CONNECT_IND PDU so connection
cannot be established.