### PR TITLE
os_time: Prevent 0 ticks returned when OS_TICKS_PER_SEC < 1000

### DIFF
--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -194,7 +194,7 @@ os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks)
     _Static_assert(OS_TICKS_PER_SEC <= UINT32_MAX,
                    "OS_TICKS_PER_SEC must be <= UINT32_MAX");
 
-    ticks = (uint64_t)ms * OS_TICKS_PER_SEC / 1000;
+    ticks = ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
     if (ticks > UINT32_MAX) {
         return OS_EINVAL;
     }


### PR DESCRIPTION
The os_time_ms_to_ticks assumes the multiplication always proceeds the division in the following piece of code: 

```
 ticks = (uint64_t)ms * OS_TICKS_PER_SEC / 1000;
```

With an OS_TICKS_PER_SEC < 1000 the division could result in 0 and give the wrong number of ticks. This PR adds () to force multiplication before division. Thus:

```
 ticks = ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
```