### PR TITLE
Battery manager

### DIFF
--- a/hw/battery/include/battery/battery.h
+++ b/hw/battery/include/battery/battery.h
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @file battery.h
+ * @brief Hardware-agnostic interface for fuel gauge ICs
+ *
+ * The Batter interface provides a hardware-agnostic layer for reading
+ * fuel gauge controller ICs.
+ */
+
+#ifndef __BATTERY_H__
+#define __BATTERY_H__
+
+#include "os/mynewt.h"
+#include "battery/battery_prop.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MYNEWT_VAL(BATTERY_DRIVERS_MAX)
+#define BATTERY_DRIVERS_MAX MYNEWT_VAL(BATTERY_DRIVERS_MAX)
+#else
+#define BATTERY_DRIVERS_MAX 2
+#endif
+
+/* Package init function.  Remove when we have post-kernel init stages.
+ */
+void battery_pkg_init(void);
+
+
+/* Forward declaration of battery structure. */
+struct battery;
+struct battery_driver;
+struct battery_property;
+struct battery_driver_data;
+
+struct battery_init_cfg {
+    /* Empty structure for future use */
+};
+
+struct battery_open_arg {
+    const char **devices;
+};
+
+/* Comments above intentionally not in Doxygen format */
+
+/* =================================================================
+ * ====================== DEFINES/MACROS ===========================
+ * =================================================================
+ */
+
+/**
+ * @{ Fuel Gauge API
+ */
+
+// ------------------------ BATTERY OBJECT -------------------------
+
+/* Private struct */
+struct listener_data;
+
+struct battery {
+    /* The OS device this battery inherits from, this is typically a
+     * fuel gauge specific driver.
+     */
+    struct os_dev b_dev;
+    /*
+     * Driver data, set by driver init function
+     */
+    struct battery_driver *b_drivers[BATTERY_DRIVERS_MAX];
+
+    /*
+     * Battery manager managed fields
+     */
+
+    /* The lock for battery object */
+    struct os_mutex b_lock;
+
+    /* All propertied are numbered for battery manager internal use */
+    uint8_t b_all_property_count;
+
+    /* Numbre of registered listeners */
+    uint8_t b_listener_count;
+
+    /* Array of properties created by battery manager
+     * for alarms that are not fully supported by hardware.
+     * Filled by battery manager.
+     */
+    struct battery_property *b_properties;
+
+    /**
+     * Poll rate in ms for this battery.
+     * Field managed by battery manager.
+     */
+    uint32_t b_poll_rate;
+
+    /* The next time at which we will poll data from this fuel gauge
+     * Field managed by battery manager.
+     */
+    os_time_t b_next_run;
+
+    /* Battery last reading time stamp. */
+    os_time_t b_last_read_time;
+
+    /* A list of listeners that are registered to receive data from this
+     * battery.
+     */
+    struct listener_data *b_listeners;
+};
+
+/* =================================================================
+ * ========================== BATTERY ==============================
+ * =================================================================
+ */
+
+/**
+ * Initialize battery structure data and mutex and associate it with an
+ * os_dev.
+ *
+ * @param os_dev to associate with the battery struct
+ * @param Battery struct to initialize
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_init(struct os_dev *dev, void *cfg);
+
+/**
+ * Find battery property or create one
+ *
+ * @param The battery to get property from
+ * @param The flags to select property
+ * @param The battery property flags, if BATTERY_PROPERY_CREATE
+ *        is specified property can be created if not existed before.
+ * @param The driver name to get property from, this parameter is optional
+ *        and can be NULL.
+ *
+ * @return NULL if property could not be found
+ */
+struct battery_property *battery_find_property(struct os_dev *battery,
+        battery_property_type_t type, battery_property_flags_t flags,
+        const char *dev_name);
+
+/**
+ * Find battery property by name
+ *
+ * @param The battery to get property from
+ * @param The name of property
+ *
+ * @return NULL if property could not be found
+ */
+struct battery_property *battery_find_property_by_name(struct os_dev *battery,
+        const char *name);
+
+/**
+ * Returns battery property count
+ *
+ * @param The battery to get property count from
+ * @param Battery driver to get property from, can be NULL.
+ *
+ * @return number of properties register to battery
+ */
+int battery_get_property_count(struct os_dev *battery,
+        struct battery_driver *driver);
+
+/**
+ * Returns battery property specified by number
+ * It can be used to enumerate properties.
+ *
+ * @param The battery to enum property from
+ * @param Battery driver to get property from, can be NULL.
+ * @param Index of property, should be less that value returned
+ *        by bettery_get_property_couunt
+ *
+ * @return pointer to property for valid index, or NULL if prop_num is to high
+ */
+struct battery_property *
+battery_enum_property(struct os_dev *battery, struct battery_driver *driver,
+        uint8_t prop_num);
+
+/**
+ * Gets battery property name
+ *
+ * @param The battery property
+ * @param Buffer for property name
+ * @param Size of the buffer for property
+ *
+ * @return pointer buffer for easy usage in printf like functions
+ */
+char *battery_prop_get_name(const struct battery_property *prop, char *buf,
+        size_t buf_size);
+
+/**
+ * Set the battery poll rate
+ *
+ * @param The battery
+ * @param The poll rate in milliseconds
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_set_poll_rate_ms(struct os_dev *battery, uint32_t poll_rate);
+
+// =================================================================
+// ========================== BATTERY MANAGER ======================
+// =================================================================
+
+/**
+ * @{ Battery Manager API
+ */
+
+/**
+ * Registers a battery with the battery manager.
+ * This function should be called from driver init function.
+ *
+ * @param The battery to register
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_mgr_register_battery(struct os_dev *battery);
+
+/**
+ * Search the battery list and find the next battery that
+ * corresponds to a given device name.
+ *
+ * @param The battery to search for, if NULL first registered
+ *        battery is returned.
+ *
+ * @return battery pointer, NULL if such battery is not registered
+ */
+struct os_dev *battery_mgr_find_by_name(const char *name);
+
+/**
+ * Add interrupt from driver so it can be processed in user context.
+ *
+ * @param The event passed from driver to be processed in battery
+ *        manager task.
+ */
+void battery_mgr_process_event(struct os_event *event);
+
+/**
+ * Returns number of batteries in the system.
+ *
+ * @return number of batteries.
+ */
+int battery_mgr_get_battery_count(void);
+
+/**
+ * Get battery by its number
+ */
+struct os_dev *battery_get_battery(int bat_num);
+
+/**
+ * Returns number of battery driver for battery instance
+ *
+ * There may be several drivers serving battery information (fuel gauge, adc),
+ * they can provide separate properties for same information like voltage.
+ * This function returns number of configured drivers.
+ *
+ * @return number of drivers for battery.
+ */
+int battery_get_driver_count(struct os_dev *battery);
+
+/**
+ * Returns battery driver specified by it device name.
+ *
+ * @return battery driver.
+ */
+struct battery_driver *get_battery_driver(struct os_dev *battery,
+        const char *dev_name);
+
+#if MYNEWT_VAL(BATTERY_SHELL)
+void battery_shell_register(void);
+#endif
+
+/**
+ * }@
+ */
+
+/* End Battery Manager API */
+
+
+/**
+ * @}
+ */
+
+/* End Battery API */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BATTERY_H__ */

