### PR TITLE
Fix console echo in minimal console

### DIFF
--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -45,11 +45,7 @@ int console_read(char *str, int cnt, int *newline);
 
 void console_blocking_mode(void);
 void console_non_blocking_mode(void);
-
-static void inline
-console_echo(int on)
-{
-}
+void console_echo(int on);
 
 static int console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;

--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -64,6 +64,12 @@ console_out(int c)
 }
 
 void
+console_echo(int on)
+{
+    echo = on;
+}
+
+void
 console_write(const char *str, int cnt)
 {
     int i;


### PR DESCRIPTION
console minimal was using `console_echo()` function to set echo, but this function is empty on the minimal version. It is only implemented on `console/full`.

Signed-off-by: Fabio Utzig <utzig@apache.org>