### PR TITLE
fixing sr_from_macro global symbol conflict

### DIFF
--- a/hw/mcu/nordic/include/nrfx_glue.h
+++ b/hw/mcu/nordic/include/nrfx_glue.h
@@ -97,7 +97,7 @@ extern "C" {
 /**
  * @brief Macro for entering into a critical section.
  */
-os_sr_t sr_from_macro;
+static os_sr_t sr_from_macro __attribute__((unused));
 
 #define NRFX_CRITICAL_SECTION_ENTER() OS_ENTER_CRITICAL(sr_from_macro);
 


### PR DESCRIPTION
This PR fixes the Global Symbol Conflict on sr_from_macro