### PR TITLE
boot_serial - Allow UART string for serial mode.

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -491,6 +491,70 @@ boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
     return 0;
 }
 
+#if MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) != 0
+
+/** Don't include null-terminator in comparison. */
+#define BOOT_SERIAL_DETECT_STRING_LEN \
+    (sizeof MYNEWT_VAL(BOOT_SERIAL_DETECT_STRING) - 1)
+
+/**
+ * Listens on the UART for the management string.  Blocks for up to
+ * BOOT_SERIAL_DETECT_TIMEOUT milliseconds.
+ *
+ * @return                      true if the management string was received;
+ *                              false if the management string was not received
+ *                                  before the UART listen timeout expired.
+ */
+static bool
+boot_serial_detect_uart_string(void)
+{
+    uint32_t start_tick;
+    char buf[BOOT_SERIAL_DETECT_STRING_LEN] = { 0 };
+    char ch;
+    int newline;
+    int rc;
+
+    /* Calculate the timeout duration in OS cputime ticks. */
+    static const uint32_t timeout_dur =
+        MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) /
+        (1000.0 / MYNEWT_VAL(OS_CPUTIME_FREQ));
+
+    rc = boot_serial_uart_open();
+    assert(rc == 0);
+
+    start_tick = os_cputime_get32();
+
+    while (1) {
+        /* Read a single character from the UART. */
+        rc = boot_serial_uart_read(&ch, 1, &newline);
+        if (rc > 0) {
+            /* Eliminate the oldest character in the buffer to make room for
+             * the new one.
+             */
+            memmove(buf, buf + 1, BOOT_SERIAL_DETECT_STRING_LEN - 1);
+            buf[BOOT_SERIAL_DETECT_STRING_LEN - 1] = ch;
+
+            /* If the full management string has been received, indicate that
+             * the serial boot loader should start.
+             */
+            rc = memcmp(buf,
+                        MYNEWT_VAL(BOOT_SERIAL_DETECT_STRING),
+                        BOOT_SERIAL_DETECT_STRING_LEN);
+            if (rc == 0) {
+                boot_serial_uart_close();
+                return true;
+            }
+        }
+
+        /* Abort the listen on timeout. */
+        if (os_cputime_get32() >= start_tick + timeout_dur) {
+            boot_serial_uart_close();
+            return false;
+        }
+    }
+}
+#endif
+
 /*
  * Task which waits reading console, expecting to get image over
  * serial port.
@@ -597,10 +661,23 @@ boot_serial_pkg_init(void)
      * Configure a GPIO as input, and compare it against expected value.
      * If it matches, await for download commands from serial.
      */
+#if MYNEWT_VAL(BOOT_SERIAL_DETECT_PIN) != -1
     if (hal_gpio_read(MYNEWT_VAL(BOOT_SERIAL_DETECT_PIN)) ==
         MYNEWT_VAL(BOOT_SERIAL_DETECT_PIN_VAL)) {
 
         boot_serial_start(BOOT_SERIAL_INPUT_MAX);
         assert(0);
     }
+#endif
+
+    /*
+     * Listen for management pattern in UART input.  If detected, await for
+     * download commands from serial.
+     */
+#if MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) != 0
+    if (boot_serial_detect_uart_string()) {
+        boot_serial_start(BOOT_SERIAL_INPUT_MAX);
+        assert(0);
+    }
+#endif
 }

--- a/boot/boot_serial/src/boot_uart.c
+++ b/boot/boot_serial/src/boot_uart.c
@@ -71,6 +71,10 @@ boot_serial_uart_open(void)
 void
 boot_serial_uart_close(void)
 {
+    os_dev_close(&bs_uart->ud_dev);
+    bs_uart_rx.head = 0;
+    bs_uart_rx.tail = 0;
+    bs_uart_tx.cnt = 0;
 }
 
 static int

--- a/boot/boot_serial/syscfg.yml
+++ b/boot/boot_serial/syscfg.yml
@@ -20,9 +20,10 @@ syscfg.defs:
     BOOT_SERIAL_DETECT_PIN:
         description: >
             Start the serial boot loader if this pin is asserted at boot time.
-        value:
+        value: '-1'
         restrictions:
-            - '$notnull'
+            - '(BOOT_SERIAL_DETECT_PIN != -1) ||
+               (BOOT_SERIAL_DETECT_TIMEOUT != 0)'
 
     BOOT_SERIAL_DETECT_PIN_CFG:
         description: >
@@ -34,6 +35,29 @@ syscfg.defs:
             The value the detect pin must be set to for the serial boot loader
             to start.
         value: 0
+
+    BOOT_SERIAL_DETECT_TIMEOUT:
+        description: >
+            The duration, in milliseconds, to listen on the UART for the
+            management string (BOOT_SERIAL_DETECT_STRING).  If the management
+            string is detected during this period, the serial boot loader is
+            started.  If the period expires without the management string being
+            received, the boot loader runs in the normal (non-serial) mode.
+            Specify 0 to disable listening on the UART for the management
+            string.
+        value: 0
+        restrictions:
+            - '(BOOT_SERIAL_DETECT_PIN != -1) ||
+               (BOOT_SERIAL_DETECT_TIMEOUT != 0)'
+
+    BOOT_SERIAL_DETECT_STRING:
+        description: >
+            The string to listen for on the UART.  If this management string is
+            detected during the timeout period, the serial boot loader is
+            started.  If the period expires without this string being received,
+            the boot loader runs in the normal (non-serial) mode.  This setting
+            has no effect if BOOT_SERIAL_DETECT_TIMEOUT is set to 0.
+        value: '"nmgr"'
 
     BOOT_SERIAL_REPORT_PIN:
         description: >


### PR DESCRIPTION
*Note: This feature was requested by a user.  If we are unsure if this feature belongs in the boot loader in its current state, I am happy to just point him to this branch in the meantime.  Also, maybe this should be filed against MCUboot instead?*
 
If enabled, the serial boot loader listens on the UART for a string for a configurable amount of time.  If the string is detected, the boot loader enters serial mode.  If the string is not detected when the timeout expires, the boot loader proceeds in normal (non-serial) mode.

This feature is intended for setups that lack a suitable pin to use for enabling serial mode (either the pins are inaccessible or inconvenient to use).

Enabling this feature added 248 bytes to the boot loader binary when built on the nRF52dk with the default string setting ("nmgr").