### PR TITLE
docs: use the proper error code in example

### DIFF
--- a/docs/os/modules/fs/fs/fsutil_write_file.rst
+++ b/docs/os/modules/fs/fs/fsutil_write_file.rst
@@ -51,7 +51,7 @@ This example creates a 4-byte file.
 
         /* Create the parent directory. */
         rc = fs_mkdir("/cfg");
-        if (rc != 0 && rc != FS_EALREADY) {
+        if (rc != 0 && rc != FS_EEXIST) {
             return -1;
         }
 


### PR DESCRIPTION
I'm fairly sure that this is the intention for this example code fragment.

It certainly needs to be fixed, since FS_EALREADY doesn't exist anywhere that grep can find.