### PR TITLE
hw/drivers/lora: Add MYNEWT_VALs to select PA_BOOST or RFO

### DIFF
--- a/hw/drivers/lora/sx1272/src/sx1272-board.c
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.c
@@ -232,7 +232,11 @@ SX1272SetRfTxPower(int8_t power)
 uint8_t
 SX1272GetPaSelect(uint32_t channel)
 {
+#if (MYNEWT_VAL(SX1272_USE_PA_BOOST) == 1)
     return RF_PACONFIG_PASELECT_PABOOST;
+#else
+    return RF_PACONFIG_PASELECT_RFO;
+#endif
 }
 
 #if (MYNEWT_VAL(SX1272_HAS_ANT_SW) || MYNEWT_VAL(SX1272_HAS_COMP_ANT_SW))

--- a/hw/drivers/lora/sx1272/syscfg.yml
+++ b/hw/drivers/lora/sx1272/syscfg.yml
@@ -47,27 +47,27 @@ syscfg.defs:
         value:  -1
 
     SX1272_DIO0_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO0 gpio  pin number'
         value:  -1
 
     SX1272_DIO1_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO1 gpio  pin number'
         value:  -1
 
     SX1272_DIO2_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO2 gpio  pin number'
         value:  -1
 
     SX1272_DIO3_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO3 gpio  pin number'
         value:  -1
 
     SX1272_DIO4_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO4 gpio  pin number'
         value:  -1
 
     SX1272_DIO5_PIN:
-        description: 'SPI chip select pin number'
+        description: 'DIO5 gpio pin number'
         value:  -1
 
     SX1272_RXTX_PIN:
@@ -77,6 +77,10 @@ syscfg.defs:
     SX1272_N_RXTX_PIN:
         description: 'Complement RxTx switch control pin number'
         value:  -1
+
+    SX1272_USE_PA_BOOST:
+        description: 'Transmit path connected to PA_BOOST or RFO (0 = RFO 1 = PABOOST)'
+        value: 0
 
     BSP_USE_HAL_SPI:
         description: 'Use alternate spi read/write buffer routines'

--- a/hw/drivers/lora/sx1276/src/sx1276-board.c
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.c
@@ -156,13 +156,26 @@ SX1276IoDeInit( void )
     }
 }
 
-uint8_t SX1276GetPaSelect( uint32_t channel )
+uint8_t
+SX1276GetPaSelect(uint32_t channel)
 {
+    uint8_t pacfg;
+
     if (channel < RF_MID_BAND_THRESH) {
-        return RF_PACONFIG_PASELECT_PABOOST;
+#if (MYNEWT_VAL(SX1276_LF_USE_PA_BOOST) == 1)
+        pacfg = RF_PACONFIG_PASELECT_PABOOST;
+#else
+        pacfg = RF_PACONFIG_PASELECT_RFO;
+#endif
     } else {
-        return RF_PACONFIG_PASELECT_RFO;
+#if (MYNEWT_VAL(SX1276_HF_USE_PA_BOOST) == 1)
+        pacfg = RF_PACONFIG_PASELECT_PABOOST;
+#else
+        pacfg = RF_PACONFIG_PASELECT_RFO;
+#endif
     }
+
+    return pacfg;
 }
 
 #if MYNEWT_VAL(SX1276_HAS_ANT_SW)

--- a/hw/drivers/lora/sx1276/syscfg.yml
+++ b/hw/drivers/lora/sx1276/syscfg.yml
@@ -30,6 +30,14 @@ syscfg.defs:
         description:
         value: 500
 
+    SX1276_LF_USE_PA_BOOST:
+        description: 'LF transmit path connected to PA_BOOST or RFO (0 = RFO 1 = PABOOST)'
+        value: 0
+
+    SX1276_HF_USE_PA_BOOST:
+        description: 'HF transmit path connected to PA_BOOST or RFO (0 = RFO 1 = PABOOST)'
+        value: 0
+
     SX1276_HAS_ANT_SW:
         description: 'Set to 1 if board has an antenna switch'
         value: 0


### PR DESCRIPTION
The sx1272 and 1276 have different possible RF output paths. The
code was assuming that PABOOST was always used for the sx1272
and that PABOOST was used for the HF band on the sx1276 always.

The new code allows the bsp/app/target/etc to specify the RF
output path for transmit. The added configuration variables are:
SX1272_USE_PA_BOOST and SX1276_HF_USE_PA_BOOST and
SX1276_LF_USE_PA_BOOST. The default is to use the normal RF
output path in all cases.