### PR TITLE
hw/drivers/sx1272: Make driver shield compatible and fix driver issues.

### DIFF
--- a/hw/drivers/lora/sx1272/src/sx1272-board.c
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.c
@@ -113,42 +113,42 @@ void SX1272IoIrqInit( DioIrqHandler **irqHandlers )
 
     if (irqHandlers[0] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO0, irqHandlers[0], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO0);
     }
 
     if (irqHandlers[1] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO1, irqHandlers[1], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO1);
     }
 
     if (irqHandlers[2] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO2, irqHandlers[2], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO2);
     }
 
     if (irqHandlers[3] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO3, irqHandlers[3], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO3);
     }
 
     if (irqHandlers[4] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO4, irqHandlers[4], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO4);
     }
 
     if (irqHandlers[5] != NULL) {
         rc = hal_gpio_irq_init(SX1272_DIO5, irqHandlers[5], NULL,
-                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_NONE);
+                               HAL_GPIO_TRIG_RISING, HAL_GPIO_PULL_DOWN);
         assert(rc == 0);
         hal_gpio_irq_enable(SX1272_DIO5);
     }
@@ -307,10 +307,36 @@ void SX1272SetAntSw( uint8_t opMode )
     }
     OS_EXIT_CRITICAL(sr);
 }
+#else
+void SX1272SetAntSwLowPower( bool status )
+{
+    (void)status;
+}
+
+void SX1272AntSwInit( void )
+{
+    /*
+     * XXX: consider doing this to save power. Currently the gpio are
+     * set to rx mode automatically in the IO init function.
+     */
+}
+
+void SX1272AntSwDeInit( void )
+{
+    /*
+     * XXX: consider doing this to save power. Currently the gpio are
+     * set to rx mode automatically in the IO init function.
+     */
+}
+
+void SX1272SetAntSw( uint8_t opMode )
+{
+    (void)opMode;
+}
+#endif
 
 bool SX1272CheckRfFrequency( uint32_t frequency )
 {
     // Implement check. Currently all frequencies are supported
     return true;
 }
-#endif

--- a/hw/drivers/lora/sx1272/src/sx1272-board.h
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.h
@@ -15,12 +15,37 @@ Maintainer: Miguel Luis and Gregory Cristian
 #ifndef __SX1272_ARCH_H__
 #define __SX1272_ARCH_H__
 
-#define RADIO_SPI_IDX               MYNEWT_VAL(SX1272_SPI_IDX)
+#define RADIO_SPI_IDX           MYNEWT_VAL(SX1272_SPI_IDX)
+#if RADIO_SPI_IDX != 0
+#error "Invalid SX1272_SPI_IDX value. Must be zero"
+#endif
 
-#if RADIO_SPI_IDX == 0
-#define RADIO_NSS                   MYNEWT_VAL(SX1272_SPI_CS_PIN)
+#if MYNEWT_VAL(SX1272_SPI_CS_PIN) == -1
+#error "Must set SX1272_SPI_CS_PIN pin (spi slave select)"
 #else
-#error "Invalid SX1272_SPI_IDX value"
+#define RADIO_NSS               MYNEWT_VAL(SX1272_SPI_CS_PIN)
+#endif
+
+#define SX1272_DIO0             MYNEWT_VAL(SX1272_DIO0_PIN)
+#define SX1272_DIO1             MYNEWT_VAL(SX1272_DIO1_PIN)
+#define SX1272_DIO2             MYNEWT_VAL(SX1272_DIO2_PIN)
+#define SX1272_DIO3             MYNEWT_VAL(SX1272_DIO3_PIN)
+#define SX1272_DIO4             MYNEWT_VAL(SX1272_DIO4_PIN)
+#define SX1272_DIO5             MYNEWT_VAL(SX1272_DIO5_PIN)
+
+#if MYNEWT_VAL(SX1272_RESET_PIN) == -1
+#error "Must set SX1272_RESET_PIN pin (spi slave select)"
+#else
+#define SX1272_NRESET           MYNEWT_VAL(SX1272_RESET_PIN)
+#endif
+
+#if MYNEWT_VAL(SX1272_HAS_ANT_SW)
+#define SX1272_RXTX             MYNEWT_VAL(SX1272_RXTX_PIN)
+#endif
+
+#if MYNEWT_VAL(SX1272_HAS_COMP_ANT_SW)
+#define SX1272_RXTX             MYNEWT_VAL(SX1272_RXTX_PIN)
+#define SX1272_N_RXTX           MYNEWT_VAL(SX1272_N_RXTX_PIN)
 #endif
 
 /*!

--- a/hw/drivers/lora/sx1272/src/sx1272.c
+++ b/hw/drivers/lora/sx1272/src/sx1272.c
@@ -14,6 +14,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 */
 #include <math.h>
 #include <string.h>
