### PR TITLE
Add convenience header: os/mynewt.h

### DIFF
--- a/apps/blecent/src/blecent.h
+++ b/apps/blecent/src/blecent.h
@@ -20,7 +20,7 @@
 #ifndef H_BLECENT_
 #define H_BLECENT_
 
-#include "os/queue.h"
+#include "os/mynewt.h"
 #include "log/log.h"
 #ifdef __cplusplus
 extern "C" {

--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -19,10 +19,8 @@
 
 #include <assert.h>
 #include <string.h>
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 
 /* BLE */
 #include "nimble/ble.h"

--- a/apps/blecsc/src/gatt_svr.c
+++ b/apps/blecsc/src/gatt_svr.c
@@ -20,10 +20,10 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "host/ble_hs.h"
 #include "host/ble_uuid.h"
 #include "blecsc_sens.h"
-#include "os/endian.h"
 
 #define CSC_ERR_CCC_DESC_IMPROPERLY_CONFIGURED  0x81
 

--- a/apps/blecsc/src/main.c
+++ b/apps/blecsc/src/main.c
@@ -22,8 +22,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "config/config.h"
 #include "nimble/ble.h"

--- a/apps/blehci/src/main.c
+++ b/apps/blehci/src/main.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 
 int
 main(void)

--- a/apps/blehr/src/main.c
+++ b/apps/blehr/src/main.c
@@ -22,8 +22,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "config/config.h"
 #include "nimble/ble.h"

--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "mesh/mesh.h"
 #include "console/console.h"
 #include "hal/hal_system.h"

--- a/apps/blemesh_shell/src/main.c
+++ b/apps/blemesh_shell/src/main.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "mesh/mesh.h"
 #include "console/console.h"
 #include "hal/hal_system.h"

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
-#include "bsp/bsp.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"

--- a/apps/bleprph/src/phy.c
+++ b/apps/bleprph/src/phy.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "host/ble_gap.h"
-#include "os/os_eventq.h"
-#include "syscfg/syscfg.h"
 #include "bleprph.h"
 
 #if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)

--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <sysinit/sysinit.h>
-#include <bsp/bsp.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <console/console.h>

--- a/apps/blesplit/src/main.c
+++ b/apps/blesplit/src/main.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
-#include "bsp/bsp.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"

--- a/apps/bletest/src/bletest_hci.c
+++ b/apps/bletest/src/bletest_hci.c
@@ -19,9 +19,8 @@
 
 #include <assert.h>
 #include <string.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
-#include "syscfg/syscfg.h"
 
 /* BLE */
 #include "nimble/ble.h"

--- a/apps/bletest/src/main.c
+++ b/apps/bletest/src/main.c
@@ -19,9 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_gpio.h"

--- a/apps/bletiny/src/bletiny.h
+++ b/apps/bletiny/src/bletiny.h
@@ -21,10 +21,10 @@
 #define H_BLETINY_PRIV_
 
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "log/log.h"
-#include "os/queue.h"
 
 #include "host/ble_gatt.h"
 #include "host/ble_gap.h"

--- a/apps/bletiny/src/main.c
+++ b/apps/bletiny/src/main.c
@@ -21,13 +21,10 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "log/log.h"
 #include "stats/stats.h"
-#include "os/os.h"
-#include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"
 #include "shell/shell.h"

--- a/apps/bleuart/src/main.c
+++ b/apps/bleuart/src/main.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
-#include "bsp/bsp.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include <imgmgr/imgmgr.h>

--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -20,16 +20,12 @@
 #include <assert.h>
 #include <stddef.h>
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <flash_map/flash_map.h>
-#include <os/os.h>
 
 #include <hal/hal_bsp.h>
 #include <hal/hal_system.h>
 #include <hal/hal_flash.h>
-#if MYNEWT_VAL(BOOT_SERIAL)
-#include <sysinit/sysinit.h>
-#endif
 #include <console/console.h>
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"

--- a/apps/bsncent/src/bsncent.h
+++ b/apps/bsncent/src/bsncent.h
@@ -20,7 +20,7 @@
 #ifndef H_BSNCENT_
 #define H_BSNCENT_
 
-#include "os/queue.h"
+#include "os/mynewt.h"
 #include "log/log.h"
 #ifdef __cplusplus
 extern "C" {

--- a/apps/bsncent/src/main.c
+++ b/apps/bsncent/src/main.c
@@ -19,10 +19,8 @@
 
 #include <assert.h>
 #include <string.h>
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 
 /* BLE */
 #include "nimble/ble.h"

--- a/apps/bsnprph/src/main.c
+++ b/apps/bsnprph/src/main.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
-#include "bsp/bsp.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"

--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -21,10 +21,10 @@
 #define H_BTSHELL_PRIV_
 
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "log/log.h"
-#include "os/queue.h"
 
 #include "host/ble_gatt.h"
 #include "host/ble_gap.h"

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
-
 #include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 
 #include "nimble/ble.h"

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -21,12 +21,10 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "log/log.h"
 #include "stats/stats.h"
-#include "os/os.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"

--- a/apps/ffs2native/src/main.c
+++ b/apps/ffs2native/src/main.c
@@ -24,17 +24,13 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "../src/nffs_priv.h"
-#include <os/queue.h>
 #include <fs/fs.h>
 #include <bsp/bsp.h>
 #include <nffs/nffs.h>
 #include <hal/hal_flash.h>
 #include <flash_map/flash_map.h>
-
-#include <sysinit/sysinit.h>
-#include <syscfg/syscfg.h>
-#include <sysflash/sysflash.h>
 
 #ifdef ARCH_sim
 #include <mcu/mcu_sim.h>

--- a/apps/iptest/src/main.c
+++ b/apps/iptest/src/main.c
@@ -17,11 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 
 #include <hal/hal_gpio.h>
@@ -41,7 +37,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <os/os_time.h>
 #include <id/id.h>
 
 #if MYNEWT_VAL(BUILD_WITH_OIC)

--- a/apps/lora_app_shell/src/las_cmd.c
+++ b/apps/lora_app_shell/src/las_cmd.c
@@ -20,8 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "parse/parse.h"

--- a/apps/lora_app_shell/src/main.c
+++ b/apps/lora_app_shell/src/main.c
@@ -20,12 +20,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "parse/parse.h"

--- a/apps/loraping/src/main.c
+++ b/apps/loraping/src/main.c
@@ -28,12 +28,10 @@ Description: Ping-Pong implementation.  Adapted to run in the MyNewt OS.
 */
 
 #include <string.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "radio/radio.h"
 #include "loraping.h"
 

--- a/apps/lorashell/src/main.c
+++ b/apps/lorashell/src/main.c
@@ -59,12 +59,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "node/radio.h"
 #include "console/console.h"
 #include "shell/shell.h"

--- a/apps/ocf_sample/src/main.c
+++ b/apps/ocf_sample/src/main.c
@@ -17,9 +17,7 @@
  * under the License.
  */
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include <os/os.h>
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <log/log.h>
 #include <oic/oc_api.h>

--- a/apps/ocf_sample/src/ocf_ble.c
+++ b/apps/ocf_sample/src/ocf_ble.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(OC_TRANSPORT_GATT)
 

--- a/apps/pwm_test/src/main.c
+++ b/apps/pwm_test/src/main.c
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include <os/os.h>
+
+#include "os/mynewt.h"
 #include <pwm/pwm.h>
 #include <bsp/bsp.h>
 #include <easing/easing.h>

--- a/apps/sensors_test/src/gatt_svr.c
+++ b/apps/sensors_test/src/gatt_svr.c
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
+
+#include "os/mynewt.h"
+
 #if MYNEWT_VAL(SENSOR_BLE)
 
 #include <assert.h>

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -34,8 +31,6 @@
 #include <string.h>
 #include <reboot/log_reboot.h>
 #include <id/id.h>
-#include <os/os_time.h>
-#include <defs/error.h>
 
 #if MYNEWT_VAL(BNO055_CLI)
 #include <bno055/bno055.h>

--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -41,7 +38,6 @@
 #include <assert.h>
 #include <string.h>
 #include <reboot/log_reboot.h>
-#include <os/os_time.h>
 #include <id/id.h>
 
 #ifdef ARCH_sim

--- a/apps/slinky_oic/src/main.c
+++ b/apps/slinky_oic/src/main.c
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-#include <sysinit/sysinit.h>
-
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -38,7 +35,6 @@
 #include <assert.h>
 #include <string.h>
 #include <reboot/log_reboot.h>
-#include <os/os_time.h>
 
 #ifdef ARCH_sim
 #include <mcu/mcu_sim.h>

--- a/apps/spitest/src/main.c
+++ b/apps/spitest/src/main.c
@@ -16,16 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+
+#include <assert.h>
+#include <string.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "stats/stats.h"
 #include "config/config.h"
-#include <os/os_dev.h>
-#include <assert.h>
-#include <string.h>
 #include <console/console.h>
 #ifdef ARCH_sim
 #include <mcu/mcu_sim.h>

--- a/apps/splitty/src/main.c
+++ b/apps/splitty/src/main.c
@@ -16,8 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "sysinit/sysinit.h"
-#include <os/os.h>
+
+#include <assert.h>
+#include <string.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -32,10 +34,7 @@
 #include <bootutil/image.h>
 #include <bootutil/bootutil.h>
 #include <imgmgr/imgmgr.h>
-#include <assert.h>
-#include <string.h>
 #include <reboot/log_reboot.h>
-#include <os/os_time.h>
 #include <id/id.h>
 
 #ifdef ARCH_sim

--- a/apps/testbench/src/tbb.c
+++ b/apps/testbench/src/tbb.c
@@ -19,7 +19,7 @@
 
 /** tbb - test bench BLE. */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(TESTBENCH_BLE)
 
@@ -27,9 +27,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "console/console.h"

--- a/apps/testbench/src/tbb.h
+++ b/apps/testbench/src/tbb.h
@@ -20,7 +20,7 @@
 #ifndef H_TBB_
 #define H_TBB_
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(TESTBENCH_BLE)
 

--- a/apps/testbench/src/testbench.c
+++ b/apps/testbench/src/testbench.c
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -43,9 +40,7 @@
 #include <string.h>
 #include <json/json.h>
 #include <reboot/log_reboot.h>
-#include <os/os_time.h>
 #include <id/id.h>
-#include <os/os_eventq.h>
 #include <oic/oc_api.h>
 #include <oic/oc_gatt.h>
 
@@ -62,7 +57,6 @@
 /*#include "../fcb/fcb_test.h"*/
 #endif /* FCB */
 
-#include "os/os_test.h"
 #include "bootutil/bootutil_test.h"
 
 #include <stddef.h>

--- a/apps/testbench/src/testbench.h
+++ b/apps/testbench/src/testbench.h
@@ -19,11 +19,8 @@
 #ifndef _H_TESTBENCH
 #define _H_TESTBENCH
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 
-#include <os/os.h>
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
@@ -46,7 +43,6 @@
 #include <string.h>
 #include <json/json.h>
 #include <reboot/log_reboot.h>
-#include <os/os_time.h>
 #include <id/id.h>
 
 #include "testutil/testutil.h"
@@ -60,7 +56,6 @@
 #include <fcb/fcb.h>
 #endif
 
-#include "os/os_test.h"
 #include "bootutil/bootutil_test.h"
 
 #include <stddef.h>

--- a/apps/testbench/src/testbench_json.c
+++ b/apps/testbench/src/testbench_json.c
@@ -18,9 +18,8 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
-
 #include "testbench.h"
 
 #ifndef JSON_BIGBUF_SIZE

--- a/apps/testbench/src/testbench_mempool.c
+++ b/apps/testbench/src/testbench_mempool.c
@@ -18,9 +18,8 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
-
 #include "testbench.h"
 
 /* Limit max blocks for testing */

--- a/apps/testbench/src/testbench_mutex.c
+++ b/apps/testbench/src/testbench_mutex.c
@@ -20,10 +20,8 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/time.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
-#include "os/os_test.h"
 
 #include "testbench.h"
 

--- a/apps/testbench/src/testbench_sem.c
+++ b/apps/testbench/src/testbench_sem.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 
 #include "testbench.h"
 

--- a/apps/timtest/src/main.c
+++ b/apps/timtest/src/main.c
@@ -16,16 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+
+#include <assert.h>
+#include <string.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_timer.h"
 #include "stats/stats.h"
 #include "config/config.h"
-#include <os/os_dev.h>
-#include <assert.h>
-#include <string.h>
 
 /* Task 1 */
 #define TASK1_PRIO (1)

--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 #include <stddef.h>
 #include <inttypes.h>
 #include <ctype.h>
 #include <stdio.h>
 
-#include "sysflash/sysflash.h"
-
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 
 #include <flash_map/flash_map.h>
@@ -31,11 +31,6 @@
 #include <hal/hal_system.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_watchdog.h>
-
-#include <os/endian.h>
-#include <os/os.h>
-#include <os/os_malloc.h>
-#include <os/os_cputime.h>
 
 #include <tinycbor/cbor.h>
 #include <tinycbor/cbor_buf_reader.h>

--- a/boot/boot_serial/src/boot_uart.c
+++ b/boot/boot_serial/src/boot_uart.c
@@ -19,9 +19,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <inttypes.h>
-
-#include <syscfg/syscfg.h>
-
+#include "os/mynewt.h"
 #include <uart/uart.h>
 
 /*

--- a/boot/boot_serial/test/src/boot_test.c
+++ b/boot/boot_serial/test/src/boot_test.c
@@ -22,10 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
-#include "os/endian.h"
+#include "os/mynewt.h"
 #include "base64/base64.h"
 #include "crc/crc16.h"
 #include "testutil/testutil.h"

--- a/boot/boot_serial/test/src/boot_test.h
+++ b/boot/boot_serial/test/src/boot_test.h
@@ -25,9 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
-#include "os/endian.h"
+#include "os/mynewt.h"
 #include "base64/base64.h"
 #include "crc/crc16.h"
 #include "testutil/testutil.h"

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -21,12 +21,10 @@
 #include <string.h>
 #include <inttypes.h>
 
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash.h"
 #include "flash_map/flash_map.h"
-#include "os/os.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
 #include "bootutil_priv.h"

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -20,7 +20,7 @@
 #ifndef H_BOOTUTIL_PRIV_
 #define H_BOOTUTIL_PRIV_
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bootutil/image.h"
 
 #ifdef __cplusplus

--- a/boot/bootutil/src/image_ec.c
+++ b/boot/bootutil/src/image_ec.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(BOOTUTIL_SIGN_EC)
 #include "bootutil/sign_key.h"

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -19,7 +19,8 @@
 
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
+
 #if MYNEWT_VAL(BOOTUTIL_SIGN_EC256)
 #include "bootutil/sign_key.h"
 

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(BOOTUTIL_SIGN_RSA)
 #include "bootutil/sign_key.h"

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_watchdog.h"
 #include "flash_map/flash_map.h"

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -27,11 +27,10 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include <hal/hal_flash.h>
 #include <hal/hal_watchdog.h>
-#include <os/os_malloc.h>
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
 #include "bootutil_priv.h"

--- a/boot/bootutil/test/src/boot_test.c
+++ b/boot/bootutil/test/src/boot_test.c
@@ -23,9 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "hal/hal_flash.h"
 #include "flash_map/flash_map.h"

--- a/boot/bootutil/test/src/boot_test.h
+++ b/boot/bootutil/test/src/boot_test.h
@@ -25,8 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "hal/hal_flash.h"
 #include "flash_map/flash_map.h"

--- a/boot/split/src/split.c
+++ b/boot/split/src/split.c
@@ -18,8 +18,7 @@
  */
 
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "defs/error.h"
+#include "os/mynewt.h"
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
 #include "split/split.h"

--- a/boot/split_app/src/split_app.c
+++ b/boot/split_app/src/split_app.c
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <stdlib.h>
 
-#include <sysinit/sysinit.h>
-#include <os/os.h>
+#include <stdlib.h>
+#include "os/mynewt.h"
 
 extern int main(int argc, char **argv);
 

--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #undef MBEDTLS_HAVE_TIME /* we have no time.h */
 #undef MBEDTLS_HAVE_TIME_DATE

--- a/crypto/mbedtls/test/src/mbedtls_test.c
+++ b/crypto/mbedtls/test/src/mbedtls_test.c
@@ -19,8 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "mbedtls/mbedtls_test.h"

--- a/crypto/mbedtls/test/src/mbedtls_test.h
+++ b/crypto/mbedtls/test/src/mbedtls_test.h
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "mbedtls/mbedtls_test.h"

--- a/encoding/base64/test/src/encoding_test.c
+++ b/encoding/base64/test/src/encoding_test.c
@@ -18,8 +18,7 @@
  */
 #include <assert.h>
 #include <stddef.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "encoding_test_priv.h"
 

--- a/encoding/base64/test/src/encoding_test_priv.h
+++ b/encoding/base64/test/src/encoding_test_priv.h
@@ -21,7 +21,7 @@
 
 #include <assert.h>
 #include <stddef.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "base64/hex.h"
 #include "testutil/testutil.h"
 

--- a/encoding/cborattr/src/cborattr.c
+++ b/encoding/cborattr/src/cborattr.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 #include <cborattr/cborattr.h>
 #include <tinycbor/cbor.h>
 #include <tinycbor/cbor_buf_reader.h>

--- a/encoding/cborattr/test/src/test_cborattr.c
+++ b/encoding/cborattr/test/src/test_cborattr.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "test_cborattr.h"
 

--- a/encoding/json/test/src/test_json.c
+++ b/encoding/json/test/src/test_json.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "test_json.h"
 

--- a/encoding/tinycbor/include/tinycbor/cbor_mbuf_reader.h
+++ b/encoding/tinycbor/include/tinycbor/cbor_mbuf_reader.h
@@ -20,8 +20,8 @@
 #ifndef CBOR_MBUF_READER_H
 #define CBOR_MBUF_READER_H
 
+#include "os/mynewt.h"
 #include <tinycbor/cbor.h>
-#include <os/os_mbuf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/encoding/tinycbor/include/tinycbor/cbor_mbuf_writer.h
+++ b/encoding/tinycbor/include/tinycbor/cbor_mbuf_writer.h
@@ -20,8 +20,8 @@
 #ifndef CBOR_MBUF_WRITER_H
 #define CBOR_MBUF_WRITER_H
 
+#include "os/mynewt.h"
 #include <tinycbor/cbor.h>
-#include <os/os_mbuf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/encoding/tinycbor/src/cbor_mbuf_reader.c
+++ b/encoding/tinycbor/src/cbor_mbuf_reader.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include <tinycbor/cbor_mbuf_reader.h>
 #include <tinycbor/compilersupport_p.h>
-#include <os/os_mbuf.h>
 
 static uint8_t
 cbor_mbuf_reader_get8(struct cbor_decoder_reader *d, int offset)

--- a/encoding/tinycbor/src/cbor_mbuf_writer.c
+++ b/encoding/tinycbor/src/cbor_mbuf_writer.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include <tinycbor/cbor.h>
-#include <os/os_mbuf.h>
 #include <tinycbor/cbor.h>
 #include <tinycbor/cbor_mbuf_writer.h>
 

--- a/fs/disk/include/disk/disk.h
+++ b/fs/disk/include/disk/disk.h
@@ -22,7 +22,7 @@
 
 #include <stddef.h>
 #include <inttypes.h>
-#include <os/queue.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/fs/disk/src/disk.c
+++ b/fs/disk/src/disk.c
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-#include <disk/disk.h>
 #include <stdlib.h>
 #include <string.h>
+#include "os/mynewt.h"
+#include <disk/disk.h>
 
 struct disk_info {
     const char *disk_name;

--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -16,14 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include <sysinit/sysinit.h>
-#include <hal/hal_flash.h>
-#include <disk/disk.h>
-#include <flash_map/flash_map.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "os/mynewt.h"
+#include <hal/hal_flash.h>
+#include <disk/disk.h>
+#include <flash_map/flash_map.h>
 
 #include <fatfs/ff.h>
 #include <fatfs/diskio.h>

--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -29,9 +29,8 @@ extern "C" {
 #include <inttypes.h>
 #include <limits.h>
 
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
-
-#include "os/os_mutex.h"
 
 #define FCB_MAX_LEN	(CHAR_MAX | CHAR_MAX << 7) /* Max length of element */
 

--- a/fs/fcb/test/src/fcb_test.c
+++ b/fs/fcb/test/src/fcb_test.c
@@ -20,9 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "fcb/fcb.h"

--- a/fs/fcb/test/src/fcb_test.h
+++ b/fs/fcb/test/src/fcb_test.h
@@ -22,12 +22,11 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "fcb/fcb.h"
-#include "fcb/../../src/fcb_priv.h"
+#include "fcb_priv.h"
 
 #ifdef __cplusplus
 #extern "C" {

--- a/fs/fs/include/fs/fs_if.h
+++ b/fs/fs/include/fs/fs_if.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#include <os/queue.h>
+#include "os/mynewt.h"
 
 /*
  * Common interface filesystem(s) provide.

--- a/fs/fs/src/fs_cli.c
+++ b/fs/fs/src/fs_cli.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(FS_CLI)
 

--- a/fs/fs/src/fs_mount.c
+++ b/fs/fs/src/fs_mount.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
 #include "fs/fs.h"
 #include "fs/fs_if.h"
 #include "fs_priv.h"

--- a/fs/fs/src/fs_nmgr.c
+++ b/fs/fs/src/fs_nmgr.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(FS_NMGR)
 
@@ -26,8 +26,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "os/os.h"
-#include "os/endian.h"
 #include "bootutil/image.h"
 #include "fs/fs.h"
 #include "cborattr/cborattr.h"

--- a/fs/fs/src/fs_priv.h
+++ b/fs/fs/src/fs_priv.h
@@ -19,7 +19,7 @@
 #ifndef __FS_PRIV_H__
 #define __FS_PRIV_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/fs/nffs/src/nffs.c
+++ b/fs/nffs/src/nffs.c
@@ -22,14 +22,10 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_flash.h"
 #include "flash_map/flash_map.h"
-#include "os/os_mempool.h"
-#include "os/os_mutex.h"
-#include "os/os_malloc.h"
 #include "stats/stats.h"
 #include "nffs_priv.h"
 #include "nffs/nffs.h"

--- a/fs/nffs/src/nffs_gc.c
+++ b/fs/nffs/src/nffs_gc.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include "os/os_malloc.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "nffs_priv.h"
 #include "nffs/nffs.h"

--- a/fs/nffs/src/nffs_inode.c
+++ b/fs/nffs/src/nffs_inode.c
@@ -20,8 +20,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os_mempool.h"
 #include "nffs/nffs.h"
 #include "nffs_priv.h"
 

--- a/fs/nffs/src/nffs_misc.c
+++ b/fs/nffs/src/nffs_misc.c
@@ -18,10 +18,10 @@
  */
 
 #include <assert.h>
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash_int.h"
-#include "os/os_malloc.h"
 #include "nffs/nffs.h"
 #include "nffs_priv.h"
 

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -22,8 +22,7 @@
 
 #include <inttypes.h>
 #include "log/log.h"
-#include "os/queue.h"
-#include "os/os_mempool.h"
+#include "os/mynewt.h"
 #include "nffs/nffs.h"
 #include "fs/fs.h"
 #include "crc/crc16.h"

--- a/fs/nffs/src/nffs_restore.c
+++ b/fs/nffs/src/nffs_restore.c
@@ -20,9 +20,8 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "hal/hal_flash.h"
-#include "os/os_mempool.h"
-#include "os/os_malloc.h"
 #include "nffs/nffs.h"
 #include "nffs_priv.h"
 

--- a/fs/nffs/test/src/nffs_test.c
+++ b/fs/nffs/test/src/nffs_test.c
@@ -39,8 +39,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_flash.h"
 #include "testutil/testutil.h"
 #include "fs/fs.h"

--- a/hw/bsp/ada_feather_nrf52/include/bsp/bsp.h
+++ b/hw/bsp/ada_feather_nrf52/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -20,10 +20,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/apollo2_evb/src/hal_bsp.c
+++ b/hw/bsp/apollo2_evb/src/hal_bsp.c
@@ -18,7 +18,7 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_bsp.h>
 #include <bsp/bsp.h>

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include <nrf52.h>
 #include "hal/hal_bsp.h"
@@ -27,9 +28,6 @@
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
 #include "mcu/nrf52_hal.h"
-#include <os/os_dev.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart/uart.h"
@@ -40,7 +38,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/bbc_microbit/src/hal_bsp.c
+++ b/hw/bsp/bbc_microbit/src/hal_bsp.c
@@ -20,17 +20,15 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 #include "bsp/bsp.h"
 #include <nrf51.h>
 #include "mcu/nrf51_hal.h"
 #include "hal/hal_bsp.h"
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
-#include "os/os_dev.h"
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/ble400/src/hal_bsp.c
+++ b/hw/bsp/ble400/src/hal_bsp.c
@@ -20,13 +20,11 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf51_hal.h"
 #include "bsp/bsp.h"
-#include "os/os_dev.h"
-#include "os/os_cputime.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -20,13 +20,11 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf51_hal.h"
 #include "bsp/bsp.h"
-#include "os/os_dev.h"
-#include "os/os_cputime.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -21,8 +21,7 @@
 #include <stddef.h>
 #include <nrf52.h>
 #include <assert.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -38,7 +37,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/calliope_mini/include/bsp/bsp.h
+++ b/hw/bsp/calliope_mini/include/bsp/bsp.h
@@ -24,8 +24,8 @@
 extern "C" {
 #endif
 
-#include "inttypes.h"
-#include <os/os_eventq.h>
+#include <inttypes.h>
+#include "os/mynewt.h"
 
 /* Define special stackos sections */
 #define sec_data_core   __attribute__((section(".data.core")))

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 #include "bsp/bsp.h"
 #include <nrf51.h>
@@ -27,12 +28,9 @@
 #include "hal/hal_bsp.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_i2c.h"
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
-#include "os/os_dev.h"
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/ci40/src/hal_bsp.c
+++ b/hw/bsp/ci40/src/hal_bsp.c
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "bsp/bsp.h"
-#include "syscfg/syscfg.h"
 #include "uart/uart.h"
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart_hal/uart_hal.h"

--- a/hw/bsp/dwm1001-dev/include/bsp/bsp.h
+++ b/hw/bsp/dwm1001-dev/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -21,9 +21,7 @@
 #include <stddef.h>
 #include <assert.h>
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/embarc_emsk/include/bsp/bsp.h
+++ b/hw/bsp/embarc_emsk/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/embarc_emsk/src/hal_bsp.c
+++ b/hw/bsp/embarc_emsk/src/hal_bsp.c
@@ -20,9 +20,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -39,7 +37,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp/bsp.h"
 
 /*

--- a/hw/bsp/frdm-k64f/src/hal_bsp.c
+++ b/hw/bsp/frdm-k64f/src/hal_bsp.c
@@ -22,8 +22,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <stdio.h>
-#include "os/os_dev.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash_int.h"

--- a/hw/bsp/hifive1/src/hal_bsp.c
+++ b/hw/bsp/hifive1/src/hal_bsp.c
@@ -21,9 +21,7 @@
 #include <stddef.h>
 #include <assert.h>
 
-#include <os/os_cputime.h>
-#include <syscfg/syscfg.h>
-#include <sysflash/sysflash.h>
+#include "os/mynewt.h"
 #include <flash_map/flash_map.h>
 #include <hal/hal_bsp.h>
 #include <hal/hal_flash.h>
@@ -34,7 +32,6 @@
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>
 #endif
-#include <os/os_dev.h>
 #include <bsp/bsp.h>
 #include <env/freedom-e300-hifive1/platform.h>
 

--- a/hw/bsp/native-armv7/src/hal_bsp.c
+++ b/hw/bsp/native-armv7/src/hal_bsp.c
@@ -21,16 +21,14 @@
 #include <assert.h>
 #include <string.h>
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
-#include "sysflash/sysflash.h"
-#include "os/os.h"
 #include "hal/hal_flash_int.h"
 #include "flash_map/flash_map.h"
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #include "mcu/native_bsp.h"
 #include "mcu/mcu_hal.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
 #include "sim/sim_accel.h"

--- a/hw/bsp/native-mips/src/hal_bsp.c
+++ b/hw/bsp/native-mips/src/hal_bsp.c
@@ -21,16 +21,14 @@
 #include <assert.h>
 #include <string.h>
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
-#include "sysflash/sysflash.h"
-#include "os/os.h"
 #include "hal/hal_flash_int.h"
 #include "flash_map/flash_map.h"
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #include "mcu/native_bsp.h"
 #include "mcu/mcu_hal.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
 #include "sim/sim_accel.h"

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -21,16 +21,14 @@
 #include <assert.h>
 #include <string.h>
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
-#include "sysflash/sysflash.h"
-#include "os/os.h"
 #include "hal/hal_flash_int.h"
 #include "flash_map/flash_map.h"
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #include "mcu/native_bsp.h"
 #include "mcu/mcu_hal.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
 #include "sim/sim_accel.h"

--- a/hw/bsp/nina-b1/include/bsp/bsp.h
+++ b/hw/bsp/nina-b1/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -20,10 +20,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -20,19 +20,17 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf51.h>
 #include <mcu/nrf51_hal.h>
 #include <hal/hal_bsp.h>
 #include "hal/hal_system.h"
 #include "bsp/bsp.h"
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "mcu/cmsis_nvic.h"
 #include "nrf51_bitfields.h"
 #include "hal/hal_spi.h"
-#include "os/os_dev.h"
 
 #if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"

--- a/hw/bsp/nrf51-blenano/src/hal_bsp.c
+++ b/hw/bsp/nrf51-blenano/src/hal_bsp.c
@@ -20,17 +20,15 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 #include "bsp/bsp.h"
 #include <nrf51.h>
 #include "mcu/nrf51_hal.h"
 #include "hal/hal_bsp.h"
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
-#include "os/os_dev.h"
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -20,13 +20,11 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf51_hal.h"
 #include "bsp/bsp.h"
-#include "os/os_dev.h"
-#include "os/os_cputime.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"

--- a/hw/bsp/nrf51dk/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk/src/hal_bsp.c
@@ -20,13 +20,11 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf51_hal.h"
 #include "bsp/bsp.h"
-#include "os/os_dev.h"
-#include "os/os_cputime.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"

--- a/hw/bsp/nrf52-thingy/include/bsp/bsp.h
+++ b/hw/bsp/nrf52-thingy/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/nrf52-thingy/src/hal_bsp.c
+++ b/hw/bsp/nrf52-thingy/src/hal_bsp.c
@@ -21,11 +21,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -43,7 +40,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -21,9 +21,7 @@
 #include <stddef.h>
 #include <assert.h>
 #include <nrf52840.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/nrf52dk/include/bsp/bsp.h
+++ b/hw/bsp/nrf52dk/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -21,9 +21,7 @@
 #include <stddef.h>
 #include <assert.h>
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/nucleo-f303k8/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f303k8/include/bsp/bsp.h
@@ -21,7 +21,7 @@
 
 #include <inttypes.h>
 #include <mcu/mcu.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/nucleo-f303k8/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f303k8/src/hal_bsp.c
@@ -18,7 +18,7 @@
  */
 #include <stddef.h>
 
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 /*
@@ -37,12 +37,10 @@
 #include "hal/hal_system.h"
 #include "mcu/mcu.h"
 #include "mcu/stm32f3_bsp.h"
-#include "os/os_cputime.h"
 #include "stm32f3xx.h"
 #include "stm32f3xx_hal.h"
 #include "stm32f3xx_hal_gpio.h"
 #include "stm32f3xx_hal_rcc.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 static struct uart_dev hal_uart[2];

--- a/hw/bsp/nucleo-f303re/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f303re/include/bsp/bsp.h
@@ -21,7 +21,7 @@
 
 #include <inttypes.h>
 #include <mcu/mcu.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/nucleo-f303re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f303re/src/hal_bsp.c
@@ -18,7 +18,7 @@
  */
 #include <stddef.h>
 
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 /*
@@ -37,12 +37,10 @@
 #include "hal/hal_system.h"
 #include "mcu/mcu.h"
 #include "mcu/stm32f3_bsp.h"
-#include "os/os_cputime.h"
 #include "stm32f3xx.h"
 #include "stm32f3xx_hal.h"
 #include "stm32f3xx_hal_gpio.h"
 #include "stm32f3xx_hal_rcc.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 static struct uart_dev hal_uart[2];

--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
 
-#include <os/os_dev.h>
+#include "os/mynewt.h"
+
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/nucleo-f413re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413re/src/hal_bsp.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/olimex-p103/src/hal_bsp.c
+++ b/hw/bsp/olimex-p103/src/hal_bsp.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -18,14 +18,13 @@
  */
 
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "stm32f407xx.h"
 #include "stm32f4xx_hal_gpio_ex.h"
 #include "stm32f4xx_hal_dma.h"
 #include "stm32f4xx_hal_adc.h"
 #include "flash_map/flash_map.h"
-#include "os/os_dev.h"
 #if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
-#include <syscfg/syscfg.h>
 #include <mcu/mcu.h>
 #include <mcu/mips_bsp.h>
 #include <mcu/mips_hal.h>

--- a/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
@@ -18,7 +18,7 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_bsp.h>
 #include <mcu/mips_bsp.h>

--- a/hw/bsp/puckjs/include/bsp/bsp.h
+++ b/hw/bsp/puckjs/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -20,10 +20,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -19,14 +19,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "nrf52.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf52_hal.h"
-#include "os/os_cputime.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -19,14 +19,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "nrf52.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf52_hal.h"
-#include "os/os_cputime.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
@@ -40,7 +38,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/ruuvi_tag_revb2/include/bsp/bsp.h
+++ b/hw/bsp/ruuvi_tag_revb2/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
+++ b/hw/bsp/ruuvi_tag_revb2/src/hal_bsp.c
@@ -21,11 +21,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -34,7 +31,6 @@
 #include "hal/hal_watchdog.h"
 #include "hal/hal_i2c.h"
 #include "mcu/nrf52_hal.h"
-#include "defs/error.h"
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
 #include "uart/uart.h"
 #endif
@@ -44,7 +40,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/sensorhub/include/bsp/bsp.h
+++ b/hw/bsp/sensorhub/include/bsp/bsp.h
@@ -21,7 +21,7 @@
 
 #include <inttypes.h>
 #include <mcu/mcu.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/sensorhub/src/hal_bsp.c
+++ b/hw/bsp/sensorhub/src/hal_bsp.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 #include <assert.h>
-#include "syscfg/syscfg.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/stm32f3discovery/include/bsp/bsp.h
+++ b/hw/bsp/stm32f3discovery/include/bsp/bsp.h
@@ -21,7 +21,7 @@
 
 #include <inttypes.h>
 #include <mcu/mcu.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/stm32f3discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f3discovery/src/hal_bsp.c
@@ -17,11 +17,8 @@
  * under the License.
  */
 #include <stddef.h>
-
-#include <syscfg/syscfg.h>
-
-#include <os/os_dev.h>
 #include <assert.h>
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(UART_0)
 /*
@@ -36,7 +33,6 @@
 #include <hal/hal_flash_int.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_system.h>
-#include <os/os_cputime.h>
 
 #if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE) || \
     MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_1_SLAVE)

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -18,11 +18,10 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <mcu/cmsis_nvic.h>
 #include <flash_map/flash_map.h>
-#include <os/os_dev.h>
 #include <stm32f429xx.h>
 #include <stm32f4xx_hal_gpio_ex.h>
 
@@ -39,8 +38,6 @@
 #include <hal/hal_system.h>
 
 #include <mcu/stm32f4_bsp.h>
-
-
 
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -18,9 +18,8 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/stm32f767-nucleo/src/hal_bsp.c
+++ b/hw/bsp/stm32f767-nucleo/src/hal_bsp.c
@@ -18,10 +18,8 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
-#include <os/os_cputime.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/stm32f7discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f7discovery/src/hal_bsp.c
@@ -18,10 +18,8 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
-#include <os/os_cputime.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/stm32l152discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32l152discovery/src/hal_bsp.c
@@ -18,9 +18,8 @@
  */
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os_dev.h>
 #if MYNEWT_VAL(UART_0)
 #include <uart/uart.h>
 #include <uart_hal/uart_hal.h>

--- a/hw/bsp/telee02/include/bsp/bsp.h
+++ b/hw/bsp/telee02/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -20,10 +20,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -42,7 +40,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -20,13 +20,11 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
 #include "mcu/nrf51_hal.h"
 #include "bsp/bsp.h"
-#include "os/os_dev.h"
-#include "os/os_cputime.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"

--- a/hw/bsp/vbluno52/include/bsp/bsp.h
+++ b/hw/bsp/vbluno52/include/bsp/bsp.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -20,10 +20,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <nrf52.h>
-#include "os/os_cputime.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_system.h"
@@ -41,7 +39,6 @@
 #if MYNEWT_VAL(UART_1)
 #include "uart_bitbang/uart_bitbang.h"
 #endif
-#include "os/os_dev.h"
 #include "bsp.h"
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/charge-control/include/charge-control/charge_control.h
+++ b/hw/charge-control/include/charge-control/charge_control.h
@@ -28,9 +28,7 @@
 #ifndef __CHARGE_CONTROL_H__
 #define __CHARGE_CONTROL_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/charge-control/src/charge_control.c
+++ b/hw/charge-control/src/charge_control.c
@@ -19,11 +19,7 @@
 
 #include <string.h>
 
-#include "os/os.h"
-#include "os/os_dev.h"
-#include "defs/error.h"
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "charge-control/charge_control.h"
 #include "charge_control_priv.h"
 

--- a/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
+++ b/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
@@ -16,16 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+#include <assert.h>
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <adc/adc.h>
-#include <assert.h>
-#include <os/os.h>
 #include <mcu/cmsis_nvic.h>
 
 /* Nordic headers */
 #include <nrfx.h>
 #include <nrfx_adc.h>
-
 
 #include "adc_nrf51/adc_nrf51.h"
 

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-
+#include <assert.h>
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <adc/adc.h>
-#include <assert.h>
-#include <os/os.h>
 #include <mcu/cmsis_nvic.h>
 
 /* Nordic headers */

--- a/hw/drivers/adc/adc_stm32f4/src/adc_stm32f4.c
+++ b/hw/drivers/adc/adc_stm32f4/src/adc_stm32f4.c
@@ -20,7 +20,7 @@
 
 #include <hal/hal_bsp.h>
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <mcu/cmsis_nvic.h>
 #include "stm32f4xx_hal_dma.h"
 #include "stm32f4xx_hal_adc.h"
@@ -30,7 +30,6 @@
 #include "adc_stm32f4/adc_stm32f4.h"
 #include "stm32f4xx_hal_dma.h"
 #include "mcu/stm32f4xx_mynewt_hal.h"
-#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(ADC_1)||MYNEWT_VAL(ADC_2)||MYNEWT_VAL(ADC_3)
 #include <adc/adc.h>

--- a/hw/drivers/adc/include/adc/adc.h
+++ b/hw/drivers/adc/include/adc/adc.h
@@ -20,7 +20,7 @@
 #ifndef __ADC_H__
 #define __ADC_H__
 
-#include <os/os_dev.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/drivers/chg_ctrl/bq24040/include/bq24040/bq24040.h
+++ b/hw/drivers/chg_ctrl/bq24040/include/bq24040/bq24040.h
@@ -20,7 +20,7 @@
 #ifndef __BQ24040_H__
 #define __BQ24040_H__
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "charge-control/charge_control.h"
 

--- a/hw/drivers/chg_ctrl/bq24040/src/bq24040.c
+++ b/hw/drivers/chg_ctrl/bq24040/src/bq24040.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "defs/error.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "bq24040/bq24040.h"
 #include "console/console.h"

--- a/hw/drivers/debounce/src/debounce.c
+++ b/hw/drivers/debounce/src/debounce.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-#include "debounce/debounce.h"
-#include "syscfg/syscfg.h"
 #include <string.h>
+#include "os/mynewt.h"
+#include "debounce/debounce.h"
 
 static void
 debounce_check(void *arg)

--- a/hw/drivers/drv2605/include/drv2605/drv2605.h
+++ b/hw/drivers/drv2605/include/drv2605/drv2605.h
@@ -20,8 +20,7 @@
 #ifndef __DRV2605_H__
 #define __DRV2605_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/drv2605/src/drv2605.c
+++ b/hw/drivers/drv2605/src/drv2605.c
@@ -21,9 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "hal/hal_gpio.h"
 #include "drv2605/drv2605.h"

--- a/hw/drivers/drv2605/src/drv2605_shell.c
+++ b/hw/drivers/drv2605/src/drv2605_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "drv2605_priv.h"

--- a/hw/drivers/flash/at45db/src/at45db.c
+++ b/hw/drivers/flash/at45db/src/at45db.c
@@ -17,15 +17,14 @@
  * under the License.
  */
 
-#include <os/os.h>
+#include <string.h>
 
+#include "os/mynewt.h"
 #include <hal/hal_spi.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>
 #include <hal/hal_flash_int.h>
 #include <at45db/at45db.h>
-
-#include <string.h>
 
 /**
  * Memory Architecture:

--- a/hw/drivers/lora/sx1272/src/sx1272-board.c
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.c
@@ -12,8 +12,9 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 
 Maintainer: Miguel Luis and Gregory Cristian
 */
+
 #include <assert.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_gpio.h"
 #include "bsp/bsp.h"

--- a/hw/drivers/lora/sx1272/src/sx1272.c
+++ b/hw/drivers/lora/sx1272/src/sx1272.c
@@ -15,13 +15,11 @@ Maintainer: Miguel Luis and Gregory Cristian
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_timer.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "radio/radio.h"
 #include "sx1272.h"
 #include "sx1272-board.h"

--- a/hw/drivers/lora/sx1276/src/sx1276.c
+++ b/hw/drivers/lora/sx1276/src/sx1276.c
@@ -15,13 +15,11 @@ Maintainer: Miguel Luis, Gregory Cristian and Wael Guibene
 #include <assert.h>
 #include <math.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_timer.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
 #include "radio/radio.h"
 #include "sx1276.h"
 #include "sx1276-board.h"

--- a/hw/drivers/lp5523/src/lp5523.c
+++ b/hw/drivers/lp5523/src/lp5523.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#include <defs/error.h>
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <hal/hal_i2c.h>
 #include <log/log.h>
 #include <stats/stats.h>

--- a/hw/drivers/lp5523/src/lp5523_shell.c
+++ b/hw/drivers/lp5523/src/lp5523_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "sensor/sensor.h"
 #include "shell/shell.h"

--- a/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
+++ b/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_gpio.h>
 #include <hal/hal_timer.h>
 #include <mcu/cmsis_nvic.h>
-
-#include <os/os_cputime.h>
 
 #if MYNEWT_VAL(MCU_STM32F4)
 #include <bsp/stm32f4xx_hal_conf.h>

--- a/hw/drivers/mmc/include/mmc/mmc.h
+++ b/hw/drivers/mmc/include/mmc/mmc.h
@@ -20,7 +20,7 @@
 #ifndef __MMC_H__
 #define __MMC_H__
 
-#include <os/os_dev.h>
+#include "os/mynewt.h"
 #include <disk/disk.h>
 
 #ifdef __cplusplus

--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -20,7 +20,7 @@
 #ifndef __PWM_H__
 #define __PWM_H__
 
-#include <os/os_dev.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -17,13 +17,13 @@
  * under the License.
  */
 
+#include <assert.h>
+#include <string.h>
+#include <errno.h>
+#include "os/mynewt.h"
 #include <bsp.h>
 #include <hal/hal_bsp.h>
-#include <assert.h>
-#include <os/os.h>
-#include <errno.h>
 #include <pwm/pwm.h>
-#include <string.h>
 #include <mcu/cmsis_nvic.h>
 
 /* Nordic headers */

--- a/hw/drivers/pwm/soft_pwm/src/soft_pwm.c
+++ b/hw/drivers/pwm/soft_pwm/src/soft_pwm.c
@@ -18,9 +18,9 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
 #include <errno.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include <pwm/pwm.h>
 #include <hal/hal_bsp.h>
 #include <hal/hal_gpio.h>

--- a/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf.h
+++ b/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf.h
@@ -63,7 +63,7 @@ Revision: $Rev: 4351 $
 #ifndef SEGGER_RTT_CONF_H
 #define SEGGER_RTT_CONF_H
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __IAR_SYSTEMS_ICC__
   #include <intrinsics.h>

--- a/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf_Mynewt.h
+++ b/hw/drivers/rtt/include/rtt/SEGGER_RTT_Conf_Mynewt.h
@@ -1,7 +1,7 @@
 #ifndef SEGGER_RTT_CONF_H
 #define SEGGER_RTT_CONF_H
 
-#include "os/os.h"
+#include "os/mynewt.h"
 
 #define SEGGER_RTT_LOCK()   {                       \
                             int sr;                 \

--- a/hw/drivers/rtt/src/SEGGER_RTT.c
+++ b/hw/drivers/rtt/src/SEGGER_RTT.c
@@ -79,10 +79,9 @@ Additional information:
 ----------------------------------------------------------------------
 */
 
-#include "rtt/SEGGER_RTT.h"
-#include "sysinit/sysinit.h"
-
 #include <string.h>                 // for memcpy
+#include "os/mynewt.h"
+#include "rtt/SEGGER_RTT.h"
 
 /*********************************************************************
 *

--- a/hw/drivers/sensors/adxl345/include/adxl345/adxl345.h
+++ b/hw/drivers/sensors/adxl345/include/adxl345/adxl345.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_ADXL345_H__
 #define __SENSOR_ADXL345_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -22,9 +22,7 @@
 #include <assert.h>
 #include <math.h>
 
-#include "sysinit/sysinit.h"
-#include "defs/error.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_gpio.h"

--- a/hw/drivers/sensors/adxl345/src/adxl345_shell.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/bma253/include/bma253/bma253.h
+++ b/hw/drivers/sensors/bma253/include/bma253/bma253.h
@@ -20,8 +20,7 @@
 #ifndef __BMA253_H__
 #define __BMA253_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 #include "sensor/accel.h"
 #include "sensor/temperature.h"

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -21,9 +21,9 @@
 #include <math.h>
 #include <string.h>
 
+#include "os/mynewt.h"
 #include "bma253/bma253.h"
 #include "bma253_priv.h"
-#include "defs/error.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_i2c.h"
 

--- a/hw/drivers/sensors/bma253/src/bma253_shell.c
+++ b/hw/drivers/sensors/bma253/src/bma253_shell.c
@@ -19,7 +19,7 @@
 
 #include <errno.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bma253/bma253.h"
 #include "bma253_priv.h"
 #include "console/console.h"

--- a/hw/drivers/sensors/bme280/include/bme280/bme280.h
+++ b/hw/drivers/sensors/bme280/include/bme280/bme280.h
@@ -21,8 +21,7 @@
 #ifndef __BME280_H__
 #define __BME280_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #define BME280_SPI_READ_CMD_BIT 0x80

--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -22,9 +22,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "sensor/sensor.h"
 #include "bme280/bme280.h"

--- a/hw/drivers/sensors/bme280/src/bme280_shell.c
+++ b/hw/drivers/sensors/bme280/src/bme280_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_gpio.h"

--- a/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
+++ b/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
@@ -21,8 +21,7 @@
 #ifndef __bmp280_H__
 #define __bmp280_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #define BMP280_SPI_READ_CMD_BIT 0x80

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -22,9 +22,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"

--- a/hw/drivers/sensors/bmp280/src/bmp280_shell.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_gpio.h"

--- a/hw/drivers/sensors/bno055/include/bno055/bno055.h
+++ b/hw/drivers/sensors/bno055/include/bno055/bno055.h
@@ -20,8 +20,7 @@
 #ifndef __BNO055_H__
 #define __BNO055_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -21,9 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/bno055/src/bno055_shell.c
+++ b/hw/drivers/sensors/bno055/src/bno055_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_gpio.h"

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -20,8 +20,7 @@
 #ifndef __LIS2DH12_H__
 #define __LIS2DH12_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -22,9 +22,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "defs/error.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -20,8 +20,7 @@
 #ifndef __LIS2DW12_H__
 #define __LIS2DW12_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -22,9 +22,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "defs/error.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
+++ b/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_LPS33HW_H__
 #define __SENSOR_LPS33HW_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 #include "hal/hal_gpio.h"
 

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -22,9 +22,7 @@
 #include <assert.h>
 #include <math.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "sensor/pressure.h"

--- a/hw/drivers/sensors/lps33hw/src/lps33hw_shell.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw_shell.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_gpio.h"
 #include "lps33hw/lps33hw.h"

--- a/hw/drivers/sensors/lsm303dlhc/include/lsm303dlhc/lsm303dlhc.h
+++ b/hw/drivers/sensors/lsm303dlhc/include/lsm303dlhc/lsm303dlhc.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_LSM303DLHC_H__
 #define __SENSOR_LSM303DLHC_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -21,9 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/mpu6050/include/mpu6050/mpu6050.h
+++ b/hw/drivers/sensors/mpu6050/include/mpu6050/mpu6050.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_MPU6050_H__
 #define __SENSOR_MPU6050_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/mpu6050/src/mpu6050.c
+++ b/hw/drivers/sensors/mpu6050/src/mpu6050.c
@@ -21,9 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
+++ b/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
@@ -21,8 +21,7 @@
 #ifndef __MS5837_H__
 #define __MS5837_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #define MS5837_I2C_ADDRESS		0x76

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -22,16 +22,13 @@
 #include <errno.h>
 #include <string.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "ms5837/ms5837.h"
 #include "sensor/temperature.h"
 #include "sensor/pressure.h"
 #include "ms5837_priv.h"
-#include "os/os_cputime.h"
 #include "console/console.h"
 #include "log/log.h"
 #include "stats/stats.h"

--- a/hw/drivers/sensors/sim/include/sim/sim_accel.h
+++ b/hw/drivers/sensors/sim/include/sim/sim_accel.h
@@ -20,8 +20,7 @@
 #ifndef __SIM_ACCEL_H__
 #define __SIM_ACCEL_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/sim/include/sim/sim_mag.h
+++ b/hw/drivers/sensors/sim/include/sim/sim_mag.h
@@ -20,8 +20,7 @@
 #ifndef __SIM_MAG_H__
 #define __SIM_MAG_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/drivers/sensors/sim/src/generic_accel.c
+++ b/hw/drivers/sensors/sim/src/generic_accel.c
@@ -21,10 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 
 #include "sensor/sensor.h"
 #include "sensor/accel.h"

--- a/hw/drivers/sensors/sim/src/generic_mag.c
+++ b/hw/drivers/sensors/sim/src/generic_mag.c
@@ -21,10 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 
 #include "sensor/sensor.h"
 #include "sensor/mag.h"

--- a/hw/drivers/sensors/tcs34725/include/tcs34725/tcs34725.h
+++ b/hw/drivers/sensors/tcs34725/include/tcs34725/tcs34725.h
@@ -32,8 +32,7 @@
 #define TCS34725_GAIN_16X               0x02   /* 16x gain */
 #define TCS34725_GAIN_60X               0x03   /* 60x gain */
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -21,9 +21,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "tcs34725/tcs34725.h"

--- a/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
@@ -18,13 +18,12 @@
  */
 
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_gpio.h"
 #include "tcs34725/tcs34725.h"
 #include "tcs34725_priv.h"
-#include "defs/error.h"
 #include "parse/parse.h"
 
 #if MYNEWT_VAL(TCS34725_CLI)

--- a/hw/drivers/sensors/tsl2561/include/tsl2561/tsl2561.h
+++ b/hw/drivers/sensors/tsl2561/include/tsl2561/tsl2561.h
@@ -37,8 +37,7 @@
 #ifndef __ADAFRUIT_TSL2561_H__
 #define __ADAFRUIT_TSL2561_H__
 
-#include <os/os.h>
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -39,9 +39,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "defs/error.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_i2c.h"
 #include "sensor/sensor.h"
 #include "sensor/light.h"

--- a/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561_shell.c
@@ -36,7 +36,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_gpio.h"

--- a/hw/drivers/uart/include/uart/uart.h
+++ b/hw/drivers/uart/include/uart/uart.h
@@ -21,7 +21,7 @@
 #define __DRIVERS_UART_H_
 
 #include <inttypes.h>
-#include <os/os_dev.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/drivers/uart/uart_bitbang/src/uart_bitbang.c
+++ b/hw/drivers/uart/uart_bitbang/src/uart_bitbang.c
@@ -16,18 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
 
+#include "os/mynewt.h"
 #include <hal/hal_gpio.h>
 #include <hal/hal_uart.h>
 #include <hal/hal_timer.h>
 
-#include <os/os.h>
-#include <os/os_dev.h>
-#include <os/os_cputime.h>
 #include <uart/uart.h>
 
 #include "uart_bitbang/uart_bitbang.h"

--- a/hw/drivers/uart/uart_hal/src/uart_hal.c
+++ b/hw/drivers/uart/uart_hal/src/uart_hal.c
@@ -21,8 +21,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include <os/os.h>
-#include <os/os_dev.h>
+#include "os/mynewt.h"
 #include <hal/hal_uart.h>
 
 #include <uart/uart.h>

--- a/hw/hal/include/hal/hal_os_tick.h
+++ b/hw/hal/include/hal/hal_os_tick.h
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-#include <os/os_time.h>
+#include "os/mynewt.h"
 
 /**
  * Set up the periodic timer to interrupt at a frequency of 'os_ticks_per_sec'.

--- a/hw/hal/include/hal/hal_timer.h
+++ b/hw/hal/include/hal/hal_timer.h
@@ -29,15 +29,11 @@
 #define H_HAL_TIMER_
 
 #include <inttypes.h>
-#include "os/queue.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <inttypes.h>
-
-#include "os/queue.h"
 
 /* HAL timer callback */
 typedef void (*hal_timer_cb)(void *arg);

--- a/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
+++ b/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
@@ -20,7 +20,7 @@
 #ifndef __MCU_CORTEX_M4_H__
 #define __MCU_CORTEX_M4_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #include "mcu/apollo2.h"
 

--- a/hw/mcu/ambiq/apollo2/include/mcu/hal_apollo2.h
+++ b/hw/mcu/ambiq/apollo2/include/mcu/hal_apollo2.h
@@ -20,7 +20,7 @@
 #ifndef __HAL_APOLLO2_H_
 #define __HAL_APOLLO2_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/ambiq/apollo2/src/hal_flash.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_flash.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <am_hal_flash.h>
 #include <hal/hal_flash_int.h>
 #include <hal/hal_flash.h>

--- a/hw/mcu/ambiq/apollo2/src/hal_gpio.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_gpio.c
@@ -18,12 +18,10 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "mcu/apollo2.h"
 #include "mcu/cmsis_nvic.h"
-#include "os/os_trace_api.h"
-#include "defs/error.h"
 #include "am_mcu_apollo.h"
 #include "am_hal_pin.h"
 #include "am_hal_gpio.h"

--- a/hw/mcu/ambiq/apollo2/src/hal_os_tick.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_os_tick.c
@@ -27,7 +27,7 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "mcu/system_apollo2.h"
 #include "hal/hal_os_tick.h"
 #include "mcu/cmsis_nvic.h"

--- a/hw/mcu/ambiq/apollo2/src/hal_spi.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_spi.c
@@ -20,11 +20,10 @@
 #include <errno.h>
 #include <assert.h>
 #include <stdbool.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_spi.h"
 #include "mcu/hal_apollo2.h"
 #include "mcu/cmsis_nvic.h"
-#include "defs/error.h"
 
 #include "am_mcu_apollo.h"
 

--- a/hw/mcu/ambiq/apollo2/src/hal_timer.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_timer.c
@@ -21,12 +21,10 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "mcu/cmsis_nvic.h"
 #include "mcu/hal_apollo2.h"
 #include "hal/hal_timer.h"
-#include "defs/error.h"
 
 #include "am_mcu_apollo.h"
 

--- a/hw/mcu/ambiq/apollo2/src/hal_uart.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_uart.c
@@ -19,12 +19,11 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include "os/mynewt.h"
 #include "mcu/hal_apollo2.h"
-#include "defs/error.h"
 #include "hal/hal_uart.h"
 #include "mcu/cmsis_nvic.h"
 #include "bsp/bsp.h"
-#include "os/os_trace_api.h"
 
 #include "am_mcu_apollo.h"
 

--- a/hw/mcu/arc/snps/include/mcu/mcu_arc.h
+++ b/hw/mcu/arc/snps/include/mcu/mcu_arc.h
@@ -20,7 +20,7 @@
 #ifndef __MCU_ARC_H__
 #define __MCU_ARC_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/arc/snps/src/hal_os_tick.c
+++ b/hw/mcu/arc/snps/src/hal_os_tick.c
@@ -17,9 +17,8 @@
  * under the License.
  */
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "hal/hal_os_tick.h"
-#include "os/os_trace_api.h"
 #include "inc/arc/arc.h"
 #include "inc/arc/arc_exception.h"
 #include "inc/arc/arc_timer.h"

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_gpio.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_gpio.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_gpio.h>
 #include <mcu/mips_hal.h>
 #include <mcu/p32mx470f512h.h>

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_i2c.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_i2c.c
@@ -18,13 +18,12 @@
  */
 
 #include <xc.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include <hal/hal_gpio.h>
 #include <hal/hal_i2c.h>
 #include <mcu/p32mx470f512h.h>
 #include "mcu/mips_hal.h"
-#include <os/os_time.h>
 
 #define I2CxCON(I)              (base_address[I][0x00 / 0x04])
 #define I2CxCONCLR(I)           (base_address[I][0x04 / 0x04])

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_os_tick.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_os_tick.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 
 /*

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_spi.c
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
@@ -26,7 +27,6 @@
 #include "mcu/mips_hal.h"
 #include "mcu/p32mx470f512h.h"
 #include "mcu/pps.h"
-#include "syscfg/syscfg.h"
 
 #define SPIxCON(P)          (base_address[P][0x0 / 0x4])
 #define SPIxCONCLR(P)       (base_address[P][0x4 / 0x4])

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_timer.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_timer.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-#include <os/os.h>
 #include <stdint.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include <xc.h>
 #include "hal/hal_timer.h"
 #include "mcu/mips_hal.h"

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_uart.c
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-#include "hal/hal_uart.h"
-#include "bsp/bsp.h"
-#include "syscfg/syscfg.h"
-#include "mcu/mips_hal.h"
-#include "mcu/pps.h"
 #include <assert.h>
 #include <stdlib.h>
+#include "os/mynewt.h"
+#include "hal/hal_uart.h"
+#include "bsp/bsp.h"
+#include "mcu/mips_hal.h"
+#include "mcu/pps.h"
 
 #include <xc.h>
 

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_gpio.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_gpio.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_gpio.h>
 #include <mcu/mips_hal.h>
 #include <mcu/p32mz2048efg100.h>

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_i2c.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_i2c.c
@@ -18,13 +18,12 @@
  */
 
 #include <xc.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include <hal/hal_gpio.h>
 #include <hal/hal_i2c.h>
 #include <mcu/p32mz2048efg100.h>
 #include "mcu/mips_hal.h"
-#include <os/os_time.h>
 
 #define I2CxCON(I)              (base_address[I][0x00 / 0x04])
 #define I2CxCONCLR(I)           (base_address[I][0x04 / 0x04])

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_os_tick.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_os_tick.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 
 /*

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_spi.c
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_spi.h"
@@ -26,7 +27,6 @@
 #include "mcu/mips_hal.h"
 #include "mcu/p32mz2048efg100.h"
 #include "mcu/pps.h"
-#include "syscfg/syscfg.h"
 
 #define SPIxCON(P)          (base_address[P][0x0 / 0x4])
 #define SPIxCONCLR(P)       (base_address[P][0x4 / 0x4])

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_timer.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_timer.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-#include <os/os.h>
 #include <stdint.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include <xc.h>
 #include "hal/hal_timer.h"
 #include "mcu/mips_hal.h"

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_uart.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_uart.c
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-#include "hal/hal_uart.h"
-#include "bsp/bsp.h"
-#include "syscfg/syscfg.h"
-#include "mcu/mips_hal.h"
-#include "mcu/pps.h"
 #include <assert.h>
 #include <stdlib.h>
+#include "os/mynewt.h"
+#include "hal/hal_uart.h"
+#include "bsp/bsp.h"
+#include "mcu/mips_hal.h"
+#include "mcu/pps.h"
 
 #include <xc.h>
 

--- a/hw/mcu/mips/danube/src/hal_os_tick.c
+++ b/hw/mcu/mips/danube/src/hal_os_tick.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 #include "mcu/gic.h"
 

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "hal/hal_flash_int.h"
 #include "mcu/mcu_sim.h"

--- a/hw/mcu/native/src/hal_system.c
+++ b/hw/mcu/native/src/hal_system.c
@@ -23,14 +23,10 @@
 #include <assert.h>
 #include <getopt.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 #include "mcu/mcu_sim.h"
 #include "hal_native_priv.h"
-
-#if MYNEWT_VAL(OS_SCHEDULING)
-#include <os/os.h>
-#endif
 
 void
 hal_system_reset(void)

--- a/hw/mcu/native/src/hal_timer.c
+++ b/hw/mcu/native/src/hal_timer.c
@@ -18,7 +18,7 @@
  */
 #include <stdint.h>
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #include "hal/hal_timer.h"
 

--- a/hw/mcu/native/src/hal_uart.c
+++ b/hw/mcu/native/src/hal_uart.c
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-
-#include "defs/error.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "hal/hal_uart.h"
 #include "bsp/bsp.h"
 

--- a/hw/mcu/native/src/native_uart_cfg.c
+++ b/hw/mcu/native/src/native_uart_cfg.c
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include <termios.h>
 
-#include "defs/error.h"
+#include "os/mynewt.h"
 #include "native_uart_cfg_priv.h"
 
 /* uint64 is used here to accommodate speed_t, whatever that is. */

--- a/hw/mcu/nordic/include/nrfx_glue.h
+++ b/hw/mcu/nordic/include/nrfx_glue.h
@@ -33,7 +33,7 @@
 #define NRFX_GLUE_H__
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/nordic/nrf51xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_i2c.c
@@ -22,9 +22,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#include <os/os_time.h>
-
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>
 #include <mcu/nrf51_hal.h>

--- a/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_os_tick.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 #include <assert.h>
-#include <os/os.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 #include <hal/hal_system.h>
 #include <mcu/cmsis_nvic.h>

--- a/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-#include <hal/hal_spi.h>
-#include <syscfg/syscfg.h>
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include "os/mynewt.h"
+#include <hal/hal_spi.h>
 #include <hal/hal_spi.h>
 #include <mcu/cmsis_nvic.h>
 #include "mcu/nrf51_hal.h"

--- a/hw/mcu/nordic/nrf51xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_system.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include <mcu/cortex_m0.h>
-#include "syscfg/syscfg.h"
 #include "hal/hal_system.h"
 #include <nrf51.h>
 #include <nrf51_bitfields.h>

--- a/hw/mcu/nordic/nrf51xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_timer.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "mcu/cmsis_nvic.h"
 #include "hal/hal_timer.h"
 #include "nrf51.h"

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -20,7 +20,7 @@
 #ifndef __MCU_CORTEX_M4_H__
 #define __MCU_CORTEX_M4_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef NRF52840_XXAA
 #include "nrf52840.h"

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -17,12 +17,12 @@
  * under the License.
  */
 
+#include <stdlib.h>
+#include <assert.h>
+#include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #include "mcu/cmsis_nvic.h"
-#include "os/os_trace_api.h"
-#include <stdlib.h>
 #include "nrf.h"
-#include <assert.h>
 #include "mcu/nrf52_hal.h"
 
 /* XXX:

--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -21,8 +21,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <assert.h>
-#include <os/os_time.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>
 #include <mcu/nrf52_hal.h>

--- a/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include <os/os.h>
-#include <os/os_trace_api.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_os_tick.h"
 #include "nrf.h"
 #include "mcu/cmsis_nvic.h"

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 #include <mcu/cmsis_nvic.h>
 #include <hal/hal_spi.h>
-#include "os/os_trace_api.h"
 #include "mcu/nrf52_hal.h"
 #include "nrf.h"
 

--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "mcu/cmsis_nvic.h"
 #include "hal/hal_timer.h"
-#include "os/os_trace_api.h"
 #include "nrf.h"
 #include "mcu/nrf52_hal.h"
 

--- a/hw/mcu/nordic/nrf52xxx/src/hal_uart.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_uart.c
@@ -17,15 +17,16 @@
  * under the License.
  */
 
+#include <assert.h>
+
+#include "os/mynewt.h"
 #include "hal/hal_uart.h"
 #include "mcu/cmsis_nvic.h"
 #include "bsp/bsp.h"
 
 #include "nrf.h"
 #include "mcu/nrf52_hal.h"
-#include "os/os_trace_api.h"
 
-#include <assert.h>
 
 #define UARTE_INT_ENDTX		UARTE_INTEN_ENDTX_Msk
 #define UARTE_INT_ENDRX		UARTE_INTEN_ENDRX_Msk

--- a/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
@@ -18,11 +18,10 @@
  */
 
 #include <assert.h>
+#include "os/mynewt.h"
 #include "hal/hal_watchdog.h"
 #include "mcu/cmsis_nvic.h"
-#include "os/os_trace_api.h"
 #include "nrf.h"
-
 
 static void
 nrf52_hal_wdt_default_handler(void)

--- a/hw/mcu/nxp/MK64F12/src/hal_flash.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_flash.c
@@ -23,11 +23,12 @@
  * and is divided to 2k sectors throughout.
  * Programming is done 2 bytes at a time.
  */
+
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include <hal/hal_flash_int.h>
-#include <os/os.h>
 
 #include "MK64F12.h"
 #include "fsl_flash.h"

--- a/hw/mcu/nxp/MK64F12/src/hal_os_tick.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_os_tick.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <stdio.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 
 #include "mcu/cmsis_nvic.h"

--- a/hw/mcu/nxp/MK64F12/src/hal_uart.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_uart.c
@@ -17,16 +17,15 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include <assert.h>
+#include <stdlib.h>
+
+#include "os/mynewt.h"
 #include "hal/hal_uart.h"
 #include "hal/hal_gpio.h"
 #include "hal/hal_system.h"
 #include "mcu/cmsis_nvic.h"
 #include "bsp/bsp.h"
-#include "os/os.h"
-
-#include <assert.h>
-#include <stdlib.h>
 
 #include "mcu/frdm-k64f_hal.h"
 #include "MK64F12.h"

--- a/hw/mcu/nxp/mkw41z/src/hal_os_tick.c
+++ b/hw/mcu/nxp/mkw41z/src/hal_os_tick.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 #include <assert.h>
-#include <os/os.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>
 //#include <mkw41z4.h>

--- a/hw/mcu/sifive/fe310/include/mcu/fe310.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310.h
@@ -20,7 +20,7 @@
 #ifndef __MCU_FE310_H__
 #define __MCU_FE310_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/sifive/fe310/src/hal_os_tick.c
+++ b/hw/mcu/sifive/fe310/src/hal_os_tick.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 #include <assert.h>
-#include <os/os.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "hal/hal_os_tick.h"
 #include <env/encoding.h>
 #include <env/freedom-e300-hifive1/platform.h>

--- a/hw/mcu/sifive/fe310/src/hal_timer.c
+++ b/hw/mcu/sifive/fe310/src/hal_timer.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 #include <hal/hal_timer.h>
 #include <mcu/plic.h>
 #include <mcu/fe310_hal.h>

--- a/hw/mcu/sifive/fe310/src/init.c
+++ b/hw/mcu/sifive/fe310/src/init.c
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <env/freedom-e300-hifive1/platform.h>
 #include <env/encoding.h>

--- a/hw/mcu/sifive/fe310/src/plic.c
+++ b/hw/mcu/sifive/fe310/src/plic.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include <env/freedom-e300-hifive1/platform.h>
 #include <mcu/plic.h>
-#include <syscfg/syscfg.h>
 
 interrupt_handler_t plic_interrupts[PLIC_NUM_INTERRUPTS];
 

--- a/hw/mcu/sifive/fe310/src/sys_clock.c
+++ b/hw/mcu/sifive/fe310/src/sys_clock.c
@@ -18,11 +18,11 @@
  */
 
 #include <stdlib.h>
+#include "os/mynewt.h"
 #include <env/freedom-e300-hifive1/platform.h>
 #include <env/encoding.h>
 #include <mcu/plic.h>
 #include <mcu/sys_clock.h>
-#include <syscfg/syscfg.h>
 
 #define PLL_DIVR(r) ((r) - 1)
 #define PLL_MULF(f) ((f) / 2 - 1)

--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <hal/hal_os_tick.h>
 
 /*

--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -17,17 +17,12 @@
  * under the License.
  */
 
+#include <string.h>
+#include <assert.h>
+#include "os/mynewt.h"
 #include <hal/hal_spi.h>
 #include <hal/hal_gpio.h>
-
-#include <string.h>
-
-#include <assert.h>
-
-#include <syscfg/syscfg.h>
-
 #include "mcu/stm32_hal.h"
-
 #include "mcu/cmsis_nvic.h"
 
 #define SPI_0_ENABLED (MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE))

--- a/hw/mcu/stm/stm32_common/src/hal_system.c
+++ b/hw/mcu/stm/stm32_common/src/hal_system.c
@@ -18,7 +18,7 @@
  */
 
 #include "mcu/stm32_hal.h"
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 
 void

--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
@@ -24,8 +24,8 @@
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
 
+#include "os/mynewt.h"
 #include "mcu/stm32_hal.h"
-#include <syscfg/syscfg.h>
 
 #define SPI_DEFAULT_TIMEOUT 100U
 

--- a/hw/mcu/stm/stm32f1xx/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_i2c.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>

--- a/hw/mcu/stm/stm32f1xx/src/hal_timer.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <mcu/cmsis_nvic.h>
-#include <os/queue.h>
 #include <hal/hal_timer.h>
 
 #if 0

--- a/hw/mcu/stm/stm32f3xx/src/hal_timer.c
+++ b/hw/mcu/stm/stm32f3xx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <mcu/cmsis_nvic.h>
-#include <os/queue.h>
 #include <hal/hal_timer.h>
 
 #include "stm32f3xx.h"

--- a/hw/mcu/stm/stm32f4xx/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32f4xx/src/hal_i2c.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>

--- a/hw/mcu/stm/stm32f4xx/src/hal_timer.c
+++ b/hw/mcu/stm/stm32f4xx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <mcu/cmsis_nvic.h>
-#include <os/queue.h>
 #include <hal/hal_timer.h>
 
 #include "stm32f4xx.h"

--- a/hw/mcu/stm/stm32f7xx/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32f7xx/src/hal_i2c.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>

--- a/hw/mcu/stm/stm32f7xx/src/hal_timer.c
+++ b/hw/mcu/stm/stm32f7xx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <mcu/cmsis_nvic.h>
-#include <os/queue.h>
 #include <hal/hal_timer.h>
 
 #include "stm32f7xx.h"

--- a/hw/mcu/stm/stm32l1xx/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32l1xx/src/hal_i2c.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>

--- a/hw/mcu/stm/stm32l1xx/src/hal_timer.c
+++ b/hw/mcu/stm/stm32l1xx/src/hal_timer.c
@@ -21,10 +21,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <mcu/cmsis_nvic.h>
-#include <os/queue.h>
 #include <hal/hal_timer.h>
 
 #include "stm32l1xx.h"

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-#include <os/os_dev.h>
 #include <assert.h>
-#include <defs/error.h>
 #include <string.h>
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(DRV2605_OFB)
 #include "hal/hal_gpio.h"

--- a/hw/sensor/include/sensor/accel.h
+++ b/hw/sensor/include/sensor/accel.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_ACCEL_H__
 #define __SENSOR_ACCEL_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/color.h
+++ b/hw/sensor/include/sensor/color.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_COLOR_H__
 #define __SENSOR_COLOR_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/euler.h
+++ b/hw/sensor/include/sensor/euler.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_EULER_H__
 #define __SENSOR_EULER_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/gyro.h
+++ b/hw/sensor/include/sensor/gyro.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_GYRO_H__
 #define __SENSOR_GYRO_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/humidity.h
+++ b/hw/sensor/include/sensor/humidity.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_HUMIDITY_H__
 #define __SENSOR_HUMIDITY_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/light.h
+++ b/hw/sensor/include/sensor/light.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_LIGHT_H__
 #define __SENSOR_LIGHT_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/mag.h
+++ b/hw/sensor/include/sensor/mag.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_MAG_H__
 #define __SENSOR_MAG_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/pressure.h
+++ b/hw/sensor/include/sensor/pressure.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_PRESSURE_H__
 #define __SENSOR_PRESSURE_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/quat.h
+++ b/hw/sensor/include/sensor/quat.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_QUAT_H__
 #define __SENSOR_QUAT_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -21,9 +21,7 @@
 #define __SENSOR_H__
 
 #include <string.h>
-#include "os/os.h"
-#include "os/os_dev.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SENSOR_OIC)
 #include "oic/oc_ri.h"

--- a/hw/sensor/include/sensor/temperature.h
+++ b/hw/sensor/include/sensor/temperature.h
@@ -20,8 +20,7 @@
 #ifndef __SENSOR_TEMPERATURE_H__
 #define __SENSOR_TEMPERATURE_H__
 
-#include "os/os.h"
-#include "os/os_dev.h"
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
 
 #ifdef __cplusplus

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -20,17 +20,9 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-
-#include "os/os.h"
-#include "sysinit/sysinit.h"
-
+#include "os/mynewt.h"
 #include "sensor/sensor.h"
-
 #include "sensor_priv.h"
-#include "os/os_time.h"
-#include "os/os_cputime.h"
-#include "defs/error.h"
-#include "syscfg/syscfg.h"
 #include "sensor/accel.h"
 #include "sensor/mag.h"
 #include "sensor/light.h"

--- a/hw/sensor/src/sensor_oic.c
+++ b/hw/sensor/src/sensor_oic.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SENSOR_OIC)
 
@@ -25,10 +25,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <assert.h>
-
-#include "defs/error.h"
-
-#include "os/os.h"
 
 #include "sensor/sensor.h"
 #include "sensor/accel.h"

--- a/hw/sensor/src/sensor_priv.h
+++ b/hw/sensor/src/sensor_priv.h
@@ -20,7 +20,7 @@
 #ifndef __SENSOR_PRIV_H__
 #define __SENSOR_PRIV_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SENSOR_CLI)
 int sensor_shell_register(void);

--- a/hw/sensor/src/sensor_shell.c
+++ b/hw/sensor/src/sensor_shell.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SENSOR_CLI)
 
@@ -25,10 +25,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <assert.h>
-
-#include "defs/error.h"
-
-#include "os/os.h"
 
 #include "sensor/sensor.h"
 #include "sensor/accel.h"
@@ -44,7 +40,6 @@
 #include "console/console.h"
 #include "shell/shell.h"
 #include "hal/hal_i2c.h"
-#include "os/os_cputime.h"
 #include "parse/parse.h"
 
 static int sensor_cmd_exec(int, char **);

--- a/hw/util/button/include/button/button.h
+++ b/hw/util/button/include/button/button.h
@@ -2,7 +2,7 @@
 #define _BUTTON_H_
 
 #include <stdbool.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 
 /**
  * This library generate events in the default queue to deal 

--- a/hw/util/button/src/button.c
+++ b/hw/util/button/src/button.c
@@ -1,5 +1,23 @@
 #include <assert.h>
 #include <syscfg/syscfg.h>
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 #include "button/button.h"
 

--- a/hw/util/button/src/button.c
+++ b/hw/util/button/src/button.c
@@ -1,5 +1,3 @@
-#include <assert.h>
-#include <syscfg/syscfg.h>
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,6 +17,8 @@
  * under the License.
  */
 
+#include <assert.h>
+#include "os/mynewt.h"
 #include "button/button.h"
 
 #define _BUTTON_FSM_INIT			0

--- a/kernel/os/include/os/mynewt.h
+++ b/kernel/os/include/os/mynewt.h
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_OS_MYNEWT_
+#define H_OS_MYNEWT_
+
+#include "syscfg/syscfg.h"
+#include "sysinit/sysinit.h"
+#include "sysflash/sysflash.h"
+#include "os/os.h"
+#include "defs/error.h"
+
+#endif

--- a/kernel/os/include/os/os.h
+++ b/kernel/os/include/os/os.h
@@ -108,14 +108,14 @@ void os_init(int (*fn)(int argc, char **argv));
 void os_start(void);
 
 #include "os/endian.h"
-#include "os/os_arch.h"
 #include "os/os_callout.h"
+#include "os/os_cfg.h"
 #include "os/os_cputime.h"
 #include "os/os_dev.h"
 #include "os/os_error.h"
 #include "os/os_eventq.h"
-#include "os/os_heap.h"
 #include "os/os_fault.h"
+#include "os/os_heap.h"
 #include "os/os_mbuf.h"
 #include "os/os_mempool.h"
 #include "os/os_mutex.h"
@@ -123,7 +123,10 @@ void os_start(void);
 #include "os/os_sched.h"
 #include "os/os_sem.h"
 #include "os/os_task.h"
+#include "os/os_test.h"
 #include "os/os_time.h"
+#include "os/os_trace_api.h"
+#include "os/queue.h"
 
 #ifdef __cplusplus
 }

--- a/kernel/os/include/os/os_task.h
+++ b/kernel/os/include/os/os_task.h
@@ -30,6 +30,7 @@
 
 #include "os/os.h"
 #include "os/os_sanity.h"
+#include "os/os_arch.h"
 #include "os/queue.h"
 
 #ifdef __cplusplus

--- a/kernel/os/src/arch/arc/os_arch_arc.c
+++ b/kernel/os/src/arch/arc/os_arch_arc.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <string.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "inc/arc/arc_builtin.h"
 #include "inc/arc/arc_exception.h"
-#include "os/os_arch.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 #include "os_priv.h"

--- a/kernel/os/src/arch/arc/os_fault.c
+++ b/kernel/os/src/arch/arc/os_fault.c
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
-#include "os/os.h"
 #include "os_priv.h"
 
 #if MYNEWT_VAL(OS_COREDUMP)

--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
-#include "os/os_arch.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -20,13 +20,12 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
 #if MYNEWT_VAL(OS_COREDUMP)
 #include "coredump/coredump.h"
 #endif
-#include "os/os.h"
 #include "os_priv.h"
 
 struct exception_frame {

--- a/kernel/os/src/arch/cortex_m3/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m3/os_arch_arm.c
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
 
-#include "os/os.h"
-#include "os/os_arch.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
-#include "os/os.h"
 #include "os_priv.h"
 
 #if MYNEWT_VAL(OS_COREDUMP)

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
 
-#include "os/os.h"
-#include "os/os_arch.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
-#include "os/os.h"
 #include "os_priv.h"
 
 #if MYNEWT_VAL(OS_COREDUMP)

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
 
-#include "os/os.h"
-#include "os/os_arch.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>

--- a/kernel/os/src/arch/cortex_m7/os_fault.c
+++ b/kernel/os/src/arch/cortex_m7/os_fault.c
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
-#include "os/os.h"
 #include "os_priv.h"
 
 #if MYNEWT_VAL(OS_COREDUMP)

--- a/kernel/os/src/arch/mips/os_arch_mips.c
+++ b/kernel/os/src/arch/mips/os_arch_mips.c
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-
-#include "os/os.h"
-#include "os/os_arch.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 

--- a/kernel/os/src/arch/mips/os_fault.c
+++ b/kernel/os/src/arch/mips/os_fault.c
@@ -18,7 +18,7 @@
  */
 
 #include <hal/hal_system.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "os_priv.h"
 
 void

--- a/kernel/os/src/arch/pic32/os_arch_pic32.c
+++ b/kernel/os/src/arch/pic32/os_arch_pic32.c
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
-#include "os/os_arch.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include <hal/hal_bsp.h>
 #include <hal/hal_os_tick.h>
 

--- a/kernel/os/src/arch/pic32/os_fault.c
+++ b/kernel/os/src/arch/pic32/os_fault.c
@@ -19,7 +19,7 @@
 
 #include <console/console.h>
 #include <hal/hal_system.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "os_priv.h"
 
 void

--- a/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
+++ b/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "os_priv.h"
 
 #include <hal/hal_bsp.h>

--- a/kernel/os/src/arch/rv32imac/os_fault.c
+++ b/kernel/os/src/arch/rv32imac/os_fault.c
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "os_priv.h"
 #include "hal/hal_system.h"
 

--- a/kernel/os/src/arch/sim-armv7/os_arch.c
+++ b/kernel/os/src/arch/sim-armv7/os_arch.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "sim/sim.h"
 
 /*

--- a/kernel/os/src/arch/sim-mips/os_arch.c
+++ b/kernel/os/src/arch/sim-mips/os_arch.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "sim/sim.h"
 
 /*

--- a/kernel/os/src/arch/sim/os_arch.c
+++ b/kernel/os/src/arch/sim/os_arch.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "sim/sim.h"
 
 /*

--- a/kernel/os/src/endian.c
+++ b/kernel/os/src/endian.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/endian.h"
+#include "os/mynewt.h"
 
 void
 put_le16(void *buf, uint16_t x)

--- a/kernel/os/src/os.c
+++ b/kernel/os/src/os.c
@@ -17,18 +17,14 @@
  * under the License.
  */
 
-#include "sysinit/sysinit.h"
-#include "os/os.h"
-#include "os/queue.h"
-#include "os/os_dev.h"
-#include "os/os_trace_api.h"
+#include <assert.h>
+
+#include "os/mynewt.h"
 #include "os_priv.h"
 
 #include "hal/hal_os_tick.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_watchdog.h"
-
-#include <assert.h>
 
 /**
  * @defgroup OSKernel Operating System Kernel

--- a/kernel/os/src/os_callout.c
+++ b/kernel/os/src/os_callout.c
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "os_priv.h"
 
 struct os_callout_list g_callout_list;

--- a/kernel/os/src/os_cputime.c
+++ b/kernel/os/src/os_cputime.c
@@ -20,8 +20,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <assert.h>
-#include "os/os.h"
-#include "os/os_cputime.h"
+#include "os/mynewt.h"
 
 #if defined(OS_CPUTIME_FREQ_HIGH)
 struct os_cputime_data g_os_cputime;

--- a/kernel/os/src/os_cputime_1mhz.c
+++ b/kernel/os/src/os_cputime_1mhz.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os_cputime.h"
+#include "os/mynewt.h"
 
 /**
  * This module implements cputime functionality for timers whose frequency is

--- a/kernel/os/src/os_cputime_high.c
+++ b/kernel/os/src/os_cputime_high.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os_cputime.h"
+#include "os/mynewt.h"
 
 /**
  * This module implements cputime functionality for timers whose frequency is

--- a/kernel/os/src/os_cputime_pwr2.c
+++ b/kernel/os/src/os_cputime_pwr2.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os_cputime.h"
+#include "os/mynewt.h"
 
 /**
  * This module implements cputime functionality for timers for which:

--- a/kernel/os/src/os_dev.c
+++ b/kernel/os/src/os_dev.c
@@ -17,12 +17,8 @@
  * under the License.
  */
 
-#include "os/os.h"
-#include "os/queue.h"
-#include "os/os_dev.h"
-
 #include <string.h>
-
+#include "os/mynewt.h"
 
 static STAILQ_HEAD(, os_dev) g_os_dev_list;
 

--- a/kernel/os/src/os_eventq.c
+++ b/kernel/os/src/os_eventq.c
@@ -19,9 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include "os/os_trace_api.h"
-
-#include "os/os.h"
+#include "os/mynewt.h"
 
 static struct os_eventq os_eventq_main;
 

--- a/kernel/os/src/os_heap.c
+++ b/kernel/os/src/os_heap.c
@@ -16,11 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "syscfg/syscfg.h"
 
 #include <assert.h>
-#include "os/os_mutex.h"
-#include "os/os_heap.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(OS_SCHEDULING)
 static struct os_mutex os_malloc_mutex;

--- a/kernel/os/src/os_mbuf.c
+++ b/kernel/os/src/os_mbuf.c
@@ -33,11 +33,10 @@
  *
  */
 
-#include "os/os.h"
-
 #include <assert.h>
 #include <string.h>
 #include <limits.h>
+#include "os/mynewt.h"
 
 /**
  * @addtogroup OSKernel

--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "os/os.h"
-
 #include <string.h>
 #include <assert.h>
 #include <stdbool.h>
+#include "os/mynewt.h"
 
 #define OS_MEM_TRUE_BLOCK_SIZE(bsize)   OS_ALIGN(bsize, OS_ALIGNMENT)
 #define OS_MEMPOOL_TRUE_BLOCK_SIZE(mp) OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size)

--- a/kernel/os/src/os_msys_init.c
+++ b/kernel/os/src/os_msys_init.c
@@ -18,9 +18,7 @@
  */
 
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os_mempool.h"
+#include "os/mynewt.h"
 #include "mem/mem.h"
 #include "os_priv.h"
 

--- a/kernel/os/src/os_mutex.c
+++ b/kernel/os/src/os_mutex.c
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-#include "os/os.h"
-#include "os/os_trace_api.h"
 #include <assert.h>
+#include "os/mynewt.h"
 
 os_error_t
 os_mutex_init(struct os_mutex *mu)

--- a/kernel/os/src/os_priv.h
+++ b/kernel/os/src/os_priv.h
@@ -20,8 +20,8 @@
 #ifndef H_OS_PRIV_
 #define H_OS_PRIV_
 
+#include "os/mynewt.h"
 #include "console/console.h"
-#include "os/queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/os/src/os_sanity.c
+++ b/kernel/os/src/os_sanity.c
@@ -19,8 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-
-#include "os/os.h"
+#include "os/mynewt.h"
 
 SLIST_HEAD(, os_sanity_check) g_os_sanity_check_list =
     SLIST_HEAD_INITIALIZER(os_sanity_check_list);

--- a/kernel/os/src/os_sched.c
+++ b/kernel/os/src/os_sched.c
@@ -17,12 +17,9 @@
  * under the License.
  */
 
-#include "os/os.h"
-#include "os/os_trace_api.h"
-#include "os/queue.h"
-#include "os_priv.h"
-
 #include <assert.h>
+#include "os/mynewt.h"
+#include "os_priv.h"
 
 struct os_task_list g_os_run_list = TAILQ_HEAD_INITIALIZER(g_os_run_list);
 struct os_task_list g_os_sleep_list = TAILQ_HEAD_INITIALIZER(g_os_sleep_list);

--- a/kernel/os/src/os_sem.c
+++ b/kernel/os/src/os_sem.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include "os/os.h"
 #include <assert.h>
+#include "os/mynewt.h"
 
 /* XXX:
  * 1) Should I check to see if we are within an ISR for some of these?

--- a/kernel/os/src/os_task.c
+++ b/kernel/os/src/os_task.c
@@ -17,14 +17,10 @@
  * under the License.
  */
 
-
-#include "os/os.h"
-#include "os_priv.h"
-#include "os/os_trace_api.h"
-
 #include <assert.h>
 #include <string.h>
-
+#include "os/mynewt.h"
+#include "os_priv.h"
 
 uint8_t g_task_id;
 

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -16,13 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "syscfg/syscfg.h"
 
 #include <assert.h>
-
-#include "os/os.h"
-#include "os/queue.h"
-
+#include "os/mynewt.h"
 
 CTASSERT(sizeof(os_time_t) == 4);
 

--- a/kernel/os/test/src/callout_test.c
+++ b/kernel/os/test/src/callout_test.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "sysinit/sysinit.h"
+
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 /* Task 1 for sending */

--- a/kernel/os/test/src/callout_test.h
+++ b/kernel/os/test/src/callout_test.h
@@ -19,9 +19,8 @@
 #ifndef _CALLOUT_TEST_H
 #define _CALLOUT_TEST_H
 
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #ifdef __cplusplus

--- a/kernel/os/test/src/eventq_test.c
+++ b/kernel/os/test/src/eventq_test.c
@@ -18,11 +18,9 @@
  */
  
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
-#include "os/os_eventq.h"
 
 /* Task 1 sending task */
 /* Define task stack and task object */

--- a/kernel/os/test/src/eventq_test.h
+++ b/kernel/os/test/src/eventq_test.h
@@ -20,11 +20,9 @@
 #define _EVENTQ_TEST_H
  
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
-#include "os/os_eventq.h"
 
 #ifdef __cplusplus
 #extern "C" {

--- a/kernel/os/test/src/mbuf_test.c
+++ b/kernel/os/test/src/mbuf_test.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "testutil/testutil.h"
-#include "os/os.h"
-#include "os_test_priv.h"
-
 #include <string.h>
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+#include "os_test_priv.h"
 
 /* 
  * NOTE: currently, the buffer size cannot be changed as some tests are

--- a/kernel/os/test/src/mbuf_test.h
+++ b/kernel/os/test/src/mbuf_test.h
@@ -19,11 +19,10 @@
 #ifndef _MBUF_TEST_H
 #define _MBUF_TEST_H
 
-#include "testutil/testutil.h"
-#include "os/os.h"
-#include "os_test_priv.h"
-
 #include <string.h>
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+#include "os_test_priv.h"
 
 #ifdef __cplusplus
 #extern "C" {

--- a/kernel/os/test/src/mempool_test.c
+++ b/kernel/os/test/src/mempool_test.c
@@ -18,8 +18,8 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #if OS_CFG_ALIGNMENT == OS_CFG_ALIGN_4

--- a/kernel/os/test/src/mempool_test.h
+++ b/kernel/os/test/src/mempool_test.h
@@ -21,8 +21,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #ifdef __cplusplus

--- a/kernel/os/test/src/mutex_test.c
+++ b/kernel/os/test/src/mutex_test.c
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
 #include <sys/time.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
-#include "os/os_test.h"
 #include "os_test_priv.h"
 
 #if MYNEWT_VAL(SELFTEST)

--- a/kernel/os/test/src/mutex_test.h
+++ b/kernel/os/test/src/mutex_test.h
@@ -23,10 +23,8 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/time.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
-#include "os/os_test.h"
 #include "os_test_priv.h"
 
 #ifdef __cplusplus

--- a/kernel/os/test/src/os_test.c
+++ b/kernel/os/test/src/os_test.c
@@ -16,20 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
 #include <stddef.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "testutil/testutil.h"
-#include "os/os_test.h"
-#include "os_test_priv.h"
-
 #include <stdio.h>
 #include <setjmp.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/time.h>
-#include "os/os.h"
+
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+#include "os_test_priv.h"
 
 uint32_t stack1_size;
 uint32_t stack2_size;

--- a/kernel/os/test/src/os_test_priv.h
+++ b/kernel/os/test/src/os_test_priv.h
@@ -20,9 +20,8 @@
 #ifndef H_OS_TEST_PRIV_
 #define H_OS_TEST_PRIV_
 
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #include "callout_test.h"

--- a/kernel/os/test/src/sem_test.c
+++ b/kernel/os/test/src/sem_test.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #if MYNEWT_VAL(SELFTEST)

--- a/kernel/os/test/src/sem_test.h
+++ b/kernel/os/test/src/sem_test.h
@@ -21,9 +21,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
-#include "os/os.h"
 #include "os_test_priv.h"
 
 #ifdef __cplusplus

--- a/kernel/sim/include/sim/sim.h
+++ b/kernel/sim/include/sim/sim.h
@@ -26,9 +26,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <setjmp.h>
-#include "os/os_arch.h"
-#include "os/os_error.h"
-#include "os/os_time.h"
+#include "os/mynewt.h"
 struct os_task;
 struct stack_frame;
 

--- a/kernel/sim/src/sim_priv.h
+++ b/kernel/sim/src/sim_priv.h
@@ -21,7 +21,7 @@
 #define H_SIM_PRIV_
 
 #include <sys/types.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/sim/src/sim_sched_gen.c
+++ b/kernel/sim/src/sim_sched_gen.c
@@ -22,7 +22,7 @@
  * and no-signals).
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 
 #include <hal/hal_bsp.h>
 

--- a/kernel/sim/src/sim_sched_nosig.c
+++ b/kernel/sim/src/sim_sched_nosig.c
@@ -30,11 +30,9 @@
  * setting.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if !MYNEWT_VAL(MCU_NATIVE_USE_SIGNALS)
-
-#include "os/os.h"
 
 #include <hal/hal_bsp.h>
 

--- a/kernel/sim/src/sim_sched_sig.c
+++ b/kernel/sim/src/sim_sched_sig.c
@@ -29,11 +29,10 @@
  * setting.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(MCU_NATIVE_USE_SIGNALS)
 
-#include "os/os.h"
 #include "sim_priv.h"
 
 #include <hal/hal_bsp.h>

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -5,7 +5,7 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libc/baselibc/src/start.c
+++ b/libc/baselibc/src/start.c
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <stdlib.h>
 
-#include <sysinit/sysinit.h>
-#include <os/os.h>
+#include <stdlib.h>
+#include "os/mynewt.h"
 
 extern int main(int argc, char **argv);
 

--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -65,7 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <inttypes.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 struct param {
     unsigned char width; /**< field width */

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <os/endian.h>
 
 #include <limits.h>
 #include <assert.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "flash_map/flash_map.h"
 #include "cborattr/cborattr.h"

--- a/mgmt/imgmgr/src/imgmgr_cli.c
+++ b/mgmt/imgmgr/src/imgmgr_cli.c
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(IMGMGR_CLI)
 
 #include <string.h>
 
-#include <defs/error.h>
 #include <flash_map/flash_map.h>
 #include <hal/hal_bsp.h>
 

--- a/mgmt/imgmgr/src/imgmgr_coredump.c
+++ b/mgmt/imgmgr/src/imgmgr_coredump.c
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(IMGMGR_COREDUMP)
 
 #include <limits.h>
 
-#include "sysflash/sysflash.h"
 #include "flash_map/flash_map.h"
 #include "mgmt/mgmt.h"
 #include "coredump/coredump.h"

--- a/mgmt/imgmgr/src/imgmgr_priv.h
+++ b/mgmt/imgmgr/src/imgmgr_priv.h
@@ -21,7 +21,7 @@
 #define __IMGMGR_PRIV_H_
 
 #include <stdint.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/mgmt/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/mgmt/include/mgmt/mgmt.h
@@ -21,8 +21,7 @@
 #define _MGMT_MGMT_H_
 
 #include <inttypes.h>
-
-#include <os/queue.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/mgmt/mgmt/src/mgmt.c
+++ b/mgmt/mgmt/src/mgmt.c
@@ -18,7 +18,7 @@
  */
 #include <string.h>
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <tinycbor/cbor.h>
 #include "mgmt/mgmt.h"
 

--- a/mgmt/newtmgr/include/newtmgr/newtmgr.h
+++ b/mgmt/newtmgr/include/newtmgr/newtmgr.h
@@ -22,8 +22,7 @@
 
 #include <tinycbor/cbor.h>
 #include <inttypes.h>
-#include <os/os.h>
-#include <os/endian.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
+++ b/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
-
-#include <os/os.h>
-#include <os/endian.h>
 
 #include <assert.h>
 #include <string.h>
+
+#include "os/mynewt.h"
 
 #include <hal/hal_system.h>
 #include <hal/hal_watchdog.h>

--- a/mgmt/newtmgr/src/newtmgr.c
+++ b/mgmt/newtmgr/src/newtmgr.c
@@ -20,10 +20,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "os/os.h"
-#include "os/endian.h"
+#include "os/mynewt.h"
 
 #include "mem/mem.h"
 

--- a/mgmt/newtmgr/transport/ble/src/newtmgr_ble.c
+++ b/mgmt/newtmgr/transport/ble/src/newtmgr_ble.c
@@ -20,11 +20,10 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "host/ble_hs.h"
 #include "mgmt/mgmt.h"
 #include "newtmgr/newtmgr.h"
-#include "os/endian.h"
 #include "console/console.h"
 
 /* nmgr ble mqueue */

--- a/mgmt/newtmgr/transport/nmgr_shell/src/nmgr_shell.c
+++ b/mgmt/newtmgr/transport/nmgr_shell/src/nmgr_shell.c
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <inttypes.h>
 #include <assert.h>
 
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <shell/shell.h>
 #include <mgmt/mgmt.h>
 #include <newtmgr/newtmgr.h>

--- a/mgmt/newtmgr/transport/nmgr_uart/src/nmgr_uart.c
+++ b/mgmt/newtmgr/transport/nmgr_uart/src/nmgr_uart.c
@@ -19,11 +19,9 @@
 #include <inttypes.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
-#include <sysinit/sysinit.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 
-#include <os/os.h>
 #include <mgmt/mgmt.h>
 #include <newtmgr/newtmgr.h>
 #include <uart/uart.h>

--- a/mgmt/oicmgr/src/oicmgr.c
+++ b/mgmt/oicmgr/src/oicmgr.c
@@ -17,15 +17,10 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-#include <sysinit/sysinit.h>
-
-#include <os/os.h>
-#include <os/endian.h>
-#include <defs/error.h>
-
 #include <assert.h>
 #include <string.h>
+
+#include "os/mynewt.h"
 
 #include <mgmt/mgmt.h>
 #include <nmgr_os/nmgr_os.h>

--- a/net/ip/include/arch/sys_arch.h
+++ b/net/ip/include/arch/sys_arch.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 #undef LITTLE_ENDIAN
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <ip/os_queue.h>
 
 #define SYS_MBOX_NULL NULL

--- a/net/ip/inet_def_service/src/inet_def_service.c
+++ b/net/ip/inet_def_service/src/inet_def_service.c
@@ -19,8 +19,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include <os/os.h>
-#include <os/endian.h>
+#include "os/mynewt.h"
 #include <mn_socket/mn_socket.h>
 #include <console/console.h>
 

--- a/net/ip/mn_socket/src/mn_socket.c
+++ b/net/ip/mn_socket/src/mn_socket.c
@@ -21,7 +21,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #include "mn_socket/mn_socket.h"
 #include "mn_socket/mn_socket_ops.h"

--- a/net/ip/mn_socket/src/mn_socket_aconv.c
+++ b/net/ip/mn_socket/src/mn_socket_aconv.c
@@ -19,7 +19,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <os/endian.h>
+#include "os/mynewt.h"
 #include "mn_socket/mn_socket.h"
 
 int

--- a/net/ip/mn_socket/test/src/mn_sock_test.c
+++ b/net/ip/mn_socket/test/src/mn_sock_test.c
@@ -20,9 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "mn_socket/mn_socket.h"

--- a/net/ip/mn_socket/test/src/mn_sock_test.h
+++ b/net/ip/mn_socket/test/src/mn_sock_test.h
@@ -22,9 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "mn_socket/mn_socket.h"

--- a/net/ip/mn_socket/test/src/mn_sock_util.c
+++ b/net/ip/mn_socket/test/src/mn_sock_util.c
@@ -20,9 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 
 #include "mn_socket/mn_socket.h"

--- a/net/ip/native_sockets/src/native_sock.c
+++ b/net/ip/native_sockets/src/native_sock.c
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <sys/socket.h>
 #include <unistd.h>
 #include <errno.h>
@@ -28,9 +29,7 @@
 #include <sys/un.h>
 #include <stdio.h>
 
-#include <sysinit/sysinit.h>
-#include <os/os.h>
-#include <os/os_mbuf.h>
+#include "os/mynewt.h"
 #include "mn_socket/mn_socket.h"
 #include "mn_socket/mn_socket_ops.h"
 #include "native_sockets/native_sock.h"

--- a/net/ip/src/ip_init.c
+++ b/net/ip/src/ip_init.c
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "syscfg/syscfg.h"
 
+#include "os/mynewt.h"
 #include <lwip/tcpip.h>
 
 #include "ip_priv.h"

--- a/net/ip/src/lwip_cli.c
+++ b/net/ip/src/lwip_cli.c
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <syscfg/syscfg.h>
+
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(LWIP_CLI)
 #include <string.h>

--- a/net/ip/src/lwip_if.c
+++ b/net/ip/src/lwip_if.c
@@ -19,8 +19,7 @@
 #include <limits.h>
 #include <string.h>
 
-#include <os/os.h>
-#include <os/os_mbuf.h>
+#include "os/mynewt.h"
 #include <mn_socket/mn_socket.h>
 
 #include <lwip/tcpip.h>

--- a/net/ip/src/lwip_socket.c
+++ b/net/ip/src/lwip_socket.c
@@ -18,8 +18,7 @@
  */
 #include <string.h>
 
-#include <os/os.h>
-#include <os/os_mbuf.h>
+#include "os/mynewt.h"
 
 #include <mn_socket/mn_socket.h>
 #include <mn_socket/mn_socket_ops.h>

--- a/net/ip/src/os_queue.c
+++ b/net/ip/src/os_queue.c
@@ -20,9 +20,9 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
-
 #include <inttypes.h>
-#include <os/os.h>
+
+#include "os/mynewt.h"
 #include <ip/os_queue.h>
 
 /*

--- a/net/lora/node/include/node/lora.h
+++ b/net/lora/node/include/node/lora.h
@@ -21,7 +21,7 @@
 #define H_LORA_
 
 #include "stats/stats.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "node/mac/LoRaMac.h"
 
 STATS_SECT_START(lora_mac_stats)

--- a/net/lora/node/include/node/lora_band.h
+++ b/net/lora/node/include/node/lora_band.h
@@ -20,7 +20,7 @@
 #ifndef H_LORA_BAND_
 #define H_LORA_BAND_
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if   MYNEWT_VAL(LORA_NODE_FREQ_BAND) == 433
 #define USE_BAND_433

--- a/net/lora/node/include/node/lora_priv.h
+++ b/net/lora/node/include/node/lora_priv.h
@@ -21,7 +21,7 @@
 #define H_LORA_PRIV_
 
 #include "node/mac/LoRaMac.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "node/lora.h"
 
 /*

--- a/net/lora/node/include/node/mac/LoRaMac.h
+++ b/net/lora/node/include/node/mac/LoRaMac.h
@@ -51,7 +51,7 @@
 // Includes board dependent definitions such as channels frequencies
 #include "node/mac/LoRaMac-definitions.h"
 #include "node/utilities.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 
 struct lora_pkt_info;
 

--- a/net/lora/node/src/lora_app.c
+++ b/net/lora/node/src/lora_app.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "node/lora.h"
 #include "node/lora_priv.h"
 

--- a/net/lora/node/src/lora_cli.c
+++ b/net/lora/node/src/lora_cli.c
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(LORA_NODE_CLI)
 
 #include <inttypes.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
 #include "shell/shell.h"
 #include "console/console.h"
 #include "node/radio.h"

--- a/net/lora/node/src/lora_node.c
+++ b/net/lora/node/src/lora_node.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <string.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "node/lora_priv.h"
 
 STATS_SECT_DECL(lora_mac_stats) lora_mac_stats;

--- a/net/lora/node/src/mac/LoRaMac.c
+++ b/net/lora/node/src/mac/LoRaMac.c
@@ -20,13 +20,13 @@ Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jäc
 
 #include <string.h>
 #include <assert.h>
+#include "os/mynewt.h"
 #include "node/lora.h"
 #include "radio/radio.h"
 #include "node/utilities.h"
 #include "node/mac/LoRaMacCrypto.h"
 #include "node/mac/LoRaMac.h"
 #include "node/mac/LoRaMacTest.h"
-#include "os/os.h"
 #include "hal/hal_timer.h"
 #include "node/lora_priv.h"
 

--- a/net/lora/node/src/utilities.c
+++ b/net/lora/node/src/utilities.c
@@ -19,8 +19,7 @@
 
 #include <stdlib.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "node/utilities.h"
 #include "node/lora_priv.h"
 

--- a/net/oic/include/oic/messaging/coap/coap.h
+++ b/net/oic/include/oic/messaging/coap/coap.h
@@ -37,7 +37,7 @@
 #include <stddef.h> /* for size_t */
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <stats/stats.h>
 

--- a/net/oic/include/oic/port/mynewt/config.h
+++ b/net/oic/include/oic/port/mynewt/config.h
@@ -8,9 +8,8 @@ extern "C" {
 
 /* Time resolution */
 #include <inttypes.h>
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
-#include <os/os.h>
 #include <log/log.h>
 
 /* rather than change all their source files, just translate the mynewt

--- a/net/oic/include/oic/port/mynewt/transport.h
+++ b/net/oic/include/oic/port/mynewt/transport.h
@@ -20,8 +20,7 @@
 #ifndef __MYNEWT_TRANSPORT_H_
 #define __MYNEWT_TRANSPORT_H_
 
-#include <os/queue.h>
-
+#include "os/mynewt.h"
 #include "oic/oc_ri.h"
 #include "oic/oc_ri_const.h"
 

--- a/net/oic/src/api/oc_buffer.c
+++ b/net/oic/src/api/oc_buffer.c
@@ -13,14 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
+
 #include <stdint.h>
 #include <stdio.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_eventq.h>
-#include <os/os_mempool.h>
-#include <os/os_mbuf.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "messaging/coap/engine.h"

--- a/net/oic/src/api/oc_client_api.c
+++ b/net/oic/src/api/oc_client_api.c
@@ -14,7 +14,7 @@
 // limitations under the License.
 */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "oic/messaging/coap/coap.h"

--- a/net/oic/src/api/oc_core_res.c
+++ b/net/oic/src/api/oc_core_res.c
@@ -14,9 +14,7 @@
  // limitations under the License.
  */
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_mbuf.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "oic/oc_core_res.h"

--- a/net/oic/src/api/oc_discovery.c
+++ b/net/oic/src/api/oc_discovery.c
@@ -14,7 +14,7 @@
 // limitations under the License.
 */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #ifdef OC_CLIENT

--- a/net/oic/src/api/oc_helpers.c
+++ b/net/oic/src/api/oc_helpers.c
@@ -17,7 +17,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "oic/oc_helpers.h"

--- a/net/oic/src/api/oc_main.c
+++ b/net/oic/src/api/oc_main.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "port/oc_assert.h"

--- a/net/oic/src/api/oc_rep.c
+++ b/net/oic/src/api/oc_rep.c
@@ -16,9 +16,7 @@
 
 #include <stddef.h>
 
-#include <os/os_mempool.h>
-
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <tinycbor/cbor_mbuf_writer.h>
 #include <tinycbor/cbor_mbuf_reader.h>

--- a/net/oic/src/api/oc_ri.c
+++ b/net/oic/src/api/oc_ri.c
@@ -18,11 +18,7 @@
 #include <stddef.h>
 #include <strings.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_callout.h>
-#include <os/os_mempool.h>
-#include <os/queue.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 

--- a/net/oic/src/api/oc_server_api.c
+++ b/net/oic/src/api/oc_server_api.c
@@ -15,9 +15,7 @@
 */
 #include <stddef.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_callout.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "messaging/coap/engine.h"

--- a/net/oic/src/api/oc_uuid.c
+++ b/net/oic/src/api/oc_uuid.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include <hal/hal_bsp.h>
 

--- a/net/oic/src/messaging/coap/coap.c
+++ b/net/oic/src/messaging/coap/coap.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "oic/messaging/coap/coap.h"

--- a/net/oic/src/messaging/coap/engine.c
+++ b/net/oic/src/messaging/coap/engine.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 /* OIC Stack headers */

--- a/net/oic/src/messaging/coap/observe.c
+++ b/net/oic/src/messaging/coap/observe.c
@@ -34,10 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_mempool.h>
-#include <os/queue.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 

--- a/net/oic/src/messaging/coap/separate.c
+++ b/net/oic/src/messaging/coap/separate.c
@@ -34,9 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_mempool.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 

--- a/net/oic/src/messaging/coap/transactions.c
+++ b/net/oic/src/messaging/coap/transactions.c
@@ -30,13 +30,11 @@
  *
  * This file is part of the Contiki operating system.
  */
+
 #include <string.h>
 #include <stddef.h>
 
-#include <syscfg/syscfg.h>
-
-#include <os/os_callout.h>
-#include <os/os_mempool.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 #include "oic/messaging/coap/transactions.h"

--- a/net/oic/src/port/mynewt/abort.c
+++ b/net/oic/src/port/mynewt/abort.c
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
-
 #include <assert.h>
 
+#include "os/mynewt.h"
 #include "port/oc_assert.h"
 
 #ifndef abort_impl

--- a/net/oic/src/port/mynewt/adaptor.c
+++ b/net/oic/src/port/mynewt/adaptor.c
@@ -16,12 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include <syscfg/syscfg.h>
-#include <sysinit/sysinit.h>
-#include <os/os.h>
-#include <os/endian.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include <log/log.h>
 #include "oic/oc_log.h"
 #include "oic/oc_ri.h"

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -21,9 +21,9 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
+
 #if (MYNEWT_VAL(OC_TRANSPORT_GATT) == 1)
-#include <os/os.h>
 
 #include <stats/stats.h>
 #include "oic/oc_gatt.h"

--- a/net/oic/src/port/mynewt/clock.c
+++ b/net/oic/src/port/mynewt/clock.c
@@ -18,7 +18,7 @@
  */
 
 #include <stdint.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include "../oc_clock.h"
 
 void oc_clock_init(void)

--- a/net/oic/src/port/mynewt/ip4_adaptor.c
+++ b/net/oic/src/port/mynewt/ip4_adaptor.c
@@ -21,12 +21,9 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #if (MYNEWT_VAL(OC_TRANSPORT_IP) == 1) && (MYNEWT_VAL(OC_TRANSPORT_IPV4) == 1)
-#include <os/os.h>
-#include <os/endian.h>
-
 #include <log/log.h>
 #include <mn_socket/mn_socket.h>
 #include <stats/stats.h>

--- a/net/oic/src/port/mynewt/ip_adaptor.c
+++ b/net/oic/src/port/mynewt/ip_adaptor.c
@@ -21,12 +21,9 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #if (MYNEWT_VAL(OC_TRANSPORT_IP) == 1) && (MYNEWT_VAL(OC_TRANSPORT_IPV6) == 1)
-
-#include <os/os.h>
-#include <os/endian.h>
 
 #include <log/log.h>
 #include <mn_socket/mn_socket.h>

--- a/net/oic/src/port/mynewt/lora_adaptor.c
+++ b/net/oic/src/port/mynewt/lora_adaptor.c
@@ -21,11 +21,9 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
-#if MYNEWT_VAL(OC_TRANSPORT_LORA)
+#include "os/mynewt.h"
 
-#include <os/os.h>
-#include <os/endian.h>
+#if MYNEWT_VAL(OC_TRANSPORT_LORA)
 
 #include <log/log.h>
 #include <stats/stats.h>

--- a/net/oic/src/port/mynewt/serial_adaptor.c
+++ b/net/oic/src/port/mynewt/serial_adaptor.c
@@ -20,10 +20,9 @@
 #include <assert.h>
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
-#if (MYNEWT_VAL(OC_TRANSPORT_SERIAL) == 1)
+#include "os/mynewt.h"
 
-#include <os/os.h>
+#if (MYNEWT_VAL(OC_TRANSPORT_SERIAL) == 1)
 
 #include <shell/shell.h>
 

--- a/net/oic/src/port/oc_clock.h
+++ b/net/oic/src/port/oc_clock.h
@@ -52,7 +52,7 @@
 
 #include <stdint.h>
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #include "oic/port/mynewt/config.h"
 

--- a/net/oic/test/src/test_discovery.c
+++ b/net/oic/test/src/test_discovery.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "test_oic.h"
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <oic/oc_api.h>
 #include <oic/port/mynewt/ip.h>
+#include "test_oic.h"
 
 static int test_discovery_state;
 static volatile int test_discovery_done;

--- a/net/oic/test/src/test_getset.c
+++ b/net/oic/test/src/test_getset.c
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "test_oic.h"
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <oic/oc_api.h>
+#include "test_oic.h"
 
 static int test_getset_state;
 static volatile int test_getset_done;

--- a/net/oic/test/src/test_observe.c
+++ b/net/oic/test/src/test_observe.c
@@ -16,12 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "test_oic.h"
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <oic/oc_api.h>
-
 #include <cborattr/cborattr.h>
+#include "test_oic.h"
 
 static int test_observe_state;
 static volatile int test_observe_done;

--- a/net/oic/test/src/test_oic.c
+++ b/net/oic/test/src/test_oic.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "test_oic.h"
 

--- a/net/oic/test/src/testcases/oic_tests.c
+++ b/net/oic/test/src/testcases/oic_tests.c
@@ -16,12 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "test_oic.h"
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <oic/oc_api.h>
-
 #include <mn_socket/mn_socket.h>
+#include "test_oic.h"
 
 #define OIC_TAPP_PRIO       9
 #define OIC_TAPP_STACK_SIZE OS_STACK_ALIGN(1024)

--- a/net/wifi/wifi_mgmt/include/wifi_mgmt/wifi_mgmt.h
+++ b/net/wifi/wifi_mgmt/include/wifi_mgmt/wifi_mgmt.h
@@ -19,7 +19,7 @@
 #ifndef __WIFI_MGMT_H__
 #define __WIFI_MGMT_H__
 
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/net/wifi/wifi_mgmt/include/wifi_mgmt/wifi_mgmt_if.h
+++ b/net/wifi/wifi_mgmt/include/wifi_mgmt/wifi_mgmt_if.h
@@ -19,7 +19,7 @@
 #ifndef __WIFI_MGMT_IF_H__
 #define __WIFI_MGMT_IF_H__
 
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/net/wifi/wifi_mgmt/src/wifi.c
+++ b/net/wifi/wifi_mgmt/src/wifi.c
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
 
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <bsp/bsp.h>
 #include <hal/hal_gpio.h>
 #include <shell/shell.h>

--- a/net/wifi/wifi_mgmt/src/wifi_cli.c
+++ b/net/wifi/wifi_mgmt/src/wifi_cli.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(WIFI_MGMT_CLI)
 

--- a/net/wifi/wifi_mgmt/src/wifi_priv.h
+++ b/net/wifi/wifi_mgmt/src/wifi_priv.h
@@ -20,7 +20,7 @@
 #ifndef __WIFI_PRIV_H__
 #define __WIFI_PRIV_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -19,8 +19,8 @@
 #ifndef __SYS_CONFIG_H_
 #define __SYS_CONFIG_H_
 
-#include <os/queue.h>
 #include <stdint.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -20,9 +20,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "base64/base64.h"
 
 #include "config/config.h"

--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -19,7 +19,7 @@
 
 #include <stddef.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "config/config.h"
 #include "config_priv.h"
 

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONFIG_FCB)
 
-#include <os/os.h>
 #include <fcb/fcb.h>
 #include <string.h>
 

--- a/sys/config/src/config_file.c
+++ b/sys/config/src/config_file.c
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONFIG_NFFS)
 
 #include <string.h>
 #include <assert.h>
 
-#include <os/os.h>
 #include <fs/fs.h>
 
 #include "config/config.h"

--- a/sys/config/src/config_init.c
+++ b/sys/config/src/config_init.c
@@ -19,9 +19,7 @@
 
 #include <assert.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "bsp/bsp.h"
 
 #include "config/config.h"

--- a/sys/config/src/config_json_line.c
+++ b/sys/config/src/config_json_line.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONFIG_NEWTMGR)
 

--- a/sys/config/src/config_nmgr.c
+++ b/sys/config/src/config_nmgr.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONFIG_NEWTMGR)
 

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -20,8 +20,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <os/os.h>
-
+#include "os/mynewt.h"
 #include "config/config.h"
 #include "config_priv.h"
 

