### PR TITLE
nrf52 adc fixes

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -223,13 +221,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -95,10 +95,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -220,13 +218,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -44,6 +44,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -94,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -39,6 +39,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -93,10 +93,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -42,6 +42,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -92,10 +93,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -36,6 +36,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -108,10 +108,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi1s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -235,13 +233,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -107,10 +108,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi1s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -223,13 +221,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -41,6 +41,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nrf51-arduino_101/syscfg.yml
+++ b/hw/bsp/nrf51-arduino_101/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  29

--- a/hw/bsp/nrf51-blenano/src/hal_bsp.c
+++ b/hw/bsp/nrf51-blenano/src/hal_bsp.c
@@ -34,6 +34,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(I2C_0) || MYNEWT_VAL(I2C_1)

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     I2C_0_SDA_PIN:
         description: 'Data pin for I2C0'
         value: 6

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -39,6 +39,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -40,17 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  29

--- a/hw/bsp/nrf51dk/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk/src/hal_bsp.c
@@ -34,6 +34,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -40,15 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  29

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -100,6 +100,13 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(ADC_0)
+static struct adc_dev os_bsp_adc0;
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
+};
+#endif
+
 #if MYNEWT_VAL(PWM_0)
 static struct pwm_dev os_bsp_pwm0;
 int pwm0_idx;
@@ -273,13 +280,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -100,15 +100,6 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 };
 #endif
 
-#if MYNEWT_VAL(ADC_0)
-static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
-};
-#endif
-
 #if MYNEWT_VAL(PWM_0)
 static struct pwm_dev os_bsp_pwm0;
 int pwm0_idx;

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -99,10 +99,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -230,13 +228,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || \
     MYNEWT_VAL(PWM_1) || \
@@ -98,10 +99,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -223,13 +221,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -96,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -223,13 +221,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -223,13 +221,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -95,10 +95,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -214,13 +212,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -44,6 +44,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -94,10 +95,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -127,12 +127,11 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
+
 
 #if MYNEWT_VAL(PWM_0)
 static struct pwm_dev os_bsp_pwm0;
@@ -343,13 +342,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -48,6 +48,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -126,10 +127,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -88,10 +88,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -208,13 +206,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -46,6 +46,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -87,10 +88,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -39,6 +39,7 @@
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
+#include <nrfx_adc.h>
 #endif
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -96,10 +96,8 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static nrfx_saadc_config_t os_bsp_adc0_config = {
-    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
 };
 #endif
 
@@ -231,13 +229,13 @@ hal_bsp_init(void)
 #endif
 
 #if MYNEWT_VAL(ADC_0)
-rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                   "adc0",
-                   OS_DEV_INIT_KERNEL,
-                   OS_DEV_INIT_PRIO_DEFAULT,
-                   nrf52_adc_dev_init,
-                   &os_bsp_adc0_config);
-assert(rc == 0);
+    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
+                       "adc0",
+                       OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init,
+                       &os_bsp_adc0_config);
+    assert(rc == 0);
 #endif
 
 #if MYNEWT_VAL(PWM_0)

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -45,6 +45,7 @@
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>
+#include <nrfx_saadc.h>
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_nrf52/pwm_nrf52.h>
@@ -95,10 +96,10 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
 
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .saadc_cfg.resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
-    .saadc_cfg.oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
-    .saadc_cfg.interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
+static nrfx_saadc_config_t os_bsp_adc0_config = {
+    .resolution         = MYNEWT_VAL(ADC_0_RESOLUTION),
+    .oversample         = MYNEWT_VAL(ADC_0_OVERSAMPLE),
+    .interrupt_priority = MYNEWT_VAL(ADC_0_INTERRUPT_PRIORITY),
 };
 #endif
 

--- a/hw/drivers/adc/adc_nrf51/include/adc_nrf51/adc_nrf51.h
+++ b/hw/drivers/adc/adc_nrf51/include/adc_nrf51/adc_nrf51.h
@@ -24,14 +24,12 @@
 
 #include <nrfx.h>
 #include <nrf_adc.h>
-#include <nrfx_adc.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct nrf51_adc_dev_cfg {
-    nrfx_adc_config_t adc_cfg;
     uint16_t nadc_refmv0;	/* reference mV in AREF0 */
     uint16_t nadc_refmv1;	/* reference mV in AREF1 */
     uint16_t nadc_refmv_vdd;	/* reference mV in VDD */

--- a/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
+++ b/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
@@ -45,7 +45,7 @@ static struct nrf51_adc_stats nrf51_adc_stats;
 
 static struct adc_dev *global_adc_dev;
 
-static struct nrf51_adc_dev_cfg *global_adc_config;
+static nrfx_adc_config_t *global_adc_config;
 static struct nrf51_adc_dev_cfg *init_adc_config;
 
 static struct adc_chan_config nrf51_adc_chans[NRF_ADC_CHANNEL_COUNT];
@@ -99,7 +99,7 @@ static int
 nrf51_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
 {
     struct adc_dev *dev;
-    struct nrf51_adc_dev_cfg *cfg = arg;
+    nrfx_adc_config_t *cfg;
     int rc;
 
     if (arg == NULL) {
@@ -116,13 +116,9 @@ nrf51_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
         }
     }
 
