### PR TITLE
fsutil_write_file: open the file, truncating if it exists

### DIFF
--- a/fs/fs/src/fsutil.c
+++ b/fs/fs/src/fsutil.c
@@ -49,7 +49,7 @@ fsutil_write_file(const char *path, const void *data, uint32_t len)
     struct fs_file *file;
     int rc;
 
-    rc = fs_open(path, FS_ACCESS_WRITE, &file);
+    rc = fs_open(path, FS_ACCESS_WRITE | FS_ACCESS_TRUNCATE, &file);
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
The documentation for fsutil_write_file states that it should truncate the file if it already exists.   That's not the case right now, but this patch fixes that.   I think this is the right behavior, rather than updating the docs to match the code.