--- a/sys/config/test-fcb/src/conf_test_fcb.c
+++ b/sys/config/test-fcb/src/conf_test_fcb.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <flash_map/flash_map.h>
 #include <testutil/testutil.h>
 #include <fcb/fcb.h>

--- a/sys/config/test-fcb/src/conf_test_fcb.h
+++ b/sys/config/test-fcb/src/conf_test_fcb.h
@@ -21,8 +21,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <syscfg/syscfg.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <flash_map/flash_map.h>
 #include <testutil/testutil.h>
 #include <fcb/fcb.h>

--- a/sys/config/test-nffs/src/conf_test_nffs.c
+++ b/sys/config/test-nffs/src/conf_test_nffs.c
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <testutil/testutil.h>
 #include <nffs/nffs.h>
 #include <fs/fs.h>

--- a/sys/config/test-nffs/src/conf_test_nffs.h
+++ b/sys/config/test-nffs/src/conf_test_nffs.h
@@ -22,9 +22,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
-#include <os/os.h>
 #include <testutil/testutil.h>
 #include <nffs/nffs.h>
 #include <fs/fs.h>

--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -21,7 +21,7 @@
 #define __CONSOLE_H__
 
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONSOLE_BLE_MONITOR)
 

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -24,9 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "console/ticks.h"
 #include "console_priv.h"

