### PR TITLE
Adding support for SPI_2 for nrf52

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -71,6 +71,13 @@ syscfg.defs:
             - "!SPI_1_MASTER"
             - "!I2C_1"
 
+    SPI_2_MASTER:
+        description: 'SPI 2 master'
+        value: 0
+    SPI_2_SLAVE:
+        description: 'SPI 2 slave'
+        value: 0
+
     ADC_0:
         description: 'NRF52 ADC 0'
         value:  0

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -74,9 +74,13 @@ syscfg.defs:
     SPI_2_MASTER:
         description: 'SPI 2 master'
         value: 0
+        restrictions:
+            - "!SPI_2_SLAVE"
     SPI_2_SLAVE:
         description: 'SPI 2 slave'
         value: 0
+        restrictions:
+            - "!SPI_2_MASTER"
 
     ADC_0:
         description: 'NRF52 ADC 0'


### PR DESCRIPTION
NRF52832 has support for a third SPIM or SPIS peripheral. Just making that available. 
Credit to Marcus Engholm for helping with this.