-    if (!cfg) {
-        /* Use initial configuration */
-        cfg = init_adc_config;
-    }
- 
     /* Initialize the device */
-    rc = nrfx_adc_init(&cfg->adc_cfg, nrf51_adc_event_handler);
+    cfg = (nrfx_adc_config_t *)arg;
+    rc = nrfx_adc_init(cfg, nrf51_adc_event_handler);
     if (rc != NRFX_SUCCESS) {
         goto err;
     }

--- a/hw/drivers/adc/adc_nrf52/include/adc_nrf52/adc_nrf52.h
+++ b/hw/drivers/adc/adc_nrf52/include/adc_nrf52/adc_nrf52.h
@@ -21,14 +21,12 @@
 #define __ADC_NRF52_H__
 
 #include <adc/adc.h>
-#include <nrfx_saadc.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct nrf52_adc_dev_cfg {
-    nrfx_saadc_config_t saadc_cfg;
     uint16_t nadc_refmv;		/* reference VDD in mV */
 };
 

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -38,7 +38,7 @@ struct nrf52_saadc_stats {
 static struct nrf52_saadc_stats nrf52_saadc_stats;
 
 static struct adc_dev *global_adc_dev;
-static struct nrf52_adc_dev_cfg *global_adc_config;
+static nrfx_saadc_config_t *global_adc_config;
 static struct nrf52_adc_dev_cfg *init_adc_config;
 
 static uint8_t nrf52_adc_chans[NRF_SAADC_CHANNEL_COUNT * sizeof(struct adc_chan_config)];
@@ -92,7 +92,6 @@ static int
 nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
 {
     struct adc_dev *dev;
-    struct nrf52_adc_dev_cfg *cfg = arg;
     int rc;
 
     dev = (struct adc_dev *) odev;
@@ -110,13 +109,9 @@ nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
         goto err;
     }
 
-    /* If user did not provide config let us use init */
-    if (!cfg) {
-        cfg = init_adc_config;
-    }
-
     /* Initialize the device */
-    rc = nrfx_saadc_init(&cfg->saadc_cfg, nrf52_saadc_event_handler);
+    rc = nrfx_saadc_init((nrfx_saadc_config_t *) arg,
+            nrf52_saadc_event_handler);
     if (rc != NRFX_SUCCESS) {
         goto err;
     }
@@ -186,7 +181,7 @@ nrf52_adc_configure_channel(struct adc_dev *dev, uint8_t cnum,
         /* Set the resolution and reference voltage for this channel to
         * enable conversion functions.
         */
-        switch (global_adc_config->saadc_cfg.resolution) {
+        switch (global_adc_config->resolution) {
             case NRF_SAADC_RESOLUTION_8BIT:
                 res = 8;
                 break;

--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -75,6 +75,16 @@ syscfg.defs:
         description: 'ADC'
         value:  0
 
+    ADC_0_REFMV_0:
+        description: 'reference mV in AREF0 if used'
+        value: 0
+    ADC_0_REFMV_1:
+        description: 'reference mV in AREF1 if used'
+        value: 0
+    ADC_0_REFMV_VDD:
+        description: 'reference mV in VDD if used'
+        value: 0
+
 # The XTAL_xxx definitions are used to set the clock source used for the low
 # frequency clock. It is required that at least one of these sources is
 # enabled (the bsp should set one of these clock sources).

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -86,17 +86,9 @@ syscfg.defs:
         description: 'NRF52 ADC 0'
         value:  0
 
-    ADC_0_RESOLUTION:
-        description: 'NRF52 ADC 0 RESOLUTION'
-        value: 'NRFX_SAADC_CONFIG_RESOLUTION'
-
-    ADC_0_OVERSAMPLE:
-        description: 'NRF52 ADC 0 OVERSAMPLE'
-        value: 'NRFX_SAADC_CONFIG_OVERSAMPLE'
-
-    ADC_0_INTERRUPT_PRIORITY:
-        description: 'NRF52 ADC IRQ PRIORITY'
-        value: 'NRFX_SAADC_CONFIG_IRQ_PRIORITY'
+    ADC_0_REFMV_0:
+        description: 'reference mV in AREF0 if used'
+        value: 0
 
     PWM_0:
         description: 'NRF52 PWM 0'


### PR DESCRIPTION
Oddly enough I separately came across the same issues last night https://github.com/apache/mynewt-core/pull/951, though I completely disagree with that patch.

The actual bug was that neither the nrf51 or nrf52 init takes its saadc nordic config as input, and SHOULDNT. Resolution and oversample etc are runtime options. The nrf52 didnt know that though and was incorrectly attempting to input those via syscfg, hence @rymanluk trying to fudge them into place.

INSTEAD what should happen is that PR should be reverted and those syscfg values should be replaced with nadc_refmv like the nrf51 driver.

Please see this fix and I request to roll back that change. Or at least we have other breaking 

cc @sterlinghughes 