--- a/sys/console/full/src/console_fmt.c
+++ b/sys/console/full/src/console_fmt.c
@@ -18,10 +18,9 @@
  */
 #include <stdarg.h>
 #include <stdio.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "console/ticks.h"
-#include "os/os_time.h"
 
 #define CONS_OUTPUT_MAX_LINE    128
 

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONSOLE_RTT)
 #include <ctype.h>
 
-#include "os/os.h"
-#include "os/os_cputime.h"
 #include "rtt/SEGGER_RTT.h"
 #include "console/console.h"
 #include "console_priv.h"

--- a/sys/console/full/src/ticks.c
+++ b/sys/console/full/src/ticks.c
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "console/prompt.h"
 

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONSOLE_UART)
 #include <ctype.h>
 #include <assert.h>
 
-#include "os/os.h"
 #include "uart/uart.h"
 #include "bsp/bsp.h"
 

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -21,7 +21,7 @@
 #define __CONSOLE_H__
 
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -24,9 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "console_priv.h"
 

--- a/sys/console/minimal/src/rtt_console.c
+++ b/sys/console/minimal/src/rtt_console.c
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONSOLE_RTT)
 #include <ctype.h>
 
-#include "os/os.h"
-#include "os/os_cputime.h"
 #include "rtt/SEGGER_RTT.h"
 #include "console/console.h"
 #include "console_priv.h"

