### PR TITLE
Fix stm32f1xx/olimex-p103 UART

### DIFF
--- a/hw/bsp/olimex-p103/src/hal_bsp.c
+++ b/hw/bsp/olimex-p103/src/hal_bsp.c
@@ -36,6 +36,7 @@
 #include <stm32f1xx_hal_pwr.h>
 #include <stm32f1xx_hal_flash.h>
 #include <stm32f1xx_hal_gpio_ex.h>
+#include <stm32f1xx_ll_gpio.h>       /* AF remapping */
 #include <mcu/stm32f1_bsp.h>
 #include "mcu/stm32f1xx_mynewt_hal.h"
 #include "hal/hal_i2c.h"
@@ -47,17 +48,15 @@ static struct uart_dev hal_uart0;
 
 static const struct stm32f1_uart_cfg uart_cfg[UART_CNT] = {
     [0] = {
-        .suc_uart = USART3,
+        .suc_uart = USART2,
         .suc_rcc_reg = &RCC->APB1ENR,
-        .suc_rcc_dev = RCC_APB1ENR_USART3EN,
-        .suc_pin_tx = MCU_GPIO_PORTB(10),
-        .suc_pin_rx = MCU_GPIO_PORTB(11),
+        .suc_rcc_dev = RCC_APB1ENR_USART2EN,
+        .suc_pin_tx = MCU_GPIO_PORTA(2),
+        .suc_pin_rx = MCU_GPIO_PORTA(3),
         .suc_pin_rts = -1,
         .suc_pin_cts = -1,
-        //.suc_pin_af = GPIO_AF7_USART3,
-        /* TODO: AF must be implemented! */
-        .suc_pin_af = -1,
-        .suc_irqn = USART3_IRQn
+        .suc_pin_remap_fn = LL_GPIO_AF_DisableRemap_USART2,
+        .suc_irqn = USART2_IRQn,
     }
 };
 #endif

--- a/hw/mcu/stm/stm32f1xx/include/mcu/stm32f1_bsp.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/stm32f1_bsp.h
@@ -35,15 +35,9 @@ struct stm32f1_uart_cfg {
     int8_t suc_pin_rx;
     int8_t suc_pin_rts;
     int8_t suc_pin_cts;
-    uint8_t suc_pin_af;                 /* AF selection for this */
+    void (*suc_pin_remap_fn)(void);     /* AF selection for this */
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
-
-/*
- * Internal API for stm32f1xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
 
 struct hal_flash;
 extern struct hal_flash stm32f1_flash_dev;

--- a/hw/mcu/stm/stm32f1xx/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_gpio.c
@@ -489,32 +489,6 @@ int hal_gpio_init_out(int pin, int val)
 }
 
 /**
- * gpio init af
- *
- * Configure the specified pin for AF.
- */
-int
-hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od)
-{
-    GPIO_InitTypeDef gpio;
-
-    if (!od) {
-        gpio.Mode = GPIO_MODE_AF_PP;
-    } else {
-        gpio.Mode = GPIO_MODE_AF_OD;
-    }
-    gpio.Speed = GPIO_SPEED_HIGH;
-    gpio.Pull = pull;
-
-    /* TODO: no alternate on STM32F1xx
-     *
-     * gpio.Alternate = af_type;
-     */
-
-    return hal_gpio_init_stm(pin, &gpio);
-}
-
-/**
  * gpio write
  *
  * Write a value (either high or low) to the specified pin.

--- a/hw/mcu/stm/stm32f1xx/src/hal_uart.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_uart.c
@@ -233,6 +233,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     struct hal_uart *u;
     const struct stm32f1_uart_cfg *cfg;
     uint32_t cr1, cr2, cr3;
+    GPIO_InitTypeDef gpio;
 
     if (port >= UART_CNT) {
         return -1;
@@ -244,6 +245,25 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     }
     cfg = u->u_cfg;
     assert(cfg);
+
+    gpio.Mode = GPIO_MODE_AF_PP;
+    gpio.Speed = GPIO_SPEED_FREQ_HIGH;
+
+    gpio.Pull = GPIO_PULLUP;
+    hal_gpio_init_stm(cfg->suc_pin_tx, &gpio);
+    if (flow_ctl == HAL_UART_FLOW_CTL_RTS_CTS) {
+        hal_gpio_init_stm(cfg->suc_pin_rts, &gpio);
+    }
+
+    gpio.Mode = GPIO_MODE_AF_INPUT;
+    hal_gpio_init_stm(cfg->suc_pin_rx, &gpio);
+    if (flow_ctl == HAL_UART_FLOW_CTL_RTS_CTS) {
+        hal_gpio_init_stm(cfg->suc_pin_cts, &gpio);
+    }
+
+    if (cfg->suc_pin_remap_fn) {
+        cfg->suc_pin_remap_fn();
+    }
 
     /*
      * RCC
@@ -313,16 +333,9 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         break;
     }
 
-    cr1 |= (UART_MODE_RX | UART_MODE_TX | UART_OVERSAMPLING_16);
+    cr1 |= (UART_MODE_TX_RX | UART_OVERSAMPLING_16);
 
     *cfg->suc_rcc_reg |= cfg->suc_rcc_dev;
-
-    hal_gpio_init_af(cfg->suc_pin_tx, cfg->suc_pin_af, 0, 0);
-    hal_gpio_init_af(cfg->suc_pin_rx, cfg->suc_pin_af, 0, 0);
-    if (flow_ctl == HAL_UART_FLOW_CTL_RTS_CTS) {
-        hal_gpio_init_af(cfg->suc_pin_rts, cfg->suc_pin_af, 0, 0);
-        hal_gpio_init_af(cfg->suc_pin_cts, cfg->suc_pin_af, 0, 0);
-    }
 
     u->u_regs = cfg->suc_uart;
     u->u_regs->CR3 = cr3;


### PR DESCRIPTION
This fixes the UART configuration on Olimex STM32-P103 and also fixes the uart driver for STM32F1 which uses a slightly different mechanism for configuring alternate function for GPIOs. Hopefully this will live a short life and be replaced by a unified stm32-common uart driver!