### PR TITLE
Fix build errors in BSPs

### DIFF
--- a/hw/bsp/ble400/src/hal_bsp.c
+++ b/hw/bsp/ble400/src/hal_bsp.c
@@ -31,8 +31,11 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
+
+#if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
+#endif
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -31,8 +31,11 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
+
+#if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
+#endif
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -181,6 +181,8 @@ hal_bsp_init(void)
 {
     int rc;
 
+    (void)rc;
+
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
@@ -210,13 +212,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -33,8 +33,11 @@
 #include "nrf51_bitfields.h"
 #include "hal/hal_spi.h"
 #include "os/os_dev.h"
+
+#if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
+#endif
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -31,8 +31,11 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
+
+#if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
+#endif
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -32,8 +32,15 @@
 #include "hal/hal_watchdog.h"
 #include "hal/hal_i2c.h"
 #include "mcu/nrf52_hal.h"
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart/uart.h"
+#endif
+#if MYNEWT_VAL(UART_0)
 #include "uart_hal/uart_hal.h"
+#endif
+#if MYNEWT_VAL(UART_1)
+#include "uart_bitbang/uart_bitbang.h"
+#endif
 #include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
@@ -191,6 +198,8 @@ void
 hal_bsp_init(void)
 {
     int rc;
+
+    (void)rc;
 
     /* Make sure system clocks have started */
     hal_system_clock_start();

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -192,6 +192,8 @@ hal_bsp_init(void)
 {
     int rc;
 
+    (void)rc;
+
     /* Make sure system clocks have started */
     hal_system_clock_start();
 

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -183,6 +183,8 @@ hal_bsp_init(void)
 {
     int rc;
 
+    (void)rc;
+
     /* Make sure system clocks have started */
     hal_system_clock_start();
 

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -31,8 +31,11 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
+
+#if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
+#endif
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>


### PR DESCRIPTION
Fixes issues building the bootloader, with not peripherals enabled (non used var warning) or UART include errors when no UART is enabled.