### PR TITLE
lis2dw12: Support sleep change event for notifications

### DIFF
--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -98,7 +98,7 @@ lis2dw12_i2c_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 {
     int rc;
     uint8_t payload[2] = { reg, value };
-    
+
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
         .len = 2,
@@ -119,7 +119,7 @@ lis2dw12_i2c_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
 /**
  * Read multiple bytes starting from specified register over i2c
- *    
+ *
  * @param The sensor interface
  * @param The register address start reading from
  * @param Pointer to where the register value should be written
@@ -230,7 +230,7 @@ lis2dw12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     /* Send the address */
     retval = hal_spi_tx_val(itf->si_num, reg | LIS2DW12_SPI_READ_CMD_BIT);
-    
+
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
         LIS2DW12_ERR("SPI_%u register write failed addr:0x%02X\n",
@@ -617,7 +617,7 @@ lis2dw12_set_power_mode(struct sensor_itf *itf, uint8_t mode)
     reg &= ~LIS2DW12_CTRL_REG1_MODE;
     reg &= ~LIS2DW12_CTRL_REG1_LP_MODE;
     reg |= mode;
-    
+
     rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG1, reg);
     if (rc) {
         goto err;
@@ -675,7 +675,7 @@ lis2dw12_set_self_test(struct sensor_itf *itf, uint8_t mode)
 
     reg &= ~LIS2DW12_CTRL_REG3_ST_MODE;
     reg |= (mode & LIS2DW12_CTRL_REG3_ST_MODE);
-    
+
     rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
     if (rc) {
         goto err;
@@ -733,7 +733,7 @@ lis2dw12_set_int_pp_od(struct sensor_itf *itf, uint8_t mode)
 
     reg &= ~LIS2DW12_CTRL_REG3_PP_OD;
     reg |= mode ? LIS2DW12_CTRL_REG3_PP_OD : 0;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
 }
 
@@ -782,7 +782,7 @@ lis2dw12_set_latched_int(struct sensor_itf *itf, uint8_t en)
 
     reg &= ~LIS2DW12_CTRL_REG3_LIR;
     reg |= en ? LIS2DW12_CTRL_REG3_LIR : 0;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
 
 }
@@ -832,7 +832,7 @@ lis2dw12_set_int_active(struct sensor_itf *itf, uint8_t low)
 
     reg &= ~LIS2DW12_CTRL_REG3_H_LACTIVE;
     reg |= low ? LIS2DW12_CTRL_REG3_H_LACTIVE : 0;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
 
 }
@@ -883,7 +883,7 @@ lis2dw12_set_slp_mode(struct sensor_itf *itf, uint8_t mode)
 
     reg &= ~LIS2DW12_CTRL_REG3_SLP_MODE_SEL;
     reg |= mode ? LIS2DW12_CTRL_REG3_SLP_MODE_SEL : 0;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
 }
 
@@ -930,7 +930,7 @@ lis2dw12_start_on_demand_conversion(struct sensor_itf *itf)
     }
 
     reg |= LIS2DW12_CTRL_REG3_SLP_MODE_1;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG3, reg);
 }
 
@@ -960,7 +960,7 @@ lis2dw12_set_filter_cfg(struct sensor_itf *itf, uint8_t bw, uint8_t type)
     if (type) {
         reg |= LIS2DW12_CTRL_REG6_FDS;
     }
