### PR TITLE
btshell: Add way to reject LE CoC connection request

### DIFF
--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -155,7 +155,7 @@ int btshell_sec_restart(uint16_t conn_handle, uint8_t *ltk, uint16_t ediv,
 int btshell_tx_start(uint16_t handle, uint16_t len, uint16_t rate,
                      uint16_t num);
 int btshell_rssi(uint16_t conn_handle, int8_t *out_rssi);
-int btshell_l2cap_create_srv(uint16_t psm);
+int btshell_l2cap_create_srv(uint16_t psm, int accept_response);
 int btshell_l2cap_connect(uint16_t conn, uint16_t psm);
 int btshell_l2cap_disconnect(uint16_t conn, uint16_t idx);
 int btshell_l2cap_send(uint16_t conn, uint16_t idx, uint16_t bytes);

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -3251,6 +3251,11 @@ static const struct shell_cmd_help l2cap_update_help = {
 
 static const struct shell_param l2cap_create_server_params[] = {
     {"psm", "usage: =<UINT16>"},
+    {"error", "usage: used for PTS testing:"},
+    {"", "0 - always accept"},
+    {"", "1 - reject with insufficient authentication"},
+    {"", "2 - reject with insufficient authorization"},
+    {"", "3 - reject with insufficient key size"},
     {NULL, NULL}
 };
 

--- a/apps/btshell/src/cmd_l2cap.c
+++ b/apps/btshell/src/cmd_l2cap.c
@@ -95,6 +95,8 @@ int
 cmd_l2cap_create_server(int argc, char **argv)
 {
     uint16_t psm = 0;
+    int error;
+    int accept_response = 0;
     int rc;
 
     rc = parse_arg_all(argc - 1, argv + 1);
@@ -108,7 +110,25 @@ cmd_l2cap_create_server(int argc, char **argv)
         return rc;
     }
 
-    rc = btshell_l2cap_create_srv(psm);
+    error = parse_arg_uint32_dflt("error", 0, &rc);
+    if (rc != 0) {
+        console_printf("invalid 'error' parameter\n");
+        return rc;
+    }
+
+    switch (error) {
+    case 1:
+        accept_response = BLE_HS_EAUTHEN;
+        break;
+    case 2:
+        accept_response = BLE_HS_EAUTHOR;
+        break;
+    case 3:
+        accept_response = BLE_HS_EENCRYPT_KEY_SZ;
+        break;
+    }
+
+    rc = btshell_l2cap_create_srv(psm, accept_response);
     if (rc) {
         console_printf("Server create error: 0x%02x", rc);
     }


### PR DESCRIPTION
With this patch it is possible to create server which will response with
error for each connection request. This is needed for PTS tests.