### PR TITLE
net/oic; export ids for serial and lora transports. Used when creating

### DIFF
--- a/net/oic/include/oic/port/mynewt/serial.h
+++ b/net/oic/include/oic/port/mynewt/serial.h
@@ -17,25 +17,17 @@
  * under the License.
  */
 
-#ifndef __OIC_MYNEWT_LORA_H_
-#define __OIC_MYNEWT_LORA_H_
+#ifndef __OIC_MYNEWT_SERIAL_H_
+#define __OIC_MYNEWT_SERIAL_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/*
- * oc_endpoint for LORA.
- */
-struct oc_endpoint_lora {
-    struct oc_ep_hdr ep;
-    uint8_t port;
-};
-
-extern uint8_t oc_lora_transport_id;
+extern uint8_t oc_serial_transport_id;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __OIC_MYNEWT_LORA_H_ */
+#endif /* __OIC_MYNEWT_SERIAL_H_ */

--- a/net/oic/src/port/mynewt/lora_adaptor.c
+++ b/net/oic/src/port/mynewt/lora_adaptor.c
@@ -62,7 +62,7 @@ static const struct oc_transport oc_lora_transport = {
     .ot_shutdown = oc_connectivity_shutdown_lora
 };
 
-static uint8_t oc_lora_transport_id;
+uint8_t oc_lora_transport_id;
 
 STATS_SECT_START(oc_lora_stats)
     STATS_SECT_ENTRY(iframe)

--- a/net/oic/src/port/mynewt/serial_adaptor.c
+++ b/net/oic/src/port/mynewt/serial_adaptor.c
@@ -48,7 +48,7 @@ static const struct oc_transport oc_serial_transport = {
     .ot_shutdown = oc_connectivity_shutdown_serial
 };
 
-static uint8_t oc_serial_transport_id;
+uint8_t oc_serial_transport_id;
 static struct os_mqueue oc_serial_mqueue;
 static struct os_mbuf *oc_attempt_rx_serial(void);
 


### PR DESCRIPTION
requests as CoAP client.