-    
+
     rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG6, reg);
     if (rc) {
         goto err;
@@ -1015,7 +1015,7 @@ lis2dw12_set_offsets(struct sensor_itf *itf, int8_t offset_x,
 {
     uint8_t reg;
     int rc;
-  
+
     rc = lis2dw12_write8(itf, LIS2DW12_REG_X_OFS, offset_x);
     if (rc) {
         return rc;
@@ -1061,7 +1061,7 @@ lis2dw12_get_offsets(struct sensor_itf *itf, int8_t *offset_x,
 {
     uint8_t reg;
     int rc;
-  
+
     rc = lis2dw12_read8(itf, LIS2DW12_REG_X_OFS, (uint8_t *)offset_x);
     if (rc) {
         return rc;
@@ -1150,7 +1150,7 @@ int lis2dw12_set_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
     reg |= cfg->en_y ? LIS2DW12_TAP_THS_Z_Y_EN : 0;
     reg |= cfg->en_z ? LIS2DW12_TAP_THS_Z_Z_EN : 0;
     reg |= cfg->tap_ths_z & LIS2DW12_REG_TAP_THS_Z;
-    
+
     rc = lis2dw12_write8(itf, LIS2DW12_REG_TAP_THS_Z, reg);
     if (rc) {
         return rc;
@@ -1211,7 +1211,7 @@ int lis2dw12_get_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
     cfg->latency = (reg & LIS2DW12_INT_DUR_LATENCY) >> 4;
     cfg->quiet = (reg & LIS2DW12_INT_DUR_QUIET) >> 2;
     cfg->shock = reg & LIS2DW12_INT_DUR_SHOCK;
-    
+
     return 0;
 }
 
@@ -1260,7 +1260,7 @@ int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths)
 {
     int rc;
     uint8_t ff_reg, wake_reg;
-    
+
     rc = lis2dw12_read8(itf, LIS2DW12_REG_FREEFALL, &ff_reg);
     if (rc) {
         return rc;
@@ -1271,7 +1271,6 @@ int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths)
         return rc;
     }
 
-    
     *dur = (ff_reg & LIS2DW12_FREEFALL_DUR) >> 3;
     *dur |= wake_reg & LIS2DW12_WAKE_DUR_FF_DUR ? (1 << 5) : 0;
     *ths = wake_reg & LIS2DW12_FREEFALL_THS;
@@ -1365,7 +1364,7 @@ int lis2dw12_set_wake_up_ths(struct sensor_itf *itf, uint8_t val)
 
     reg &= ~LIS2DW12_WAKE_THS_THS;
     reg |= val & LIS2DW12_WAKE_THS_THS;
-    
+
     return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_THS, reg);
 }
 
@@ -1408,9 +1407,9 @@ int lis2dw12_set_inactivity_sleep_en(struct sensor_itf *itf, uint8_t en)
     }
 
     reg &= ~LIS2DW12_WAKE_THS_SLEEP_ON;
-    reg |= en ? LIS2DW12_WAKE_THS_SLEEP_ON : 0;        
-    
-    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_THS, reg);  
+    reg |= en ? LIS2DW12_WAKE_THS_SLEEP_ON : 0;
+
+    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_THS, reg);
 }
 
 /**
@@ -1430,7 +1429,7 @@ int lis2dw12_get_inactivity_sleep_en(struct sensor_itf *itf, uint8_t *en)
         return rc;
     }
 
-    *en = (reg & LIS2DW12_WAKE_THS_SLEEP_ON) ? 1 : 0; 
+    *en = (reg & LIS2DW12_WAKE_THS_SLEEP_ON) ? 1 : 0;
     return 0;
 
 }
@@ -1454,8 +1453,8 @@ int lis2dw12_set_double_tap_event_en(struct sensor_itf *itf, uint8_t en)
 
     reg &= ~LIS2DW12_WAKE_THS_SINGLE_DOUBLE_TAP;
     reg |= en ? LIS2DW12_WAKE_THS_SINGLE_DOUBLE_TAP : en;
-    
-    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_THS, reg);    
+
+    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_THS, reg);
 }
 
 /**
@@ -1475,11 +1474,11 @@ int lis2dw12_get_double_tap_event_en(struct sensor_itf *itf, uint8_t *en)
         return rc;
     }
 
-    *en = (reg & LIS2DW12_WAKE_THS_SINGLE_DOUBLE_TAP) ? 1 : 0; 
+    *en = (reg & LIS2DW12_WAKE_THS_SINGLE_DOUBLE_TAP) ? 1 : 0;
     return 0;
-    
+
 }
-    
+
 /**
  * Set Wake Up Duration
  *
@@ -1499,9 +1498,9 @@ int lis2dw12_set_wake_up_dur(struct sensor_itf *itf, uint8_t val)
 
     reg &= ~LIS2DW12_WAKE_DUR_DUR;
     reg |= (val & LIS2DW12_WAKE_DUR_DUR) << 5;
-    
-    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);    
-    
+
+    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);
+
 }
 
 /**
@@ -1522,7 +1521,7 @@ int lis2dw12_get_wake_up_dur(struct sensor_itf *itf, uint8_t *val)
     }
 
     *val = (reg & LIS2DW12_WAKE_DUR_DUR) >> 5;
-    return 0;   
+    return 0;
 }
 
 /**
@@ -1544,8 +1543,8 @@ int lis2dw12_set_sleep_dur(struct sensor_itf *itf, uint8_t val)
 
     reg &= ~LIS2DW12_WAKE_DUR_SLEEP_DUR;
     reg |= (val & LIS2DW12_WAKE_DUR_SLEEP_DUR);
-    
-    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);    
+
+    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);
 }
 
 /**
@@ -1588,9 +1587,9 @@ int lis2dw12_set_stationary_en(struct sensor_itf *itf, uint8_t en)
 
     reg &= ~LIS2DW12_WAKE_DUR_STATIONARY;
     reg |= en ? LIS2DW12_WAKE_DUR_STATIONARY : 0;
-    
-    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);    
-    
+
+    return lis2dw12_write8(itf, LIS2DW12_REG_WAKE_UP_DUR, reg);
+
 }
 
 /**
@@ -1622,7 +1621,7 @@ int lis2dw12_get_stationary_en(struct sensor_itf *itf, uint8_t *en)
 int
 lis2dw12_clear_int(struct sensor_itf *itf, uint8_t *src)
 {
-    return lis2dw12_read8(itf, LIS2DW12_REG_INT_SRC, src);  
+    return lis2dw12_read8(itf, LIS2DW12_REG_INT_SRC, src);
 }
 
 /**
@@ -1767,15 +1766,15 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result)
     if (rc) {
         return rc;
     }
-    
+
     /* ensure self test mode is disabled */
     rc = lis2dw12_set_self_test(itf, LIS2DW12_ST_MODE_DISABLE);
     if (rc) {
         return rc;
     }
