### PR TITLE
ms5837: build failure due to over the bounds access

### DIFF
--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -432,7 +432,8 @@ ms5837_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
     rc = ms5837_crc_check(payload, (payload[MS5837_IDX_CRC] & 0xF000) >> 12);
     if (rc) {
         rc = SYS_EINVAL;
-        MS5837_ERR("Failure in CRC, 0x%02X\n", payload[idx]);
+        MS5837_ERR("Failure in CRC, 0x%02X\n",
+                   payload[MS5837_IDX_CRC] &  0xF000 >> 12);
         STATS_INC(g_ms5837stats, eeprom_crc_errors);
         goto err;
     }


### PR DESCRIPTION
- Fixing build failure due to over the bounds write of the array in logs