--- a/hw/battery/include/battery/battery_drv.h
+++ b/hw/battery/include/battery/battery_drv.h
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @file battery.h
+ * @brief Hardware-agnostic interface for fuel gauge ICs
+ *
+ * The Batter interface provides a hardware-agnostic layer for reading
+ * fuel gauge controller ICs.
+ */
+
+#ifndef __BATTERY_DRV_H__
+#define __BATTERY_DRV_H__
+
+#include "os/mynewt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Package init function.  Remove when we have post-kernel init stages.
+ */
+void battery_pkg_init(void);
+
+
+/* Forward declaration of battery structure. */
+struct battery;
+struct battery_driver;
+struct battery_property;
+
+/* Comments above intentionally not in Doxygen format */
+
+/* =================================================================
+ * ====================== DEFINES/MACROS ===========================
+ * =================================================================
+ */
+
+/**
+ * @{ Fuel Gauge API
+ */
+
+
+/* ---------------------- DRIVER FUNCTIONS ------------------------- */
+
+/**
+ * Set the driver functions for this battery, along with the type of
+ * data available for the given battery.
+ *
+ * @param The battery to set the driver information for
+ * @param The battery driver
+ * @param The battery properties provided by driver
+ *
+ * @return 0 on success, non-zero error code on failure
+ */
+int battery_add_driver(struct os_dev *battery, struct battery_driver *driver);
+
+/**
+ * Get value of battery property
+ * (e.g. BATTERY_PROP_STATUS).
+ *
+ * @param The battery to get property from
+ * @param The property to read. The type of property should have type
+ *        supported by fuel gauge. Data filed in property will be filled
+ *        by the driver.
+ * @param Timeout. If block until result, specify OS_TIMEOUT_NEVER, 0 returns
+ *        immediately (no wait.)
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*battery_property_get_func_t)(struct battery_driver *driver,
+        struct battery_property *property, uint32_t timeout);
+
+/**
+ * Set value of battery property
+ * Setting value is supported for certain values only.
+ * Usually threshold properties can be set.
+ *
+ * @param The desired battery
+ * @param The new value of battery property, type must be known to driver
+ *        and data files should be set to correct value.
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*battery_property_set_func_t)(struct battery_driver *driver,
+        struct battery_property *property);
+
+/**
+ * Enable a fuel gauge
+ *
+ * @param The battery to enable fuel gauge functionality
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*battery_enable_func_t)(struct battery *battery);
+
+/**
+ * Disable a fuel gauge
+ *
+ * @param The battery to disable fuel gauge
+ *
+ * @return 0 on success, non-zero error code on failure
+ */
+typedef int (*battery_disable_func_t)(struct battery *battery);
+
+/**
+ * Let driver handle interrupt in the battery manager context
+ *
+ * @param The battery.
+ * @param Interrupt argument
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*battery_handle_interrupt_t)(struct battery *battery, void *arg);
+
+/**
+ * Pointers to battery-specific driver functions.
+ */
+struct battery_driver_functions {
+    battery_property_get_func_t  bdf_property_get;
+    battery_property_set_func_t  bdf_property_set;
+
+    battery_enable_func_t        bdf_enable;
+    battery_disable_func_t       bdf_disable;
+};
+
+struct battery_driver {
+    /* Underlying OS device */
+    struct os_dev dev;
+
+    const struct battery_driver_functions *bd_funcs;
+    /* Array of properties supported by this battery */
+    const struct battery_driver_property  *bd_driver_properties;
+    void                                  *bd_driver_data;
+
+    /*
+     * Fields below are managed by battery manager, they don't need
+     * to be filled by the driver.
+     */
+
+    /* Number of elements in b_driver_properties array
+     * Battery manager will fill this field using data from
+     * bd_driver_properties field
+     */
+    uint8_t                                bd_property_count;
+    uint8_t                                bd_first_property;
+};
+
+/**
+ * }@
+ */
+
+/* End Battery Manager API */
+
+
+/**
+ * @}
+ */
+
+/* End Battery API */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BATTERY_DRV_H__ */