-    
+
     os_time_delay(OS_TICKS_PER_SEC / 10);
-    
+
     /* take base reading */
     rc = lis2dw12_get_data(itf, fs, &(base[0]), &(base[1]), &(base[2]));
     if (rc) {
@@ -1819,7 +1818,7 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result)
 
 
 static void
-init_interrupt(struct lis2dw12_int * interrupt, struct sensor_int *ints)
+init_interrupt(struct lis2dw12_int *interrupt, struct sensor_int *ints)
 {
     os_error_t error;
 
@@ -1841,7 +1840,7 @@ undo_interrupt(struct lis2dw12_int * interrupt)
 }
 
 static void
-wait_interrupt(struct lis2dw12_int * interrupt, uint8_t int_num)
+wait_interrupt(struct lis2dw12_int *interrupt, uint8_t int_num)
 {
     bool wait;
 
@@ -1872,7 +1871,7 @@ wait_interrupt(struct lis2dw12_int * interrupt, uint8_t int_num)
 }
 
 static void
-wake_interrupt(struct lis2dw12_int * interrupt)
+wake_interrupt(struct lis2dw12_int *interrupt)
 {
     bool wake;
 
@@ -1910,10 +1909,9 @@ lis2dw12_int_irq_handler(void *arg)
 }
 
 static int
