### PR TITLE
LIS2DW12 add bitfields

### DIFF
--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -49,15 +49,10 @@ extern "C" {
 #define LIS2DW12_ST_MODE_MODE1                  0x40
 #define LIS2DW12_ST_MODE_MODE2                  0x80
 
-#define LIS2DW12_HPF_M_NORMAL0                  0x00
-#define LIS2DW12_HPF_M_REF                      0x01
-#define LIS2DW12_HPF_M_NORMAL1                  0x02
-#define LIS2DW12_HPF_M_AIE                      0x03
-
 #define LIS2DW12_FILTER_BW_ODR_DIV_2            0x00
-#define LIS2DW12_FILTER_BW_ODR_DIV_4            0x40
-#define LIS2DW12_FILTER_BW_ODR_DIV_10           0x80
-#define LIS2DW12_FILTER_BW_ODR_DIV_20           0xC0
+#define LIS2DW12_FILTER_BW_ODR_DIV_4            0x01
+#define LIS2DW12_FILTER_BW_ODR_DIV_10           0x02
+#define LIS2DW12_FILTER_BW_ODR_DIV_20           0x03
 
 #define LIS2DW12_FS_2G                          0x00
 #define LIS2DW12_FS_4G                          0x10
@@ -176,13 +171,8 @@ struct lis2dw12_cfg {
     int8_t offset_y;
     int8_t offset_z;
     uint8_t offset_weight;
-    uint8_t offset_en;
-
-    uint8_t filter_bw;
-    uint8_t high_pass;
 
     struct lis2dw12_tap_settings tap_cfg;
-    uint8_t double_tap_event_enable;
 
     uint8_t freefall_dur;
     uint8_t freefall_ths;
@@ -190,27 +180,33 @@ struct lis2dw12_cfg {
     uint8_t int1_pin_cfg;
     uint8_t int2_pin_cfg;
     bool map_int2_to_int1;
-    uint8_t int_enable;
 
-    uint8_t int_pp_od;
-    uint8_t int_latched;
-    uint8_t int_active;
-    uint8_t slp_mode;
-    uint8_t self_test_mode;
+    uint8_t offset_en : 1;
 
+    uint8_t filter_bw : 2;
+    uint8_t high_pass : 1;
+    
+    uint8_t int_enable : 1;
+    uint8_t int_pp_od : 1;
+    uint8_t int_latched : 1;
+    uint8_t int_active : 1;
+    uint8_t inactivity_sleep_enable : 1;
+    uint8_t low_noise_enable : 1;
+    uint8_t stationary_detection_enable : 1;
+    uint8_t double_tap_event_enable : 1;
+
+    uint8_t slp_mode : 1;
+    uint8_t self_test_mode : 3;
+
+    uint8_t power_mode : 4;
+    
     enum lis2dw12_fifo_mode fifo_mode;
     uint8_t fifo_threshold;
 
     uint8_t wake_up_ths;
     uint8_t wake_up_dur;
     uint8_t sleep_duration;
-
-    uint8_t stationary_detection_enable;
-
-    uint8_t power_mode;
-    uint8_t inactivity_sleep_enable;
-    uint8_t low_noise_enable;
-    
+   
     enum lis2dw12_read_mode read_mode;
     uint8_t stream_read_interrupt;
     

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -956,7 +956,7 @@ lis2dw12_set_filter_cfg(struct sensor_itf *itf, uint8_t bw, uint8_t type)
 
     reg &= ~LIS2DW12_CTRL_REG6_BW_FILT;
     reg &= ~LIS2DW12_CTRL_REG6_FDS;
-    reg |= (bw & LIS2DW12_CTRL_REG6_BW_FILT);
+    reg |= (bw & 0x3) << 6;
     if (type) {
         reg |= LIS2DW12_CTRL_REG6_FDS;
     }
@@ -991,7 +991,7 @@ lis2dw12_get_filter_cfg(struct sensor_itf *itf, uint8_t *bw, uint8_t *type)
         goto err;
     }
 
-    *bw = reg & LIS2DW12_CTRL_REG6_BW_FILT;
+    *bw = (reg & LIS2DW12_CTRL_REG6_BW_FILT) >> 6;
     *type = (reg & LIS2DW12_CTRL_REG6_FDS) > 0;
 
     return 0;
@@ -1743,7 +1743,7 @@ int lis2dw12_get_int1_on_int2_map(struct sensor_itf *itf, uint8_t *val)
         return rc;
     }
 
-    *val = (reg & LIS2DW12_CTRL_REG7_INT2_ON_INT1) >> 5;
+    *val = (reg & LIS2DW12_CTRL_REG7_INT2_ON_INT1) >> 6;
     return 0;
 }
 
@@ -2324,11 +2324,9 @@ lis2dw12_sensor_set_notification(struct sensor *sensor, sensor_event_type_t type
 
     if(type == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
         int_cfg |= LIS2DW12_INT1_CFG_DOUBLE_TAP;
-    }
-    else if(type == SENSOR_EVENT_TYPE_SINGLE_TAP) {
+    } else if(type == SENSOR_EVENT_TYPE_SINGLE_TAP) {
         int_cfg |= LIS2DW12_INT1_CFG_SINGLE_TAP;
-    }
-    else if(type == SENSOR_EVENT_TYPE_FREE_FALL) {
+    } else if(type == SENSOR_EVENT_TYPE_FREE_FALL) {
         int_cfg |= LIS2DW12_INT1_CFG_FF;
     } else {
         /* here if type is set to no valid event or more than one event */


### PR DESCRIPTION
Change config structure to use bitfields to reduce structure size. 

Fix bit shift value and if else style as well.