--- a/sys/console/minimal/src/uart_console.c
+++ b/sys/console/minimal/src/uart_console.c
@@ -17,13 +17,12 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CONSOLE_UART)
 #include <ctype.h>
 #include <assert.h>
 
-#include "os/os.h"
 #include "uart/uart.h"
 #include "bsp/bsp.h"
 

--- a/sys/coredump/src/coredump.c
+++ b/sys/coredump/src/coredump.c
@@ -19,8 +19,7 @@
 
 #include <stddef.h>
 #include <limits.h>
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "flash_map/flash_map.h"
 #include "bootutil/image.h"

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -21,11 +21,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include <os/os.h>
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-#include "defs/error.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_flash_int.h"

--- a/sys/flash_map/test/src/flash_map_test.c
+++ b/sys/flash_map/test/src/flash_map_test.c
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"

--- a/sys/flash_map/test/src/flash_map_test.h
+++ b/sys/flash_map/test/src/flash_map_test.h
@@ -21,10 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
 
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
-#include "os/os.h"
 #include "config/config.h"
 #include "base64/base64.h"
 #include "mfg/mfg.h"

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -19,11 +19,9 @@
 #ifndef __SYS_LOG_FULL_H__
 #define __SYS_LOG_FULL_H__
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "log/ignore.h"
 #include "cbmem/cbmem.h"
