### PR TITLE
WIP: hal_nvreg (Retained register interface)

### DIFF
--- a/boot/boot_serial/syscfg.yml
+++ b/boot/boot_serial/syscfg.yml
@@ -69,3 +69,18 @@ syscfg.defs:
         description: >
             The toggle rate, in Hz, of the serial boot loader report pin.
         value: 4
+
+    BOOT_SERIAL_NVREG_MAGIC:
+        description: >
+            Magic number, to be saved in a retained (reset-surviving) register.
+            If the value in the register matches, the serial bootloader will
+            load. Value must not be 0.
+        value: 0xB7
+        restrictions:
+            - '(BOOT_SERIAL_NVREG_MAGIC != 0)'
+
+    BOOT_SERIAL_NVREG_INDEX:
+        description: >
+            Index of retained register to use (using hal_nvreg_read) for reading
+            magic value.
+        value: -1

--- a/hw/hal/include/hal/hal_nvreg.h
+++ b/hw/hal/include/hal/hal_nvreg.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * @addtogroup HAL
+ * @{
+ *   @defgroup HALNvreg HAL NVReg
+ *   @{
+ */
+
+#ifndef __HAL_NVREG_H_
+#define __HAL_NVREG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+
+/**
+ * Writes to a retained register
+ */
+void hal_nvreg_write(unsigned int reg, uint32_t val);
+
+/**
+ * Reads from a retained register
+ */
+uint32_t hal_nvreg_read(unsigned int reg);
+
+/**
+ * Get number of available retained registers
+ */
+unsigned int hal_nvreg_get_num_regs();
+
+/**
+ * Get retained register width (in bytes)
+ */
+unsigned int hal_nvreg_get_reg_width();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/**
+ *   @} HALNvreg
+ * @} HAL
+ */

--- a/hw/hal/include/hal/hal_nvreg.h
+++ b/hw/hal/include/hal/hal_nvreg.h
@@ -47,12 +47,12 @@ uint32_t hal_nvreg_read(unsigned int reg);
 /**
  * Get number of available retained registers
  */
-unsigned int hal_nvreg_get_num_regs();
+unsigned int hal_nvreg_get_num_regs(void);
 
 /**
  * Get retained register width (in bytes)
  */
-unsigned int hal_nvreg_get_reg_width();
+unsigned int hal_nvreg_get_reg_width(void);
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_nvreg.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_nvreg.c
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <mcu/cortex_m4.h>
+#include "hal/hal_nvreg.h"
+#include "nrf.h"
+
+
+#define HAL_NVREG_MAX (2) // There are two GPREGRET registers on the NRF52
+
+#define HAL_NVREG_WIDTH_BYTES (1) // GPREGRET registers only save the 8 lsbits
+
+static volatile uint32_t *regs[HAL_NVREG_MAX] = {
+    &NRF_POWER->GPREGRET,
+    &NRF_POWER->GPREGRET2
+};
+
+void
+hal_nvreg_write(unsigned int reg, uint32_t val)
+{
+    if(reg < HAL_NVREG_MAX) {
+        *regs[reg] = val;
+    }
+}
+
+uint32_t
+hal_nvreg_read(unsigned int reg)
+{
+    uint32_t val = 0;
+
+    if(reg < HAL_NVREG_MAX) {
+        val = *regs[reg];
+    }
+
+    return val;
+}
+
+unsigned int hal_nvreg_get_num_regs()
+{
+    return HAL_NVREG_MAX;
+}
+
+unsigned int hal_nvreg_get_reg_width()
+{
+    return HAL_NVREG_WIDTH_BYTES;
+}

--- a/hw/mcu/nordic/nrf52xxx/src/hal_nvreg.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_nvreg.c
@@ -21,10 +21,11 @@
 #include "hal/hal_nvreg.h"
 #include "nrf.h"
 
+/* There are two GPREGRET registers on the NRF52 */
+#define HAL_NVREG_MAX (2)
 
-#define HAL_NVREG_MAX (2) // There are two GPREGRET registers on the NRF52
-
-#define HAL_NVREG_WIDTH_BYTES (1) // GPREGRET registers only save the 8 lsbits
+/* GPREGRET registers only save the 8 lsbits */
+#define HAL_NVREG_WIDTH_BYTES (1)
 
 static volatile uint32_t *regs[HAL_NVREG_MAX] = {
     &NRF_POWER->GPREGRET,
@@ -51,12 +52,12 @@ hal_nvreg_read(unsigned int reg)
     return val;
 }
 
-unsigned int hal_nvreg_get_num_regs()
+unsigned int hal_nvreg_get_num_regs(void)
 {
     return HAL_NVREG_MAX;
 }
 
-unsigned int hal_nvreg_get_reg_width()
+unsigned int hal_nvreg_get_reg_width(void)
 {
     return HAL_NVREG_WIDTH_BYTES;
 }


### PR DESCRIPTION
This is a first attempt at a hal interface to retained registers. (And added support for serial bootloader to use it to enter bootloader on reset if a specific value is saved in one of them)

Various microcontrollers have a few registers that survive a soft reset. This interface exposes them (if available) via hal_nvreg (Happy to change the name if we can think of something better).
I was thinking nv for nonvolatile, which isn't always true since they will get cleared after hard reset (in some devices). Another options was hal_retained_reg, which is a bit long, but also works.

## hal_nvreg functions
* `void hal_nvreg_write(unsigned int reg, uint32_t val);`
  * Stores value to retained register at index <reg>
* `uint32_t hal_nvreg_read(unsigned int reg);`
  * Returns value of retained register at index <reg>
* `unsigned int hal_nvreg_get_num_regs(void);`
  * Different devices might have more, less, or no retained registers. This will return how many there are.
* `unsigned int hal_nvreg_get_reg_width(void);`
  * Since not all registers are 32 bits, this function allows for querying the actual stored size

## boot_serial modifications
Added an optional check for a specific value if **MYNEWT_VAL(BOOT_SERIAL_NVREG_INDEX) != -1**.

If the value stored in retained register <**MYNEWT_VAL(BOOT_SERIAL_NVREG_INDEX)** > matches  <**MYNEWT_VAL(BOOT_SERIAL_NVREG_MAGIC)**>, then the serial bootloader starts instead of continuing to run the main application.

## Serial Bootloader Example
I wrote a small example app to test the serial bootloader here: https://github.com/alvarop/mynewt_bootloader_app