### PR TITLE
hw/nrfxx/adc: Fix handling ADC configuration

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -96,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -44,7 +44,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +94,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -39,7 +39,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -93,10 +93,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -42,7 +42,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -36,7 +36,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -108,10 +107,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi1s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -96,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -41,7 +41,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nrf51-blenano/src/hal_bsp.c
+++ b/hw/bsp/nrf51-blenano/src/hal_bsp.c
@@ -34,7 +34,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(I2C_0) || MYNEWT_VAL(I2C_1)

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -39,7 +39,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nrf51dk/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk/src/hal_bsp.c
@@ -34,7 +34,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -100,6 +100,15 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(ADC_0)
+static struct adc_dev os_bsp_adc0;
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+};
+#endif
+
 #if MYNEWT_VAL(PWM_0)
 static struct pwm_dev os_bsp_pwm0;
 int pwm0_idx;

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || \
     MYNEWT_VAL(PWM_1) || \
@@ -99,10 +98,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -96,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -96,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -96,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -44,7 +44,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +94,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -48,7 +48,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -127,10 +126,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -46,7 +46,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -88,10 +87,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -39,7 +39,6 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
-#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -45,7 +45,6 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -96,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/drivers/adc/adc_nrf51/include/adc_nrf51/adc_nrf51.h
+++ b/hw/drivers/adc/adc_nrf51/include/adc_nrf51/adc_nrf51.h
@@ -24,12 +24,14 @@
 
 #include <nrfx.h>
 #include <nrf_adc.h>
+#include <nrfx_adc.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct nrf51_adc_dev_cfg {
+    nrfx_adc_config_t adc_cfg;
     uint16_t nadc_refmv0;	/* reference mV in AREF0 */
     uint16_t nadc_refmv1;	/* reference mV in AREF1 */
     uint16_t nadc_refmv_vdd;	/* reference mV in VDD */

--- a/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
+++ b/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
@@ -45,7 +45,7 @@ static struct nrf51_adc_stats nrf51_adc_stats;
 
 static struct adc_dev *global_adc_dev;
 
-static nrfx_adc_config_t *global_adc_config;
+static struct nrf51_adc_dev_cfg *global_adc_config;
 static struct nrf51_adc_dev_cfg *init_adc_config;
 
 static struct adc_chan_config nrf51_adc_chans[NRF_ADC_CHANNEL_COUNT];
@@ -99,7 +99,7 @@ static int
 nrf51_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
 {
     struct adc_dev *dev;
-    nrfx_adc_config_t *cfg;
+    struct nrf51_adc_dev_cfg *cfg = arg;
     int rc;
 
     if (arg == NULL) {
@@ -117,8 +117,7 @@ nrf51_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
     }
 
     /* Initialize the device */
-    cfg = (nrfx_adc_config_t *)arg;
-    rc = nrfx_adc_init(cfg, nrf51_adc_event_handler);
+    rc = nrfx_adc_init(&cfg->adc_cfg, nrf51_adc_event_handler);
     if (rc != NRFX_SUCCESS) {
         goto err;
     }

--- a/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
+++ b/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
@@ -116,6 +116,11 @@ nrf51_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
         }
     }
 
+    if (!cfg) {
+        /* Use initial configuration */
+        cfg = init_adc_config;
+    }
+ 
     /* Initialize the device */
     rc = nrfx_adc_init(&cfg->adc_cfg, nrf51_adc_event_handler);
     if (rc != NRFX_SUCCESS) {

--- a/hw/drivers/adc/adc_nrf52/include/adc_nrf52/adc_nrf52.h
+++ b/hw/drivers/adc/adc_nrf52/include/adc_nrf52/adc_nrf52.h
@@ -21,12 +21,14 @@
 #define __ADC_NRF52_H__
 
 #include <adc/adc.h>
+#include <nrfx_saadc.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct nrf52_adc_dev_cfg {
+    nrfx_saadc_config_t saadc_cfg;
     uint16_t nadc_refmv;		/* reference VDD in mV */
 };
 

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -110,6 +110,11 @@ nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
         goto err;
     }
 
+    /* If user did not provide config let us use init */
+    if (!cfg) {
+        cfg = init_adc_config;
+    }
+
     /* Initialize the device */
     rc = nrfx_saadc_init(&cfg->saadc_cfg, nrf52_saadc_event_handler);
     if (rc != NRFX_SUCCESS) {

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -38,7 +38,7 @@ struct nrf52_saadc_stats {
 static struct nrf52_saadc_stats nrf52_saadc_stats;
 
 static struct adc_dev *global_adc_dev;
-static nrfx_saadc_config_t *global_adc_config;
+static struct nrf52_adc_dev_cfg *global_adc_config;
 static struct nrf52_adc_dev_cfg *init_adc_config;
 
 static uint8_t nrf52_adc_chans[NRF_SAADC_CHANNEL_COUNT * sizeof(struct adc_chan_config)];
@@ -92,6 +92,7 @@ static int
 nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
 {
     struct adc_dev *dev;
+    struct nrf52_adc_dev_cfg *cfg = arg;
     int rc;
 
     dev = (struct adc_dev *) odev;
@@ -110,8 +111,7 @@ nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
     }
 
     /* Initialize the device */
-    rc = nrfx_saadc_init((nrfx_saadc_config_t *) arg,
-            nrf52_saadc_event_handler);
+    rc = nrfx_saadc_init(&cfg->saadc_cfg, nrf52_saadc_event_handler);
     if (rc != NRFX_SUCCESS) {
         goto err;
     }
@@ -181,7 +181,7 @@ nrf52_adc_configure_channel(struct adc_dev *dev, uint8_t cnum,
         /* Set the resolution and reference voltage for this channel to
         * enable conversion functions.
         */
-        switch (global_adc_config->resolution) {
+        switch (global_adc_config->saadc_cfg.resolution) {
             case NRF_SAADC_RESOLUTION_8BIT:
                 res = 8;
                 break;


### PR DESCRIPTION
When doing some work with ADC I've noticed that in both adc drivers for nrf51/nrf52 uses static variables for global_adc_config and init_adc_config  with different types which does not match each other. So far so good. However, init_adc_config is stored from init function and global_adc_config from open function. The issue here is that on both open and init functions takes same configuration type. Not sure how it works so far. Hope this PR straight it up. 