### PR TITLE
bsp: allow override of i2c, spis and spim pins

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -79,18 +79,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 12,
-    .mosi_pin     = 13,
-    .miso_pin     = 14,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 12,
-    .mosi_pin     = 13,
-    .miso_pin     = 14,
-    .ss_pin       = 15,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 26,
-    .sda_pin = 25,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  12
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  13
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  14
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  12
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  13
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  14
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  15
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  26
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  25
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/apollo2_evb/src/hal_bsp.c
+++ b/hw/bsp/apollo2_evb/src/hal_bsp.c
@@ -57,49 +57,49 @@ static const struct hal_bsp_mem_dump dump_cfg[] = {
 
 #if MYNEWT_VAL(SPI_0_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi0m_cfg = {
-    .sck_pin      = 5,
-    .mosi_pin     = 7,
-    .miso_pin     = 6,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi1m_cfg = {
-    .sck_pin      = 8,
-    .mosi_pin     = 10,
-    .miso_pin     = 9,
+    .sck_pin      = MYNEWT_VAL(SPI_1_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_2_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi2m_cfg = {
-    .sck_pin      = 0,
-    .mosi_pin     = 1,
-    .miso_pin     = 2,
+    .sck_pin      = MYNEWT_VAL(SPI_2_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_3_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi3m_cfg = {
-    .sck_pin      = 42,
-    .mosi_pin     = 38,
-    .miso_pin     = 43,
+    .sck_pin      = MYNEWT_VAL(SPI_3_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_4_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi4m_cfg = {
-    .sck_pin      = 39,
-    .mosi_pin     = 44,
-    .miso_pin     = 40,
+    .sck_pin      = MYNEWT_VAL(SPI_4_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_4_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_4_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_5_MASTER)
 static const struct apollo2_spi_cfg hal_bsp_spi5m_cfg = {
-    .sck_pin      = 48,
-    .mosi_pin     = 47,
-    .miso_pin     = 49,
+    .sck_pin      = MYNEWT_VAL(SPI_5_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_5_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_5_MASTER_PIN_MISO),
 };
 #endif
 

--- a/hw/bsp/apollo2_evb/syscfg.yml
+++ b/hw/bsp/apollo2_evb/syscfg.yml
@@ -39,6 +39,66 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 38
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  5
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  7
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  6
+
+    SPI_1_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_1_MASTER'
+        value:  8
+    SPI_1_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_MASTER'
+        value:  10
+    SPI_1_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_1_MASTER'
+        value:  9
+
+    SPI_2_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_2_MASTER'
+        value:  0
+    SPI_2_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_2_MASTER'
+        value:  1
+    SPI_2_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_2_MASTER'
+        value:  2
+
+    SPI_3_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_3_MASTER'
+        value:  42
+    SPI_3_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_3_MASTER'
+        value:  38
+    SPI_3_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_3_MASTER'
+        value:  43
+
+    SPI_4_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_4_MASTER'
+        value:  39
+    SPI_4_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_4_MASTER'
+        value:  44
+    SPI_4_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_4_MASTER'
+        value:  40
+
+    SPI_5_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_5_MASTER'
+        value:  48
+    SPI_5_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_5_MASTER'
+        value:  47
+    SPI_5_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_5_MASTER'
+        value:  49
+
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -78,18 +78,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 24,
-    .mosi_pin     = 23,
-    .miso_pin     = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 24,
-    .mosi_pin     = 23,
-    .miso_pin     = 22,
-    .ss_pin       = 19,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -120,9 +120,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/arduino_primo_nrf52/syscfg.yml
+++ b/hw/bsp/arduino_primo_nrf52/syscfg.yml
@@ -54,6 +54,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  5
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  22
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  22
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  19
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/bbc_microbit/src/hal_bsp.c
+++ b/hw/bsp/bbc_microbit/src/hal_bsp.c
@@ -56,18 +56,18 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -50,6 +50,29 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/ble400/src/hal_bsp.c
+++ b/hw/bsp/ble400/src/hal_bsp.c
@@ -55,26 +55,26 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 25,
-    .mosi_pin     = 24,
-    .miso_pin     = 23
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 1,
-    .sda_pin = 0,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -50,6 +50,39 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  23
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  1
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  0
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -55,26 +55,26 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 7,
-    .sda_pin = 30,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -50,6 +50,39 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  7
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  30
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -76,18 +76,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ssn_pin      = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 

--- a/hw/bsp/bmd300eval/syscfg.yml
+++ b/hw/bsp/bmd300eval/syscfg.yml
@@ -50,6 +50,29 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -79,18 +79,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nina-b1/syscfg.yml
+++ b/hw/bsp/nina-b1/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -57,18 +57,18 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 

--- a/hw/bsp/nrf51-arduino_101/syscfg.yml
+++ b/hw/bsp/nrf51-arduino_101/syscfg.yml
@@ -50,6 +50,29 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -54,27 +54,27 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * NOTE: Our HAL expects that the SS pin, if used, is treated as a gpio line
  * and is handled outside the SPI routines.
  */
-static const struct  nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28
+static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 7,
-    .sda_pin = 30,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -50,6 +50,40 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
+    I2C_0_SDA_PIN:
+        description: 'Data pin for I2C0'
+        value: 30
+    I2C_0_SCL_PIN:
+        description: 'Clock pin for I2C0'
+        value: 7
+    I2C_0_FREQUENCY:
+        description: 'Bus frequency in KHz for I2C0'
+        value: 100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/nrf51dk/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk/src/hal_bsp.c
@@ -60,26 +60,26 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 24
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 7,
-    .sda_pin = 30,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -49,6 +49,38 @@ syscfg.defs:
     ADC_0_REFMV_VDD:
         description: 'reference mV in VDD if used'
         value: 0
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  29
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  24
+
+    I2C_0_SDA_PIN:
+        description: 'Data pin for I2C0'
+        value: 30
+    I2C_0_SCL_PIN:
+        description: 'Clock pin for I2C0'
+        value: 7
+    I2C_0_FREQUENCY:
+        description: 'Bus frequency in KHz for I2C0'
+        value: 100
 
     TIMER_0:
         description: 'NRF51 Timer 0'

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -85,18 +85,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -118,9 +118,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 15,
-    .sda_pin = 14,
-    .i2c_frequency = 400    /* 400 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 
 #if MYNEWT_VAL(LIS2DH12_ONB)

--- a/hw/bsp/nrf52-thingy/syscfg.yml
+++ b/hw/bsp/nrf52-thingy/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  15
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  14
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  400
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -75,18 +75,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 45,
-    .mosi_pin     = 46,
-    .miso_pin     = 47,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 45,
-    .mosi_pin     = 46,
-    .miso_pin     = 47,
-    .ss_pin       = 44,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c0_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nrf52840pdk/syscfg.yml
+++ b/hw/bsp/nrf52840pdk/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  45
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  46
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  47
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  45
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  46
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  47
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  44
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52840 Timer 0'
         value:  1

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -79,18 +79,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nrf52dk/syscfg.yml
+++ b/hw/bsp/nrf52dk/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -79,18 +79,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 20,
-    .mosi_pin     = 23,
-    .miso_pin     = 24,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 20,
-    .mosi_pin     = 23,
-    .miso_pin     = 24,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-        .scl_pin = 27,
-        .sda_pin = 26,
-        .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/rb-blend2/syscfg.yml
+++ b/hw/bsp/rb-blend2/syscfg.yml
@@ -50,6 +50,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value: 11
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  20
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  24
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  20
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -78,18 +78,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 23,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 

--- a/hw/bsp/rb-nano2/syscfg.yml
+++ b/hw/bsp/rb-nano2/syscfg.yml
@@ -50,6 +50,29 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  23
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  24
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -92,9 +92,9 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 
 #if MYNEWT_VAL(BME280_ONB)
@@ -118,10 +118,10 @@ static const struct sensor_itf spi_0_itf_lis = {
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 29,
-    .mosi_pin     = 25,
-    .miso_pin     = 28,
-    .ss_pin       = 22,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -152,9 +152,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/ruuvi_tag_revb2/syscfg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/syscfg.yml
@@ -49,6 +49,39 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  29
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  28
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  29
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  25
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  28
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  22
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -80,9 +80,9 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 25,
-    .mosi_pin     = 23,
-    .miso_pin     = 24,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 

--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -49,6 +49,16 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  25
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  23
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  24
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -55,34 +55,34 @@ static const struct nrf51_uart_cfg os_bsp_uart0_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf51_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 28,
-    .mosi_pin     = 24,
-    .miso_pin     = 25
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
 static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
-    .sck_pin      = 28,
-    .mosi_pin     = 24,
-    .miso_pin     = 25,
-    .ss_pin       = 23
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg hal_i2c0_cfg = {
-    .scl_pin = 30,
-    .sda_pin = 29,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_1)
 static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
-    .scl_pin = 6,
-    .sda_pin = 5,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/vbluno51/syscfg.yml
+++ b/hw/bsp/vbluno51/syscfg.yml
@@ -50,6 +50,49 @@ syscfg.defs:
         description: 'reference mV in VDD if used'
         value: 0
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  28
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  24
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  25
+
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value:  28
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value:  24
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value:  25
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value:  23
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  30
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  29
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  6
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  5
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -79,18 +79,18 @@ static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
  * and is handled outside the SPI routines.
  */
 static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = 15,
-    .mosi_pin     = 13,
-    .miso_pin     = 14,
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
 };
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
 static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = 15,
-    .mosi_pin     = 13,
-    .miso_pin     = 14,
-    .ss_pin       = 11,
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
 };
 #endif
 
@@ -121,17 +121,17 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c0_cfg = {
-    .scl_pin = 27,
-    .sda_pin = 26,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_1)
 static const struct nrf52_hal_i2c_cfg hal_i2c1_cfg = {
-    .scl_pin = 31,
-    .sda_pin = 30,
-    .i2c_frequency = 100    /* 100 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -49,6 +49,49 @@ syscfg.defs:
         description: 'RX pin for UART1'
         value:  -1
 
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value:  15
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value:  13
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value:  14
+
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value:  15
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value:  13
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value:  14
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value:  11
+
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  27
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  26
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  31
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  30
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1


### PR DESCRIPTION
Uart pins are allowed to be overridden but not i2c and spis/spim. If this is wanted Ill do the other boards as well