### PR TITLE
lis2dw12: Add support for set/clear int cfg bits

### DIFF
--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -261,7 +261,7 @@ struct lis2dw12 {
 /**
  * Reset lis2dw12
  *
- * @param The sensor interface
+ * @param itf The sensor interface
  *
  * @return 0 on success, non-zero on failure
  */
@@ -270,16 +270,16 @@ int lis2dw12_reset(struct sensor_itf *itf);
 /**
  * Get chip ID
  *
- * @param sensor interface
- * @param ptr to chip id to be filled up
+ * @param itf The sensor interface
+ * @param chip_id Ptr to chip id to be filled up
  */
 int lis2dw12_get_chip_id(struct sensor_itf *itf, uint8_t *chip_id);
 
 /**
  * Sets the full scale selection
  *
- * @param The sensor interface
- * @param fs to set
+ * @param itf The sensor interface
+ * @param fs The full scale value to set
  *
  * @return 0 on success, non-zero on failure
  */
@@ -288,8 +288,8 @@ int lis2dw12_set_full_scale(struct sensor_itf *itf, uint8_t fs);
 /**
  * Gets the full scale selection
  *
- * @param The sensor interface
- * @param ptr to fs
+ * @param itf The sensor interface
+ * @param fs Ptr to full scale read from the sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -298,8 +298,8 @@ int lis2dw12_get_full_scale(struct sensor_itf *itf, uint8_t *fs);
 /**
  * Sets the rate
  *
- * @param The sensor interface
- * @param The rate
+ * @param itf The sensor interface
+ * @param rate The sampling rate of the sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -308,8 +308,8 @@ int lis2dw12_set_rate(struct sensor_itf *itf, uint8_t rate);
 /**
  * Gets the current rate
  *
- * @param The sensor interface
- * @param ptr to rate read from the sensor
+ * @param itf The sensor interface
+ * @param rate Ptr to rate read from the sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -318,8 +318,8 @@ int lis2dw12_get_rate(struct sensor_itf *itf, uint8_t *rate);
 /**
  * Sets the low noise enable
  *
- * @param The sensor interface
- * @param low noise enabled
+ * @param itf The sensor interface
+ * @param en Low noise enabled
  *
  * @return 0 on success, non-zero on failure
  */
@@ -328,8 +328,8 @@ int lis2dw12_set_low_noise(struct sensor_itf *itf, uint8_t en);
 /**
  * Gets whether low noise is enabled
  *
- * @param The sensor interface
- * @param ptr to low noise settings read from sensor
+ * @param itf The sensor interface
+ * @param en Ptr to low noise settings read from sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -338,8 +338,8 @@ int lis2dw12_get_low_noise(struct sensor_itf *itf, uint8_t *en);
 /**
  * Sets the power mode of the sensor
  *
- * @param The sensor interface
- * @param power mode
+ * @param itf The sensor interface
+ * @param mode Power mode
  *
  * @return 0 on success, non-zero on failure
  */
@@ -348,8 +348,8 @@ int lis2dw12_set_power_mode(struct sensor_itf *itf, uint8_t mode);
 /**
  * Gets the power mode of the sensor
  *
- * @param The sensor interface
- * @param ptr to power mode setting read from sensor
+ * @param itf The sensor interface
+ * @param mode Ptr to power mode setting read from sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -358,8 +358,8 @@ int lis2dw12_get_power_mode(struct sensor_itf *itf, uint8_t *mode);
 /**
  * Sets the self test mode of the sensor
  *
- * @param The sensor interface
- * @param self test mode
+ * @param itf The sensor interface
+ * @param mode Self test mode
  *
  * @return 0 on success, non-zero on failure
  */
@@ -368,8 +368,8 @@ int lis2dw12_set_self_test(struct sensor_itf *itf, uint8_t mode);
 /**
  * Gets the self test mode of the sensor
  *
- * @param The sensor interface
- * @param ptr to self test mode read from sensor
+ * @param itf The sensor interface
+ * @param mode Ptr to self test mode read from sensor
  *
  * @return 0 on success, non-zero on failure
  */
@@ -378,8 +378,8 @@ int lis2dw12_get_self_test(struct sensor_itf *itf, uint8_t *mode);
 /**
  * Sets the interrupt push-pull/open-drain selection
  *
- * @param The sensor interface
- * @param interrupt setting (0 = push-pull, 1 = open-drain)
+ * @param itf The sensor interface
+ * @param mode Interrupt setting (0 = push-pull, 1 = open-drain)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -388,8 +388,8 @@ int lis2dw12_set_int_pp_od(struct sensor_itf *itf, uint8_t mode);
 /**
  * Gets the interrupt push-pull/open-drain selection
  *
- * @param The sensor interface
- * @param ptr to store setting (0 = push-pull, 1 = open-drain)
+ * @param itf The sensor interface
+ * @param mode Ptr to store setting (0 = push-pull, 1 = open-drain)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -398,8 +398,8 @@ int lis2dw12_get_int_pp_od(struct sensor_itf *itf, uint8_t *mode);
 /**
  * Sets whether latched interrupts are enabled
  *
- * @param The sensor interface
- * @param value to set (0 = not latched, 1 = latched)
+ * @param itf The sensor interface
+ * @param en Value to set (0 = not latched, 1 = latched)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -408,8 +408,8 @@ int lis2dw12_set_latched_int(struct sensor_itf *itf, uint8_t en);
 /**
  * Gets whether latched interrupts are enabled
  *
- * @param The sensor interface
- * @param ptr to store value (0 = not latched, 1 = latched)
+ * @param itf The sensor interface
+ * @param en Ptr to store value (0 = not latched, 1 = latched)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -418,8 +418,8 @@ int lis2dw12_get_latched_int(struct sensor_itf *itf, uint8_t *en);
 /**
  * Sets whether interrupts are active high or low
  *
- * @param The sensor interface
- * @param value to set (0 = active high, 1 = active low)
+ * @param itf The sensor interface
+ * @param low Value to set (0 = active high, 1 = active low)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -428,8 +428,8 @@ int lis2dw12_set_int_active_low(struct sensor_itf *itf, uint8_t low);
 /**
  * Gets whether interrupts are active high or low
  *
- * @param The sensor interface
- * @param ptr to store value (0 = active high, 1 = active low)
+ * @param itf The sensor interface
+ * @param low Ptr to store value (0 = active high, 1 = active low)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -438,8 +438,8 @@ int lis2dw12_get_int_active_low(struct sensor_itf *itf, uint8_t *low);
 /**
  * Sets single data conversion mode
  *
- * @param The sensor interface
- * @param value to set (0 = trigger on INT2 pin, 1 = trigger on write to SLP_MODE_1)
+ * @param itf The sensor interface
+ * @param mode Value to set (0 = trigger on INT2 pin, 1 = trigger on write to SLP_MODE_1)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -448,8 +448,8 @@ int lis2dw12_set_slp_mode(struct sensor_itf *itf, uint8_t mode);
 /**
  * Gets single data conversion mode
  *
- * @param The sensor interface
- * @param ptr to store value (0 = trigger on INT2 pin, 1 = trigger on write to SLP_MODE_1)
+ * @param itf The sensor interface
+ * @param mode Ptr to store value (0 = trigger on INT2 pin, 1 = trigger on write to SLP_MODE_1)
  *
  * @return 0 on success, non-zero on failure
  */
@@ -458,7 +458,7 @@ int lis2dw12_get_slp_mode(struct sensor_itf *itf, uint8_t *mode);
 /**
  * Starts a data conversion in on demand mode
  *
- * @param The sensor interface
+ * @param itf The sensor interface
  *
  * @return 0 on success, non-zero on failure
  */
@@ -467,9 +467,10 @@ int lis2dw12_start_on_demand_conversion(struct sensor_itf *itf);
 /**
  * Set filter config
  *
- * @param the sensor interface
- * @param the filter bandwidth
- * @param filter type (1 = high pass, 0 = low pass)
+ * @param itf The sensor interface
+ * @param bw The filter bandwidth
+ * @param type The filter type (1 = high pass, 0 = low pass)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_filter_cfg(struct sensor_itf *itf, uint8_t bw, uint8_t type);
@@ -477,9 +478,10 @@ int lis2dw12_set_filter_cfg(struct sensor_itf *itf, uint8_t bw, uint8_t type);
 /**
  * Get filter config
  *
- * @param the sensor interface
- * @param ptr to the filter bandwidth
- * @param ptr to filter type (1 = high pass, 0 = low pass)
+ * @param itf The sensor interface
+ * @param bw Ptr to the filter bandwidth
+ * @param type Ptr to filter type (1 = high pass, 0 = low pass)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_filter_cfg(struct sensor_itf *itf, uint8_t *bw, uint8_t *type);
@@ -487,11 +489,11 @@ int lis2dw12_get_filter_cfg(struct sensor_itf *itf, uint8_t *bw, uint8_t *type);
 /**
  * Sets new offsets in sensor
  *
- * @param The sensor interface
- * @param X offset
- * @param Y offset
- * @param Z offset
- * @param Value Weight (0 = 977ug/LSB, 1 = 15.6mg/LSB)
+ * @param itf The sensor interface
+ * @param offset_x X offset
+ * @param offset_y Y offset
+ * @param offset_z Z offset
+ * @param weight Value Weight (0 = 977ug/LSB, 1 = 15.6mg/LSB)
  *
  * @return 0 on success, non-zero error on failure.
  */
@@ -501,22 +503,22 @@ int lis2dw12_set_offsets(struct sensor_itf *itf, int8_t offset_x,
 /**
  * Gets the offsets currently set
  *
- * @param The sensor interface
- * @param Pointer to location to store X offset
- * @param Pointer to location to store Y offset
- * @param Pointer to location to store Z offset
- * @param Pointer to value weight
+ * @param itf The sensor interface
+ * @param offset_x Ptr to location to store X offset
+ * @param offset_y Ptr to location to store Y offset
+ * @param offset_z Ptr to location to store Z offset
+ * @param weight Ptr to value weight
  *
  * @return 0 on success, non-zero error on failure.
  */
 int lis2dw12_get_offsets(struct sensor_itf *itf, int8_t *offset_x,
-                         int8_t *offset_y, int8_t *offset_z, uint8_t * weight);
+                         int8_t *offset_y, int8_t *offset_z, uint8_t *weight);
 
 /**
  * Sets whether offset are enabled (only work when low pass filtering is enabled)
  *
- * @param The sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param enabled value to set (0 = disabled, 1 = enabled)
  *
  * @return 0 on success, non-zero error on failure.
  */
@@ -525,8 +527,9 @@ int lis2dw12_set_offset_enable(struct sensor_itf *itf, uint8_t enabled);
 /**
  * Set tap detection configuration
  *
- * @param the sensor interface
- * @param the tap settings
+ * @param itf The sensor interface
+ * @param cfg The tap settings config
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *cfg);
@@ -534,8 +537,9 @@ int lis2dw12_set_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
 /**
  * Get tap detection config
  *
- * @param the sensor interface
- * @param ptr to the tap settings
+ * @param itf the sensor interface
+ * @param cfg Ptr to the tap settings
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *cfg);
@@ -543,9 +547,10 @@ int lis2dw12_get_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
 /**
  * Set freefall detection configuration
  *
- * @param the sensor interface
- * @param freefall duration (5 bits LSB = 1/ODR)
- * @param freefall threshold (3 bits)
+ * @param itf The sensor interface
+ * @param dur Freefall duration (5 bits LSB = 1/ODR)
+ * @param ths Freefall threshold (3 bits)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_freefall(struct sensor_itf *itf, uint8_t dur, uint8_t ths);
@@ -553,9 +558,10 @@ int lis2dw12_set_freefall(struct sensor_itf *itf, uint8_t dur, uint8_t ths);
 /**
  * Get freefall detection config
  *
- * @param the sensor interface
- * @param ptr to freefall duration
- * @param ptr to freefall threshold
+ * @param itf The sensor interface
+ * @param dur Ptr to freefall duration
+ * @param ths Ptr to freefall threshold
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths);
@@ -563,8 +569,9 @@ int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths);
 /**
  * Set interrupt pin configuration for interrupt 1
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int1 config
+ *
  * @return 0 on success, non-zero on failure
  */
 int
@@ -573,8 +580,9 @@ lis2dw12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
 /**
  * Set interrupt pin configuration for interrupt 2
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int2 config
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
@@ -582,8 +590,9 @@ int lis2dw12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
 /**
  * Clear interrupt pin configuration for interrupt 1
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int1 config
+ *
  * @return 0 on success, non-zero on failure
  */
 int
@@ -592,8 +601,9 @@ lis2dw12_clear_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
 /**
  * Clear interrupt pin configuration for interrupt 2
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int2 config
+ *
  * @return 0 on success, non-zero on failure
  */
 int
@@ -602,8 +612,9 @@ lis2dw12_clear_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
 /**
  * Set whether interrupts are enabled
  *
- * @param the sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param enabled Value to set (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_int_enable(struct sensor_itf *itf, uint8_t enabled);
@@ -611,8 +622,9 @@ int lis2dw12_set_int_enable(struct sensor_itf *itf, uint8_t enabled);
 /**
  * Clear interrupts
  *
- * @param the sensor interface
- * @param pointer to return interrupt source in
+ * @param itf The sensor interface
+ * @param src Ptr to return interrupt source in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_clear_int(struct sensor_itf *itf, uint8_t *src);
@@ -620,8 +632,9 @@ int lis2dw12_clear_int(struct sensor_itf *itf, uint8_t *src);
 /**
  * Get Interrupt Source
  *
- * @param the sensor interface
- * @param pointer to return interrupt source in
+ * @param itf The sensor interface
+ * @param status Ptr to return interrupt source in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_int_src(struct sensor_itf *itf, uint8_t *status);
@@ -629,8 +642,9 @@ int lis2dw12_get_int_src(struct sensor_itf *itf, uint8_t *status);
 /**
  * Get Wake Up Source
  *
- * @param the sensor interface
- * @param pointer to return wake_up_src in
+ * @param itf The sensor interface
+ * @param Ptr to return wake_up_src in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_wake_up_src(struct sensor_itf *itf, uint8_t *status);
@@ -638,8 +652,9 @@ int lis2dw12_get_wake_up_src(struct sensor_itf *itf, uint8_t *status);
 /**
  * Get Tap Source
  *
- * @param the sensor interface
- * @param pointer to return tap_src in
+ * @param itf The sensor interface
+ * @param Ptr to return tap_src in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_tap_src(struct sensor_itf *itf, uint8_t *status);
@@ -647,8 +662,9 @@ int lis2dw12_get_tap_src(struct sensor_itf *itf, uint8_t *status);
 /**
  * Get 6D Source
  *
- * @param the sensor interface
- * @param pointer to return sixd_src in
+ * @param itf The sensor interface
+ * @param Ptr to return sixd_src in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_sixd_src(struct sensor_itf *itf, uint8_t *status);
@@ -656,9 +672,10 @@ int lis2dw12_get_sixd_src(struct sensor_itf *itf, uint8_t *status);
 /**
  * Setup FIFO
  *
- * @param the sensor interface
- * @param FIFO mode to setup
- * @patam Threshold to set for FIFO
+ * @param itf The sensor interface
+ * @param mode FIFO mode to setup
+ * @patam fifo_ths Threshold to set for FIFO
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_fifo_cfg(struct sensor_itf *itf, enum lis2dw12_fifo_mode mode, uint8_t fifo_ths);
@@ -666,8 +683,9 @@ int lis2dw12_set_fifo_cfg(struct sensor_itf *itf, enum lis2dw12_fifo_mode mode, 
 /**
  * Get Number of Samples in FIFO
  *
- * @param the sensor interface
- * @patam Pointer to return number of samples in
+ * @param itf The sensor interface
+ * @patam samples Ptr to return number of samples in
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples);
@@ -675,8 +693,9 @@ int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples);
 /**
  * Set Wake Up Threshold configuration
  *
- * @param the sensor interface
- * @param wake_up_ths value to set
+ * @param itf The sensor interface
+ * @param reg wake_up_ths value to set
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_wake_up_ths(struct sensor_itf *itf, uint8_t reg);
@@ -684,8 +703,9 @@ int lis2dw12_set_wake_up_ths(struct sensor_itf *itf, uint8_t reg);
 /**
  * Get Wake Up Threshold config
  *
- * @param the sensor interface
- * @param ptr to store wake_up_ths value
+ * @param itf The sensor interface
+ * @param reg Ptr to store wake_up_ths value
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_wake_up_ths(struct sensor_itf *itf, uint8_t *reg);
@@ -693,8 +713,9 @@ int lis2dw12_get_wake_up_ths(struct sensor_itf *itf, uint8_t *reg);
 /**
  * Set whether sleep on inactivity is enabled
  *
- * @param the sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param en Value to set (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_inactivity_sleep_en(struct sensor_itf *itf, uint8_t en);
@@ -702,8 +723,9 @@ int lis2dw12_set_inactivity_sleep_en(struct sensor_itf *itf, uint8_t en);
 /**
  * Get whether sleep on inactivity is enabled
  *
- * @param the sensor interface
- * @param ptr to store read state (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param en Ptr to store read state (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_inactivity_sleep_en(struct sensor_itf *itf, uint8_t *en);
@@ -711,8 +733,9 @@ int lis2dw12_get_inactivity_sleep_en(struct sensor_itf *itf, uint8_t *en);
 /**
  * Set whether double tap event is enabled
  *
- * @param the sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param en Value to set (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_double_tap_event_en(struct sensor_itf *itf, uint8_t en);
@@ -720,8 +743,9 @@ int lis2dw12_set_double_tap_event_en(struct sensor_itf *itf, uint8_t en);
 /**
  * Get whether double tap event is enabled
  *
- * @param the sensor interface
- * @param ptr to store read state (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param Ptr to store read state (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_double_tap_event_en(struct sensor_itf *itf, uint8_t *en);
@@ -729,8 +753,9 @@ int lis2dw12_get_double_tap_event_en(struct sensor_itf *itf, uint8_t *en);
 /**
  * Set Wake Up Duration
  *
- * @param the sensor interface
- * @param duration to set
+ * @param itf The sensor interface
+ * @param reg duration to set
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_wake_up_dur(struct sensor_itf *itf, uint8_t reg);
@@ -738,8 +763,9 @@ int lis2dw12_set_wake_up_dur(struct sensor_itf *itf, uint8_t reg);
 /**
  * Get Wake Up Duration
  *
- * @param the sensor interface
- * @param ptr to store wake_up_dur value
+ * @param itf The sensor interface
+ * @param reg Ptr to store wake_up_dur value
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_wake_up_dur(struct sensor_itf *itf, uint8_t *reg);
@@ -747,8 +773,9 @@ int lis2dw12_get_wake_up_dur(struct sensor_itf *itf, uint8_t *reg);
 /**
  * Set Sleep Duration
  *
- * @param the sensor interface
- * @param duration to set
+ * @param itf The sensor interface
+ * @param reg Duration to set
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_sleep_dur(struct sensor_itf *itf, uint8_t reg);
@@ -756,8 +783,9 @@ int lis2dw12_set_sleep_dur(struct sensor_itf *itf, uint8_t reg);
 /**
  * Get Sleep Duration
  *
- * @param the sensor interface
- * @param ptr to store sleep_dur value
+ * @param itf The sensor interface
+ * @param reg Ptr to store sleep_dur value
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_sleep_dur(struct sensor_itf *itf, uint8_t *reg);
@@ -765,8 +793,9 @@ int lis2dw12_get_sleep_dur(struct sensor_itf *itf, uint8_t *reg);
 /**
  * Set Stationary Detection Enable
  *
- * @param the sensor interface
- * @param value to set
+ * @param itf The sensor interface
+ * @param en value to set
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_stationary_en(struct sensor_itf *itf, uint8_t en);
@@ -774,8 +803,9 @@ int lis2dw12_set_stationary_en(struct sensor_itf *itf, uint8_t en);
 /**
  * Get Stationary Detection Enable
  *
- * @param the sensor interface
- * @param ptr to store sleep_dur value
+ * @param itf The sensor interface
+ * @param en ptr to store sleep_dur value
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_stationary_en(struct sensor_itf *itf, uint8_t *en);
@@ -783,8 +813,9 @@ int lis2dw12_get_stationary_en(struct sensor_itf *itf, uint8_t *en);
 /**
  * Set whether interrupts are enabled
  *
- * @param the sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param enable Value to set (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_int1_on_int2_map(struct sensor_itf *itf, bool enable);
@@ -792,8 +823,9 @@ int lis2dw12_set_int1_on_int2_map(struct sensor_itf *itf, bool enable);
 /**
  * Get whether interrupt 1 signals is mapped onto interrupt 2 pin
  *
- * @param the sensor interface
- * @param value to set (0 = disabled, 1 = enabled)
+ * @param itf The sensor interface
+ * @param val Value to set (0 = disabled, 1 = enabled)
+ *
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_int1_on_int2_map(struct sensor_itf *itf, uint8_t *val);
@@ -801,8 +833,8 @@ int lis2dw12_get_int1_on_int2_map(struct sensor_itf *itf, uint8_t *val);
 /**
  * Run Self test on sensor
  *
- * @param the sensor interface
- * @param pointer to return test result in (0 on pass, non-zero on failure)
+ * @param itf The sensor interface
+ * @param result Ptr to return test result in (0 on pass, non-zero on failure)
  *
  * @return 0 on sucess, non-zero on failure
  */
@@ -811,11 +843,11 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result);
 /**
  * Provide a continuous stream of accelerometer readings.
  *
- * @param The sensor ptr
- * @param The sensor type
- * @param The function pointer to invoke for each accelerometer reading.
- * @param The opaque pointer that will be passed in to the function.
- * @param If non-zero, how long the stream should run in milliseconds.
+ * @param sensor The sensor ptr
+ * @param type The sensor type
+ * @param read_func The function pointer to invoke for each accelerometer reading.
+ * @param read_arg The opaque pointer that will be passed in to the function.
+ * @param time_ms If non-zero, how long the stream should run in milliseconds.
  *
  * @return 0 on success, non-zero on failure.
  */
