### PR TITLE
lwIP - Disable -Werror

### DIFF
--- a/net/ip/lwip_base/pkg.yml
+++ b/net/ip/lwip_base/pkg.yml
@@ -31,6 +31,6 @@ pkg.deps:
     - net/ip
 
 pkg.cflags:
-    - -Wno-unused-but-set-variable
+    - -Wno-unused
     - -Wno-error=address
     - -DLWIP_HTTPD_STRNSTR_PRIVATE=0


### PR DESCRIPTION
The latest version of lwIP (2.0.3) provokes `unused-const-variable` warnings in some versions of gcc.  For example:

```
Error: net/ip/lwip_base/src/apps/httpd/fsdata.c:137:27: error: 'dummy_align__index_html' defined but not used [-Werror=unused-const-variable=]
 static const unsigned int dummy_align__index_html = 2;
                           ^~~~~~~~~~~~~~~~~~~~~~~
```

We can't disable this particular warning in the `lwip_core` package's cflags, because older versions of gcc complain when they don't recognize the command line option:

```
cc1: error: unrecognized command line option '-Wno-unused-const-variable' [-Werror]
```

This commit disables all "unused" warnings in the `lwip_core` package by adding the `-Wno-unused` cflag.
