### PR TITLE
PWM add cycle interrupt handling to pwm_nrf52 driver

### DIFF
--- a/apps/pwm_test/pkg.yml
+++ b/apps/pwm_test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
     - kernel/os
     - sys/console/full
     - hw/drivers/pwm
+    - util/easing

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -99,6 +99,8 @@ typedef int (*pwm_get_resolution_bits_func_t) (struct pwm_dev *);
  */
 typedef int (*pwm_disable_func_t) (struct pwm_dev *, uint8_t);
 
+typedef void (*user_handler_t) (void*);
+
 struct pwm_driver_funcs {
     pwm_configure_channel_func_t pwm_configure_channel;
     pwm_enable_duty_cycle_func_t pwm_enable_duty_cycle;
@@ -121,11 +123,16 @@ struct pwm_dev {
  *
  * pin - The pin to be assigned to this pwm channel.
  * inverted - Whether this channel's output polarity is inverted or not.
- * data - A pointer do a driver specific parameter.
+ * user_handler - A pointer to a user_handler_t function for a cycle interrupt.
+ * cycle_int_prio - The cycle interrupt priority.
+ * data - A pointer do a driver specific parameter, if cycle_handler is set it
+ *  will be passed to it as a parameter.
  */
 struct pwm_chan_cfg {
     uint8_t pin;
     bool inverted;
+    user_handler_t cycle_handler;
+    uint32_t cycle_int_prio;
     void* data;
 };
 

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -135,7 +135,7 @@ struct pwm_dev {
  * pin - The pin to be assigned to this pwm channel.
  * inverted - Whether this channel's output polarity is inverted or not.
  * n_cycles - The number of cycles for the channel to play. 0 for loop mode.
- * interrupts - Whether interruptions are to be used or not.
+ * interrupts - Whether interruptions are to be configured or not.
  * data - Driver specific data.
  */
 struct pwm_chan_cfg {

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -42,7 +42,7 @@ typedef int (*pwm_configure_channel_func_t)(struct pwm_dev *,
                                             uint8_t,
                                             struct pwm_chan_cfg *);
 
- /**
+/**
  * Enable the PWM with specified duty cycle.
  *
  * This duty cycle is a fractional duty cycle where 0 == off, 65535=on,
@@ -81,6 +81,16 @@ typedef int (*pwm_set_frequency_func_t) (struct pwm_dev *, uint32_t);
 typedef int (*pwm_get_clock_freq_func_t) (struct pwm_dev *);
 
 /**
+ * Get the top value for the cycle counter, i.e. the value which sets
+ * the duty cycle to 100%.
+ *
+ * @param dev
+ *
+ * @return value in cycles on success, negative on error.
+ */
+typedef int (*pwm_get_top_value_funct_t) (struct pwm_dev *dev);
+
+/**
  * Get the resolution of the PWM in bits.
  *
  * @param dev The device to query.
@@ -106,6 +116,7 @@ struct pwm_driver_funcs {
     pwm_enable_duty_cycle_func_t pwm_enable_duty_cycle;
     pwm_set_frequency_func_t pwm_set_frequency;
     pwm_get_clock_freq_func_t pwm_get_clock_freq;
+    pwm_get_top_value_funct_t pwm_get_top_value;
     pwm_get_resolution_bits_func_t pwm_get_resolution_bits;
     pwm_disable_func_t pwm_disable;
 };
@@ -123,29 +134,43 @@ struct pwm_dev {
  *
  * pin - The pin to be assigned to this pwm channel.
  * inverted - Whether this channel's output polarity is inverted or not.
- * int_prio - Driver Interrupts priority.
- * cycle_handler - A pointer to a user_handler_t function for a cycle interrupt.
- * seq_end_handler - A pointer to a user_handler_t function for a end-of-sequence interrupt.
- * cycle_data - User data to be passed to cycle_handler as a parameter.
- * seq_end_data - User data to be passed to seq_end_handler as a parameter.
+ * n_cycles - The number of cycles for the channel to play. 0 for loop mode.
+ * interrupts - Whether interruptions are to be used or not.
  * data - Driver specific data.
  */
 struct pwm_chan_cfg {
     uint8_t pin;
     bool inverted;
     uint32_t n_cycles;
+    bool interrupts_cfg;
+    void* data;
+};
+
+/**
+ * PWM device interrupt configuration data.
+ *
+ * int_prio - Driver Interrupts priority.
+ * cycle_handler - A pointer to a user_handler_t function for a cycle interrupt.
+ * seq_end_handler - A pointer to a user_handler_t function for
+ * a end-of-sequence interrupt.
+ * cycle_data - User data to be passed to cycle_handler as a parameter.
+ * seq_end_data - User data to be passed to seq_end_handler as a parameter.
+ *
+ */
+struct pwm_dev_interrupt_cfg {
+    struct pwm_chan_cfg cfg;
     uint32_t int_prio;
     user_handler_t cycle_handler;
     user_handler_t seq_end_handler;
     void* cycle_data;
     void* seq_end_data;
-    void* data;
 };
 
 int pwm_chan_config(struct pwm_dev *dev, uint8_t cnum, struct pwm_chan_cfg *cfg);
 int pwm_enable_duty_cycle(struct pwm_dev *pwm_d, uint8_t cnum, uint16_t fraction);
 int pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz);
 int pwm_get_clock_freq(struct pwm_dev *dev);
+int pwm_get_top_value(struct pwm_dev *dev);
 int pwm_get_resolution_bits(struct pwm_dev *dev);
 int pwm_disable(struct pwm_dev *dev, uint8_t cnum);
 

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -99,13 +99,6 @@ typedef int (*pwm_get_resolution_bits_func_t) (struct pwm_dev *);
  */
 typedef int (*pwm_disable_func_t) (struct pwm_dev *, uint8_t);
 
-/**
- * User interrupt handler.
- *
- * @param user_data Pointer to user data.
- *
- * @return 0 on success, negative on error.
- */
 typedef void (*user_handler_t) (void*);
 
 struct pwm_driver_funcs {
@@ -130,16 +123,22 @@ struct pwm_dev {
  *
  * pin - The pin to be assigned to this pwm channel.
  * inverted - Whether this channel's output polarity is inverted or not.
- * user_handler - A pointer to a user_handler_t function for a cycle interrupt.
- * cycle_int_prio - The cycle interrupt priority.
- * data - A pointer do a driver specific parameter, if cycle_handler is set it
- *  will be passed to it as a parameter.
+ * int_prio - Driver Interrupts priority.
+ * cycle_handler - A pointer to a user_handler_t function for a cycle interrupt.
+ * seq_end_handler - A pointer to a user_handler_t function for a end-of-sequence interrupt.
+ * cycle_data - User data to be passed to cycle_handler as a parameter.
+ * seq_end_data - User data to be passed to seq_end_handler as a parameter.
+ * data - Driver specific data.
  */
 struct pwm_chan_cfg {
     uint8_t pin;
     bool inverted;
-    uint32_t cycle_int_prio;
+    uint32_t n_cycles;
+    uint32_t int_prio;
     user_handler_t cycle_handler;
+    user_handler_t seq_end_handler;
+    void* cycle_data;
+    void* seq_end_data;
     void* data;
 };
 

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -99,6 +99,13 @@ typedef int (*pwm_get_resolution_bits_func_t) (struct pwm_dev *);
  */
 typedef int (*pwm_disable_func_t) (struct pwm_dev *, uint8_t);
 
+/**
+ * User interrupt handler.
+ *
+ * @param user_data Pointer to user data.
+ *
+ * @return 0 on success, negative on error.
+ */
 typedef void (*user_handler_t) (void*);
 
 struct pwm_driver_funcs {
@@ -131,8 +138,8 @@ struct pwm_dev {
 struct pwm_chan_cfg {
     uint8_t pin;
     bool inverted;
-    user_handler_t cycle_handler;
     uint32_t cycle_int_prio;
+    user_handler_t cycle_handler;
     void* data;
 };
 

--- a/hw/drivers/pwm/src/pwm.c
+++ b/hw/drivers/pwm/src/pwm.c
@@ -101,6 +101,22 @@ pwm_get_clock_freq(struct pwm_dev *dev)
 }
 
 /**
+ * Get the top value for the cycle counter, i.e. the value which sets
+ * the duty cycle to 100%.
+ *
+ * @param dev
+ *
+ * @return value in cycles on success, negative on error.
+ */
+int
+pwm_get_top_value(struct pwm_dev *dev)
+{
+    assert(dev->pwm_funcs.pwm_get_top_value != NULL);
+
+    return (dev->pwm_funcs.pwm_get_top_value(dev));
+}
+
+/**
  * Get the resolution of the PWM in bits.
  *
  * @param dev The device to query.


### PR DESCRIPTION
To-Do:

- [x] have the user set interrupt priority  
- [x] have a default and a n cycle mode, where pwm plays for n cycles.  
- [x] update pwm_test in order to have this working there (use easing lib? https://github.com/apache/mynewt-core/pull/822)
- [x] cleanup/refactor 