-init_intpin(struct lis2dw12 * lis2dw12, hal_gpio_irq_handler_t handler,
-            void * arg)
+init_intpin(struct lis2dw12 *lis2dw12, hal_gpio_irq_handler_t handler,
+            void *arg)
 {
-    struct lis2dw12_private_driver_data *pdd = &lis2dw12->pdd;
     hal_gpio_irq_trig_t trig;
     int pin = -1;
     int rc;
@@ -1931,13 +1929,12 @@ init_intpin(struct lis2dw12 * lis2dw12, hal_gpio_irq_handler_t handler,
         return SYS_EINVAL;
     }
 
-    pdd->int_num = i;
-    if (lis2dw12->sensor.s_itf.si_ints[pdd->int_num].active) {
+    if (lis2dw12->sensor.s_itf.si_ints[i].active) {
         trig = HAL_GPIO_TRIG_RISING;
     } else {
         trig = HAL_GPIO_TRIG_FALLING;
     }
-  
+
     rc = hal_gpio_irq_init(pin,
                            handler,
                            arg,
@@ -1946,19 +1943,24 @@ init_intpin(struct lis2dw12 * lis2dw12, hal_gpio_irq_handler_t handler,
     if (rc != 0) {
         LIS2DW12_ERR("Failed to initialise interrupt pin %d\n", pin);
         return rc;
-    } 
+    }
 
     return 0;
 }
 
 static int
-enable_interrupt(struct sensor * sensor, uint8_t int_to_enable)
+enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
 {
     struct lis2dw12 *lis2dw12;
-    struct lis2dw12_private_driver_data *pdd;
+    struct lis2dw12_pdd *pdd;
     struct sensor_itf *itf;
     uint8_t reg;
     int rc;
+
+    if (!int_to_enable) {
+        rc = SYS_EINVAL;
+        goto err;
+    }
 
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
@@ -1966,69 +1968,81 @@ enable_interrupt(struct sensor * sensor, uint8_t int_to_enable)
 
     rc = lis2dw12_clear_int(itf, &reg);
     if (rc) {
-        return rc;
+        goto err;
     }
-    
+
     /* if no interrupts are currently in use enable int pin */
-    if (pdd->int_enable == 0) {
-        hal_gpio_irq_enable(itf->si_ints[pdd->int_num].host_pin);
+    if (!pdd->int_enable) {
+        hal_gpio_irq_enable(itf->si_ints[int_num].host_pin);
 
         rc = lis2dw12_set_int_enable(itf, 1);
         if (rc) {
-            return rc;
+            goto err;
         }
     }
 
-    /*update which interrupts are enabled */
-    pdd->int_enable |= int_to_enable;
-    
+    pdd->int_enable++;
+
     /* enable interrupt in device */
-    rc = lis2dw12_set_int1_pin_cfg(itf, pdd->int_enable);
+    if (int_num == 0) {
+        rc = lis2dw12_set_int1_pin_cfg(itf, int_to_enable);
+    } else {
+        rc = lis2dw12_set_int2_pin_cfg(itf, int_to_enable);
+    }
+
     if (rc) {
-        return rc;
+        disable_interrupt(sensor, int_to_enable, int_num);
+        goto err;
     }
 
     return 0;
-    
+err:
+    return rc;
 }
 
 static int
-disable_interrupt(struct sensor * sensor, uint8_t int_to_disable)
+disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num)
 {
     struct lis2dw12 *lis2dw12;
-    struct lis2dw12_private_driver_data *pdd;
+    struct lis2dw12_pdd *pdd;
     struct sensor_itf *itf;
     int rc;
 
     if (int_to_disable == 0) {
         return SYS_EINVAL;
     }
-    
+
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
     pdd = &lis2dw12->pdd;
 
-    pdd->int_enable &= ~int_to_disable;
-    
     /* disable int pin */
-    if (pdd->int_enable == 0) {
-        hal_gpio_irq_disable(itf->si_ints[pdd->int_num].host_pin);
-           
+    if (!pdd->int_enable) {
+        hal_gpio_irq_disable(itf->si_ints[int_num].host_pin);
+        /* disable interrupt in device */
         rc = lis2dw12_set_int_enable(itf, 0);
         if (rc) {
             return rc;
         }
     }
-    
+
+    pdd->int_enable--;
+
     /* update interrupt setup in device */
-    return lis2dw12_set_int1_pin_cfg(itf, pdd->int_enable);
+    if (int_num == 0) {
+        rc = lis2dw12_set_int1_pin_cfg(itf, int_to_disable);
+    } else {
+        rc = lis2dw12_set_int2_pin_cfg(itf, int_to_disable);
+    }
+
+    return rc;
 }
 
 int
 lis2dw12_get_fs(struct sensor_itf *itf, uint8_t *fs)
 {
     int rc;
-    
+
     rc = lis2dw12_get_full_scale(itf, fs);
     if (rc) {
         return rc;
@@ -2131,7 +2145,7 @@ static int lis2dw12_do_read(struct sensor *sensor, sensor_data_func_t data_func,
 
     return 0;
 err:
-    return rc;  
+    return rc;
 }
 
 /**
@@ -2146,44 +2160,62 @@ err:
  * @return 0 on success, non-zero on failure.
  */
 int
-lis2dw12_poll_read(struct sensor * sensor, sensor_type_t sensor_type,
-                 sensor_data_func_t data_func, void * data_arg,
-                 uint32_t timeout)
+lis2dw12_poll_read(struct sensor *sensor, sensor_type_t sensor_type,
+                   sensor_data_func_t data_func, void *data_arg,
+                   uint32_t timeout)
 {
-    int rc;
+    struct lis2dw12 *lis2dw12;
+    struct lis2dw12_cfg *cfg;
     struct sensor_itf *itf;
     uint8_t fs;
+    int rc;
 
+    lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
-    
+    cfg = &lis2dw12->cfg;
+
     /* If the read isn't looking for accel data, don't do anything. */
     if (!(sensor_type & SENSOR_TYPE_ACCELEROMETER)) {
-        return SYS_EINVAL;
+        rc = SYS_EINVAL;
+        goto err;
+    }
+
+    if (cfg->read_mode.mode != LIS2DW12_READ_M_STREAM) {
+        rc = SYS_EINVAL;
+        goto err;
     }
 
     rc = lis2dw12_get_fs(itf, &fs);
     if (rc) {
-        return rc;
+        goto err;
     }
 
-    return lis2dw12_do_read(sensor, data_func, data_arg, fs);
+    rc = lis2dw12_do_read(sensor, data_func, data_arg, fs);
+    if (rc) {
+        goto err;
+    }
+
+    return 0;
+err:
+    return rc;
 }
 
 int
 lis2dw12_stream_read(struct sensor *sensor,
-                   sensor_type_t sensor_type,
-                   sensor_data_func_t read_func,
-                   void *read_arg,
-                   uint32_t time_ms)
+                     sensor_type_t sensor_type,
+                     sensor_data_func_t read_func,
+                     void *read_arg,
+                     uint32_t time_ms)
 {
+    struct lis2dw12_pdd *pdd;
     struct lis2dw12 *lis2dw12;
     struct sensor_itf *itf;
-    int rc;
+    struct lis2dw12_cfg *cfg;
     os_time_t time_ticks;
     os_time_t stop_ticks = 0;
-    struct lis2dw12_private_driver_data *pdd;
     uint8_t fifo_samples;
     uint8_t fs;
+    int rc;
 
     /* If the read isn't looking for accel data, don't do anything. */
     if (!(sensor_type & SENSOR_TYPE_ACCELEROMETER)) {
@@ -2193,6 +2225,11 @@ lis2dw12_stream_read(struct sensor *sensor,
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
     pdd = &lis2dw12->pdd;
+    cfg = &lis2dw12->cfg;
+
+    if (cfg->read_mode.mode != LIS2DW12_READ_M_STREAM) {
+        return SYS_EINVAL;
+    }
 
     undo_interrupt(&lis2dw12->intr);
 
@@ -2203,38 +2240,37 @@ lis2dw12_stream_read(struct sensor *sensor,
     /* enable interrupt */
     pdd->interrupt = &lis2dw12->intr;
 
-    rc = enable_interrupt(sensor, lis2dw12->cfg.stream_read_interrupt);
+    rc = enable_interrupt(sensor, cfg->read_mode.int_cfg,
+                          cfg->read_mode.int_num);
     if (rc) {
-        goto done;
+        return rc;
     }
 
     if (time_ms != 0) {
         rc = os_time_ms_to_ticks(time_ms, &time_ticks);
         if (rc) {
-            goto done;
+            goto err;
         }
         stop_ticks = os_time_get() + time_ticks;
     }
 
-    
     rc = lis2dw12_get_fs(itf, &fs);
     if (rc) {
-        goto done;
+        goto err;
     }
 
     for (;;) {
-        wait_interrupt(&lis2dw12->intr, pdd->int_num);
-        
         /* force at least one read for cases when fifo is disabled */
+        wait_interrupt(&lis2dw12->intr, cfg->read_mode.int_num);
         fifo_samples = 1;
-        
+
         while(fifo_samples > 0) {
 
             /* read all data we beleive is currently in fifo */
             while(fifo_samples > 0) {
                 rc = lis2dw12_do_read(sensor, read_func, read_arg, fs);
                 if (rc) {
-                    goto done;
+                    goto err;
                 }
                 fifo_samples--;
 
@@ -2243,7 +2279,7 @@ lis2dw12_stream_read(struct sensor *sensor,
             /* check if any data is available in fifo */
             rc = lis2dw12_get_fifo_samples(itf, &fifo_samples);
             if (rc) {
-                goto done;
+                goto err;
             }
 
         }
@@ -2254,10 +2290,11 @@ lis2dw12_stream_read(struct sensor *sensor,
 
     }
 
-done:
+err:
     /* disable interrupt */
     pdd->interrupt = NULL;
-    rc = disable_interrupt(sensor, lis2dw12->cfg.stream_read_interrupt);
+    rc = disable_interrupt(sensor, cfg->read_mode.int_cfg,
+                           cfg->read_mode.int_num);
 
     return rc;
 }
@@ -2280,7 +2317,7 @@ lis2dw12_sensor_read(struct sensor *sensor, sensor_type_t type,
     itf = SENSOR_GET_ITF(sensor);
 
     if (itf->si_type == SENSOR_ITF_SPI) {
-        
+
         rc = hal_spi_disable(sensor->s_itf.si_num);
         if (rc) {
             goto err;
@@ -2299,66 +2336,117 @@ lis2dw12_sensor_read(struct sensor *sensor, sensor_type_t type,
             goto err;
         }
     }
-    
+
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     cfg = &lis2dw12->cfg;
 
-    if (cfg->read_mode == LIS2DW12_READ_M_POLL) {
+    if (cfg->read_mode.mode == LIS2DW12_READ_M_POLL) {
         rc = lis2dw12_poll_read(sensor, type, data_func, data_arg, timeout);
     } else {
         rc = lis2dw12_stream_read(sensor, type, data_func, data_arg, timeout);
     }
 
+    return 0;
 err:
     return rc;
 }
 
 static int
-lis2dw12_sensor_set_notification(struct sensor *sensor, sensor_event_type_t type)
+lis2dw12_find_int_by_event(sensor_event_type_t event, uint8_t *int_cfg,
+                           uint8_t *int_num)
 {
-    struct lis2dw12 * lis2dw12;
-    struct sensor_itf *itf;
-    uint8_t int_cfg = 0;
-    struct lis2dw12_private_driver_data *pdd;
-    int rc;
-
-    if(type == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
-        int_cfg |= LIS2DW12_INT1_CFG_DOUBLE_TAP;
-    } else if(type == SENSOR_EVENT_TYPE_SINGLE_TAP) {
-        int_cfg |= LIS2DW12_INT1_CFG_SINGLE_TAP;
-    } else if(type == SENSOR_EVENT_TYPE_FREE_FALL) {
-        int_cfg |= LIS2DW12_INT1_CFG_FF;
+    if (event == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
+        *int_cfg = LIS2DW12_INT1_CFG_DOUBLE_TAP;
+        *int_num = 0;
+    } else if (event == SENSOR_EVENT_TYPE_SINGLE_TAP) {
+        *int_cfg = LIS2DW12_INT1_CFG_SINGLE_TAP;
+        *int_num = 0;
+    } else if (event == SENSOR_EVENT_TYPE_FREE_FALL) {
+        *int_cfg = LIS2DW12_INT1_CFG_FF;
+        *int_num = 0;
+    } else if (event == SENSOR_EVENT_TYPE_SLEEP_CHANGE) {
+        *int_cfg = LIS2DW12_INT2_CFG_SLEEP_CHG;
+        *int_num = 0;
     } else {
-        /* here if type is set to no valid event or more than one event */
-        /* we do not currently support registering for more than one event */
+        /* here if type is set to a non valid event or more than one event
+         * we do not currently support registering for more than one event
+         * per notification
+         */
         return SYS_EINVAL;
     }
+
+    return 0;
+}
+
+static int
+lis2dw12_sensor_set_notification(struct sensor *sensor, sensor_event_type_t event)
+{
+    struct lis2dw12 *lis2dw12;
+    struct lis2dw12_pdd *pdd;
+    struct sensor_itf *itf;
+    uint8_t int_cfg;
+    uint8_t int_num;
+    int rc;
 
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
     pdd = &lis2dw12->pdd;
 
-    if (pdd->registered_mask & LIS2DW12_NOTIFY_MASK) {
-        return SYS_EBUSY;
-    }
-    
-    rc = enable_interrupt(sensor, int_cfg);
+    rc = lis2dw12_find_int_by_event(event, &int_cfg, &int_num);
     if (rc) {
-        return rc;
+        goto err;
+    }
+
+    rc = enable_interrupt(sensor,  int_cfg, int_num);
+    if (rc) {
+        goto err;
     }
 
     /* enable double tap detection in wake_up_ths */
-    if(type == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
+    if(event == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
         rc = lis2dw12_set_double_tap_event_en(itf, 1);
         if (rc) {
-            return rc;
+            goto err;
         }
     }
 
-    pdd->notify_ctx.snec_evtype |= type;
-    pdd->registered_mask |= LIS2DW12_NOTIFY_MASK;
+    pdd->notify_ctx.snec_evtype |= event;
 
     return 0;
+err:
+    return rc;
+}
+
+static int
+lis2dw12_sensor_unset_notification(struct sensor *sensor, sensor_event_type_t event)
+{
+    struct lis2dw12 *lis2dw12;
+    struct sensor_itf *itf;
+    uint8_t int_num;
+    uint8_t int_cfg;
+    int rc;
+
+    lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
+    itf = SENSOR_GET_ITF(sensor);
+
+    lis2dw12->pdd.notify_ctx.snec_evtype &= ~event;
+
+    if(event == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
+        rc = lis2dw12_set_double_tap_event_en(itf, 0);
+        if (rc) {
+            goto err;
+        }
+    }
+
+    rc = lis2dw12_find_int_by_event(event, &int_cfg, &int_num);
+    if (rc) {
+        goto err;
+    }
+
+    rc = disable_interrupt(sensor, int_cfg, int_num);
+
+err:
+    return rc;
 }
 
 static int
@@ -2372,55 +2460,15 @@ lis2dw12_sensor_set_config(struct sensor *sensor, void *cfg)
 }
 
 static int
-lis2dw12_sensor_unset_notification(struct sensor *sensor, sensor_event_type_t type)
+lis2dw12_sensor_handle_interrupt(struct sensor *sensor)
 {
-    struct lis2dw12 * lis2dw12;
-    struct sensor_itf *itf;
-    int rc;
-    uint8_t int_cfg = 0;
-    
-    if(type == SENSOR_EVENT_TYPE_DOUBLE_TAP) {
-        int_cfg |= LIS2DW12_INT1_CFG_DOUBLE_TAP;
-    }
-    else if(type == SENSOR_EVENT_TYPE_SINGLE_TAP) {
-        int_cfg |= LIS2DW12_INT1_CFG_SINGLE_TAP;
-    }
-    else if(type == SENSOR_EVENT_TYPE_FREE_FALL) {
-        int_cfg |= LIS2DW12_INT1_CFG_FF;
-    } else {
-        /* here if type is set to no valid event or more than one event */
-        /* we do not currently support registering for more than one event */
-        return SYS_EINVAL;
-    }
-        
-    lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
-    itf = SENSOR_GET_ITF(sensor);
-
-    lis2dw12->pdd.notify_ctx.snec_evtype &= ~type;
-    lis2dw12->pdd.registered_mask &= ~LIS2DW12_NOTIFY_MASK;
-
-    rc = lis2dw12_set_double_tap_event_en(itf, lis2dw12->cfg.double_tap_event_enable);
-    if (rc) {
-        return rc;
-    }
-    
-    return disable_interrupt(sensor, int_cfg);
-}
-
-static int
-lis2dw12_sensor_handle_interrupt(struct sensor * sensor)
-{
-    struct lis2dw12 * lis2dw12;
-    struct lis2dw12_private_driver_data *pdd;
+    struct lis2dw12 *lis2dw12;
     struct sensor_itf *itf;
     uint8_t int_src;
-    
     int rc;
 
     lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
-
-    pdd = &lis2dw12->pdd;
 
     rc = lis2dw12_clear_int(itf, &int_src);
     if (rc) {
@@ -2428,11 +2476,11 @@ lis2dw12_sensor_handle_interrupt(struct sensor * sensor)
         return rc;
     }
 
-    if ((pdd->registered_mask & LIS2DW12_NOTIFY_MASK) &&
-        ((int_src & LIS2DW12_INT_SRC_STAP) ||
-         (int_src & LIS2DW12_INT_SRC_DTAP) ||
-         (int_src & LIS2DW12_INT_SRC_FF_IA))) {
-        sensor_mgr_put_notify_evt(&pdd->notify_ctx);
+    if ((int_src & LIS2DW12_INT_SRC_STAP) ||
+        (int_src & LIS2DW12_INT_SRC_DTAP) ||
+        (int_src & LIS2DW12_INT_SRC_FF_IA)||
+        (int_src & LIS2DW12_INT_SRC_SLP_CHG)) {
+        sensor_mgr_put_notify_evt(&lis2dw12->pdd.notify_ctx);
     }
 
     return 0;
@@ -2545,9 +2593,8 @@ lis2dw12_init(struct os_dev *dev, void *arg)
 
 
     init_interrupt(&lis2dw12->intr, lis2dw12->sensor.s_itf.si_ints);
-    
+
     lis2dw12->pdd.notify_ctx.snec_sensor = sensor;
-    lis2dw12->pdd.registered_mask = 0;
     lis2dw12->pdd.interrupt = NULL;
 
     rc = init_intpin(lis2dw12, lis2dw12_int_irq_handler, sensor);
@@ -2638,7 +2685,6 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     }
     lis2dw12->cfg.slp_mode = cfg->slp_mode;
 
-    
     rc = lis2dw12_set_offsets(itf, cfg->offset_x, cfg->offset_y, cfg->offset_z,
                               cfg->offset_weight);
     if (rc) {
@@ -2654,9 +2700,9 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     if (rc) {
         goto err;
     }
-    
+
     lis2dw12->cfg.offset_en = cfg->offset_en;
-    
+
     rc = lis2dw12_set_filter_cfg(itf, cfg->filter_bw, cfg->high_pass);
     if (rc) {
         goto err;
@@ -2698,7 +2744,7 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     }
 
     lis2dw12->cfg.low_noise_enable = cfg->low_noise_enable;
-    
+
     rc = lis2dw12_set_fifo_cfg(itf, cfg->fifo_mode, cfg->fifo_threshold);
     if (rc) {
         goto err;
@@ -2742,12 +2788,12 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
         goto err;
     }
     lis2dw12->cfg.double_tap_event_enable = cfg->double_tap_event_enable;
-    
+
     rc = lis2dw12_set_freefall(itf, cfg->freefall_dur, cfg->freefall_ths);
     if (rc) {
         goto err;
     }
-    
+
     lis2dw12->cfg.freefall_dur = cfg->freefall_dur;
     lis2dw12->cfg.freefall_ths = cfg->freefall_ths;
 
@@ -2765,7 +2811,7 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     }
 
     lis2dw12->cfg.int1_pin_cfg = cfg->int1_pin_cfg;
-    
+
     rc = lis2dw12_set_int2_pin_cfg(itf, cfg->int2_pin_cfg);
     if (rc) {
         goto err;
@@ -2773,11 +2819,11 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
 
     lis2dw12->cfg.int2_pin_cfg = cfg->int2_pin_cfg;
 
-    rc = lis2dw12_set_tap_cfg(itf, &cfg->tap_cfg);
+    rc = lis2dw12_set_tap_cfg(itf, &cfg->tap);
     if (rc) {
         goto err;
     }
-    lis2dw12->cfg.tap_cfg = cfg->tap_cfg;
+    lis2dw12->cfg.tap = cfg->tap;
 
     rc = lis2dw12_set_int1_on_int2_map(itf, cfg->map_int2_to_int1);
     if(rc) {
@@ -2790,8 +2836,9 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
         goto err;
     }
 
-    lis2dw12->cfg.stream_read_interrupt = cfg->stream_read_interrupt;
-    lis2dw12->cfg.read_mode = cfg->read_mode;    
+    lis2dw12->cfg.read_mode.int_cfg = cfg->read_mode.int_cfg;
+    lis2dw12->cfg.read_mode.int_num = cfg->read_mode.int_num;
+    lis2dw12->cfg.read_mode.mode = cfg->read_mode.mode;
     lis2dw12->cfg.mask = cfg->mask;
 
     return 0;

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -103,7 +103,9 @@ typedef enum {
     /* Accelerometer single tap event */
     SENSOR_EVENT_TYPE_SINGLE_TAP     = (1 << 1),
     /* Accelerometer free fall event */
-    SENSOR_EVENT_TYPE_FREE_FALL      = (1 << 2)
+    SENSOR_EVENT_TYPE_FREE_FALL      = (1 << 2),
+    /* Accelerometer sleep change event */
+    SENSOR_EVENT_TYPE_SLEEP_CHANGE   = (1 << 3),
 } sensor_event_type_t;
 
 


### PR DESCRIPTION
- lis2dw12: Support sleep change event for notifications
- Also cleaning up a bit, removing extraneous spaces, adding comments
- Also fixes #1020, lis2dw12: int2 not routable for sensor notifications
- This fixes #1022 