### PR TITLE
nimble: Adding missing inttypes.h include

### DIFF
--- a/net/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
+++ b/net/nimble/host/services/gap/include/services/gap/ble_svc_gap.h
@@ -20,6 +20,8 @@
 #ifndef H_BLE_SVC_GAP_
 #define H_BLE_SVC_GAP_
 
+#include <inttypes.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
- This was causing a build failure