### PR TITLE
kernel/os: Add helpers for converting ms<->ticks

### DIFF
--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -213,6 +213,31 @@ int os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks);
  */
 int os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms);
 
+
+/**
+ * Converts milliseconds to OS ticks.
+ *
+ * This function does not check if conversion overflows and should be only used
+ * in cases where input is known to be small enough not to overflow.
+ *
+ * @param ms                    The milliseconds input.
+ *
+ * @return                      result on success
+ */
+uint32_t os_time_ms_to_ticks32(uint32_t ms);
+
+/**
+ * Converts OS ticks to milliseconds.
+ *
+ * This function does not check if conversion overflows and should be only used
+ * in cases where input is known to be small enough not to overflow.
+ *
+ * @param ticks                 The OS ticks input.
+ *
+ * @return                      result on success
+ */
+uint32_t os_time_ticks_to_ms32(uint32_t ticks);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -229,3 +229,23 @@ os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms)
 
     return 0;
 }
+
+uint32_t
+os_time_ms_to_ticks32(uint32_t ms)
+{
+#if OS_TICKS_PER_SEC == 1000
+    return ms;
+#else
+    return ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
+#endif
+}
+
+uint32_t
+os_time_ticks_to_ms32(uint32_t ticks)
+{
+#if OS_TICKS_PER_SEC == 1000
+    return ticks;
+#else
+    return ((uint64_t)ticks * 1000) / OS_TICKS_PER_SEC;
+#endif
+}


### PR DESCRIPTION
These helpers do not check for overflow so should be used with care,
but in general they allow for more compact code.

Note that would be nice to have them as static inline but since we need
OS_TICKS_PER_SEC in header file, there are some weird dependencies in
os/os_*.h files which needs to be resolved first so code can build
properly.