### PR TITLE
Fix stm32f3 uart overrun handling

### DIFF
--- a/hw/mcu/stm/stm32f3xx/src/hal_uart.c
+++ b/hw/mcu/stm/stm32f3xx/src/hal_uart.c
@@ -114,6 +114,9 @@ uart_irq_handler(int num)
         }
         regs->CR1 = cr1;
     }
+    if (isr & USART_ISR_ORE) {
+        regs->ICR |= USART_ICR_ORECF;
+    }
 }
 
 void


### PR DESCRIPTION
When an overrun happened it would never leave the overrun state and it would basically halt from receiving packets.

Signed-off-by: Fabio Utzig <utzig@apache.org>