### PR TITLE
Align heap base on an 8-byte offset.

### DIFF
--- a/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
+++ b/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/ada_feather_nrf52/split_ada_feather_nrf52.ld
+++ b/hw/bsp/ada_feather_nrf52/split_ada_feather_nrf52.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
+++ b/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/arduino_primo_nrf52/split-primo.ld
+++ b/hw/bsp/arduino_primo_nrf52/split-primo.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/bbc_microbit/split-microbit.ld
+++ b/hw/bsp/bbc_microbit/split-microbit.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/ble400/ble400_no_boot.ld
+++ b/hw/bsp/ble400/ble400_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/ble400/split-ble400.ld
+++ b/hw/bsp/ble400/split-ble400.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/bmd200/nrf51dk_no_boot.ld
+++ b/hw/bsp/bmd200/nrf51dk_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/bmd200/split-nrf51dk.ld
+++ b/hw/bsp/bmd200/split-nrf51dk.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
+++ b/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
@@ -170,6 +170,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/bmd300eval/split-bmd300eval.ld
+++ b/hw/bsp/bmd300eval/split-bmd300eval.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/calliope_mini/split-calliope_mini.ld
+++ b/hw/bsp/calliope_mini/split-calliope_mini.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
+++ b/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/dwm1001-dev/split-dwm1001-dev.ld
+++ b/hw/bsp/dwm1001-dev/split-dwm1001-dev.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/embarc_emsk/arc_core.ld
+++ b/hw/bsp/embarc_emsk/arc_core.ld
@@ -111,7 +111,7 @@ SECTIONS
     } > DCCM
 
     /* Allocate remaining RAM (RAM between _e_bss and __StackLimit to heap */
-    . = ALIGN(4);
+    . = ALIGN(8);
     __HeapBase = .;
 
     __StackTop = ORIGIN(DCCM) + LENGTH(DCCM);

--- a/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
@@ -232,6 +232,7 @@ SECTIONS
     . = ALIGN(8);
     __end__ = .;
     PROVIDE(end = .);
+    . = ALIGN(8);
     __HeapBase = .;
     . += HEAP_SIZE;
     __HeapLimit = .;

--- a/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
@@ -227,6 +227,7 @@ SECTIONS
     . = ALIGN(8);
     __end__ = .;
     PROVIDE(end = .);
+    . = ALIGN(8);
     __HeapBase = .;
     . += HEAP_SIZE;
     __HeapLimit = .;

--- a/hw/bsp/nina-b1/nrf52dk_no_boot.ld
+++ b/hw/bsp/nina-b1/nrf52dk_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nina-b1/split-nrf52dk.ld
+++ b/hw/bsp/nina-b1/split-nrf52dk.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
+++ b/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
+++ b/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51-blenano/split-nrf51dk.ld
+++ b/hw/bsp/nrf51-blenano/split-nrf51dk.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_no_boot.ld
+++ b/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51dk-16kbram/split-nrf51dk-16kbram.ld
+++ b/hw/bsp/nrf51dk-16kbram/split-nrf51dk-16kbram.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51dk/nrf51dk_no_boot.ld
+++ b/hw/bsp/nrf51dk/nrf51dk_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf51dk/split-nrf51dk.ld
+++ b/hw/bsp/nrf51dk/split-nrf51dk.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52-thingy/nrf52-thingy_no_boot.ld
+++ b/hw/bsp/nrf52-thingy/nrf52-thingy_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52-thingy/split-nrf52-thingy.ld
+++ b/hw/bsp/nrf52-thingy/split-nrf52-thingy.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52840pdk/nrf52840pdk_no_boot.ld
+++ b/hw/bsp/nrf52840pdk/nrf52840pdk_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52840pdk/split-nrf52840pdk.ld
+++ b/hw/bsp/nrf52840pdk/split-nrf52840pdk.ld
@@ -177,6 +177,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52dk/nrf52dk_no_boot.ld
+++ b/hw/bsp/nrf52dk/nrf52dk_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/nrf52dk/split-nrf52dk.ld
+++ b/hw/bsp/nrf52dk/split-nrf52dk.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
+++ b/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
@@ -180,6 +180,7 @@ SECTIONS
         __bss_end__ = .;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/bsp/puckjs/puckjs_no_boot.ld
