### PR TITLE
 kernel/os: Make os_callout_remaining_ticks thread-safe

### DIFF
--- a/kernel/os/src/os_callout.c
+++ b/kernel/os/src/os_callout.c
@@ -170,15 +170,18 @@ os_callout_wakeup_ticks(os_time_t now)
 os_time_t
 os_callout_remaining_ticks(struct os_callout *c, os_time_t now)
 {
+    os_sr_t sr;
     os_time_t rt;
 
-    OS_ASSERT_CRITICAL();
+    OS_ENTER_CRITICAL(sr);
 
     if (OS_TIME_TICK_GEQ(c->c_ticks, now)) {
         rt = c->c_ticks - now;
     } else {
         rt = 0;     /* callout time is in the past */
     }
+
+    OS_EXIT_CRITICAL(sr);
 
     return rt;
 }


### PR DESCRIPTION
Not sure why these 2 APIs expected to be called within critical section
only, but let's make them callable from anywhere just like other APIs.