### PR TITLE
mempool: Add os_mempool_clear function

### DIFF
--- a/kernel/os/include/os/os_mempool.h
+++ b/kernel/os/include/os/os_mempool.h
@@ -189,6 +189,15 @@ os_error_t os_mempool_ext_init(struct os_mempool_ext *mpe, uint16_t blocks,
                                uint32_t block_size, void *membuf, char *name);
 
 /**
+ * Clears a memory pool.
+ *
+ * @param mp            The mempool to clear.
+ *
+ * @return os_error_t
+ */
+os_error_t os_mempool_clear(struct os_mempool *mp);
+
+/**
  * Performs an integrity check of the specified mempool.  This function
  * attempts to detect memory corruption in the specified memory pool.
  *

--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -135,6 +135,45 @@ os_mempool_ext_init(struct os_mempool_ext *mpe, uint16_t blocks,
     return 0;
 }
 
+os_error_t
+os_mempool_clear(struct os_mempool *mp)
+{
+    struct os_memblock *block_ptr;
+    int true_block_size;
+    uint8_t *block_addr;
+    uint16_t blocks;
+
+    if (!mp) {
+        return OS_INVALID_PARM;
+    }
+
+    true_block_size = OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size);
+
+    /* cleanup the memory pool structure */
+    mp->mp_num_free = mp->mp_num_blocks;
+    mp->mp_min_free = mp->mp_num_blocks;
+    os_mempool_poison((void *)mp->mp_membuf_addr, true_block_size);
+    SLIST_FIRST(mp) = (void *)mp->mp_membuf_addr;
+
+    /* Chain the memory blocks to the free list */
+    block_addr = (uint8_t *)mp->mp_membuf_addr;
+    block_ptr = (struct os_memblock *)block_addr;
+    blocks = mp->mp_num_blocks;
+
+    while (blocks > 1) {
+        block_addr += true_block_size;
+        os_mempool_poison(block_addr, true_block_size);
+        SLIST_NEXT(block_ptr, mb_next) = (struct os_memblock *)block_addr;
+        block_ptr = (struct os_memblock *)block_addr;
+        --blocks;
+    }
+
+    /* Last one in the list should be NULL */
+    SLIST_NEXT(block_ptr, mb_next) = NULL;
+
+    return OS_OK;
+}
+
 bool
 os_mempool_is_sane(const struct os_mempool *mp)
 {

--- a/kernel/os/test/src/mempool_test.h
+++ b/kernel/os/test/src/mempool_test.h
@@ -59,7 +59,7 @@ extern int verbose;
 
 int mempool_test_get_pool_size(int num_blocks, int block_size);
 
-void mempool_test(int num_blocks, int block_size);
+void mempool_test(int num_blocks, int block_size, bool clear);
 
 #ifdef __cplusplus
 }

--- a/kernel/os/test/src/testcases/os_mempool_test_case.c
+++ b/kernel/os/test/src/testcases/os_mempool_test_case.c
@@ -26,7 +26,7 @@
  * @return int
  */
 void
-mempool_test(int num_blocks, int block_size)
+mempool_test(int num_blocks, int block_size, bool clear)
 {
     int cnt;
     int true_block_size;
@@ -43,6 +43,7 @@ mempool_test(int num_blocks, int block_size)
                          &TstMembuf[0], "TestMemPool");
     TEST_ASSERT_FATAL(rc == 0, "Error creating memory pool %d", rc);
 
+retest:
     TEST_ASSERT(g_TstMempool.mp_num_free == num_blocks,
                 "Number of free blocks not equal to total blocks!");
 
@@ -134,6 +135,15 @@ mempool_test(int num_blocks, int block_size)
                 "Got all blocks but number free not zero! (%d)",
                 g_TstMempool.mp_num_free);
 
+    /* clear mempool and rerun tests */
+    if (clear) {
+        clear = false;
+        rc = os_mempool_clear(&g_TstMempool);
+        TEST_ASSERT_FATAL(rc == 0, "Error reseting memory pool %d", rc);
+
+        goto retest;
+    }
+
     /* Now put them all back */
     for (cnt = 0; cnt < g_TstMempool.mp_num_blocks; ++cnt) {
         rc = os_memblock_put(&g_TstMempool, block_array[cnt]);
@@ -161,5 +171,6 @@ mempool_test(int num_blocks, int block_size)
 
 TEST_CASE(os_mempool_test_case)
 {
-    mempool_test(NUM_MEM_BLOCKS, MEM_BLOCK_SIZE);
+    mempool_test(NUM_MEM_BLOCKS, MEM_BLOCK_SIZE, false);
+    mempool_test(NUM_MEM_BLOCKS, MEM_BLOCK_SIZE, true);
 }


### PR DESCRIPTION
This is used to clear mempool (ie all block taken are invalidated)
without doing full initialisation of it. Unlike init this function
can be called multiple time on same mempool.