### PR TITLE
sys/log: Better handling for long/non-text entries

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -72,6 +72,7 @@ struct fcb {
 #define FCB_ERR_NOMEM	-5
 #define FCB_ERR_CRC	-6
 #define FCB_ERR_MAGIC   -7
+#define FCB_ERR_VERSION -8
 
 int fcb_init(struct fcb *fcb);
 

--- a/fs/fcb/src/fcb.c
+++ b/fs/fcb/src/fcb.c
@@ -204,6 +204,9 @@ fcb_sector_hdr_read(struct fcb *fcb, struct flash_area *fap,
     if (fdap->fd_magic != fcb->f_magic) {
         return FCB_ERR_MAGIC;
     }
+    if (fdap->fd_ver != fcb->f_version) {
+        return FCB_ERR_VERSION;
+    }
     return 1;
 }
 

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -260,6 +260,7 @@ extern const struct log_handler log_console_handler;
 extern const struct log_handler log_cbmem_handler;
 #if MYNEWT_VAL(LOG_FCB)
 extern const struct log_handler log_fcb_handler;
+extern const struct log_handler log_fcb_slot1_handler;
 #endif
 
 /* Private */

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -38,6 +38,7 @@ struct log_info {
 extern struct log_info g_log_info;
 
 struct log;
+struct log_entry_hdr;
 
 /**
  * Used for walks and reads; indicates part of log to access.
@@ -65,6 +66,7 @@ typedef int (*log_walk_func_t)(struct log *, struct log_offset *log_offset,
 typedef int (*lh_read_func_t)(struct log *, void *dptr, void *buf,
         uint16_t offset, uint16_t len);
 typedef int (*lh_append_func_t)(struct log *, void *buf, int len);
+typedef int (*lh_append_mbuf_func_t)(struct log *, struct os_mbuf *om);
 typedef int (*lh_walk_func_t)(struct log *,
         log_walk_func_t walk_func, struct log_offset *log_offset);
 typedef int (*lh_flush_func_t)(struct log *);
@@ -77,6 +79,7 @@ struct log_handler {
     int log_type;
     lh_read_func_t log_read;
     lh_append_func_t log_append;
+    lh_append_mbuf_func_t log_append_mbuf;
     lh_walk_func_t log_walk;
     lh_flush_func_t log_flush;
 };
@@ -205,6 +208,7 @@ struct log *log_list_get_next(struct log *);
 int log_register(char *name, struct log *log, const struct log_handler *,
                  void *arg, uint8_t level);
 int log_append(struct log *, uint16_t, uint16_t, void *, uint16_t);
+int log_append_mbuf(struct log *, uint16_t, uint16_t, struct os_mbuf *);
 
 #define LOG_PRINTF_MAX_ENTRY_LEN (128)
 void log_printf(struct log *log, uint16_t, uint16_t, char *, ...);

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -32,6 +32,7 @@ struct log_info {
     uint32_t li_next_index;
     uint8_t li_version;
 };
+#define LOG_VERSION_V3  3
 #define LOG_VERSION_V2  2
 #define LOG_VERSION_V1  1
 
@@ -84,12 +85,25 @@ struct log_handler {
     lh_flush_func_t log_flush;
 };
 
+#if MYNEWT_VAL(LOG_VERSION) == 2
 struct log_entry_hdr {
     int64_t ue_ts;
     uint32_t ue_index;
     uint8_t ue_module;
     uint8_t ue_level;
 }__attribute__((__packed__));
+#elif MYNEWT_VAL(LOG_VERSION) == 3
+struct log_entry_hdr {
+    int64_t ue_ts;
+    uint32_t ue_index;
+    uint8_t ue_module;
+    uint8_t ue_level;
+    uint8_t ue_etype;
+}__attribute__((__packed__));
+#else
+#error "Unsupported log version"
+#endif
+
 #define LOG_ENTRY_HDR_SIZE (sizeof(struct log_entry_hdr))
 
 #define LOG_LEVEL_DEBUG    (0)
@@ -132,6 +146,12 @@ struct log_entry_hdr {
     (LOG_MODULE_IOTIVITY    == module ? "IOTIVITY"    :\
     (LOG_MODULE_TEST        == module ? "TEST"        :\
      "UNKNOWN")))))))))
+
+#define LOG_ETYPE_STRING         (0)
+#if MYNEWT_VAL(LOG_VERSION) > 2
+#define LOG_ETYPE_CBOR           (1)
+#define LOG_ETYPE_BINARY         (2)
+#endif
 
 /* Logging medium */
 #define LOG_STORE_CONSOLE    1
@@ -207,8 +227,23 @@ struct log *log_list_get_next(struct log *);
 /* Log functions, manipulate a single log */
 int log_register(char *name, struct log *log, const struct log_handler *,
                  void *arg, uint8_t level);
-int log_append(struct log *, uint16_t, uint16_t, void *, uint16_t);
-int log_append_mbuf(struct log *, uint16_t, uint16_t, struct os_mbuf *);
+int log_append_typed(struct log *, uint8_t, uint8_t, uint8_t, void *, uint16_t);
+int log_append_mbuf_typed(struct log *, uint8_t, uint8_t, uint8_t,
+                          struct os_mbuf *);
+
+static inline int
+log_append(struct log *log, uint8_t module, uint8_t level, void *data,
+           uint16_t len)
+{
+    return log_append_typed(log, module, level, LOG_ETYPE_STRING, data, len);
+}
+
+static inline int
+log_append_mbuf(struct log *log, uint8_t module, uint8_t level,
+                struct os_mbuf *om)
+{
+    return log_append_mbuf_typed(log, module, level, LOG_ETYPE_STRING, om);
+}
 
 #define LOG_PRINTF_MAX_ENTRY_LEN (128)
 void log_printf(struct log *log, uint16_t, uint16_t, char *, ...);

--- a/sys/log/full/include/log/log_fcb_slot1.h
+++ b/sys/log/full/include/log/log_fcb_slot1.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SYS_LOG_FCB_SLOT1_H__
+#define __SYS_LOG_FCB_SLOT1_H__
+
+#include "syscfg/syscfg.h"
+
+#if MYNEWT_VAL(LOG_FCB_SLOT1)
+
+#include "fcb/fcb.h"
+#include "cbmem/cbmem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void log_fcb_slot1_lock(void);
+
+bool log_fcb_slot1_is_locked(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif /* __SYS_LOG_FCB_SLOT1_H__ */

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -40,6 +40,24 @@ err:
 }
 
 static int
+log_cbmem_append_mbuf(struct log *log, struct os_mbuf *om)
+{
+    struct cbmem *cbmem;
+    int rc;
+
+    cbmem = (struct cbmem *) log->l_arg;
+
+    rc = cbmem_append_mbuf(cbmem, om);
+    if (rc != 0) {
+        goto err;
+    }
+
+    return (0);
+err:
+    return (rc);
+}
+
+static int
 log_cbmem_read(struct log *log, void *dptr, void *buf, uint16_t offset,
         uint16_t len)
 {
@@ -126,6 +144,7 @@ const struct log_handler log_cbmem_handler = {
     .log_type = LOG_TYPE_MEMORY,
     .log_read = log_cbmem_read,
     .log_append = log_cbmem_append,
+    .log_append_mbuf = log_cbmem_append_mbuf,
     .log_walk = log_cbmem_walk,
     .log_flush = log_cbmem_flush,
 };

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -32,18 +32,17 @@ static struct flash_area sector;
 static int log_fcb_rtr_erase(struct log *log, void *arg);
 
 static int
-log_fcb_append(struct log *log, void *buf, int len)
+log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
 {
     struct fcb *fcb;
-    struct fcb_entry loc;
     struct fcb_log *fcb_log;
-    int rc;
+    int rc = 0;
 
     fcb_log = (struct fcb_log *)log->l_arg;
     fcb = &fcb_log->fl_fcb;
 
     while (1) {
-        rc = fcb_append(fcb, len, &loc);
+        rc = fcb_append(fcb, len, loc);
         if (rc == 0) {
             break;
         }
@@ -66,9 +65,72 @@ log_fcb_append(struct log *log, void *buf, int len)
         }
     }
 
+err:
+    return (rc);
+}
+
+static int
+log_fcb_append(struct log *log, void *buf, int len)
+{
+    struct fcb *fcb;
+    struct fcb_entry loc;
+    struct fcb_log *fcb_log;
+    int rc;
+
+    fcb_log = (struct fcb_log *)log->l_arg;
+    fcb = &fcb_log->fl_fcb;
+
+    rc = log_fcb_start_append(log, len, &loc);
+    if (rc) {
+        goto err;
+    }
+
     rc = flash_area_write(loc.fe_area, loc.fe_data_off, buf, len);
     if (rc) {
         goto err;
+    }
+
+    rc = fcb_append_finish(fcb, &loc);
+
+err:
+    return (rc);
+}
+
+static int
+log_fcb_append_mbuf(struct log *log, struct os_mbuf *om)
+{
+    struct fcb *fcb;
+    struct fcb_entry loc;
+    struct fcb_log *fcb_log;
+    struct os_mbuf *om_tmp;
+    int len;
+    int rc;
+
+    fcb_log = (struct fcb_log *)log->l_arg;
+    fcb = &fcb_log->fl_fcb;
+
+    len = 0;
+
+    om_tmp = om;
+    while (om_tmp) {
+        len += om_tmp->om_len;
+        om_tmp = SLIST_NEXT(om_tmp, om_next);
+    }
+
+    rc = log_fcb_start_append(log, len, &loc);
+    if (rc) {
+        goto err;
+    }
+
+    while (om) {
+        rc = flash_area_write(loc.fe_area, loc.fe_data_off, om->om_data,
+                              om->om_len);
+        if (rc) {
+            goto err;
+        }
+
+        loc.fe_data_off += om->om_len;
+        om = SLIST_NEXT(om, om_next);
     }
 
     rc = fcb_append_finish(fcb, &loc);
@@ -275,6 +337,7 @@ const struct log_handler log_fcb_handler = {
     .log_type = LOG_TYPE_STORAGE,
     .log_read = log_fcb_read,
     .log_append = log_fcb_append,
+    .log_append_mbuf = log_fcb_append_mbuf,
     .log_walk = log_fcb_walk,
     .log_flush = log_fcb_flush,
 };

--- a/sys/log/full/src/log_fcb_slot1.c
+++ b/sys/log/full/src/log_fcb_slot1.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "log/log.h"
+#include "log/log_fcb_slot1.h"
+
+#if MYNEWT_VAL(LOG_FCB_SLOT1)
+
+static bool g_slot1_locked;
+
+static int
+log_fcb_slot1_append(struct log *log, void *buf, int len)
+{
+    if (g_slot1_locked) {
+        return OS_EBUSY;
+    }
+
+    return log_fcb_handler.log_append(log, buf, len);
+}
+
+static int
+log_fcb_slot1_append_mbuf(struct log *log, struct os_mbuf *om)
+{
+    if (g_slot1_locked) {
+        return OS_EBUSY;
+    }
+
+    return log_fcb_handler.log_append_mbuf(log, om);
+}
+
+static int
+log_fcb_slot1_read(struct log *log, void *dptr, void *buf, uint16_t offset,
+                   uint16_t len)
+{
+    if (g_slot1_locked) {
+        return OS_EBUSY;
+    }
+
+    return log_fcb_handler.log_read(log, dptr, buf, offset, len);
+}
+
+static int
+log_fcb_slot1_walk(struct log *log, log_walk_func_t walk_func,
+                   struct log_offset *log_offset)
+{
+    if (g_slot1_locked) {
+        return OS_EBUSY;
+    }
+
+    return log_fcb_handler.log_walk(log, walk_func, log_offset);
+}
+
+static int
+log_fcb_slot1_flush(struct log *log)
+{
+    if (g_slot1_locked) {
+        return OS_EBUSY;
+    }
+
+    return log_fcb_handler.log_flush(log);
+}
+
+const struct log_handler log_fcb_slot1_handler = {
+    .log_type = LOG_TYPE_STORAGE,
+    .log_read = log_fcb_slot1_read,
+    .log_append = log_fcb_slot1_append,
+    .log_append_mbuf = log_fcb_slot1_append_mbuf,
+    .log_walk = log_fcb_slot1_walk,
+    .log_flush = log_fcb_slot1_flush,
+};
+
+void log_fcb_slot1_lock(void)
+{
+    g_slot1_locked = true;
+}
+
+bool log_fcb_slot1_is_locked(void)
+{
+    return g_slot1_locked;
+}
+
+#endif

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -18,6 +18,10 @@
 #
 
 syscfg.defs:
+    LOG_VERSION:
+        description: 'Log entry header version used.'
+        value: 2
+
     LOG_LEVEL:
         description: 'Limits what level log messages are compiled in.'
         value: 0

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -30,6 +30,17 @@ syscfg.defs:
         description: 'Support logging to FCB.'
         value: 0
 
+    LOG_FCB_SLOT1:
+        description: >
+            Support logging to FCB located in slot 1.
+            This is a thin wrapper over LOG_FCB which should be used if
+            destination FCB is located in slot 1 as it can detect when
+            a new image is uploaded to this slot and stop logging to
+            prevent data corruption.
+        value: 0
+        restrictions:
+            - "LOG_FCB"
+
     LOG_CONSOLE:
         description: 'Support logging to console.'
         value: 1

--- a/util/cbmem/include/cbmem/cbmem.h
+++ b/util/cbmem/include/cbmem/cbmem.h
@@ -58,6 +58,7 @@ int cbmem_lock_acquire(struct cbmem *cbmem);
 int cbmem_lock_release(struct cbmem *cbmem);
 int cbmem_init(struct cbmem *cbmem, void *buf, uint32_t buf_len);
 int cbmem_append(struct cbmem *cbmem, void *data, uint16_t len);
+int cbmem_append_mbuf(struct cbmem *cbmem, struct os_mbuf *om);
 void cbmem_iter_start(struct cbmem *cbmem, struct cbmem_iter *iter);
 struct cbmem_entry_hdr *cbmem_iter_next(struct cbmem *cbmem, 
         struct cbmem_iter *iter);

--- a/util/cbmem/src/cbmem.c
+++ b/util/cbmem/src/cbmem.c
@@ -21,6 +21,8 @@
 #include "os/mynewt.h"
 #include "cbmem/cbmem.h"
 
+typedef void (copy_data_func_t) (void *dst, void *data, uint16_t len);
+
 int
 cbmem_init(struct cbmem *cbmem, void *buf, uint32_t buf_len)
 {
@@ -72,8 +74,9 @@ err:
 }
 
 
-int
-cbmem_append(struct cbmem *cbmem, void *data, uint16_t len)
+static int
+cbmem_append_internal(struct cbmem *cbmem, void *data, uint16_t len,
+                      copy_data_func_t *copy_func)
 {
     struct cbmem_entry_hdr *dst;
     uint8_t *start;
@@ -124,7 +127,7 @@ cbmem_append(struct cbmem *cbmem, void *data, uint16_t len)
     /* Copy the entry into the log
      */
     dst->ceh_len = len;
-    memcpy((uint8_t *) dst + sizeof(*dst), data, len);
+    copy_func((uint8_t *) dst + sizeof(*dst), data, len);
 
     cbmem->c_entry_end = dst;
     if (!cbmem->c_entry_start) {
@@ -139,6 +142,41 @@ cbmem_append(struct cbmem *cbmem, void *data, uint16_t len)
     return (0);
 err:
     return (-1);
+}
+
+static void
+copy_data_from_flat(void *dst, void *data, uint16_t len)
+{
+    memcpy(dst, data, len);
+}
+
+static void
+copy_data_from_mbuf(void *dst, void *data, uint16_t len)
+{
+    struct os_mbuf *om = data;
+
+    os_mbuf_copydata(om, 0, len, dst);
+}
+
+int
+cbmem_append(struct cbmem *cbmem, void *data, uint16_t len)
+{
+    return cbmem_append_internal(cbmem, data, len, copy_data_from_flat);
+}
+
+int
+cbmem_append_mbuf(struct cbmem *cbmem, struct os_mbuf *om)
+{
+    struct os_mbuf *om_tmp;
+    uint16_t len = 0;
+
+    om_tmp = om;
+    while (om_tmp) {
+        len += om_tmp->om_len;
+        om_tmp = SLIST_NEXT(om_tmp, om_next);
+    }
+
+    return cbmem_append_internal(cbmem, om, len, copy_data_from_mbuf);
 }
 
 void


### PR DESCRIPTION
Few improvements to logging subsystem to allow putting more data to log entries:
- allow to log directly from mbuf
- add data type to log entry (to distinguish between text/CBOR/whatever entries)
- special log handler to put data on unused slot1

Things to consider:
- Log version is bumped from 2 to 3, but there is no backwards compatibility retained - this means data from fcb written with v2 will be unreadable. Does it matter? Previous updates to log header did not care about it.
- Should slot1 be unlockable i.e. slot1 is locked, data is collected to cbmem, then unlocked and data is copied back to fcb. I removed this piece of code from PR since it was not working well for me yet, but I wonder if we'd actually need it. I imagine when image is uploaded to slot1 we have restart after which image is swapped by bootloader and we use slot1.