+++ b/hw/bsp/puckjs/puckjs_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/puckjs/split_puckjs.ld
+++ b/hw/bsp/puckjs/split_puckjs.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
+++ b/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/rb-blend2/split-rb-blend2.ld
+++ b/hw/bsp/rb-blend2/split-rb-blend2.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
+++ b/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/rb-nano2/split-rb-nano2.ld
+++ b/hw/bsp/rb-nano2/split-rb-nano2.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/ruuvi_tag_revb2/nrf52dk_no_boot.ld
+++ b/hw/bsp/ruuvi_tag_revb2/nrf52dk_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/ruuvi_tag_revb2/split-nrf52dk.ld
+++ b/hw/bsp/ruuvi_tag_revb2/split-nrf52dk.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/telee02/split-telee02.ld
+++ b/hw/bsp/telee02/split-telee02.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/telee02/telee02_no_boot.ld
+++ b/hw/bsp/telee02/telee02_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/usbmkw41z/boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/boot-mkw41z512.ld
@@ -170,6 +170,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/usbmkw41z/mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/mkw41z512.ld
@@ -160,6 +160,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
@@ -170,6 +170,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/vbluno51/split-vbluno51.ld
+++ b/hw/bsp/vbluno51/split-vbluno51.ld
@@ -159,6 +159,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/vbluno51/vbluno51_no_boot.ld
+++ b/hw/bsp/vbluno51/vbluno51_no_boot.ld
@@ -154,6 +154,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/vbluno52/split-vbluno52.ld
+++ b/hw/bsp/vbluno52/split-vbluno52.ld
@@ -181,6 +181,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/bsp/vbluno52/vbluno52_no_boot.ld
+++ b/hw/bsp/vbluno52/vbluno52_no_boot.ld
@@ -166,6 +166,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/mcu/ambiq/apollo2/apollo2.ld
+++ b/hw/mcu/ambiq/apollo2/apollo2.ld
@@ -169,6 +169,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/mcu/nordic/nrf51xxx/nrf51.ld
+++ b/hw/mcu/nordic/nrf51xxx/nrf51.ld
@@ -153,6 +153,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/mcu/nordic/nrf52xxx/nrf52.ld
+++ b/hw/mcu/nordic/nrf52xxx/nrf52.ld
@@ -169,6 +169,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);
     __HeapBase = .;
 
     /* .stack_dummy section doesn't contains any symbols. It is only

--- a/hw/mcu/stm/stm32f1xx/stm32f103.ld
+++ b/hw/mcu/stm/stm32f1xx/stm32f103.ld
@@ -187,6 +187,7 @@ SECTIONS
         __bss_end__ = _ebss;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f3xx/stm32f303.ld
+++ b/hw/mcu/stm/stm32f3xx/stm32f303.ld
@@ -185,6 +185,7 @@ SECTIONS
         _ebss = .;
     } > SRAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(SRAM) + LENGTH(SRAM);
 

--- a/hw/mcu/stm/stm32f4xx/stm32f401.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f401.ld
@@ -178,6 +178,7 @@ SECTIONS
         __bss_end__ = .;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f4xx/stm32f407.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f407.ld
@@ -178,6 +178,7 @@ SECTIONS
         __bss_end__ = .;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f4xx/stm32f427.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f427.ld
@@ -178,6 +178,7 @@ SECTIONS
         __bss_end__ = .;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f4xx/stm32f429.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f429.ld
@@ -185,6 +185,7 @@ SECTIONS
         _ebss = .;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -187,6 +187,7 @@ SECTIONS
         __bss_end__ = _ebss;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -187,6 +187,7 @@ SECTIONS
         __bss_end__ = _ebss;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/hw/mcu/stm/stm32l1xx/stm32l152.ld
+++ b/hw/mcu/stm/stm32l1xx/stm32l152.ld
@@ -187,6 +187,7 @@ SECTIONS
         __bss_end__ = _ebss;
     } > RAM
 
+    . = ALIGN(8);
     __HeapBase = .;
     __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 

--- a/libc/baselibc/src/malloc.c
+++ b/libc/baselibc/src/malloc.c
@@ -13,14 +13,14 @@
    list with head node.  This the head node. Note that the arena list
    is sorted in order of address. */
 static struct free_arena_header __malloc_head = {
-	{
-		ARENA_TYPE_HEAD,
-		0,
-		&__malloc_head,
-		&__malloc_head,
-	},
-	&__malloc_head,
-	&__malloc_head
+    {
+        ARENA_TYPE_HEAD,
+        0,
+        &__malloc_head,
+        &__malloc_head,
+    },
+    &__malloc_head,
+    &__malloc_head
 };
 
 static bool malloc_lock_nop() {return true;}
