### PR TITLE
btshell: Fix parsing of high_duty parameter

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -273,12 +273,6 @@ cmd_advertise_configure(int argc, char **argv)
         return rc;
     }
 
-    params.high_duty_directed = parse_arg_uint8_dflt("high_duty", 0, &rc);
-    if (rc != 0) {
-        console_printf("invalid 'high_duty' parameter\n");
-        return rc;
-    }
-
     rc = btshell_ext_adv_configure(instance, &params, &selected_tx_power);
     if (rc) {
         console_printf("failed to configure advertising instance\n");


### PR DESCRIPTION
Parsing was called twice resulting always storing default value (0).