### PR TITLE
Don't include os/mynewt.h from primitive headers.

### DIFF
--- a/hw/hal/include/hal/hal_timer.h
+++ b/hw/hal/include/hal/hal_timer.h
@@ -29,7 +29,7 @@
 #define H_HAL_TIMER_
 
 #include <inttypes.h>
-#include "os/mynewt.h"
+#include "os/queue.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -5,7 +5,7 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
-#include "os/mynewt.h"
+#include "syscfg/syscfg.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/sysinit/include/sysinit/sysinit.h
+++ b/sys/sysinit/include/sysinit/sysinit.h
@@ -22,7 +22,7 @@
 
 #include <inttypes.h>
 #include <assert.h>
-#include "os/mynewt.h"
+#include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(SPLIT_APPLICATION)
 #include "split/split.h"


### PR DESCRIPTION
`os/mynewt.h` includes a set a of headers.  None of the headers in this set should include `os/mynewt.h`.