### PR TITLE
Fix build when no console device is selected

### DIFF
--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -59,6 +59,12 @@ static uint8_t cur, end;
 static struct os_eventq *avail_queue;
 static struct os_eventq *lines_queue;
 
+int __attribute__((weak))
+console_out(int c)
+{
+    return c;
+}
+
 void
 console_write(const char *str, int cnt)
 {


### PR DESCRIPTION
This enables building console/minimal when CONSOLE_UART and CONSOLE_RTT are both disabled, and allows console to be effectively "disabled" when no uart/rtt was built but console/minimal was added as dependency.

This mimics a change that was already applied on console/full.

Signed-off-by: Fabio Utzig <utzig@apache.org>