### PR TITLE
Fix build errors - Add required bootutil dependency to a few apps

### DIFF
--- a/apps/bleuart/pkg.yml
+++ b/apps/bleuart/pkg.yml
@@ -23,6 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
+    - boot/bootutil
     - kernel/os
     - net/nimble/controller
     - net/nimble/host

--- a/apps/bsnprph/pkg.yml
+++ b/apps/bsnprph/pkg.yml
@@ -23,6 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
+    - boot/bootutil
     - boot/split
     - kernel/os
     - mgmt/imgmgr


### PR DESCRIPTION
This PR modifies two apps:
* bleuart
* bsnprph

These two apps depend on `boot/split`, which requires the `bootloader` API.  This PR satisfies this requirement by adding the `boot/bootutil` package to both apps' dependency lists.