### PR TITLE
os: Add os_time_ticks_to_ms

### DIFF
--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -195,6 +195,17 @@ int64_t os_get_uptime_usec(void);
  */
 int os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks);
 
+/**
+ * Converts OS ticks to milliseconds.
+ *
+ * @param ticks                 The OS ticks input.
+ * @param out_ms                The milliseconds output.
+ *
+ * @return                      0 on success; OS_EINVAL if the result is too
+ *                                  large to fit in a uint32_t.
+ */
+int os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -203,3 +203,22 @@ os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks)
     return 0;
 }
 
+int
+os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms)
+{
+    uint64_t ms;
+
+#if OS_TICKS_PER_SEC == 1000
+    *out_ms = ticks;
+    return 0;
+#endif
+
+    ms = ((uint64_t)ticks * 1000) / OS_TICKS_PER_SEC;
+    if (ms > UINT32_MAX) {
+        return OS_EINVAL;
+    }
+
+    *out_ms = ms;
+
+    return 0;
+}


### PR DESCRIPTION
This is complementary to os_time_ms_to_ticks and allows to have more
OS abstraction in code by avoiding use of OS_TICKS_PER_SEC explicitly.