### PR TITLE
Define BUTTON_1 for the Adafruit nrf52 Feather

### DIFF
--- a/hw/bsp/ada_feather_nrf52/include/bsp/bsp.h
+++ b/hw/bsp/ada_feather_nrf52/include/bsp/bsp.h
@@ -44,6 +44,9 @@ extern uint8_t _ram_start;
 #define LED_2           (19)
 #define LED_BLINK_PIN   (LED_1)
 
+/* Buttons */
+#define BUTTON_1        (20)  /* Labelled DFU on the board */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This button is labelled as DFU, and is a general purpose IO line