+#include <stdlib.h>
 #include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "hal/hal_gpio.h"
@@ -30,6 +31,13 @@ Maintainer: Miguel Luis and Gregory Cristian
 #else
 #define SX1272_TIMER_NUM    MYNEWT_VAL(LORA_MAC_TIMER_NUM)
 #endif
+
+/* XXX: dummy for now to read sx1272 */
+#if MYNEWT_VAL(BSP_USE_HAL_SPI)
+void bsp_spi_read_buf(uint8_t addr, uint8_t *buf, uint8_t size);
+void bsp_spi_write_buf(uint8_t addr, uint8_t *buf, uint8_t size);
+#endif
+
 
 /*
  * Local types definition
@@ -204,9 +212,17 @@ SX1272_t SX1272;
 /*!
  * Hardware DIO IRQ callback initialization
  */
-DioIrqHandler *DioIrq[] = { SX1272OnDio0Irq, SX1272OnDio1Irq,
-                            SX1272OnDio2Irq, SX1272OnDio3Irq,
-                            SX1272OnDio4Irq, NULL };
+DioIrqHandler *DioIrq[] = {
+    SX1272OnDio0Irq,
+    SX1272OnDio1Irq,
+    SX1272OnDio2Irq,
+    SX1272OnDio3Irq,
+#if (SX1272_DIO4 >= 0)
+    SX1272OnDio4Irq,
+#else
+    NULL,
+#endif
+    NULL };
 
 /*!
  * Tx and Rx timers
@@ -242,7 +258,6 @@ round(double d)
 /*
  * Radio driver functions implementation
  */
