### PR TITLE
sys/log: Print timestamp as proper uint64

### DIFF
--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -37,9 +37,8 @@ log_console_append(struct log *log, void *buf, int len)
 
     if (!console_is_midline) {
         hdr = (struct log_entry_hdr *) buf;
-        console_printf("[ts=%lussb, mod=%u level=%u] ",
-                (unsigned long) hdr->ue_ts, hdr->ue_module,
-                hdr->ue_level);
+        console_printf("[ts=%llussb, mod=%u level=%u] ",
+                hdr->ue_ts, hdr->ue_module, hdr->ue_level);
     }
 
     console_write((char *) buf + LOG_ENTRY_HDR_SIZE, len - LOG_ENTRY_HDR_SIZE);

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -56,11 +56,7 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
     }
     data[rc] = 0;
 
-    /* XXX: This is evil.  newlib printf does not like 64-bit
-     * values, and this causes memory to be overwritten.  Cast to a
-     * unsigned 32-bit value for now.
-     */
-    console_printf("[%lu] %s\n", (unsigned long) ueh.ue_ts, data);
+    console_printf("[%llu] %s\n", ueh.ue_ts, data);
 
     return (0);
 err:


### PR DESCRIPTION
After PRs #888 and #890 fixed stack and malloc to use proper 8-byte
alignment uint64_t should also work with printfs.