### PR TITLE
Replace hardcoded SVC IRQ number with #define

### DIFF
--- a/hw/mcu/stm/stm32f1xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define SVC_IRQ_NUMBER SVCall_IRQn
+
 /*
  * Defines for naming GPIOs.
  */

--- a/hw/mcu/stm/stm32l1xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32l1xx/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define SVC_IRQ_NUMBER SVC_IRQn
+
 /*
  * Defines for naming GPIOs.
  */

--- a/kernel/os/src/arch/cortex_m3/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m3/os_arch_arm.c
@@ -24,6 +24,8 @@
 #include <hal/hal_os_tick.h>
 #include <bsp/cmsis_nvic.h>
 
+#include "mcu/mcu.h"
+
 #include "os_priv.h"
 
 /*
@@ -210,8 +212,7 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
-        /* SVC_IRQn or SVCall_IRQn depending on specific model */
-        NVIC_SetVector(-5, (uint32_t)SVC_Handler);
+        NVIC_SetVector(SVC_IRQ_NUMBER, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
 
@@ -233,7 +234,7 @@ os_arch_os_init(void)
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);
 
         /* Set the SVC interrupt to priority 0 (highest configurable) */
-        NVIC_SetPriority(-5, SVC_PRIO);
+        NVIC_SetPriority(SVC_IRQ_NUMBER, SVC_PRIO);
 
         /* Check if privileged or not */
         if ((__get_CONTROL() & 1) == 0) {


### PR DESCRIPTION
@mkiiskila As previously suggested SVC IRQ number moved to macro in `mcu/mcu.h`.

Signed-off-by: Fabio Utzig <utzig@apache.org>