-
 void SX1272Init( RadioEvents_t *events )
 {
     uint8_t i;
@@ -254,11 +269,10 @@ void SX1272Init( RadioEvents_t *events )
     hal_timer_set_cb(SX1272_TIMER_NUM, &RxTimeoutTimer, SX1272OnTimeoutIrq, NULL);
     hal_timer_set_cb(SX1272_TIMER_NUM, &RxTimeoutSyncWord, SX1272OnTimeoutIrq, NULL);
 
-    SX1272Reset( );
-
-    SX1272SetOpMode( RF_OPMODE_SLEEP );
-
+    SX1272IoInit( );
     SX1272IoIrqInit( DioIrq );
+    SX1272Reset( );
+    SX1272SetOpMode( RF_OPMODE_SLEEP );
 
     for( i = 0; i < sizeof( RadioRegsInit ) / sizeof( RadioRegisters_t ); i++ )
     {
@@ -1038,18 +1052,22 @@ int16_t SX1272ReadRssi( RadioModems_t modem )
     return rssi;
 }
 
+/**
+ * SX1272Reset
+ *
+ * As per Semtech, the reset sequence should be:
+ *  - Drive reset pin high
+ *  - Wait at least 100 usecs
+ *  - Put pin in High-Z state (make it an input)
+ *  - Wait at least 5 msecs
+ *
+ */
 void SX1272Reset( void )
 {
-    // Set RESET pin to 0
-    hal_gpio_init_out(SX1272_NRESET, 0);
 
-    // Wait 1 ms
+    hal_gpio_init_out(SX1272_NRESET, 1);
     hal_timer_delay(SX1272_TIMER_NUM, 1000);
-
-    // Drive reset high
-    hal_gpio_write(SX1272_NRESET, 1);
-
-    // Wait 6 ms
+    hal_gpio_init_in(SX1272_NRESET, HAL_GPIO_PULL_NONE);
     hal_timer_delay(SX1272_TIMER_NUM, 6000);
 }
 
@@ -1118,32 +1136,40 @@ uint8_t SX1272Read( uint8_t addr )
 
 void SX1272WriteBuffer( uint8_t addr, uint8_t *buffer, uint8_t size )
 {
+#if MYNEWT_VAL(BSP_USE_HAL_SPI) == 1
+    hal_gpio_write(RADIO_NSS, 0);
+    bsp_spi_write_buf(addr | 0x80, buffer, size);
+    hal_gpio_write(RADIO_NSS, 1);
+#else
     uint8_t i;
 
     hal_gpio_write(RADIO_NSS, 0);
-
     hal_spi_tx_val(RADIO_SPI_IDX, addr | 0x80);
     for( i = 0; i < size; i++ )
     {
         hal_spi_tx_val(RADIO_SPI_IDX, buffer[i]);
     }
-
     hal_gpio_write(RADIO_NSS, 1);
+#endif
 }
 
 void SX1272ReadBuffer( uint8_t addr, uint8_t *buffer, uint8_t size )
 {
+#if MYNEWT_VAL(BSP_USE_HAL_SPI) == 1
+    hal_gpio_write(RADIO_NSS, 0);
+    bsp_spi_read_buf(addr & 0x7f, buffer, size);
+    hal_gpio_write(RADIO_NSS, 1);
+#else
     uint8_t i;
 
     hal_gpio_write(RADIO_NSS, 0);
-
-    hal_spi_tx_val(RADIO_SPI_IDX, addr | 0x80);
+    hal_spi_tx_val(RADIO_SPI_IDX, addr & 0x7f);
     for( i = 0; i < size; i++ )
     {
         hal_spi_tx_val(RADIO_SPI_IDX, buffer[i]);
     }
-
     hal_gpio_write(RADIO_NSS, 1);
+#endif
 }
 
 void SX1272WriteFifo( uint8_t *buffer, uint8_t size )

--- a/hw/drivers/lora/sx1272/syscfg.yml
+++ b/hw/drivers/lora/sx1272/syscfg.yml
@@ -40,5 +40,44 @@ syscfg.defs:
         description: 'Set to 1 if board has complementary antenna switch'
         restrictions:
             - "!SX1272_HAS_ANT_SW"
-        value: 1
+        value: 0
 
+    SX1272_RESET_PIN:
+        description: 'SX1272 reset pin number'
+        value:  -1
+
+    SX1272_DIO0_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_DIO1_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_DIO2_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_DIO3_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_DIO4_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_DIO5_PIN:
+        description: 'SPI chip select pin number'
+        value:  -1
+
+    SX1272_RXTX_PIN:
+        description: 'RxTx switch control pin number'
+        value:  -1
+
+    SX1272_N_RXTX_PIN:
+        description: 'Complement RxTx switch control pin number'
+        value:  -1
+
+    BSP_USE_HAL_SPI:
+        description: 'Use alternate spi read/write buffer routines'
+        value: 0


### PR DESCRIPTION
The main changes in this commit were to make all GPIO that interface
the chip to the MCU MYNEWT_VALs so they can be configured either
in a target or bsp. This makes creating a bsp + shield combo
simple by defining the interface GPIO in a target.

Some additional fixes/changes are in this commit such as:
1) Using the proper reset sequence.
2) Fixing a bug with the spi/read write command.
3) Adding a MYNEWT_VAL to select a separate spi routine to be
used to read/write buffers to the chip. The blocking,
byte-by-byte hal spi api is not working on the 52840
when combined with the sx1272 for some reason so this is a
temporary work-around.