### PR TITLE
boot_serial: Remove required API "console"

### DIFF
--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -34,7 +34,6 @@ pkg.deps:
     - util/crc
 
 pkg.req_apis:
-    - console
     - bootloader
 
 pkg.cflags.SELFTEST:


### PR DESCRIPTION
Now that the serial boot loader accesses the UART directly, it doesn't require a console package.