### PR TITLE
Add flash area config for nffs/reboot/config/coredump

### DIFF
--- a/hw/bsp/nucleo-f303k8/syscfg.yml
+++ b/hw/bsp/nucleo-f303k8/syscfg.yml
@@ -30,3 +30,8 @@ syscfg.defs:
         description: 'Support for timer 0'
         value: 1
 
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1

--- a/hw/bsp/nucleo-f303re/syscfg.yml
+++ b/hw/bsp/nucleo-f303re/syscfg.yml
@@ -30,3 +30,8 @@ syscfg.defs:
         description: 'Support for timer 0'
         value: 1
 
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1

--- a/hw/bsp/stm32f3discovery/syscfg.yml
+++ b/hw/bsp/stm32f3discovery/syscfg.yml
@@ -30,3 +30,8 @@ syscfg.defs:
         description: 'Support for timer 0'
         value: 1
 
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1


### PR DESCRIPTION
This allows building/testing with slinky on stm32f3.