### PR TITLE
imgmgr: Prevent `maybe-uninitialized` warning.

### DIFF
--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -138,6 +138,9 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
     uint32_t data_off, data_end;
     int area_id;
 
+    /* Silence spurious warning. */
+    data_end = 0;
+
     area_id = flash_area_id_from_image_slot(image_slot);
 
     hdr = (struct image_header *)data;


### PR DESCRIPTION
gcc 5.4.1 reports the following warning when `BOOTUTIL_IMAGE_FORMAT_V2` is enabled:

```
Error: repos/apache-mynewt-core/mgmt/imgmgr/src/imgmgr.c: In function 'imgr_read_info':
repos/apache-mynewt-core/mgmt/imgmgr/src/imgmgr.c:202:16: error: 'data_end' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             if (data_off + IMGMGR_HASH_LEN > data_end) {
                ^
```

This is a spurious warning; `data_end` is always initialized at this point.  The fix is to initialize `data_end` to 0 at the start of the function.