### PR TITLE
mn_socket - Fix build error due to missing include

### DIFF
--- a/net/ip/mn_socket/src/mn_socket_aconv.c
+++ b/net/ip/mn_socket/src/mn_socket_aconv.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#include "os/mynewt.h"
 #include "mn_socket/mn_socket.h"
 
 /**


### PR DESCRIPTION
This commit fixes the following build error:

```
Error: repos/apache-mynewt-core/net/ip/mn_socket/src/mn_socket_aconv.c: In function 'mn_inet6_pton_segment':
repos/apache-mynewt-core/net/ip/mn_socket/src/mn_socket_aconv.c:139:11: error: implicit declaration of function 'htons' [-Werror=implicit-function-declaration]
     u16 = htons(u16);
```

`mn_socket_aconv.c` requires `htons`, which is declared in `os/endian.h`.  The fix is to include the catch-all header `os/mynewt.h`.