### PR TITLE
nimble/ll: Fix sending HCI Number of Completed Packets event

### DIFF
--- a/net/nimble/controller/src/ble_ll_conn_hci.c
+++ b/net/nimble/controller/src/ble_ll_conn_hci.c
@@ -279,8 +279,8 @@ ble_ll_conn_num_comp_pkts_event_send(struct ble_ll_conn_sm *connsm)
      * have completed but there are data packets in the controller buffers
      * (i.e. enqueued in a connection state machine).
      */
-    if ((uint32_t)(g_ble_ll_last_num_comp_pkt_evt - os_time_get()) <
-         (MYNEWT_VAL(BLE_NUM_COMP_PKT_RATE) * OS_TICKS_PER_SEC)) {
+    if ((int32_t)(os_time_get() - g_ble_ll_last_num_comp_pkt_evt) <
+                                            MYNEWT_VAL(BLE_NUM_COMP_PKT_RATE)) {
         /*
          * If this connection has completed packets, send an event right away.
          * We do this to increase throughput but we dont want to search the
@@ -354,8 +354,7 @@ skip_conn:
     }
 
     if (event_sent) {
-        g_ble_ll_last_num_comp_pkt_evt = os_time_get() +
-            (MYNEWT_VAL(BLE_NUM_COMP_PKT_RATE) * OS_TICKS_PER_SEC);
+        g_ble_ll_last_num_comp_pkt_evt = os_time_get();
     }
 }
 

--- a/net/nimble/controller/syscfg.yml
+++ b/net/nimble/controller/syscfg.yml
@@ -79,7 +79,7 @@ syscfg.defs:
             Determines the maximum rate at which the controller will send the
             number of completed packets event to the host. Rate is in os time
             ticks.
-        value: '((2000 * OS_TICKS_PER_SEC) / 1000)'
+        value: '(2 * OS_TICKS_PER_SEC)'
 
     BLE_LL_MFRG_ID:
         description: >


### PR DESCRIPTION
The calculations for sending this HCI event periodically seem strange,
probably something was mixed up in the past here.

After fix I believe this does what it is supposed to do: every X ticks
we'll just go through all connections and send HCI event no matter if
there is something to send or not.

Also added some with reference to spec section.