### PR TITLE
Shell: Registering help for commands registered with shell_cmd_register

### DIFF
--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -914,6 +914,9 @@ shell_cmd_register(const struct shell_cmd *sc)
 
     compat_commands[num_compat_commands].sc_cmd = sc->sc_cmd;
     compat_commands[num_compat_commands].sc_cmd_func = sc->sc_cmd_func;
+#if MYNEWT_VAL(SHELL_CMD_HELP)
+    compat_commands[num_compat_commands].help = sc->help;
+#endif
     ++num_compat_commands;
     return 0;
 }


### PR DESCRIPTION
The function shell_cmd_register() accepts help as part of the shell_cmd structure, however this is never taken across into compat_commands. This PR makes sure the help pointer is copied across if the SHELL_CMD_HELP variable is set. 