@@ -828,25 +860,25 @@ int lis2dw12_stream_read(struct sensor *sensor,
 /**
  * Do accelerometer polling reads
  *
- * @param The sensor ptr
- * @param The sensor type
- * @param The function pointer to invoke for each accelerometer reading.
- * @param The opaque pointer that will be passed in to the function.
- * @param If non-zero, how long the stream should run in milliseconds.
+ * @param sensor The sensor ptr
+ * @param sensor_type The sensor type
+ * @param data_func The function pointer to invoke for each accelerometer reading.
+ * @param data_arg The opaque pointer that will be passed in to the function.
+ * @param timeout If non-zero, how long the stream should run in milliseconds.
  *
  * @return 0 on success, non-zero on failure.
  */
-int lis2dw12_poll_read(struct sensor * sensor,
+int lis2dw12_poll_read(struct sensor *sensor,
                        sensor_type_t sensor_type,
                        sensor_data_func_t data_func,
-                       void * data_arg,
+                       void *data_arg,
                        uint32_t timeout);
 
 /**
  * Expects to be called back through os_dev_create().
  *
- * @param ptr to the device object associated with this accelerometer
- * @param argument passed to OS device init
+ * @param dev Ptr to the device object associated with this accelerometer
+ * @param arg Argument passed to OS device init
  *
  * @return 0 on success, non-zero on failure.
  */
@@ -855,10 +887,10 @@ int lis2dw12_init(struct os_dev *dev, void *arg);
 /**
  * Configure the sensor
  *
- * @param ptr to sensor driver
- * @param ptr to sensor driver config
+ * @param lis2dw12 Ptr to sensor driver
+ * @param cfg Ptr to sensor driver config
  */
-int lis2dw12_config(struct lis2dw12 *, struct lis2dw12_cfg *);
+int lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg);
 
 #if MYNEWT_VAL(LIS2DW12_CLI)
 int lis2dw12_shell_init(void);

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -247,7 +247,7 @@ struct lis2dw12_pdd {
     /* Inetrrupt state */
     struct lis2dw12_int *interrupt;
     /* Interrupt enabled flag */
-    uint8_t int_enable;
+    uint16_t int_enable;
 };
 
 struct lis2dw12 {

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -201,7 +201,7 @@ struct lis2dw12_cfg {
     uint8_t int_enable  : 1;
     uint8_t int_pp_od   : 1;
     uint8_t int_latched : 1;
-    uint8_t int_active  : 1;
+    uint8_t int_active_low  : 1;
     uint8_t inactivity_sleep_enable     : 1;
     uint8_t low_noise_enable            : 1;
     uint8_t stationary_detection_enable : 1;
@@ -423,7 +423,7 @@ int lis2dw12_get_latched_int(struct sensor_itf *itf, uint8_t *en);
  *
  * @return 0 on success, non-zero on failure
  */
-int lis2dw12_set_int_active(struct sensor_itf *itf, uint8_t low);
+int lis2dw12_set_int_active_low(struct sensor_itf *itf, uint8_t low);
 
 /**
  * Gets whether interrupts are active high or low
@@ -433,7 +433,7 @@ int lis2dw12_set_int_active(struct sensor_itf *itf, uint8_t low);
  *
  * @return 0 on success, non-zero on failure
  */
-int lis2dw12_get_int_active(struct sensor_itf *itf, uint8_t *low);
+int lis2dw12_get_int_active_low(struct sensor_itf *itf, uint8_t *low);
 
 /**
  * Sets single data conversion mode
@@ -578,6 +578,26 @@ lis2dw12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
+
+/**
+ * Clear interrupt pin configuration for interrupt 1
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_clear_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
+
+/**
+ * Clear interrupt pin configuration for interrupt 2
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_clear_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg);
 
 /**
  * Set whether interrupts are enabled

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -2267,7 +2267,7 @@ lis2dw12_poll_read(struct sensor *sensor, sensor_type_t sensor_type,
         goto err;
     }
 
-    if (cfg->read_mode.mode != LIS2DW12_READ_M_STREAM) {
+    if (cfg->read_mode.mode != LIS2DW12_READ_M_POLL) {
         rc = SYS_EINVAL;
         goto err;
     }

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -2049,17 +2049,18 @@ disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num
     itf = SENSOR_GET_ITF(sensor);
     pdd = &lis2dw12->pdd;
 
+    pdd->int_enable &= (~int_to_disable >> (int_num * 8));
+
     /* disable int pin */
     if (!pdd->int_enable) {
         hal_gpio_irq_disable(itf->si_ints[int_num].host_pin);
         /* disable interrupt in device */
         rc = lis2dw12_set_int_enable(itf, 0);
         if (rc) {
+            pdd->int_enable |= (int_to_disable >> (int_num * 8));
             return rc;
         }
     }
-
-    pdd->int_enable--;
 
     /* update interrupt setup in device */
     if (int_num == 0) {
@@ -2105,7 +2106,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
         }
     }
 
-    pdd->int_enable++;
+    pdd->int_enable |= (int_to_enable >> (int_num * 8));
 
     /* enable interrupt in device */
     if (int_num == 0) {

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -2049,7 +2049,7 @@ disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num
     itf = SENSOR_GET_ITF(sensor);
     pdd = &lis2dw12->pdd;
 
-    pdd->int_enable &= (~int_to_disable >> (int_num * 8));
+    pdd->int_enable &= ~(int_to_disable << (int_num * 8));
 
     /* disable int pin */
     if (!pdd->int_enable) {
@@ -2057,7 +2057,7 @@ disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num
         /* disable interrupt in device */
         rc = lis2dw12_set_int_enable(itf, 0);
         if (rc) {
-            pdd->int_enable |= (int_to_disable >> (int_num * 8));
+            pdd->int_enable |= (int_to_disable << (int_num * 8));
             return rc;
         }
     }
@@ -2106,7 +2106,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
         }
     }
 
-    pdd->int_enable |= (int_to_enable >> (int_num * 8));
+    pdd->int_enable |= (int_to_enable << (int_num * 8));
 
     /* enable interrupt in device */
     if (int_num == 0) {

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -60,8 +60,6 @@ STATS_SECT_DECL(lis2dw12_stat_section) g_lis2dw12stats;
 #define LIS2DW12_ERR(...)      LOG_ERROR(&_log, LOG_MODULE_LIS2DW12, __VA_ARGS__)
 static struct log _log;
 
-#define LIS2DW12_NOTIFY_MASK 0x01
-
 /* Exports for the sensor API */
 static int lis2dw12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -820,7 +818,7 @@ lis2dw12_get_latched_int(struct sensor_itf *itf, uint8_t *en)
  * @return 0 on success, non-zero on failure
  */
 int
-lis2dw12_set_int_active(struct sensor_itf *itf, uint8_t low)
+lis2dw12_set_int_active_low(struct sensor_itf *itf, uint8_t low)
 {
     int rc;
     uint8_t reg;
@@ -846,7 +844,7 @@ lis2dw12_set_int_active(struct sensor_itf *itf, uint8_t low)
  * @return 0 on success, non-zero on failure
  */
 int
-lis2dw12_get_int_active(struct sensor_itf *itf, uint8_t *low)
+lis2dw12_get_int_active_low(struct sensor_itf *itf, uint8_t *low)
 {
     int rc;
     uint8_t reg;
@@ -1318,6 +1316,63 @@ int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples)
     return 0;
 }
 
+/**
+ * Clear interrupt pin configuration for interrupt 1
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_clear_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
+{
+    int rc;
+    uint8_t reg;
+
+    reg = 0;
+
+    rc = lis2dw12_read8(itf, LIS2DW12_REG_CTRL_REG4, &reg);
+    if (rc) {
+        goto err;
+    }
+
+    reg &= ~cfg;
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG4, reg);
+
+err:
+    return rc;
+}
+
+/**
+ * Clear interrupt pin configuration for interrupt 2
+ *
+ * @param the sensor interface
+ * @param config
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_clear_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
+{
+    int rc;
+    uint8_t reg;
+
+    reg = 0;
+
+    rc = lis2dw12_read8(itf, LIS2DW12_REG_CTRL_REG5, &reg);
+    if (rc) {
+        goto err;
+    }
+
+    reg &= ~cfg;
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG5, reg);
+
+err:
+    return rc;
+}
+
+
 
 /**
  * Set interrupt pin configuration for interrupt 1
@@ -1329,7 +1384,22 @@ int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples)
 int
 lis2dw12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
 {
-    return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG4, cfg);
+    int rc;
+    uint8_t reg;
+
+    reg = 0;
+
+    rc = lis2dw12_read8(itf, LIS2DW12_REG_CTRL_REG4, &reg);
+    if (rc) {
+        goto err;
+    }
+
+    reg |= cfg;
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG4, reg);
+
+err:
+    return rc;
 }
 
 /**
@@ -1342,7 +1412,22 @@ lis2dw12_set_int1_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
 int
 lis2dw12_set_int2_pin_cfg(struct sensor_itf *itf, uint8_t cfg)
 {
-    return lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG5, cfg);
+    int rc;
+    uint8_t reg;
+
+    reg = 0;
+
+    rc = lis2dw12_read8(itf, LIS2DW12_REG_CTRL_REG5, &reg);
+    if (rc) {
+       goto err;
+    }
+
+    reg |= cfg;
+
+    rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG5, reg);
+
+err:
+    return rc;
 }
 
 /**
@@ -1949,6 +2034,45 @@ init_intpin(struct lis2dw12 *lis2dw12, hal_gpio_irq_handler_t handler,
 }
 
 static int
+disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num)
+{
+    struct lis2dw12 *lis2dw12;
+    struct lis2dw12_pdd *pdd;
+    struct sensor_itf *itf;
+    int rc;
+
+    if (int_to_disable == 0) {
+        return SYS_EINVAL;
+    }
+
+    lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
+    itf = SENSOR_GET_ITF(sensor);
+    pdd = &lis2dw12->pdd;
+
+    /* disable int pin */
+    if (!pdd->int_enable) {
+        hal_gpio_irq_disable(itf->si_ints[int_num].host_pin);
+        /* disable interrupt in device */
+        rc = lis2dw12_set_int_enable(itf, 0);
+        if (rc) {
+            return rc;
+        }
+    }
+
+    pdd->int_enable--;
+
+    /* update interrupt setup in device */
+    if (int_num == 0) {
+        rc = lis2dw12_clear_int1_pin_cfg(itf, int_to_disable);
+    } else {
+        rc = lis2dw12_clear_int2_pin_cfg(itf, int_to_disable);
+    }
+
+    return rc;
+}
+
+
+static int
 enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
 {
     struct lis2dw12 *lis2dw12;
@@ -1997,44 +2121,6 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
 
     return 0;
 err:
-    return rc;
-}
-
-static int
-disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num)
-{
-    struct lis2dw12 *lis2dw12;
-    struct lis2dw12_pdd *pdd;
-    struct sensor_itf *itf;
-    int rc;
-
-    if (int_to_disable == 0) {
-        return SYS_EINVAL;
-    }
-
-    lis2dw12 = (struct lis2dw12 *)SENSOR_GET_DEVICE(sensor);
-    itf = SENSOR_GET_ITF(sensor);
-    pdd = &lis2dw12->pdd;
-
-    /* disable int pin */
-    if (!pdd->int_enable) {
-        hal_gpio_irq_disable(itf->si_ints[int_num].host_pin);
-        /* disable interrupt in device */
-        rc = lis2dw12_set_int_enable(itf, 0);
-        if (rc) {
-            return rc;
-        }
-    }
-
-    pdd->int_enable--;
-
-    /* update interrupt setup in device */
-    if (int_num == 0) {
-        rc = lis2dw12_set_int1_pin_cfg(itf, int_to_disable);
-    } else {
-        rc = lis2dw12_set_int2_pin_cfg(itf, int_to_disable);
-    }
-
     return rc;
 }
 
