### PR TITLE
Bug fix for SCL being held low after NACK on NRF52

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -302,6 +302,10 @@ err:
     if (regs && regs->EVENTS_ERROR) {
         rc = regs->ERRORSRC;
         regs->ERRORSRC = rc;
+
+        // Disable/re-enable to release SCL after an error
+        regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+        regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
     }
     return (rc);
 }
@@ -367,6 +371,10 @@ err:
     if (regs && regs->EVENTS_ERROR) {
         rc = regs->ERRORSRC;
         regs->ERRORSRC = rc;
+
+        // Disable/re-enable to release SCL after an error
+        regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+        regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
     }
     return (rc);
 }


### PR DESCRIPTION
For some reason SCL is held low by the nrf52832 after a NACK.
For an example of the bug (and fix) using the NRF52, see:
https://github.com/alvarop/i2ctest