### PR TITLE
sys/log: Remove undefined log_rtr_erasei()

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -70,11 +70,6 @@ typedef int (*lh_append_func_t)(struct log *, void *buf, int len);
 typedef int (*lh_walk_func_t)(struct log *,
         log_walk_func_t walk_func, struct log_offset *log_offset);
 typedef int (*lh_flush_func_t)(struct log *);
-/*
- * This function pointer points to a function that restores the numebr
- * of entries that are specified while erasing
- */
-typedef int (*lh_rtr_erase_func_t)(struct log *, void *arg);
 
 #define LOG_TYPE_STREAM  (0)
 #define LOG_TYPE_MEMORY  (1)
@@ -86,7 +81,6 @@ struct log_handler {
     lh_append_func_t log_append;
     lh_walk_func_t log_walk;
     lh_flush_func_t log_flush;
-    lh_rtr_erase_func_t log_rtr_erase;
 };
 
 struct log_entry_hdr {
@@ -221,7 +215,6 @@ int log_read(struct log *log, void *dptr, void *buf, uint16_t off,
 int log_walk(struct log *log, log_walk_func_t walk_func,
         struct log_offset *log_offset);
 int log_flush(struct log *log);
-int log_rtr_erase(struct log *log, void *arg);
 
 /* Handler exports */
 #if MYNEWT_VAL(LOG_CONSOLE)

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -127,5 +127,4 @@ const struct log_handler log_cbmem_handler = {
     .log_append = log_cbmem_append,
     .log_walk = log_cbmem_walk,
     .log_flush = log_cbmem_flush,
-    .log_rtr_erase = NULL,
 };

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -76,7 +76,6 @@ const struct log_handler log_console_handler = {
     .log_append = log_console_append,
     .log_walk = log_console_walk,
     .log_flush = log_console_flush,
-    .log_rtr_erase = NULL,
 };
 
 #endif

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -32,6 +32,8 @@
 
 static struct flash_area sector;
 
+static int log_fcb_rtr_erase(struct log *log, void *arg);
+
 static int
 log_fcb_append(struct log *log, void *buf, int len)
 {
@@ -53,8 +55,8 @@ log_fcb_append(struct log *log, void *buf, int len)
             goto err;
         }
 
-        if (log->l_log->log_rtr_erase && fcb_log->fl_entries) {
-            rc = log->l_log->log_rtr_erase(log, fcb_log);
+        if (fcb_log->fl_entries) {
+            rc = log_fcb_rtr_erase(log, fcb_log);
             if (rc) {
                 goto err;
             }
@@ -278,7 +280,6 @@ const struct log_handler log_fcb_handler = {
     .log_append = log_fcb_append,
     .log_walk = log_fcb_walk,
     .log_flush = log_fcb_flush,
-    .log_rtr_erase = log_fcb_rtr_erase,
 };
 
 #endif


### PR DESCRIPTION
This seems like a good candidate for static function inside FCB log
handler only: it was added specifically to FCB handler, it is not
defined by any other handler and cannot even be used by an application
since it lacks actual implementation.