### PR TITLE
Fix printf fault before UART was initialized

### DIFF
--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -138,6 +138,13 @@ uart_console_non_blocking_mode(void)
 int
 console_out(int c)
 {
+    /* Assure that there is a write cb installed; this enables to debug
+     * code that is faulting before the console was initialized.
+     */
+    if (!write_char_cb) {
+        return c;
+    }
+
     if ('\n' == c) {
         write_char_cb(uart_dev, '\r');
         console_is_midline = 0;


### PR DESCRIPTION
This fixes an issue were `os_default_irq` is trying to print dump information before UART initialization was completed, causing a fault and losing all stack/backtrace data, making debug impossible.