--- a/hw/battery/include/battery/battery_prop.h
+++ b/hw/battery/include/battery/battery_prop.h
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @file battery.h
+ * @brief Battery property
+ *
+ * The Batter property provides software view to data provided by fuel gauge
+ * ADC or charge controllers.
+ */
+
+#ifndef __BATTERY_PROP_H__
+#define __BATTERY_PROP_H__
+
+#include "os/mynewt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MYNEWT_VAL(BATTERY_MAX_PROPERTY_COUNT)
+#define BATTERY_MAX_PROPERTY_COUNT MYNEWT_VAL(BATTERY_MAX_PROPERTY_COUNT)
+#else
+#define BATTERY_MAX_PROPERTY_COUNT 32
+#endif
+
+/* Forward declaration of battery structure. */
+struct battery;
+struct battery_property;
+struct battery_prop_listener;
+
+/* Comments above intentionally not in Doxygen format */
+
+/* =================================================================
+ * ====================== DEFINES/MACROS ===========================
+ * =================================================================
+ */
+
+/**
+ * @{ Battery properties API
+ */
+
+// ---------------------- TYPE -------------------------------------
+
+typedef enum {
+    BATTERY_STATUS_UNKNOWN = 0,
+    /* Charger connected, battery charging */
+    BATTERY_STATUS_CHARGING,
+    /* Charger not connected, battery discharging */
+    BATTERY_STATUS_DISCHARGING,
+    /* Charger connected, not charging */
+    BATTERY_STATUS_NOT_CHARGING,
+    /* Charger connected, not charging - battery full */
+    BATTERY_STATUS_FULL,
+} battery_status_t;
+
+typedef enum {
+    BATTERY_CAPACITY_LEVEL_UNKNOWN = 0,
+    BATTERY_CAPACITY_LEVEL_CRITICAL,
+    BATTERY_CAPACITY_LEVEL_LOW,
+    BATTERY_CAPACITY_LEVEL_NORMAL,
+    BATTERY_CAPACITY_LEVEL_HIGH,
+    BATTERY_CAPACITY_LEVEL_FULL,
+} battery_capacity_level_t;
+
+typedef union battery_property_value {
+    float bpv_flt;
+    uint32_t bpv_u32;
+    int32_t bpv_i32;
+    uint16_t bpv_u16;
+    int16_t bpv_i16;
+    uint8_t bpv_u8;
+    int8_t bpv_i8;
+    /* in mV */
+    int32_t bpv_voltage;
+    /* in mA */
+    int32_t bpv_current;
+    /* in mAh */
+    uint32_t bpv_capacity;
+    /* SOC in % 0..100 */
+    uint8_t bpv_soc;
+    /* Temperature in deg C */
+    float bpv_temperature;
+    /* Time in s */
+    uint32_t bpv_time_in_s;
+    /* Number of charge cycles */
+    uint16_t bpv_cycle_count;
+    battery_status_t bpv_status;
+    battery_capacity_level_t bpv_capacity_level;
+    uint8_t bpv_base_prop[4];
+} battery_property_value_t;
+
+/**
+ * Battery properties.
+ * Fuel gauge can exposes subset of those properties.
+ */
+typedef enum {
+    BATTERY_PROP_NONE,
+    /* Battery status supported */
+    BATTERY_PROP_STATUS,
+    /* Battery capacity level supported */
+    BATTERY_PROP_CAPACITY_LEVEL,
+    /* Battery capacity in mAh */
+    BATTERY_PROP_CAPACITY,
+    /* Predicted full battery capacity in mAh */
+    BATTERY_PROP_CAPACITY_FULL,
+    /* Current battery temperature in C */
+    BATTERY_PROP_TEMP_NOW,
+    /* Ambient temperature in C */
+    BATTERY_PROP_TEMP_AMBIENT,
+    /* Minimum voltage in V */
+    BATTERY_PROP_VOLTAGE_MIN,
+    /* Maximum voltage in V */
+    BATTERY_PROP_VOLTAGE_MAX,
+    /* Minimum designed voltage in V */
+    BATTERY_PROP_VOLTAGE_MIN_DESIGN,
+    /* Maximum designed voltage in V */
+    BATTERY_PROP_VOLTAGE_MAX_DESIGN,
+    /* Current voltage in V */
+    BATTERY_PROP_VOLTAGE_NOW,
+    /* Current average voltage in V */
+    BATTERY_PROP_VOLTAGE_AVG,
+    /* Maximum current in mAh */
+    BATTERY_PROP_CURRENT_MAX,
+    /* Current level at this time in mAh */
+    BATTERY_PROP_CURRENT_NOW,
+    /* Average current level in mAh */
+    BATTERY_PROP_CURRENT_AVG,
+    /* State-Of-Charge, current capacity 0-100 % */
+    BATTERY_PROP_SOC,
+    /* Predicted time to complete discharge in seconds */
+    BATTERY_PROP_TIME_TO_EMPTY_NOW,
+    /* Predicted time to full capacity when charging in seconds */
+    BATTERY_PROP_TIME_TO_FULL_NOW,
+    /* Number of full discharge/charge cycles */
+    BATTERY_PROP_CYCLE_COUNT,
+} battery_property_type_t;
+
+typedef enum {
+    BATTERY_PROPERTY_FLAGS_NONE = 0,
+    /* Set or get refers to property value that sets the alarm when
+     * property value goes below specified value
+     */
+    BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD      = 0x01,
+    /* Set or get refers to property value that sets the alarm when
+     * property value goes below specified value
+     */
+    BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD    = 0x02,
+    BATTERY_PROPERTY_FLAGS_LOW_ALARM                    = 0x03,
+    /* Set or get refers to property value that sets the alarm when
+     * property value goes above specified value
+     */
+    BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD     = 0x04,
+    /* Set or get refers to property value that clears the alarm when
+     * property value goes below specified value.
+     */
+    BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD   = 0x08,
+    /* Property is not supported by hardware
+     * This is specially important for threshold levels,
+     * battery manager can create software only threshold levels.
+     */
+    BATTERY_PROPERTY_FLAGS_HIGH_ALARM                   = 0x0C,
+    BATTERY_PROPERTY_FLAGS_ALARM_THREASH                = 0x0F,
+    BATTERY_PROPERTY_FLAGS_ALARM                        = 0x10,
+    BATTERY_PROPERTY_FLAGS_DERIVED                      = 0x80,
+    /* Flag only needed for battery_mgr_get_property() function.
+     * When property is requested that is not supported by hardware
+     * it can be synthesized as software only and used for alarms
+     */
+    BATTERY_PROPERTY_FLAGS_CREATE                       = 0x40,
+} battery_property_flags_t;
+
+/**
+ * Battery driver property declaration struct
+ *
+ * Driver provides array of those to declare what kind of properties
+ * are supported.
+ */
+struct battery_driver_property
+{
+    battery_property_type_t   bdp_type;
+    battery_property_flags_t  bdp_flags;
+    const char *              bdp_name;
+};
+
+/**
+ * Battery property
+ * It has type that specifies property type it can also have
+ * BATTERY_PROPERY_NOT_HARDWARE bit set if property was created
+ * by battery manager not a driver.
+ * It can also have threshold bits set if property is one of
+ * the threshold values.
+ */
+struct battery_property {
+    battery_property_type_t   bp_type;
+    battery_property_flags_t  bp_flags;
+    /* Field managed by battery manager */
+    /* Battery property number */
+    uint8_t                   bp_prop_num;
+    /* Battery property number in driver property array */
+    uint8_t                   bp_drv_prop_num;
+    /* Driver number, 1 based index */
+    uint8_t                   bp_drv_num:2;
+    /* Battery number, 0 based index */
+    uint8_t                   bp_bat_num:2;
+    uint8_t                   bp_comp:1;
+    uint8_t                   bp_base:1;
+    /* Value of property is valid */
+    uint8_t                   bp_valid:1;
+    battery_property_value_t  bp_value;
+};
+
+static inline int driver_property(const struct battery_property *prop)
+{
+    return 0 == (prop->bp_flags & BATTERY_PROPERTY_FLAGS_DERIVED);
+}
+
+int battery_prop_get_value(struct battery_property *prop);
+
+int battery_prop_get_value_float(struct battery_property *prop, float *value);
+int battery_prop_get_value_uint8(struct battery_property *prop, uint8_t *val);
+int battery_prop_get_value_int8(struct battery_property *prop, int8_t *val);
+int battery_prop_get_value_uint16(struct battery_property *prop, uint16_t *val);
+int battery_prop_get_value_int16(struct battery_property *prop, int16_t *val);
+int battery_prop_get_value_uint32(struct battery_property *prop, uint32_t *val);
+int battery_prop_get_value_int32(struct battery_property *prop, int32_t *val);
+
+int battery_prop_set_value_float(struct battery_property *prop, float value);
+int battery_prop_set_value_uint8(struct battery_property *prop, uint8_t val);
+int battery_prop_set_value_int8(struct battery_property *prop, int8_t val);
+int battery_prop_set_value_uint16(struct battery_property *prop, uint16_t val);
+int battery_prop_set_value_int16(struct battery_property *prop, int16_t val);
+int battery_prop_set_value_uint32(struct battery_property *prop, uint32_t val);
+int battery_prop_set_value_int32(struct battery_property *prop, int32_t val);
+
+/**
+ * Register a property change listener. This allows a calling application to
+ * receive callbacks when property changes.
+ * Same listener can be used for many properties.
+ *
+ * @param The listener to register
+ * @param The battery property to register a listener on
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_prop_change_subscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop);
+
+/**
+ * Unregister a property change listener.
+ *
+ * @param The listener to unregister
+ * @param The battery property to unregister a listener from
+ *        if prop is NULL, listener is unregistered from all properties
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop);
+
+/**
+ * Register a battery listener. This allows a calling application to
+ * receive callbacks when new data was read from fuel gauge.
+ *
+ * @param The battery property to register a listener on
+ * @param The listener to register
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_prop_poll_subscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop);
+
+/**
+ * Unregister a property read listener.
+ *
+ * @param The listener to unregister
+ * @param The battery property to unregister a listener from
+ *        if prop is NULL, listener is unregistered from all properties
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int battery_prop_poll_unsubscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop);
+
+typedef int (*battery_prop_read_t)(struct battery_prop_listener *listener,
+        const struct battery_property *prop);
+
+typedef int (*battery_prop_changed_t)(struct battery_prop_listener *listener,
+        const struct battery_property *prop);
+
+/**
+ * Listener structure which may be registered to battery properties.
+ * User bpl_prop_read function will be called for every property that
+ * this listener is register for just after data is received.
+ */
+struct battery_prop_listener {
+    /*
+     * Battery data handler function, called when data was read.
+     */
+    battery_prop_read_t bpl_prop_read;
+    /*
+     * Property changed function
+     */
+    battery_prop_changed_t bpl_prop_changed;
+};
+
+/**
+ * }@
+ */
+
+/* End Battery Manager API */
+
+
+/**
+ * @}
+ */
+
+/* End Battery API */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BATTERY_PROP_H__ */