@@ -32,213 +32,213 @@ static malloc_unlock_t malloc_unlock = &malloc_unlock_nop;
 static inline void mark_block_dead(struct free_arena_header *ah)
 {
 #ifdef DEBUG_MALLOC
-	ah->a.type = ARENA_TYPE_DEAD;
+    ah->a.type = ARENA_TYPE_DEAD;
 #endif
 }
 
 static inline void remove_from_main_chain(struct free_arena_header *ah)
 {
-	struct free_arena_header *ap, *an;
+    struct free_arena_header *ap, *an;
 
-	mark_block_dead(ah);
+    mark_block_dead(ah);
 
-	ap = ah->a.prev;
-	an = ah->a.next;
-	ap->a.next = an;
-	an->a.prev = ap;
+    ap = ah->a.prev;
+    an = ah->a.next;
+    ap->a.next = an;
+    an->a.prev = ap;
 }
 
 static inline void remove_from_free_chain(struct free_arena_header *ah)
 {
-	struct free_arena_header *ap, *an;
+    struct free_arena_header *ap, *an;
 
-	ap = ah->prev_free;
-	an = ah->next_free;
-	ap->next_free = an;
-	an->prev_free = ap;
+    ap = ah->prev_free;
+    an = ah->next_free;
+    ap->next_free = an;
+    an->prev_free = ap;
 }
 
 static inline void remove_from_chains(struct free_arena_header *ah)
 {
-	remove_from_free_chain(ah);
-	remove_from_main_chain(ah);
+    remove_from_free_chain(ah);
+    remove_from_main_chain(ah);
 }
 
 static void *__malloc_from_block(struct free_arena_header *fp, size_t size)
 {
-	size_t fsize;
-	struct free_arena_header *nfp, *na, *fpn, *fpp;
+    size_t fsize;
+    struct free_arena_header *nfp, *na, *fpn, *fpp;
 
-	fsize = fp->a.size;
+    fsize = fp->a.size;
 
-	/* We need the 2* to account for the larger requirements of a
-	   free block */
-	if (fsize >= size + 2 * sizeof(struct arena_header)) {
-		/* Bigger block than required -- split block */
-		nfp = (struct free_arena_header *)((char *)fp + size);
-		na = fp->a.next;
+    /* We need the 2* to account for the larger requirements of a
+       free block */
+    if (fsize >= size + 2 * sizeof(struct arena_header)) {
+        /* Bigger block than required -- split block */
+        nfp = (struct free_arena_header *)((char *)fp + size);
+        na = fp->a.next;
 
-		nfp->a.type = ARENA_TYPE_FREE;
-		nfp->a.size = fsize - size;
-		fp->a.type = ARENA_TYPE_USED;
-		fp->a.size = size;
+        nfp->a.type = ARENA_TYPE_FREE;
+        nfp->a.size = fsize - size;
+        fp->a.type = ARENA_TYPE_USED;
+        fp->a.size = size;
 
-		/* Insert into all-block chain */
-		nfp->a.prev = fp;
-		nfp->a.next = na;
-		na->a.prev = nfp;
-		fp->a.next = nfp;
+        /* Insert into all-block chain */
+        nfp->a.prev = fp;
+        nfp->a.next = na;
+        na->a.prev = nfp;
+        fp->a.next = nfp;
 
-		/* Replace current block on free chain */
-		nfp->next_free = fpn = fp->next_free;
-		nfp->prev_free = fpp = fp->prev_free;
-		fpn->prev_free = nfp;
-		fpp->next_free = nfp;
-	} else {
-		fp->a.type = ARENA_TYPE_USED; /* Allocate the whole block */
-		remove_from_free_chain(fp);
-	}
+        /* Replace current block on free chain */
+        nfp->next_free = fpn = fp->next_free;
+        nfp->prev_free = fpp = fp->prev_free;
+        fpn->prev_free = nfp;
+        fpp->next_free = nfp;
+    } else {
+        fp->a.type = ARENA_TYPE_USED; /* Allocate the whole block */
+        remove_from_free_chain(fp);
+    }
 
-	return (void *)(&fp->a + 1);
+    return (void *)(&fp->a + 1);
 }
 
 static struct free_arena_header *__free_block(struct free_arena_header *ah)
 {
-	struct free_arena_header *pah, *nah;
+    struct free_arena_header *pah, *nah;
 
-	pah = ah->a.prev;
-	nah = ah->a.next;
-	if (pah->a.type == ARENA_TYPE_FREE &&
-	    (char *)pah + pah->a.size == (char *)ah) {
-		/* Coalesce into the previous block */
-		pah->a.size += ah->a.size;
-		pah->a.next = nah;
-		nah->a.prev = pah;
-		mark_block_dead(ah);
+    pah = ah->a.prev;
+    nah = ah->a.next;
+    if (pah->a.type == ARENA_TYPE_FREE &&
+        (char *)pah + pah->a.size == (char *)ah) {
+        /* Coalesce into the previous block */
+        pah->a.size += ah->a.size;
+        pah->a.next = nah;
+        nah->a.prev = pah;
+        mark_block_dead(ah);
 
-		ah = pah;
-		pah = ah->a.prev;
-	} else {
-		/* Need to add this block to the free chain */
-		ah->a.type = ARENA_TYPE_FREE;
+        ah = pah;
+        pah = ah->a.prev;
+    } else {
+        /* Need to add this block to the free chain */
+        ah->a.type = ARENA_TYPE_FREE;
 
-		ah->next_free = __malloc_head.next_free;
-		ah->prev_free = &__malloc_head;
-		__malloc_head.next_free = ah;
-		ah->next_free->prev_free = ah;
-	}
+        ah->next_free = __malloc_head.next_free;
+        ah->prev_free = &__malloc_head;
+        __malloc_head.next_free = ah;
+        ah->next_free->prev_free = ah;
+    }
 
-	/* In either of the previous cases, we might be able to merge
-	   with the subsequent block... */
-	if (nah->a.type == ARENA_TYPE_FREE &&
-	    (char *)ah + ah->a.size == (char *)nah) {
-		ah->a.size += nah->a.size;
+    /* In either of the previous cases, we might be able to merge
+       with the subsequent block... */
+    if (nah->a.type == ARENA_TYPE_FREE &&
+        (char *)ah + ah->a.size == (char *)nah) {
+        ah->a.size += nah->a.size;
 
-		/* Remove the old block from the chains */
-		remove_from_chains(nah);
-	}
+        /* Remove the old block from the chains */
+        remove_from_chains(nah);
+    }
 
-	/* Return the block that contains the called block */
-	return ah;
+    /* Return the block that contains the called block */
+    return ah;
 }
 
 void *malloc(size_t size)
 {
-	struct free_arena_header *fp;
-        void *more_mem;
-        extern void *_sbrk(int incr);
+    struct free_arena_header *fp;
+    void *more_mem;
+    extern void *_sbrk(int incr);
 
-	if (size == 0)
-		return NULL;
+    if (size == 0)
+        return NULL;
 
-	/* Add the obligatory arena header, and round up */
-	size = (size + 2 * sizeof(struct arena_header) - 1) & ARENA_SIZE_MASK;
+    /* Add the obligatory arena header, and round up */
+    size = (size + 2 * sizeof(struct arena_header) - 1) & ARENA_SIZE_MASK;
 
-        if (!malloc_lock())
-                return NULL;
+    if (!malloc_lock())
+        return NULL;
 
-        void *result = NULL;
+    void *result = NULL;
 retry_alloc:
-	for (fp = __malloc_head.next_free; fp->a.type != ARENA_TYPE_HEAD;
-	     fp = fp->next_free) {
-		if (fp->a.size >= size) {
-			/* Found fit -- allocate out of this block */
-			result = __malloc_from_block(fp, size);
-                        break;
-		}
-	}
-        if (result == NULL) {
-            more_mem = _sbrk(size);
-            if (more_mem != (void *)-1) {
-                add_malloc_block(more_mem, size);
-                goto retry_alloc;
-            }
+    for (fp = __malloc_head.next_free; fp->a.type != ARENA_TYPE_HEAD;
+         fp = fp->next_free) {
+        if (fp->a.size >= size) {
+            /* Found fit -- allocate out of this block */
+            result = __malloc_from_block(fp, size);
+            break;
         }
-        malloc_unlock();
-	return result;
+    }
+    if (result == NULL) {
+        more_mem = _sbrk(size);
+        if (more_mem != (void *)-1) {
+            add_malloc_block(more_mem, size);
+            goto retry_alloc;
+        }
+    }
+    malloc_unlock();
+    return result;
 }
 
 /* Call this to give malloc some memory to allocate from */
 void add_malloc_block(void *buf, size_t size)
 {
-	struct free_arena_header *fp = buf;
-	struct free_arena_header *pah;
+    struct free_arena_header *fp = buf;
+    struct free_arena_header *pah;
 
-	if (size < sizeof(struct free_arena_header))
-		return; // Too small.
+    if (size < sizeof(struct free_arena_header))
+        return; // Too small.
 
-	/* Insert the block into the management chains.  We need to set
-	   up the size and the main block list pointer, the rest of
-	   the work is logically identical to free(). */
-	fp->a.type = ARENA_TYPE_FREE;
-	fp->a.size = size;
+    /* Insert the block into the management chains.  We need to set
+       up the size and the main block list pointer, the rest of
+       the work is logically identical to free(). */
+    fp->a.type = ARENA_TYPE_FREE;
+    fp->a.size = size;
 
-        if (!malloc_lock())
-            return;
+    if (!malloc_lock())
+        return;
 
-	/* We need to insert this into the main block list in the proper
-	   place -- this list is required to be sorted.  Since we most likely
-	   get memory assignments in ascending order, search backwards for
-	   the proper place. */
-	for (pah = __malloc_head.a.prev; pah->a.type != ARENA_TYPE_HEAD;
-	     pah = pah->a.prev) {
-		if (pah < fp)
-			break;
-	}
+    /* We need to insert this into the main block list in the proper
+       place -- this list is required to be sorted.  Since we most likely
+       get memory assignments in ascending order, search backwards for
+       the proper place. */
+    for (pah = __malloc_head.a.prev; pah->a.type != ARENA_TYPE_HEAD;
+         pah = pah->a.prev) {
+        if (pah < fp)
+            break;
+    }
 
-	/* Now pah points to the node that should be the predecessor of
-	   the new node */
-	fp->a.next = pah->a.next;
-	fp->a.prev = pah;
-	pah->a.next = fp;
-	fp->a.next->a.prev = fp;
+    /* Now pah points to the node that should be the predecessor of
+       the new node */
+    fp->a.next = pah->a.next;
+    fp->a.prev = pah;
+    pah->a.next = fp;
+    fp->a.next->a.prev = fp;
 
-	/* Insert into the free chain and coalesce with adjacent blocks */
-	fp = __free_block(fp);
+    /* Insert into the free chain and coalesce with adjacent blocks */
+    fp = __free_block(fp);
 
-        malloc_unlock();
+    malloc_unlock();
 }
 
 void free(void *ptr)
 {
-	struct free_arena_header *ah;
+    struct free_arena_header *ah;
 
-	if (!ptr)
-		return;
+    if (!ptr)
+        return;
 
-	ah = (struct free_arena_header *)
-	    ((struct arena_header *)ptr - 1);
+    ah = (struct free_arena_header *)
+        ((struct arena_header *)ptr - 1);
 
 #ifdef DEBUG_MALLOC
-	assert(ah->a.type == ARENA_TYPE_USED);
+    assert(ah->a.type == ARENA_TYPE_USED);
 #endif
 
-        if (!malloc_lock())
-            return;
+    if (!malloc_lock())
+        return;
 
-	/* Merge into adjacent free blocks */
-	ah = __free_block(ah);
-        malloc_unlock();
+    /* Merge into adjacent free blocks */
+    ah = __free_block(ah);
+    malloc_unlock();
 }
 
 void get_malloc_memory_status(size_t *free_bytes, size_t *largest_block)
@@ -248,7 +248,7 @@ void get_malloc_memory_status(size_t *free_bytes, size_t *largest_block)
     *largest_block = 0;
 
     if (!malloc_lock())
-            return;
+        return;
 
     for (fp = __malloc_head.next_free; fp->a.type != ARENA_TYPE_HEAD; fp = fp->next_free) {
         *free_bytes += fp->a.size;


### PR DESCRIPTION
**Release notes:** an attempt to store a `double` or `uint64_t` in heap-allocated memory, then pass it to a varargs function, may yield indeterminate results.  This is similar to https://github.com/apache/mynewt-core/pull/888, except it applies to memory allocated from the heap, rather than stacks allocated in BSS.

The MCU linker scripts were only imposing 4-byte alignment on the heap base, rather than 8-byte alignment.  This caused `malloc()` to return pointers that were not 8-byte aligned.  This is problematic if the pointer were subsequently used to access data that requires 8-byte alignment (e.g., a `double`).

From n1570 (c11 draft), 7.22.3 (Memory management functions):

> The pointer returned if the allocation succeeds is suitably aligned so that it may be assigned to a pointer to any type of object with a fundamental alignment requirement

By locating the heap base at an offset of 8, we ensure `_sbrk()` only returns 8-byte aligned memory blocks.

`malloc()` itself already imposes a greater restriction on itself: it only allocates blocks whose size is a multiple of 16.  So, as long as `_sbrk()` gives malloc properly aligned blocks, `malloc()` will return properly aligned pointers to the application.
