### PR TITLE
lwip - Fix time calculation

### DIFF
--- a/net/ip/include/arch/sys_arch.h
+++ b/net/ip/include/arch/sys_arch.h
@@ -101,13 +101,10 @@ sys_mutex_unlock(sys_mutex_t *mutex)
 static inline uint32_t
 sys_now(void)
 {
-    uint32_t t;
+    uint64_t t;
 
-    /*
-     * XXX not right when g_os_time rolls over
-     */
-    t = os_time_get() * 1000 / OS_TICKS_PER_SEC;
-    return t;
+    t = os_time_get();
+    return t * 1000 / OS_TICKS_PER_SEC;
 }
 
 static inline err_t

--- a/net/ip/include/arch/sys_arch.h
+++ b/net/ip/include/arch/sys_arch.h
@@ -106,7 +106,7 @@ sys_now(void)
     /*
      * XXX not right when g_os_time rolls over
      */
-    t = os_time_get() * OS_TICKS_PER_SEC / 1000;
+    t = os_time_get() * 1000 / OS_TICKS_PER_SEC;
     return t;
 }
 


### PR DESCRIPTION
The `sys_now` function is supposed to calculate milliseconds since boot.  However, the operands were not in the correct order, so the units were off.

In sim, this caused the `tcpip_thread()` task handler to never yield to other tasks during timeout calculation.