### PR TITLE
puckjs: i2c syscfg

### DIFF
--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -121,9 +121,9 @@ static struct pwm_dev os_bsp_spwm;
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = 33,
-    .sda_pin = 34,
-    .i2c_frequency = 400    /* 400 kHz */
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/puckjs/syscfg.yml
+++ b/hw/bsp/puckjs/syscfg.yml
@@ -76,6 +76,16 @@ syscfg.defs:
         description: 'SS pin for SPI_0_SLAVE'
         value:  31
 
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  33
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  34
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  400
+
     TIMER_0:
         description: 'NRF52 Timer 0'
         value:  1


### PR DESCRIPTION
These were missed in the puckjs bsp