### PR TITLE
Sensor API: Support only one event per notifier/notification

### DIFF
--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -982,19 +982,13 @@ err:
 }
 
 static int
-sensor_set_notification(struct sensor *sensor)
+sensor_set_notification(struct sensor *sensor, struct sensor_notifier *notifier)
 {
-    sensor_event_type_t event_type;
-    const struct sensor_notifier *notifier;
     int rc;
 
-    event_type = 0;
-    SLIST_FOREACH(notifier, &sensor->s_notifier_list, sn_next) {
-        event_type |= notifier->sn_sensor_event_type;
-    }
-
     if (sensor->s_funcs->sd_set_notification) {
-        rc = sensor->s_funcs->sd_set_notification(sensor, event_type);
+        rc = sensor->s_funcs->sd_set_notification(sensor,
+                 notifier->sn_sensor_event_type);
     } else {
         rc = SYS_ENODEV;
     }
@@ -1033,7 +1027,7 @@ sensor_register_notifier(struct sensor *sensor,
 
     SLIST_INSERT_HEAD(&sensor->s_notifier_list, notifier, sn_next);
 
-    rc = sensor_set_notification(sensor);
+    rc = sensor_set_notification(sensor, notifier);
     if (rc != 0) {
         goto remove;
     }


### PR DESCRIPTION
- Earlier this was multiplexing multiple events for a single notification
- This fixes #1021 