### PR TITLE
libc: Add support for float in printf

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -238,6 +238,8 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
     char ch;
     char lng;
     void *v;
+    double d;
+    int n;
 
     p.bf = bf;
 
@@ -336,6 +338,38 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 p.bf = va_arg(va, char *);
                 written += putchw(putp, &p);
                 p.bf = bf;
+                break;
+            case 'f':
+                p.base = 10;
+                d = va_arg(va, double);
+                /* Cast to an int to get the integer part of the number */
+                n = (int)d;
+                /* Convert to ascii */
+                i2a(n, &p);
+                /* Ignore left align for integer part */
+                p.left = 0;
+                /* Subtract width for decimal part and decimal point */
+                if (p.width >= 4) {
+                    p.width -= 4;
+                } else {
+                    p.width = 0;
+                }
+                /* Write integer part to console */
+                written += putchw(putp, &p);
+                /* Take the decimal part and multiply by 1000 */
+                n = (d-n)*1000;
+                /* Convert to asii */
+                i2a(n, &p);
+                /* Set the leading zeros for the next integer output to 3 */
+                p.lz = 3;
+                /* Always use the same decimal width */
+                p.width = 3;
+                /* Ignore sign for decimal part*/
+                p.sign = 0;
+                /* Output a decimal point */
+                putf(putp, '.');
+                /* Output the decimal part. */
+                written += putchw(putp, &p);
                 break;
             case '%':
                 written += putf(putp, ch);


### PR DESCRIPTION
This implementation supports only 3 decimal digits.
Left-align is not supported. When specifying width it is
counted with 3 decimal digits, point character, and sign,
if a number is negative.