@@ -2366,7 +2452,7 @@ lis2dw12_find_int_by_event(sensor_event_type_t event, uint8_t *int_cfg,
         *int_num = 0;
     } else if (event == SENSOR_EVENT_TYPE_SLEEP_CHANGE) {
         *int_cfg = LIS2DW12_INT2_CFG_SLEEP_CHG;
-        *int_num = 0;
+        *int_num = 1;
     } else {
         /* here if type is set to a non valid event or more than one event
          * we do not currently support registering for more than one event
@@ -2673,11 +2759,11 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     }
     lis2dw12->cfg.int_latched = cfg->int_latched;
 
-    rc = lis2dw12_set_int_active(itf, cfg->int_active);
+    rc = lis2dw12_set_int_active_low(itf, cfg->int_active_low);
     if (rc) {
         goto err;
     }
-    lis2dw12->cfg.int_active = cfg->int_active;
+    lis2dw12->cfg.int_active_low = cfg->int_active_low;
 
     rc = lis2dw12_set_slp_mode(itf, cfg->slp_mode);
     if (rc) {

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -757,18 +757,18 @@ config_lis2dw12_sensor(void)
     cfg.filter_bw = LIS2DW12_FILTER_BW_ODR_DIV_2;
     cfg.high_pass = 0;
     
-    cfg.tap_cfg.en_x = 1;
-    cfg.tap_cfg.en_y = 1;
-    cfg.tap_cfg.en_z = 1;
-    cfg.tap_cfg.en_4d = 0;
-    cfg.tap_cfg.ths_6d = LIS2DW12_6D_THS_80_DEG;
-    cfg.tap_cfg.tap_priority = LIS2DW12_TAP_PRIOR_XYZ;
-    cfg.tap_cfg.tap_ths_x = 0x3;
-    cfg.tap_cfg.tap_ths_y = 0x3;
-    cfg.tap_cfg.tap_ths_z = 0x3;
-    cfg.tap_cfg.latency = 8; /* 640ms */
-    cfg.tap_cfg.quiet = 0; /* 10ms */
-    cfg.tap_cfg.shock = 3; /* 120ms */
+    cfg.tap.en_x = 1;
+    cfg.tap.en_y = 1;
+    cfg.tap.en_z = 1;
+    cfg.tap.en_4d = 0;
+    cfg.tap.ths_6d = LIS2DW12_6D_THS_80_DEG;
+    cfg.tap.tap_priority = LIS2DW12_TAP_PRIOR_XYZ;
+    cfg.tap.tap_ths_x = 0x3;
+    cfg.tap.tap_ths_y = 0x3;
+    cfg.tap.tap_ths_z = 0x3;
+    cfg.tap.latency = 8; /* 640ms */
+    cfg.tap.quiet = 0; /* 10ms */
+    cfg.tap.shock = 3; /* 120ms */
     cfg.double_tap_event_enable = 0;
 
     cfg.freefall_dur = 6; 
@@ -780,13 +780,12 @@ config_lis2dw12_sensor(void)
 
     cfg.int_pp_od = 0;
     cfg.int_latched = 0;
-    cfg.int_active = 0;
+    cfg.int_active_low = 0;
     cfg.slp_mode = 0;
     cfg.self_test_mode = LIS2DW12_ST_MODE_DISABLE;
     
     cfg.fifo_mode = LIS2DW12_FIFO_M_BYPASS;
     cfg.fifo_threshold = 32;
-    cfg.stream_read_interrupt = LIS2DW12_INT1_CFG_DRDY;
 
     cfg.wake_up_ths = 0;
     cfg.wake_up_dur = 0;
@@ -798,7 +797,7 @@ config_lis2dw12_sensor(void)
     cfg.inactivity_sleep_enable = 0;
     cfg.low_noise_enable = 1;
     
-    cfg.read_mode = LIS2DW12_READ_M_POLL;
+    cfg.read_mode.mode = LIS2DW12_READ_M_POLL;
     cfg.mask = SENSOR_TYPE_ACCELEROMETER;
 
     rc = lis2dw12_config((struct lis2dw12 *) dev, &cfg);


### PR DESCRIPTION
- Set/Clear individual interrupt cfg bits
- Change config in sensor creator
- Change int_active to int_active_low to be more explicit
- Change lis2dw12_set_int_active() to lis2dw12_set_int_active_low()