### PR TITLE
hw/mcu/nordic/nrf52xxx: HAL spi broken for 52840.

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_hal.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_hal.h
@@ -62,6 +62,35 @@ struct nrf52_hal_spi_cfg {
     uint8_t ss_pin;
 };
 
+/*
+ * GPIO pin mapping
+ *
+ * The logical GPIO pin numbers (0 to N) are mapped to ports in the following
+ * manner:
+ *  pins 0 - 31: Port 0
+ *  pins 32 - 48: Port 1.
+ *
+ *  The nrf52832 has only one port with 32 pins. The nrf52840 has 48 pins and
+ *  uses two ports.
+ *
+ *  NOTE: in order to save code space, there is no checking done to see if the
+ *  user specifies a pin that is not used by the processor. If an invalid pin
+ *  number is used unexpected and/or erroneous behavior will result.
+ */
+#ifdef NRF52
+#define HAL_GPIO_INDEX(pin)     (pin)
+#define HAL_GPIO_PORT(pin)      (NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << pin)
+#define HAL_GPIOTE_PIN_MASK     GPIOTE_CONFIG_PSEL_Msk
+#endif
+
+#ifdef NRF52840_XXAA
+#define HAL_GPIO_INDEX(pin)     ((pin) & 0x1F)
+#define HAL_GPIO_PORT(pin)      ((pin) > 31 ? NRF_P1 : NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << HAL_GPIO_INDEX(pin))
+#define HAL_GPIOTE_PIN_MASK     (0x3FUL << GPIOTE_CONFIG_PSEL_Pos)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include "nrf.h"
 #include <assert.h>
+#include "mcu/nrf52_hal.h"
 
 /* XXX:
  * 1) The code probably does not handle "re-purposing" gpio very well.
@@ -30,35 +31,6 @@
  * gpio_init_in and expecting previously enabled interrupts to be stopped.
  *
  */
-
-/*
- * GPIO pin mapping
- *
- * The logical GPIO pin numbers (0 to N) are mapped to ports in the following
- * manner:
- *  pins 0 - 31: Port 0
- *  pins 32 - 48: Port 1.
- *
- *  The nrf52832 has only one port with 32 pins. The nrf52840 has 48 pins and
- *  uses two ports.
- *
- *  NOTE: in order to save code space, there is no checking done to see if the
- *  user specifies a pin that is not used by the processor. If an invalid pin
- *  number is used unexpected and/or erroneous behavior will result.
- */
-#ifdef NRF52
-#define HAL_GPIO_INDEX(pin)     (pin)
-#define HAL_GPIO_PORT(pin)      (NRF_P0)
-#define HAL_GPIO_MASK(pin)      (1 << pin)
-#define HAL_GPIOTE_PIN_MASK     GPIOTE_CONFIG_PSEL_Msk
-#endif
-
-#ifdef NRF52840_XXAA
-#define HAL_GPIO_INDEX(pin)     ((pin) & 0x1F)
-#define HAL_GPIO_PORT(pin)      ((pin) > 31 ? NRF_P1 : NRF_P0)
-#define HAL_GPIO_MASK(pin)      (1 << HAL_GPIO_INDEX(pin))
-#define HAL_GPIOTE_PIN_MASK     (0x3FUL << GPIOTE_CONFIG_PSEL_Pos)
-#endif
 
 /* GPIO interrupts */
 #define HAL_GPIO_MAX_IRQ        8

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -402,25 +402,33 @@ hal_spi_init_master(struct nrf52_hal_spi *spi,
                     nrf52_spi_irq_handler_t handler)
 {
     NRF_SPIM_Type *spim;
+    NRF_GPIO_Type *port;
+    uint32_t pin;
 
     /* Configure SCK */
+    port = HAL_GPIO_PORT(cfg->sck_pin);
+    pin = HAL_GPIO_INDEX(cfg->sck_pin);
     if (spi->spi_cfg.data_mode <= HAL_SPI_MODE1) {
-        NRF_P0->OUTCLR = (1UL << cfg->sck_pin);
+        port->OUTCLR = (1UL << pin);
     } else {
-        NRF_P0->OUTSET = (1UL << cfg->sck_pin);
+        port->OUTSET = (1UL << pin);
     }
-    NRF_P0->PIN_CNF[cfg->sck_pin] =
+    port->PIN_CNF[pin] =
         (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos) |
         (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
     /*  Configure MOSI */
-    NRF_P0->OUTCLR = (1UL << cfg->mosi_pin);
-    NRF_P0->PIN_CNF[cfg->mosi_pin] =
+    port = HAL_GPIO_PORT(cfg->mosi_pin);
+    pin = HAL_GPIO_INDEX(cfg->mosi_pin);
+    port->OUTCLR = (1UL << pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
 
     /* Configure MISO */
-    NRF_P0->PIN_CNF[cfg->miso_pin] =
+    port = HAL_GPIO_PORT(cfg->miso_pin);
+    pin = HAL_GPIO_INDEX(cfg->miso_pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
@@ -444,21 +452,32 @@ hal_spi_init_slave(struct nrf52_hal_spi *spi,
                    nrf52_spi_irq_handler_t handler)
 {
     NRF_SPIS_Type *spis;
+    NRF_GPIO_Type *port;
+    uint32_t pin;
 
-    NRF_P0->PIN_CNF[cfg->miso_pin] =
+    /* NOTE: making this pin an input is correct! See datasheet */
+    port = HAL_GPIO_PORT(cfg->miso_pin);
+    pin = HAL_GPIO_INDEX(cfg->miso_pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
-    NRF_P0->PIN_CNF[cfg->mosi_pin] =
+    port = HAL_GPIO_PORT(cfg->mosi_pin);
+    pin = HAL_GPIO_INDEX(cfg->mosi_pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
-    NRF_P0->PIN_CNF[cfg->ss_pin] =
+    port = HAL_GPIO_PORT(cfg->ss_pin);
+    pin = HAL_GPIO_INDEX(cfg->ss_pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_PULL_Pullup  << GPIO_PIN_CNF_PULL_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
-    NRF_P0->PIN_CNF[cfg->sck_pin] =
+    port = HAL_GPIO_PORT(cfg->sck_pin);
+    pin = HAL_GPIO_INDEX(cfg->sck_pin);
+    port->PIN_CNF[pin] =
         ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
         ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
 
@@ -730,7 +749,6 @@ uint16_t hal_spi_tx_val(int spi_num, uint16_t val)
         while (!spi->EVENTS_READY) {}
         spi->EVENTS_READY = 0;
         retval = (uint16_t)spi->RXD;
-
     } else {
         retval = 0xFFFF;
     }


### PR DESCRIPTION
The incorrect port was being accessed if any SPI pin was using
a pin number greater than 31 (on port 1). This issues should be
fixed with this commit.