-
-#include <os/queue.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -22,9 +22,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "cbmem/cbmem.h"
 #include "log/log.h"
 

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <os/os.h>
+
+#include "os/mynewt.h"
 #include <cbmem/cbmem.h>
 #include "log/log.h"
 

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include <syscfg/syscfg.h>
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(LOG_CONSOLE)
 
-#include <os/os.h>
 #include <cbmem/cbmem.h>
 #include <console/console.h>
 #include "log/log.h"

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -17,14 +17,11 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(LOG_FCB)
 
 #include <string.h>
-
-#include "os/os.h"
 
 #include "flash_map/flash_map.h"
 #include "fcb/fcb.h"

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include <os/os.h>
 #include <string.h>
 #include <stdio.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(LOG_NEWTMGR)
 

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 /* This whole file is conditionally compiled based on whether the
  * log package is configured to use the shell (MYNEWT_VAL(LOG_CLI)).
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "os/os.h"
 #include "cbmem/cbmem.h"
 #include "log/log.h"
 #include "shell/shell.h"

--- a/sys/log/full/test/src/log_test.c
+++ b/sys/log/full/test/src/log_test.c
@@ -18,9 +18,7 @@
  */
 #include <string.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "fcb/fcb.h"
 #include "log/log.h"

--- a/sys/log/full/test/src/log_test.h
+++ b/sys/log/full/test/src/log_test.h
@@ -20,8 +20,7 @@
 #define _LOG_TEST_H
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "fcb/fcb.h"
 #include "log/log.h"

