### PR TITLE
sys/config: Checking results on rc2 instead of rc

### DIFF
--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -295,7 +295,7 @@ conf_commit(char *name)
         SLIST_FOREACH(ch, &conf_handlers, ch_list) {
             if (ch->ch_commit) {
                 rc2 = ch->ch_commit();
-                if (!rc) {
+                if (!rc2) {
                     rc = rc2;
                 }
             }

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -176,7 +176,7 @@ conf_save(void)
     SLIST_FOREACH(ch, &conf_handlers, ch_list) {
         if (ch->ch_export) {
             rc2 = ch->ch_export(conf_store_one, CONF_EXPORT_PERSIST);
-            if (!rc) {
+            if (!rc2) {
                 rc = rc2;
             }
         }


### PR DESCRIPTION
Surely the if statements should be checking if rc2 is non-zero rather than the (unchanging in the loops) rc. 