### PR TITLE
oic: fixing `oc_resource_t` structure arrangement

### DIFF
--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -45,6 +45,7 @@
 /* OIC */
 #include <oic/oc_rep.h>
 #include <oic/oc_ri.h>
+#include <oic/oc_ri_const.h>
 #include <oic/oc_api.h>
 #include <oic/messaging/coap/observe.h>
 

--- a/net/oic/include/oic/oc_api.h
+++ b/net/oic/include/oic/oc_api.h
@@ -19,6 +19,7 @@
 
 #include "oic/port/mynewt/config.h"
 #include "oic/oc_ri.h"
+#include "oic/oc_ri_const.h"
 #include "oic/oc_api.h"
 #include "oic/port/oc_storage.h"
 #include "oic/messaging/coap/coap.h"

--- a/net/oic/include/oic/oc_client_state.h
+++ b/net/oic/include/oic/oc_client_state.h
@@ -21,6 +21,7 @@
 
 #include "oic/messaging/coap/constants.h"
 #include "oic/oc_ri.h"
+#include "oic/oc_ri_const.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/net/oic/include/oic/oc_core_res.h
+++ b/net/oic/include/oic/oc_core_res.h
@@ -17,6 +17,7 @@
 #ifndef OC_CORE_RES_H
 #define OC_CORE_RES_H
 
+#include "oc_ri_const.h"
 #include "oc_ri.h"
 
 #ifdef __cplusplus

--- a/net/oic/include/oic/oc_ri.h
+++ b/net/oic/include/oic/oc_ri.h
@@ -21,49 +21,11 @@
 #include "oic/port/oc_connectivity.h"
 #include "oic/oc_rep.h"
 #include "oic/oc_uuid.h"
+#include "oic/oc_ri_const.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef enum { OC_GET = 1, OC_POST, OC_PUT, OC_DELETE } oc_method_t;
-
-typedef enum oc_resource_properties {
-  OC_DISCOVERABLE = (1 << 0),
-  OC_OBSERVABLE = (1 << 1),
-  OC_ACTIVE = (1 << 2),
-  OC_SECURE = (1 << 4),
-  OC_PERIODIC = (1 << 6),
-  OC_TRANS_ENC = (1 << 7),    /* Requires transport layer encryption. */
-  OC_TRANS_AUTH = (1 << 8),   /* Requires transport layer authentication. */
-} oc_resource_properties_t;
-
-#define OC_TRANS_SEC_MASK (OC_TRANS_ENC | OC_TRANS_AUTH)
-
-typedef enum {
-  OC_STATUS_OK = 0,
-  OC_STATUS_CREATED,
-  OC_STATUS_CHANGED,
-  OC_STATUS_DELETED,
-  OC_STATUS_NOT_MODIFIED,
-  OC_STATUS_BAD_REQUEST,
-  OC_STATUS_UNAUTHORIZED,
-  OC_STATUS_BAD_OPTION,
-  OC_STATUS_FORBIDDEN,
-  OC_STATUS_NOT_FOUND,
-  OC_STATUS_METHOD_NOT_ALLOWED,
-  OC_STATUS_NOT_ACCEPTABLE,
-  OC_STATUS_REQUEST_ENTITY_TOO_LARGE,
-  OC_STATUS_UNSUPPORTED_MEDIA_TYPE,
-  OC_STATUS_INTERNAL_SERVER_ERROR,
-  OC_STATUS_NOT_IMPLEMENTED,
-  OC_STATUS_BAD_GATEWAY,
-  OC_STATUS_SERVICE_UNAVAILABLE,
-  OC_STATUS_GATEWAY_TIMEOUT,
-  OC_STATUS_PROXYING_NOT_SUPPORTED,
-  __NUM_OC_STATUS_CODES__,
-  OC_IGNORE
-} oc_status_t;
 
 struct oc_separate_response;
 struct oc_response_buffer;
@@ -73,30 +35,6 @@ typedef struct oc_response {
     struct oc_separate_response *separate_response;
     struct oc_response_buffer *response_buffer;
 } oc_response_t;
