### PR TITLE
Add SPI to lps33hw driver

### DIFF
--- a/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
+++ b/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
@@ -30,6 +30,8 @@ extern "C" {
 
 #define LPS33HW_I2C_ADDR (0x5C)
 
+#define LPS33HW_SPI_READ_CMD_BIT (0x80)
+
 #define LPS33HW_INT_LEVEL (0x80)
 #define LPS33HW_INT_OPEN (0x40)
 #define LPS33HW_INT_LATCH_EN (0x20)

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -63,6 +63,7 @@ static int lps33hw_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
 static int lps33hw_sensor_get_config(struct sensor *, sensor_type_t,
         struct sensor_cfg *);
+static int lps33hw_sensor_set_config(struct sensor *, void *);
 static int lps33hw_sensor_set_trigger_thresh(struct sensor *sensor,
         sensor_type_t sensor_type, struct sensor_type_traits *stt);
 static int lps33hw_sensor_handle_interrupt(struct sensor *sensor);
@@ -74,6 +75,7 @@ static int lps33hw_sensor_clear_high_thresh(struct sensor *sensor,
 static const struct sensor_driver g_lps33hw_sensor_driver = {
     .sd_read                      = lps33hw_sensor_read,
     .sd_get_config                = lps33hw_sensor_get_config,
+    .sd_set_config                = lps33hw_sensor_set_config,
     .sd_set_trigger_thresh        = lps33hw_sensor_set_trigger_thresh,
     .sd_handle_interrupt          = lps33hw_sensor_handle_interrupt,
     .sd_clear_low_trigger_thresh  = lps33hw_sensor_clear_low_thresh,
@@ -984,6 +986,14 @@ lps33hw_sensor_read(struct sensor *sensor, sensor_type_t type,
     }
 
     return rc;
+}
+
+static int
+lps33hw_sensor_set_config(struct sensor *sensor, void *cfg)
+{
+    struct lps33hw* lps33hw = (struct lps33hw *)SENSOR_GET_DEVICE(sensor);
+
+    return lps33hw_config(lps33hw, (struct lps33hw_cfg*)cfg);
 }
 
 static int

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -155,6 +155,8 @@ lps33hw_reg_to_degc(int16_t reg)
 }
 
 /**
+ * Writes a single byte to the specified register using i2c
+ * interface
  *
  * @param The sensor interface
  * @param The register address to write to
@@ -187,6 +189,8 @@ lps33hw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 }
 
 /**
+ * Writes a single byte to the specified register using SPI
+ * interface
  *
  * @param The sensor interface
  * @param The register address to write to
@@ -257,6 +261,17 @@ lps33hw_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     return rc;
 }
 
+/**
+ *
+ * Read bytes from the specified register using SPI interface
+ *
+ * @param The sensor interface
+ * @param The register address to read from
+ * @param The number of bytes to read
+ * @param Pointer to where the register value should be written
+ *
+ * @return 0 on success, non-zero error on failure.
+ */
 static int
 lps33hw_spi_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     uint8_t *buffer)
@@ -301,6 +316,16 @@ err:
     return rc;
 }
 
+/**
+ * Read bytes from the specified register using i2c interface
+ *
+ * @param The sensor interface
+ * @param The register address to read from
+ * @param The number of bytes to read
+ * @param Pointer to where the register value should be written
+ *
+ * @return 0 on success, non-zero error on failure.
+ */
 static int
 lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     uint8_t *buffer)
@@ -336,10 +361,11 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 }
 
 /**
- * Read bytes from the specified register
+ * Read bytes from the specified register using specified interface
  *
  * @param The sensor interface
  * @param The register address to read from
+ * @param The number of bytes to read
  * @param Pointer to where the register value should be written
  *
  * @return 0 on success, non-zero error on failure.


### PR DESCRIPTION
The previous version fo the lps33hw did not include support for SPI interface.  In this PR we add this support.  

Testing/Verification - via sensor CLI read sensor pressure value.  