### PR TITLE
Expose timeval <-> clocktime conversion functions from time/datetime library

### DIFF
--- a/time/datetime/include/datetime/datetime.h
+++ b/time/datetime/include/datetime/datetime.h
@@ -28,6 +28,17 @@ struct os_timezone;
 
 #define DATETIME_BUFSIZE    33
 
+struct clocktime {
+    int year;   /* year (4 digit year) */
+    int mon;    /* month (1 - 12) */
+    int day;    /* day (1 - 31) */
+    int hour;   /* hour (0 - 23) */
+    int min;    /* minute (0 - 59) */
+    int sec;    /* second (0 - 59) */
+    int dow;    /* day of week (0 - 6; 0 = Sunday) */
+    int usec;   /* micro seconds */
+};
+
 /*
  * Format the time specified by 'utctime' and 'tz' as per RFC 3339 in
  * the 'output' string. The size of the buffer pointed to by 'output'
@@ -50,6 +61,22 @@ int datetime_format(const struct os_timeval *utctime,
  */
 int datetime_parse(const char *input, struct os_timeval *utctime,
     struct os_timezone *tz);
+
+
+/*
+ * Converts from struct clocktime to struct os_timeval
+ *
+ * Returns 0 on success and OS_EINVAL on invalid input data
+ */
+int clocktime_to_timeval(const struct clocktime *ct, struct os_timeval *tv);
+
+/*
+ * Converts from struct os_timeval to struct clocktime
+ *
+ * Returns 0 on success and OS_EINVAL on invalid input data
+ */
+int timeval_to_clocktime(const struct os_timeval *tv, const struct os_timezone *tz,
+    struct clocktime *ct);
 
 #ifdef __cplusplus
 }

--- a/time/datetime/src/datetime.c
+++ b/time/datetime/src/datetime.c
@@ -58,6 +58,7 @@
  */
 
 #include <os/os_time.h>
+#include <os/os_error.h>
 
 #include <stdio.h>
 #include <ctype.h>

--- a/time/datetime/src/datetime.c
+++ b/time/datetime/src/datetime.c
@@ -64,17 +64,6 @@
 #include <string.h>
 #include <datetime/datetime.h>
 
-struct clocktime {
-    int year;   /* year (4 digit year) */
-    int mon;    /* month (1 - 12) */
-    int day;    /* day (1 - 31) */
-    int hour;   /* hour (0 - 23) */
-    int min;    /* minute (0 - 59) */
-    int sec;    /* second (0 - 59) */
-    int dow;    /* day of week (0 - 6; 0 = Sunday) */
-    int usec;   /* micro seconds */
-};
-
 #define days_in_year(y)     (leapyear(y) ? 366 : 365)
 
 #define    FEBRUARY    2
@@ -115,7 +104,7 @@ leapyear(int year)
     return (rv);
 }
 
-static int
+int
 clocktime_to_timeval(const struct clocktime *ct, struct os_timeval *tv)
 {
     int i, year, days;
@@ -130,7 +119,7 @@ clocktime_to_timeval(const struct clocktime *ct, struct os_timeval *tv)
         ct->min < 0 || ct->min > 59 ||
         ct->sec < 0 || ct->sec > 59 ||
         ct->usec < 0 || ct->usec > 999999) {
-        return (-1);
+        return (OS_EINVAL);
     }
 
     /*
@@ -153,7 +142,7 @@ clocktime_to_timeval(const struct clocktime *ct, struct os_timeval *tv)
     return (0);
 }
 
-static int
+int
 timeval_to_clocktime(const struct os_timeval *tv, const struct os_timezone *tz,
     struct clocktime *ct)
 {
@@ -169,7 +158,7 @@ timeval_to_clocktime(const struct os_timeval *tv, const struct os_timezone *tz,
     }
 
     if (secs < 0 || tv->tv_usec < 0 || tv->tv_usec > 999999) {
-        return (-1);
+        return (OS_EINVAL);
     }
 
     days = secs / SECDAY;


### PR DESCRIPTION
The conversion functions used internally in the time/datetime library are quite useful. I see no reason why they should not be exposed. Hence this small PR :)