-
-typedef enum {
-  OC_IF_BASELINE = 1 << 1,
-  OC_IF_LL = 1 << 2,
-  OC_IF_B = 1 << 3,
-  OC_IF_R = 1 << 4,
-  OC_IF_RW = 1 << 5,
-  OC_IF_A = 1 << 6,
-  OC_IF_S = 1 << 7,
-} oc_interface_mask_t;
-
-typedef enum {
-  OCF_RES = 0,
-  OCF_P,
-#ifdef OC_SECURITY
-  OCF_SEC_DOXM,
-  OCF_SEC_PSTAT,
-  OCF_SEC_ACL,
-  OCF_SEC_CRED,
-#endif
-  __NUM_OC_CORE_RESOURCES__
-} oc_core_resource_t;
-
-#define NUM_OC_CORE_RESOURCES (__NUM_OC_CORE_RESOURCES__ + MAX_NUM_DEVICES)
 
 typedef struct oc_request {
     struct oc_endpoint *origin;

--- a/net/oic/include/oic/oc_ri_const.h
+++ b/net/oic/include/oic/oc_ri_const.h
@@ -1,0 +1,83 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef OC_RI_CONST_H
+#define OC_RI_CONST_H
+
+typedef enum { OC_GET = 1, OC_POST, OC_PUT, OC_DELETE } oc_method_t;
+
+typedef enum {
+  OC_IF_BASELINE = 1 << 1,
+  OC_IF_LL = 1 << 2,
+  OC_IF_B = 1 << 3,
+  OC_IF_R = 1 << 4,
+  OC_IF_RW = 1 << 5,
+  OC_IF_A = 1 << 6,
+  OC_IF_S = 1 << 7,
+} oc_interface_mask_t;
+
+typedef enum {
+  OC_STATUS_OK = 0,
+  OC_STATUS_CREATED,
+  OC_STATUS_CHANGED,
+  OC_STATUS_DELETED,
+  OC_STATUS_NOT_MODIFIED,
+  OC_STATUS_BAD_REQUEST,
+  OC_STATUS_UNAUTHORIZED,
+  OC_STATUS_BAD_OPTION,
+  OC_STATUS_FORBIDDEN,
+  OC_STATUS_NOT_FOUND,
+  OC_STATUS_METHOD_NOT_ALLOWED,
+  OC_STATUS_NOT_ACCEPTABLE,
+  OC_STATUS_REQUEST_ENTITY_TOO_LARGE,
+  OC_STATUS_UNSUPPORTED_MEDIA_TYPE,
+  OC_STATUS_INTERNAL_SERVER_ERROR,
+  OC_STATUS_NOT_IMPLEMENTED,
+  OC_STATUS_BAD_GATEWAY,
+  OC_STATUS_SERVICE_UNAVAILABLE,
+  OC_STATUS_GATEWAY_TIMEOUT,
+  OC_STATUS_PROXYING_NOT_SUPPORTED,
+  __NUM_OC_STATUS_CODES__,
+  OC_IGNORE
+} oc_status_t;
+
+typedef enum oc_resource_properties {
+  OC_DISCOVERABLE = (1 << 0),
+  OC_OBSERVABLE = (1 << 1),
+  OC_ACTIVE = (1 << 2),
+  OC_SECURE = (1 << 4),
+  OC_PERIODIC = (1 << 6),
+  OC_TRANS_ENC = (1 << 7),    /* Requires transport layer encryption. */
+  OC_TRANS_AUTH = (1 << 8),   /* Requires transport layer authentication. */
+} oc_resource_properties_t;
+
+#define OC_TRANS_SEC_MASK (OC_TRANS_ENC | OC_TRANS_AUTH)
+
+typedef enum {
+  OCF_RES = 0,
+  OCF_P,
+#ifdef OC_SECURITY
+  OCF_SEC_DOXM,
+  OCF_SEC_PSTAT,
+  OCF_SEC_ACL,
+  OCF_SEC_CRED,
+#endif
+  __NUM_OC_CORE_RESOURCES__
+} oc_core_resource_t;
+
+#define NUM_OC_CORE_RESOURCES (__NUM_OC_CORE_RESOURCES__ + MAX_NUM_DEVICES)
+
+#endif /* OC_RI_CONST_H */

--- a/net/oic/include/oic/port/mynewt/transport.h
+++ b/net/oic/include/oic/port/mynewt/transport.h
@@ -23,6 +23,7 @@
 #include <os/queue.h>
 
 #include "oic/oc_ri.h"
+#include "oic/oc_ri_const.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,7 +34,6 @@ extern "C" {
 #define OC_TRANSPORT_USE_TCP (1 << 0)
 
 struct oc_endpoint;
-enum oc_resource_properties;
 
 struct oc_transport {
     uint8_t ot_flags;

--- a/net/oic/src/api/oc_ri.c
+++ b/net/oic/src/api/oc_ri.c
@@ -39,6 +39,7 @@
 #include "oic/oc_discovery.h"
 #include "oic/oc_ri.h"
 #include "oic/oc_uuid.h"
+#include "oic/oc_ri_const.h"
 #include "api/oc_priv.h"
 
 #ifdef OC_SECURITY


### PR DESCRIPTION
- Because of the enum forward declaration, oc_resource_t
  arrangement was different for oc_ri.c and oc_core_res.c
  source files.
- This fixes #834