--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -20,7 +20,7 @@
 #define __SYS_LOG_STUB_H__
 
 #include <inttypes.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "log/ignore.h"
 
 #ifdef __cplusplus

--- a/sys/mfg/src/mfg.c
+++ b/sys/mfg/src/mfg.c
@@ -18,11 +18,7 @@
  */
 
 #include <string.h>
-
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "mfg/mfg.h"
 
 /**

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -19,10 +19,7 @@
 
 #include <string.h>
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "sysflash/sysflash.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "log/log.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"

--- a/sys/shell/include/shell/shell.h
+++ b/sys/shell/include/shell/shell.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 struct os_eventq;
 

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -21,10 +21,8 @@
 #include <string.h>
 #include <assert.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
-#include "sysinit/sysinit.h"
 #include "shell/shell.h"
 #include "shell_priv.h"
 

--- a/sys/shell/src/shell_nlip.c
+++ b/sys/shell/src/shell_nlip.c
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SHELL_NEWTMGR)
 #include <stddef.h>
-#include "os/os.h"
-#include "os/endian.h"
 #include "base64/base64.h"
 #include "crc/crc16.h"
 #include "console/console.h"

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -20,9 +20,7 @@
 #include <assert.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "datetime/datetime.h"
 #include "console/console.h"
 

--- a/sys/shell/src/shell_prompt.c
+++ b/sys/shell/src/shell_prompt.c
@@ -20,8 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 #include "console/ticks.h"
 

--- a/sys/stats/full/include/stats/stats.h
+++ b/sys/stats/full/include/stats/stats.h
@@ -21,8 +21,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "syscfg/syscfg.h"
-#include "os/queue.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/stats/full/src/stats.c
+++ b/sys/stats/full/src/stats.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "stats/stats.h"
 
 /**

--- a/sys/stats/full/src/stats_nmgr.c
+++ b/sys/stats/full/src/stats_nmgr.c
@@ -20,11 +20,10 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(STATS_NEWTMGR)
 
-#include "os/os.h"
 #include "mgmt/mgmt.h"
 #include "cborattr/cborattr.h"
 #include "stats/stats.h"

--- a/sys/stats/full/src/stats_shell.c
+++ b/sys/stats/full/src/stats_shell.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 /* Source code is only included if the shell library is enabled.  Otherwise
  * this file is compiled out for code size.
@@ -27,7 +27,6 @@
 #include <string.h>
 #include "shell/shell.h"
 #include "console/console.h"
-#include "os/os.h"
 #include "stats/stats.h"
 
 static int shell_stats_display(int argc, char **argv);

--- a/sys/stats/stub/include/stats/stats.h
+++ b/sys/stats/stub/include/stats/stats.h
@@ -20,8 +20,7 @@
 #define __UTIL_STATS_H__
 
 #include <stdint.h>
-#include "syscfg/syscfg.h"
-#include "os/queue.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/sysinit/include/sysinit/sysinit.h
+++ b/sys/sysinit/include/sysinit/sysinit.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 #include <assert.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(SPLIT_APPLICATION)
 #include "split/split.h"

--- a/sys/sysinit/src/sysinit.c
+++ b/sys/sysinit/src/sysinit.c
@@ -20,9 +20,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <limits.h>
-#include "os/os_fault.h"
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
+#include "os/mynewt.h"
 
 static void
 sysinit_dflt_panic_cb(const char *file, int line, const char *func,

--- a/sys/sysview/src/SEGGER_SYSVIEW_Mynewt.c
+++ b/sys/sysview/src/SEGGER_SYSVIEW_Mynewt.c
@@ -20,8 +20,7 @@
 #include <ctype.h>
 #include <stdint.h>
 
-#include "os/os.h"
-#include "os/os_trace_api.h"
+#include "os/mynewt.h"
 
 #include "sysview/vendor/SEGGER_SYSVIEW.h"
 #include "sysview/vendor/Global.h"

--- a/sys/sysview/vendor/include/sysview/vendor/SEGGER_SYSVIEW_Conf.h
+++ b/sys/sysview/vendor/include/sysview/vendor/SEGGER_SYSVIEW_Conf.h
@@ -65,7 +65,7 @@ Revision: $Rev: 5626 $
 #ifndef SEGGER_SYSVIEW_CONF_H
 #define SEGGER_SYSVIEW_CONF_H
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 /*********************************************************************
 *

--- a/test/crash_test/src/crash_cli.c
+++ b/test/crash_test/src/crash_cli.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CRASH_TEST_CLI)
 #include <inttypes.h>
-#include <os/os.h>
 #include <console/console.h>
 #include <shell/shell.h>
 #include <stdio.h>

--- a/test/crash_test/src/crash_nmgr.c
+++ b/test/crash_test/src/crash_nmgr.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(CRASH_TEST_NEWTMGR)
 

--- a/test/crash_test/src/crash_test.c
+++ b/test/crash_test/src/crash_test.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 
 #include "crash_test/crash_test.h"

--- a/test/flash_test/src/flash_test/flash_test.c
+++ b/test/flash_test/src/flash_test/flash_test.c
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <inttypes.h>
-#include <os/os.h>
+#include "os/mynewt.h"
 #include <console/console.h>
 #include <hal/hal_bsp.h>
 #include <hal/hal_flash.h>

--- a/test/i2c_scan/src/i2c_scan.c
+++ b/test/i2c_scan/src/i2c_scan.c
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <inttypes.h>
-#include <os/os.h>
 
+#include <inttypes.h>
+#include "os/mynewt.h"
 #include <hal/hal_i2c.h>
 #include <shell/shell.h>
 #include <console/console.h>

--- a/test/runtest/src/runtest.c
+++ b/test/runtest/src/runtest.c
@@ -21,9 +21,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "console/console.h"
 
 #include "runtest/runtest.h"

--- a/test/runtest/src/runtest_cli.c
+++ b/test/runtest/src/runtest_cli.c
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(RUNTEST_CLI)
 #include <inttypes.h>
-#include <os/os.h>
 #include <console/console.h>
 #include <shell/shell.h>
 #include <stdio.h>

--- a/test/runtest/src/runtest_nmgr.c
+++ b/test/runtest/src/runtest_nmgr.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #if MYNEWT_VAL(RUNTEST_NEWTMGR)
 #include <string.h>
@@ -25,7 +25,6 @@
 #include "mgmt/mgmt.h"
 #include "cborattr/cborattr.h"
 #include "console/console.h"
-#include "os/os_eventq.h"
 
 #include "testutil/testutil.h"
 

--- a/test/testutil/include/testutil/testutil.h
+++ b/test/testutil/include/testutil/testutil.h
@@ -24,9 +24,7 @@
 #include <inttypes.h>
 #include <setjmp.h>
 
-#include "os/queue.h"
-
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/testutil/src/suite.c
+++ b/test/testutil/src/suite.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "testutil_priv.h"
 

--- a/test/testutil/src/testutil.c
+++ b/test/testutil/src/testutil.c
@@ -16,16 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <assert.h>
-#include "sysinit/sysinit.h"
-#include "os/os.h"
+#include <errno.h>
+#include <unistd.h>
+#include "os/mynewt.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_system.h"
 #include "testutil/testutil.h"
 #include "testutil_priv.h"
-
-#include <errno.h>
-#include <unistd.h>
 
 struct tc_config tc_config;
 struct tc_config *tc_current_config = &tc_config;

--- a/time/datetime/src/datetime.c
+++ b/time/datetime/src/datetime.c
@@ -57,12 +57,10 @@
  *    from: src/sys/i386/isa/clock.c,v 1.176 2001/09/04
  */
 
