### PR TITLE
libc: Conditionally compile float support in printf

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -65,6 +65,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <inttypes.h>
 
+#include "syscfg/syscfg.h"
+
 struct param {
     unsigned char width; /**< field width */
     char lz;            /**< Leading zeros */
@@ -238,8 +240,10 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
     char ch;
     char lng;
     void *v;
+#if MYNEWT_VAL(FLOAT_USER)
     double d;
     int n;
+#endif
 
     p.bf = bf;
 
@@ -339,11 +343,12 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 written += putchw(putp, &p);
                 p.bf = bf;
                 break;
+#if MYNEWT_VAL(FLOAT_USER)
             case 'f':
                 p.base = 10;
                 d = va_arg(va, double);
                 /* Cast to an int to get the integer part of the number */
-                n = (int)d;
+                n = d;
                 /* Convert to ascii */
                 i2a(n, &p);
                 /* Ignore left align for integer part */
@@ -358,7 +363,7 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 written += putchw(putp, &p);
                 /* Take the decimal part and multiply by 1000 */
                 n = (d-n)*1000;
-                /* Convert to asii */
+                /* Convert to ascii */
                 i2a(n, &p);
                 /* Set the leading zeros for the next integer output to 3 */
                 p.lz = 3;
@@ -371,6 +376,7 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
                 /* Output the decimal part. */
                 written += putchw(putp, &p);
                 break;
+#endif
             case '%':
                 written += putf(putp, ch);
                 break;


### PR DESCRIPTION
Libs doing float computations take a lot of text space,
so it shouldn't be compiled by default.