### PR TITLE
apps/ble: Fix GATT discovery in some apps

### DIFF
--- a/apps/blecent/src/peer.c
+++ b/apps/blecent/src/peer.c
@@ -435,7 +435,7 @@ peer_disc_chrs(struct peer *peer)
 int
 peer_svc_is_empty(const struct peer_svc *svc)
 {
-    return svc->svc.end_handle < svc->svc.start_handle;
+    return svc->svc.end_handle <= svc->svc.start_handle;
 }
 
 static struct peer_svc *

--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -74,7 +74,6 @@ SLIST_HEAD(bletiny_chr_list, bletiny_chr);
 struct bletiny_svc {
     SLIST_ENTRY(bletiny_svc) next;
     struct ble_gatt_svc svc;
-    bool char_disc_sent;
     struct bletiny_chr_list chrs;
 };
 

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -722,12 +722,7 @@ bletiny_disc_full_chrs(uint16_t conn_handle)
     }
 
     SLIST_FOREACH(svc, &conn->svcs, next) {
-        if (!svc_is_empty(svc) && !svc->char_disc_sent) {
-            /* Since it might happen that service does not have characteristics
-             * for some reason, lets keep track on services for which we send
-             * characteristic discovery
-             */
-            svc->char_disc_sent = true;
+        if (!svc_is_empty(svc) && SLIST_EMPTY(&svc->chrs)) {
             rc = bletiny_disc_all_chrs(conn_handle, svc->svc.start_handle,
                                        svc->svc.end_handle);
             if (rc != 0) {

--- a/apps/bletiny/src/misc.c
+++ b/apps/bletiny/src/misc.c
@@ -76,7 +76,7 @@ print_uuid(const ble_uuid_t *uuid)
 int
 svc_is_empty(const struct bletiny_svc *svc)
 {
-    return svc->svc.end_handle < svc->svc.start_handle;
+    return svc->svc.end_handle <= svc->svc.start_handle;
 }
 
 uint16_t

--- a/apps/bsncent/src/peer.c
+++ b/apps/bsncent/src/peer.c
@@ -435,7 +435,7 @@ peer_disc_chrs(struct peer *peer)
 int
 peer_svc_is_empty(const struct peer_svc *svc)
 {
-    return svc->svc.end_handle < svc->svc.start_handle;
+    return svc->svc.end_handle <= svc->svc.start_handle;
 }
 
 static struct peer_svc *

--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -63,8 +63,6 @@ SLIST_HEAD(btshell_chr_list, btshell_chr);
 struct btshell_svc {
     SLIST_ENTRY(btshell_svc) next;
     struct ble_gatt_svc svc;
-
-    bool char_disc_sent;
     struct btshell_chr_list chrs;
 };
 

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -733,12 +733,7 @@ btshell_disc_full_chrs(uint16_t conn_handle)
     }
 
     SLIST_FOREACH(svc, &conn->svcs, next) {
-        if (!svc_is_empty(svc) && !svc->char_disc_sent) {
-            /* Since it might happen that service does not have characteristics
-             * for some reason, lets keep track on services for which we send
-             * characteristic discovery
-             */
-            svc->char_disc_sent = true;
+        if (!svc_is_empty(svc) && SLIST_EMPTY(&svc->chrs)) {
             rc = btshell_disc_all_chrs(conn_handle, svc->svc.start_handle,
                                        svc->svc.end_handle);
             if (rc != 0) {

--- a/apps/btshell/src/misc.c
+++ b/apps/btshell/src/misc.c
@@ -76,7 +76,7 @@ print_uuid(const ble_uuid_t *uuid)
 int
 svc_is_empty(const struct btshell_svc *svc)
 {
-    return svc->svc.end_handle < svc->svc.start_handle;
+    return svc->svc.end_handle <= svc->svc.start_handle;
 }
 
 uint16_t


### PR DESCRIPTION
This fixes an issue with GATT discovery in few sample apps which
results in an infinite loop with characteristics discovery if peer's
database has service with no characteristics due to invalid check for
empty service.

The same fix is applied to bletiny and btshell which do not have this
issue anymore, but the original fix just hidden the issue instead of
fixing the root cause.