--- a/hw/battery/pkg.yml
+++ b/hw/battery/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/battery
+pkg.description: Battery/Fuel Gauge Controller IC Interface
+pkg.keywords:
+
+pkg.deps:
+    - kernel/os
+
+pkg.req_apis:
+    - console
+
+pkg.init:
+    battery_pkg_init: 501

--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -1,0 +1,765 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+
+#include "os/mynewt.h"
+#include <sys/queue.h>
+#include <battery/battery.h>
+#include <battery/battery_prop.h>
+#include <battery/battery_drv.h>
+
+#define BATTERY_MAX_COUNT 1
+
+#define PROP_MASK_SIZE (((BATTERY_MAX_PROPERTY_COUNT) + 31) / 32)
+
+/*
+ * Structure holds information about listener and what is it listening for.
+ */
+struct listener_data
+{
+    /* The properties to monitor for change */
+    uint32_t ld_prop_change_mask[PROP_MASK_SIZE];
+    /* The properties to monitor for periodic read */
+    uint32_t ld_prop_read_mask[PROP_MASK_SIZE];
+    /* Pointer to listener provided by the application. */
+    struct battery_prop_listener *ld_listener;
+};
+
+struct battery_manager
+{
+    /* The lock for battery object */
+    struct os_mutex bm_lock;
+
+    struct battery *bm_batteries[BATTERY_MAX_COUNT];
+
+    /** Event queue */
+    struct os_eventq *bm_eventq;
+
+    /** Manages poll rates of the batteries */
+    struct os_callout bm_poll_callout;
+
+} battery_manager;
+
+struct os_eventq *
+battery_mgr_evq_get(void)
+{
+    return (battery_manager.bm_eventq);
+}
+
+static void
+battery_mgr_evq_set(struct os_eventq *evq)
+{
+    assert(evq != NULL);
+    battery_manager.bm_eventq = evq;
+}
+
+static void battery_mgr_poll_battery(struct battery *battery);
+
+static void
+battery_poll_event_cb(struct os_event *ev)
+{
+    int i;
+    os_time_t next_poll = 0xFFFFFFFF;
+    os_time_t now = os_time_get();
+    struct battery *bat;
+    int ticks;
+
+    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+        bat = battery_manager.bm_batteries[i];
+        if (bat) {
+            if (now > bat->b_next_run) {
+                bat->b_last_read_time = now;
+                battery_mgr_poll_battery(battery_manager.bm_batteries[i]);
+                bat->b_next_run = now + os_time_ms_to_ticks32(bat->b_poll_rate);
+            }
+            if (bat->b_next_run < next_poll) {
+                next_poll = bat->b_next_run;
+            }
+        }
+    }
+
+    if (next_poll != 0xFFFFFFFF) {
+        ticks = next_poll - os_time_get();
+        if (ticks < 0) {
+            ticks = 1;
+        }
+        os_callout_reset(&battery_manager.bm_poll_callout, ticks);
+    }
+}
+
+void
+battery_mgr_process_event(struct os_event *event)
+{
+    os_eventq_put(battery_manager.bm_eventq, event);
+}
+
+static void
+battery_mgr_init(void)
+{
+#ifdef MYNEWT_VAL_BATTERY_MGR_EVQ
+    battery_mgr_evq_set(MYNEWT_VAL(BATTERY_MGR_EVQ));
+#else
+    battery_mgr_evq_set(os_eventq_dflt_get());
+#endif
+
+    /**
+     * Initialize battery manager polling callout.
+     */
+    os_callout_init(&battery_manager.bm_poll_callout,
+            battery_mgr_evq_get(), battery_poll_event_cb,
+            NULL);
+
+    os_mutex_init(&battery_manager.bm_lock);
+}
+
+/* =================================================================
+ * ====================== PKG ======================================
+ * =================================================================
+ */
+
+void
+battery_pkg_init(void)
+{
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    battery_mgr_init();
+
+#if MYNEWT_VAL(BATTERY_SHELL)
+    battery_shell_register();
+#endif
+}
+
+int
+battery_mgr_register(struct battery *battery)
+{
+    int i;
+
+    os_mutex_pend(&battery_manager.bm_lock, OS_WAIT_FOREVER);
+
+    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+        if (battery_manager.bm_batteries[i] == NULL) {
+            battery_manager.bm_batteries[i] = battery;
+        }
+    }
+    os_mutex_release(&battery_manager.bm_lock);
+
+    return 0;
+}
+
+int
+battery_mgr_get_battery_count(void)
+{
+    int i;
+
+    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+        if (battery_manager.bm_batteries[i] == NULL) {
+            break;
+        }
+    }
+
+    return i;
+}
+
+struct os_dev *
+battery_get_battery(int bat_num)
+{
+    assert(bat_num < BATTERY_MAX_COUNT);
+    assert(battery_manager.bm_batteries[bat_num]);
+
+    return &battery_manager.bm_batteries[bat_num]->b_dev;
+}
+
+static int
+battery_get_num(struct battery *battery)
+{
+    int i;
+
+    /* For one battery, there is no need to specify battery at all */
+    if (battery == NULL) {
+        return 0;
+    }
+    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+        if (battery_manager.bm_batteries[i] == battery) {
+            return i;
+        }
+    }
+    assert(0);
+    return 0;
+}
+
+struct battery_driver *
+battery_get_driver(struct os_dev *battery,
+        const char *dev_name)
+{
+    int i;
+    assert(battery);
+    struct battery *bat = (struct battery *)battery;
+    for (i = 0; i < BATTERY_DRIVERS_MAX && bat->b_drivers[i]; ++i) {
+        if (strcmp(bat->b_drivers[i]->dev.od_name, dev_name) == 0) {
+            return bat->b_drivers[i];
+        }
+    }
+    /* No device found */
+    assert(0);
+    return NULL;
+}
+
+static void
+set_bit(uint32_t *mask, int bit)
+{
+    mask[bit / (sizeof(*mask) * 8)] |=
+        1 << (bit & ((sizeof(*mask) * 8) - 1));
+}
+
+static void
+clear_bit(uint32_t *mask, int bit)
+{
+    mask[bit / (sizeof(*mask) * 8)] &=
+        ~(1 << (bit & ((sizeof(*mask) * 8) - 1)));
+}
+
+static struct battery_property *
+find_driver_property(struct battery *bat, struct battery_driver *driver,
+        battery_property_type_t type, battery_property_flags_t flags)
+{
+    struct battery_property *prop = bat->b_properties + driver->bd_first_property;
+    int i;
+    assert(driver);
+
+    for (i = 0; driver->bd_property_count; ++i, ++prop) {
+        if (prop->bp_type == type && prop->bp_flags == flags)
+            return prop;
+    }
+    return NULL;
+}
+
+static struct battery_property *
+find_hardware_property(struct battery *battery, struct battery_driver *driver,
+        battery_property_type_t type, battery_property_flags_t flags)
+{
+    struct battery_property *res = NULL;
+    int i;
+
+    /* Search driver properties first */
+    if (driver) {
+        res = find_driver_property(battery, driver, type, flags);
+    } else {
+        for (i = 0; res == NULL && i < BATTERY_DRIVERS_MAX; ++i) {
+            res = find_driver_property(battery, battery->b_drivers[i],
+                                       type, flags);
+        }
+    }
+    return res;
+}
+
+struct battery_property *
+battery_find_property(struct os_dev *battery,
+        battery_property_type_t type, battery_property_flags_t flags,
+        const char *dev_name)
+{
+    struct battery_property *res = NULL;
+    struct battery_property *prop;
+    struct battery *bat = (struct battery *)battery;
+    int i;
+    struct battery_driver *driver = NULL;
+
+    if (dev_name) {
+        driver = battery_get_driver(battery, dev_name);
+        assert(driver);
+    }
+    /* Search hardware properties first */
+    res = find_hardware_property(bat, driver, type, flags);
+    if (!res) {
+        /* Search battery manager created properties */
+        for (i = 0; i < bat->b_all_property_count; ++i) {
+            prop =  &bat->b_properties[i];
+            if (prop->bp_type == type &&
+                prop->bp_flags == flags &&
+                (driver == NULL ||
+                 bat->b_drivers[prop->bp_drv_num] == driver)) {
+                res = prop;
+                break;
+            }
+        }
+    }
+    if (!res) {
+        /* Create software threshold */
+        if ((flags & BATTERY_PROPERTY_FLAGS_CREATE) != 0 &&
+            (flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
+            /* Find base property that threshold is for */
+            prop = find_hardware_property(bat, driver, type,
+                    BATTERY_PROPERTY_FLAGS_NONE);
+            /* Base property found, create derived one */
+            if (prop) {
+                struct battery_property *p =
+                    calloc(1, sizeof(struct battery_property));
+                if (prop->bp_prop_num == 0) {
+                    prop->bp_prop_num = ++bat->b_all_property_count;
+                    assert(bat->b_all_property_count <= BATTERY_MAX_PROPERTY_COUNT);
+                }
+                /* Base property is marked as base for others
+                 */
+                prop->bp_base = 1;
+                p->bp_type = type;
+                p->bp_flags = flags;
+                p->bp_bat_num = prop->bp_bat_num;
+                p->bp_drv_num = prop->bp_drv_num;
+                p->bp_prop_num = ++bat->b_all_property_count;
+                assert(bat->b_all_property_count <= BATTERY_MAX_PROPERTY_COUNT);
+                res = p;
+            }
+        }
+    }
+    return res;
+}
+
+int
+battery_get_property_count(struct os_dev *battery,
+        struct battery_driver *driver)
+{
+    struct battery *bat = (struct battery *)battery;
+    int i;
+
+    if (driver == NULL) {
+        return bat->b_all_property_count;
+    } else {
+        for (i = 0; i < BATTERY_DRIVERS_MAX && bat->b_drivers[i]; ++i) {
+            if (bat->b_drivers[i] == driver) {
+                return bat->b_drivers[i]->bd_property_count;
+            }
+        }
+    }
+
+    return 0;
+}
+
+struct battery_property *
+battery_enum_property(struct os_dev *battery, struct battery_driver *driver,
+        uint8_t prop_num)
+{
+    struct battery *bat = (struct battery *)battery;
+    struct battery_property *prop = NULL;
+    int i;
+
+    if (driver == NULL) {
+        if (prop_num < bat->b_all_property_count) {
+            prop = &bat->b_properties[prop_num];
+        }
+    } else {
+        for (i = 0; i < BATTERY_DRIVERS_MAX && bat->b_drivers[i]; ++i) {
+            if (bat->b_drivers[i] == driver) {
+                if (prop_num < driver->bd_property_count) {
+                    prop = &bat->b_properties[prop_num + driver->bd_first_property];
+                }
+            }
+        }
+    }
+
+    return prop;
+}
+
+char *
+battery_prop_get_name(const struct battery_property *prop, char *buf,
+        size_t buf_size)
+{
+    struct battery *bat = battery_manager.bm_batteries[prop->bp_bat_num];
+    struct battery_driver *driver = bat->b_drivers[prop->bp_drv_num];
+    const struct battery_driver_property *driver_prop =
+            &driver->bd_driver_properties[prop->bp_prop_num - driver->bd_first_property];
+
+    strncpy(buf, driver_prop->bdp_name, buf_size);
+
+    return buf;
+}
+
+struct battery_property *
+battery_find_property_by_name(struct os_dev *battery, const char *name)
+{
+    struct battery *bat = (struct battery *)battery;
+    char buf[20];
+    int i;
+
+    for (i = 0; i < bat->b_all_property_count; ++i) {
+        battery_prop_get_name(&bat->b_properties[i], buf, 20);
+        if (strcmp(buf, name) == 0) {
+            return &bat->b_properties[i];
+        }
+    }
+    return NULL;
+}
+
+static void
+battery_mgr_poll_battery_driver(struct battery *bat,
+        struct battery_driver *drv, uint32_t changed[], uint32_t queried[])
+{
+    int i;
+    battery_property_value_t old_val;
+    struct battery_property *prop = &bat->b_properties[drv->bd_first_property];
+
+    /* Read requested properties */
+    for (i = 0; i < drv->bd_property_count; ++i, ++prop) {
+        if (driver_property(prop)) {
+            old_val = prop->bp_value;
+            if (drv->bd_funcs->bdf_property_get(drv, prop, 100)) {
+                prop->bp_valid = 0;
+            } else {
+                prop->bp_valid = 1;
+                if (memcmp(&old_val, &prop->bp_value, sizeof(old_val))) {
+                    set_bit(changed, prop->bp_prop_num);
+                }
+                set_bit(queried, prop->bp_prop_num);
+            }
+        }
+    }
+}
+
+static void
+battery_mgr_poll_battery(struct battery *battery)
+{
+    uint32_t changed[PROP_MASK_SIZE] = {0};
+    uint32_t queried[PROP_MASK_SIZE] = {0};
+    uint32_t masked;
+    int first_one;
+    struct listener_data *ld;
+    struct battery_driver *driver;
+    int i;
+    int j;
+
+    /* Poll battery drivers */
+    for(i = 0; i < BATTERY_DRIVERS_MAX; ++i) {
+        driver = battery->b_drivers[i];
+        if (driver) {
+            battery_mgr_poll_battery_driver(battery, driver, changed, queried);
+        }
+    }
+
+    /* Notify listeners about property changes */
+    for (i = 0; i < battery->b_listener_count; ++i) {
+        ld = &battery->b_listeners[i];
+        for (j = 0; j < PROP_MASK_SIZE; ++j) {
+            masked = changed[j] & ld->ld_prop_change_mask[j];
+            while (masked) {
+                /* Find first set bit */
+                first_one = __builtin_ffs(masked) - 1;
+                /* Clear it for next loop */
+                masked ^= (1 << first_one);
+                driver = battery->b_drivers[i];
+                /* Notify listener */
+                ld->ld_listener->bpl_prop_changed(ld->ld_listener,
+                                                  battery->b_properties +
+                                                  first_one + j * 32);
+            }
+        }
+    }
+
+    /* Notify listeners about periodic reads */
+    for (i = 0; i < battery->b_listener_count; ++i) {
+        ld = &battery->b_listeners[i];
+        for (j = 0; j < PROP_MASK_SIZE; ++j) {
+            masked = queried[j] & ld->ld_prop_read_mask[j];
+            while (masked) {
+                /* Find first set bit */
+                first_one = __builtin_ffs(masked) - 1;
+                /* Clear it for next loop */
+                masked ^= (1 << first_one);
+                driver = battery->b_drivers[i];
+                /* Notify listener */
+                ld->ld_listener->bpl_prop_read(ld->ld_listener,
+                                          battery->b_properties +
+                                          first_one + j * 32);
+            }
+        }
+    }
+}
+
+int
+battery_set_poll_rate_ms(struct os_dev *battery, uint32_t poll_rate)
+{
+    struct battery *bat = (struct battery *)battery;
+    bat->b_poll_rate = poll_rate;
+
+    if (bat->b_last_read_time == 0 ||
+        os_time_ms_to_ticks32(bat->b_last_read_time + poll_rate) < os_time_get()) {
+        os_callout_reset(&battery_manager.bm_poll_callout, 0);
+    } else {
+        os_callout_reset(&battery_manager.bm_poll_callout,
+            os_time_ms_to_ticks32(bat->b_last_read_time + poll_rate) - os_time_get());
+    }
+
+    return 0;
+}
+
+int
+battery_add_driver(struct os_dev *battery, struct battery_driver *driver)
+{
+    struct battery *bat = (struct battery *)battery;
+    const struct battery_driver_property *drv_prop;
+    struct battery_property *prop;
+    int bat_num;
+    int drv_num;
+    int i;
+    int j;
+
+    assert(battery);
+    assert(driver);
+
+    bat_num = battery_get_num(bat);
+    /* Find first slot */
+    for (i = 0; i < BATTERY_DRIVERS_MAX; ++i) {
+        /* Just make sure that driver is not added twice */
+        assert(bat->b_drivers[i] != driver);
+        if (bat->b_drivers[i] == NULL) {
+            break;
+        }
+    }
+    assert(i < BATTERY_DRIVERS_MAX);
+    drv_num = i;
+    bat->b_drivers[i] = driver;
+
+    drv_prop = driver->bd_driver_properties;
+    for (i = 0; drv_prop->bdp_type; ++i) {
+        ++drv_prop;
+    }
+    driver->bd_property_count = i;
+    bat->b_properties = realloc(bat->b_properties,
+                                ((i + bat->b_all_property_count) *
+                                 sizeof(struct battery_property)));
+
+    j = bat->b_all_property_count;
+    driver->bd_first_property = (uint8_t)j;
+    /* Initialize driver properties with battery manager data */
+    for (i = 0; i < driver->bd_property_count; ++i, ++j) {
+        prop = bat->b_properties + j;
+        prop->bp_type = driver->bd_driver_properties[i].bdp_type;
+        prop->bp_flags = driver->bd_driver_properties[i].bdp_flags;
+        prop->bp_valid = 0;
+        prop->bp_value.bpv_i32 = 0;
+        prop->bp_drv_prop_num = (uint8_t)i;
+        prop->bp_drv_num = drv_num;
+        prop->bp_bat_num = bat_num;
+        prop->bp_prop_num = j;
+    }
+    bat->b_all_property_count = j;
+
+    return 0;
+}
+
+static int
+get_listener_index(struct battery *battery,
+        struct battery_prop_listener *listener)
+{
+    int i;
+
+    assert(listener);
+    assert(battery);
+
+    /* Find existing listener */
+    for (i = 0; i < battery->b_listener_count; ++i) {
+        if (battery->b_listeners[i].ld_listener == listener) {
+            break;
+        }
+    }
+    /* If listener was not yet added, create space for it and fill
+     * masks with zeros so they will be filled when listener is actually
+     * added to properties.
+     */
+    if (i >= battery->b_listener_count) {
+        i = battery->b_listener_count++;
+        battery->b_listeners = realloc(battery->b_listeners,
+                sizeof(struct listener_data) * battery->b_listener_count);
+        if (battery->b_listeners == NULL) {
+            return -1;
+        }
+        battery->b_listeners[i].ld_listener = listener;
+        memset(battery->b_listeners[i].ld_prop_change_mask, 0,
+               sizeof(battery->b_listeners[i].ld_prop_change_mask));
+        memset(battery->b_listeners[i].ld_prop_read_mask, 0,
+               sizeof(battery->b_listeners[i].ld_prop_read_mask));
+    }
+
+    return i;
+}
+
+int
+battery_prop_change_subscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop)
+{
+    struct battery *battery;
+    int listener_index;
+
+    assert(listener);
+    assert(prop);
+
+    battery = (struct battery *)battery_get_battery(prop->bp_bat_num);
+    listener_index = get_listener_index(battery, listener);
+
+    set_bit(battery->b_listeners[listener_index].ld_prop_change_mask,
+            prop->bp_prop_num);
+
+    return 0;
+}
+
+int
+battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop)
+{
+    struct battery *battery;
+    int i;
+    int j;
+
+    if (prop) {
+        /* Single propety supplied */
+        battery = (struct battery *)battery_get_battery(prop->bp_bat_num);
+        for (i = 0; i < battery->b_listener_count; ++i) {
+            if (listener == battery->b_listeners[i].ld_listener) {
+                break;
+            }
+        }
+        if (i < battery->b_listener_count) {
+            clear_bit(battery->b_listeners[i].ld_prop_change_mask,
+                prop->bp_prop_num);
+            return 0;
+        } else {
+            return -1;
+        }
+    } else {
+        /* No property supplied, remove listener from all subscriptions */
+        for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+            battery =  battery_manager.bm_batteries[i];
+            for (j = 0; j < battery->b_listener_count; ++i) {
+                if (battery->b_listeners[j].ld_listener == listener) {
+                    /* Reduce number of listeners */
+                    battery->b_listener_count--;
+                    if (j < battery->b_listener_count) {
+                        /* It was not last listener,
+                         * move last to emptied space */
+                        battery->b_listeners[j] =
+                                battery->b_listeners[battery->b_listener_count];
+                    }
+                    battery->b_listeners =
+                        realloc(battery->b_listeners,
+                                sizeof(struct listener_data) *
+                                battery->b_listener_count);
+                    break;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+int
+battery_prop_poll_subscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop)
+{
+    struct battery *battery;
+    int listener_index;
+
+    assert(listener);
+    assert(prop);
+
+    battery = (struct battery *)battery_get_battery(prop->bp_bat_num);
+    listener_index = get_listener_index(battery, listener);
+
+    set_bit(battery->b_listeners[listener_index].ld_prop_read_mask,
+            prop->bp_prop_num);
+
+    return 0;
+}
+
+int
+battery_prop_poll_unsubscribe(struct battery_prop_listener *listener,
+        struct battery_property *prop)
+{
+    struct battery *battery;
+    int i;
+    int j;
+
+    if (prop) {
+        battery = (struct battery *)battery_get_battery(prop->bp_bat_num);
+        for (i = 0; i < battery->b_listener_count; ++i) {
+            if (listener == battery->b_listeners[i].ld_listener) {
+                break;
+            }
+        }
+        if (i < battery->b_listener_count) {
+            clear_bit(battery->b_listeners[i].ld_prop_read_mask,
+                prop->bp_prop_num);
+            return 0;
+        } else {
+            return -1;
+        }
+    } else {
+        for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+            battery =  battery_manager.bm_batteries[i];
+            for (j = 0; j < battery->b_listener_count; ++i) {
+                if (battery->b_listeners[j].ld_listener == listener) {
+                    battery->b_listener_count--;
+                    if (j < battery->b_listener_count) {
+                        battery->b_listeners[j] =
+                                battery->b_listeners[battery->b_listener_count];
+                    }
+                    battery->b_listeners =
+                        realloc(battery->b_listeners,
+                                sizeof(struct listener_data) *
+                                battery->b_listener_count);
+                    break;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int
+battery_open(struct os_dev *dev, uint32_t timeout, void *arg)
+{
+    return 0;
+}
+
+static int
+battery_close(struct os_dev *dev)
+{
+    return 0;
+}
+
+int
+battery_init(struct os_dev *dev, void *arg)
+{
+    int i;
+    struct battery *bat = (struct battery *)dev;
+
+    OS_DEV_SETHANDLERS(dev, battery_open, battery_close);
+
+    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
+        if (battery_manager.bm_batteries[i] == NULL) {
+            break;
+        }
+    }
+    assert(i < BATTERY_MAX_COUNT);
+    battery_manager.bm_batteries[i] = bat;
+
+    memset(bat->b_drivers, 0, sizeof(bat->b_drivers));
+
+    return 0;
+}

--- a/hw/battery/src/battery_prop.c
+++ b/hw/battery/src/battery_prop.c
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+
+#include "os/mynewt.h"
+#include <sys/queue.h>
+#include <battery/battery_prop.h>
+#include <battery/battery_drv.h>
+#include <battery/battery.h>
+
+int battery_prop_get_value(struct battery_property *prop)
+{
+    struct battery_driver *drv;
+    struct battery *bat = (struct battery *)battery_get_battery(prop->bp_bat_num);
+    int rc = -1;
+
+    if (driver_property(prop)) {
+        drv = bat->b_drivers[prop->bp_drv_num];
+        rc = drv->bd_funcs->bdf_property_get(drv, prop, OS_WAIT_FOREVER);
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_float(struct battery_property *prop, float *value) {
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_flt;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_uint8(struct battery_property *prop, uint8_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_u8;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_int8(struct battery_property *prop, int8_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_i8;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_uint16(struct battery_property *prop, uint16_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_u16;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_int16(struct battery_property *prop, int16_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_i16;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_uint32(struct battery_property *prop, uint32_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_u32;
+    }
+    return rc;
+}
+
+int
+battery_prop_get_value_int32(struct battery_property *prop, int32_t *value)
+{
+    int rc = battery_prop_get_value(prop);
+    if (rc == 0 && prop->bp_valid) {
+        *value = prop->bp_value.bpv_i32;
+    }
+    return rc;
+}
+
+static struct battery_driver *
+get_property_driver(struct battery_property *prop)
+{
+    struct battery *bat;
+    bat = (struct battery *)battery_get_battery(prop->bp_bat_num);
+    return bat->b_drivers[prop->bp_drv_num];
+}
+
+int
+battery_prop_set_value(struct battery_property *prop,
+        const battery_property_value_t *value) {
+    struct battery_driver *drv = get_property_driver(prop);
+    int rc = 0;
+    /* Driver provided property */
+    if (drv) {
+        prop->bp_value = *value;
+        rc = drv->bd_funcs->bdf_property_set(drv, prop);
+    } else {
+        prop->bp_value = *value;
+        prop->bp_valid = 1;
+    }
+    if (prop->bp_base) {
+        // TODO: Search for complex properties
+    }
+    return rc;
+}
+
+int
+battery_prop_set_value_float(struct battery_property *prop, float value) {
+    battery_property_value_t v;
+    v.bpv_flt = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_uint8(struct battery_property *prop, uint8_t value)
+{
+    battery_property_value_t v;
+    v.bpv_u8 = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_int8(struct battery_property *prop, int8_t value)
+{
+    battery_property_value_t v;
+    v.bpv_i8 = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_uint16(struct battery_property *prop, uint16_t value)
+{
+    battery_property_value_t v;
+    v.bpv_u16 = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_int16(struct battery_property *prop, int16_t value)
+{
+    battery_property_value_t v;
+    v.bpv_i16 = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_uint32(struct battery_property *prop, uint32_t value)
+{
+    battery_property_value_t v;
+    v.bpv_u32 = value;
+    return battery_prop_set_value(prop, &v);
+}
+
+int
+battery_prop_set_value_int32(struct battery_property *prop, int32_t value)
+{
+    battery_property_value_t v;
+    v.bpv_i32 = value;
+    return battery_prop_set_value(prop, &v);
+}

--- a/hw/battery/syscfg.yml
+++ b/hw/battery/syscfg.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: hw/battery
+
+syscfg.defs:
+    BATTERY_CLI:
+        description: 'Whether or not to enable the battery shell support'
+        value: 1
+
+    BATTERY_MGR_EVQ:
+        description: >
+            Specify the eventq to be used by the battery manager
+        value:
+
+    BATTERY_MAX_PROPERTY_COUNT:
+        description: >
+            Maximum number of supported battery properties. Number should
+            be a minimum multiple of 32 that is grater of supported properties.
+        value: 32

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -21,6 +21,7 @@
 #define __BQ27Z561_H__
 
 #include "os/mynewt.h"
+#include "battery/battery_drv.h"
 
 #ifdef __cplusplus
 #extern "C" {
@@ -116,6 +117,14 @@
 #define BQ27Z561_CMD_OUT_CC_ADC_CAL         (0xF081)
 #define BQ27Z561_CMD_OUT_SHORT_CC_ADC_CAL   (0xF082)
 
+#define BQ27Z561_BATTERY_STATUS_TCA         (1 << 14)
+#define BQ27Z561_BATTERY_STATUS_TDA         (1 << 11)
+#define BQ27Z561_BATTERY_STATUS_RCA         (1 << 9)
+#define BQ27Z561_BATTERY_STATUS_INIT        (1 << 7)
+#define BQ27Z561_BATTERY_STATUS_DSG         (1 << 6)
+#define BQ27Z561_BATTERY_STATUS_FC          (1 << 5)
+#define BQ27Z561_BATTERY_STATUS_FD          (1 << 4)
+
 /* Errors returned from some commands */
 typedef enum
 {
@@ -144,11 +153,17 @@ struct bq27z561_itf
     uint8_t itf_addr;
 };
 
+struct bq27z561_init_arg
+{
+    struct bq27z561_itf itf;
+    struct os_dev *battery;
+};
+
 /* BQ27Z561 device */
 struct bq27z561
 {
     /* Underlying OS device */
-    struct os_dev dev;
+    struct battery_driver dev;
 
     /* Configuration values */
     struct bq27z561_cfg bq27_cfg;

--- a/hw/drivers/bq27z561/pkg.yml
+++ b/hw/drivers/bq27z561/pkg.yml
@@ -27,6 +27,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/battery"
 
 pkg.req_apis:
     - stats
@@ -34,3 +35,6 @@ pkg.req_apis:
 
 pkg.deps.BQ27Z561_CLI:
     - "@apache-mynewt-core/util/parse"
+
+pkg.init:
+    bq27z561_pkg_init: 500


### PR DESCRIPTION
Battery management provides abstraction layer so an application
can get information about battery without hardware specific (fuel gauge)
code.

The battery is associated with set of properties (provided by hardware
driver or battery manager itself). Properties represent physical
values measured by fuel gauges or ADC converter that application may
be interested in.
The application specify how frequently battery information should be read
and can subscribe to some subset of data that is interesting for the application.
Typically application will subscribe to voltage, temperature or current readings.

On the lower layer battery API specifies simple interface that fuel gauge need to
provide.

The battery information can be provided by several drivers (fuel gauge and ADC).

This pull request also extends bq27z561 driver to conform to battery API
It adds battery ADC driver that adds additional property to battery.
Battery shell is also added