-#include <os/os_time.h>
-#include <os/os_error.h>
-
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include <datetime/datetime.h>
 
 #define days_in_year(y)     (leapyear(y) ? 366 : 365)

--- a/util/cbmem/include/cbmem/cbmem.h
+++ b/util/cbmem/include/cbmem/cbmem.h
@@ -19,7 +19,7 @@
 #ifndef __UTIL_CBMEM_H__ 
 #define __UTIL_CBMEM_H__
 
-#include <os/os.h>
+#include "os/mynewt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/util/cbmem/src/cbmem.c
+++ b/util/cbmem/src/cbmem.c
@@ -17,11 +17,9 @@
  * under the License.
  */
 
-#include <os/os.h>
 #include <string.h>
-
+#include "os/mynewt.h"
 #include "cbmem/cbmem.h"
-
 
 int
 cbmem_init(struct cbmem *cbmem, void *buf, uint32_t buf_len)

--- a/util/cbmem/test/src/cbmem_test.c
+++ b/util/cbmem/test/src/cbmem_test.c
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
 #include <stddef.h>
-#include "sysinit/sysinit.h"
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
 #include "cbmem_test.h"

--- a/util/cbmem/test/src/cbmem_test.h
+++ b/util/cbmem/test/src/cbmem_test.h
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stddef.h>
-#include "syscfg/syscfg.h"
+#include "os/mynewt.h"
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
 

--- a/util/mem/src/mem.c
+++ b/util/mem/src/mem.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "os/os.h"
+#include "os/mynewt.h"
 #include "mem/mem.h"
 
 /**

--- a/util/parse/src/parse.c
+++ b/util/parse/src/parse.c
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include <errno.h>
 #include <assert.h>
-#include "defs/error.h"
+#include "os/mynewt.h"
 
 /**
  * Determines which numeric base the specified string should be parsed with.


### PR DESCRIPTION
This new header (`os/mynewt.h) includes the following headers:

    * syscfg/syscfg.h
    * sysinit/sysinit.h
    * sysflash/sysflash.h
    * os/os.h
    * defs/error.h

This header is intended to be included before any other non-system headers.  The purpose of this header is to make an application developer's job easier, and simplify the "getting started" process.

I think a good rule of thumb is: always include `os/mynewt.h` and never directly include any of the headers listed above.

I put this header in the `kernel/os` package because, in practice, every other package has access to this one.  I am happy to move it somewhere else if there are alternative ideas.

I was tempted to include `bsp/bsp.h` in this header, but I decided it is better if Mynewt doesn't make any assumptions about which files the BSP exports.  