### PR TITLE
console: Add asynchronous RX handling for UART

### DIFF
--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -515,9 +515,13 @@ console_handle_char(uint8_t byte)
             break;
         case '\t':
             if (completion && !end) {
+#if MYNEWT_VAL(CONSOLE_UART_RX_BUF_SIZE) == 0
                 console_blocking_mode();
+#endif
                 completion(input->line, console_append_char);
+#if MYNEWT_VAL(CONSOLE_UART_RX_BUF_SIZE) == 0
                 console_non_blocking_mode();
+#endif
             }
             break;
         }

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -39,7 +39,6 @@ static struct console_ring cr_tx;
 static uint8_t cr_tx_buf[MYNEWT_VAL(CONSOLE_UART_TX_BUF_SIZE)];
 typedef void (*console_write_char)(struct uart_dev*, uint8_t);
 static console_write_char write_char_cb;
-static bool skip_if_tx_full;
 
 struct console_ring {
     uint8_t cr_head;
@@ -72,10 +71,6 @@ console_queue_char(struct uart_dev *uart_dev, uint8_t ch)
 
     OS_ENTER_CRITICAL(sr);
     while (CONSOLE_HEAD_INC(&cr_tx) == cr_tx.cr_tail) {
-        if (skip_if_tx_full) {
-            OS_EXIT_CRITICAL(sr);
-            return;
-        }
         /* TX needs to drain */
         uart_start_tx(uart_dev);
         OS_EXIT_CRITICAL(sr);
@@ -172,12 +167,7 @@ console_tx_char(void *arg)
 static int
 console_rx_char(void *arg, uint8_t byte)
 {
-    int rc;
-
-    skip_if_tx_full = true;
-    rc = console_handle_char(byte);
-    skip_if_tx_full  = false;
-    return rc;
+    return console_handle_char(byte);
 }
 
 int

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -51,14 +51,14 @@ inc_and_wrap(int i, int max)
 }
 
 static void
-console_add_char(struct console_ring *cr, char ch)
+console_ring_add_char(struct console_ring *cr, char ch)
 {
     cr->buf[cr->head] = ch;
     cr->head = inc_and_wrap(cr->head, cr->size);
 }
 
 static uint8_t
-console_pull_char(struct console_ring *cr)
+console_ring_pull_char(struct console_ring *cr)
 {
     uint8_t ch;
 
@@ -94,7 +94,7 @@ console_queue_char(struct uart_dev *uart_dev, uint8_t ch)
         }
         OS_ENTER_CRITICAL(sr);
     }
-    console_add_char(&cr_tx, ch);
+    console_ring_add_char(&cr_tx, ch);
     OS_EXIT_CRITICAL(sr);
 }
 
@@ -111,7 +111,7 @@ console_tx_flush(int cnt)
         if (console_ring_is_empty(&cr_tx)) {
             break;
         }
-        byte = console_pull_char(&cr_tx);
+        byte = console_ring_pull_char(&cr_tx);
         uart_blocking_tx(uart_dev, byte);
     }
 }
@@ -167,7 +167,7 @@ console_tx_char(void *arg)
     if (console_ring_is_empty(&cr_tx)) {
         return -1;
     }
-    return console_pull_char(&cr_tx);
+    return console_ring_pull_char(&cr_tx);
 }
 
 /*

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -53,6 +53,15 @@ syscfg.defs:
     CONSOLE_UART_TX_BUF_SIZE:
         description: 'UART console transmit buffer size; must be power of 2.'
         value: 32
+    CONSOLE_UART_RX_BUF_SIZE:
+        description: >
+            UART console receive buffer size; must be power of 2.
+            When enabled, data are received to intermediate ringbuffer and
+            processed in task context instead of interrupt. This prevents
+            from possible deadlocking when trying to output large amount of
+            data directly from RX handler (e.g. when echoing data back).
+            Set to 0 to disable (received data are handled in interrupt context)
+        value: 32
 
     CONSOLE_UART_DEV:
         description: 'Console UART device.'


### PR DESCRIPTION
There is possible deadlock when doing rx and tx at the same time, i.e. if tx buffer is full and rxd character triggers some output (e.g. echo) it is not possible to put new character to tx buffer and also tx buffer cannot be drained since we're in interrupt handler already.

To mitigate this there was workaround added which detected this condition and just dropped txd characters. This patch replaces this workaround with more generic solution: there is intermediate RX ringbuffer where data form UART are received and are not handled in interrupt context but in task context instead. Buffer can be disabled to retain original behaviour if necessary.