### PR TITLE
Export few key variables for direct use.

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -247,7 +247,7 @@ int conf_set_value(char *name, char *val_str);
  * @param name Name/key of the configuration item.
  * @param val_str Value of the configuration item.
  *
- * @return 0 on success, non-zero on failure.
+ * @return pointer to value on success, NULL on failure.
  */
 char *conf_get_value(char *name, char *buf, int buf_len);
 

--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -30,6 +30,8 @@ extern "C" {
 #define ID_SERIAL_MAX_LEN       64
 extern char id_serial[];
 extern char id_mfghash[];
+extern const char *id_bsp_str;
+extern const char *id_app_str;
 
 /*
  * Initialize manufacturing info storage/reporting.

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -39,11 +39,11 @@ static int id_conf_export(void (*export_func)(char *name, char *val),
 #define STAMP_STR1(str) #str
 
 #ifdef BSP_NAME
-static const char *bsp_str = STAMP_STR(BSP_NAME);
-static const char *app_str = STAMP_STR(APP_NAME);
+const char *id_bsp_str = STAMP_STR(BSP_NAME);
+const char *id_app_str = STAMP_STR(APP_NAME);
 #else
-static const char *bsp_str = "";
-static const char *app_str = "";
+const char *id_bsp_str = "";
+const char *id_app_str = "";
 #endif
 
 char id_serial[ID_SERIAL_MAX_LEN];
@@ -71,9 +71,9 @@ id_conf_get(int argc, char **argv, char *val, int val_len_max)
                 return conf_str_from_bytes(src_buf, len, val, val_len_max);
             }
         } else if (!strcmp(argv[0], "bsp")) {
-            return (char *)bsp_str;
+            return (char *)id_bsp_str;
         } else if (!strcmp(argv[0], "app")) {
-            return (char *)app_str;
+            return (char *)id_app_str;
         } else if (!strcmp(argv[0], "serial")) {
             return id_serial;
         } else if (!strcmp(argv[0], "mfghash")) {
@@ -108,8 +108,8 @@ id_conf_export(void (*export_func)(char *name, char *val),
             conf_str_from_bytes(src_buf, len, str, sizeof(str));
         }
         export_func("id/hwid", str);
-        export_func("id/bsp", (char *)bsp_str);
-        export_func("id/app", (char *)app_str);
+        export_func("id/bsp", (char *)id_bsp_str);
+        export_func("id/app", (char *)id_app_str);
         export_func("id/mfghash", (char *)id_mfghash);
     }
     export_func("id/serial", id_serial);

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -37,6 +37,8 @@ int reboot_init_handler(int log_store_type, uint8_t entries);
 int log_reboot(enum hal_reset_reason);
 void reboot_start(enum hal_reset_reason reason);
 
+extern uint16_t reboot_cnt;
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -36,7 +36,7 @@
 
 static struct log_handler *reboot_log_handler;
 static struct log reboot_log;
-static uint16_t reboot_cnt;
+uint16_t reboot_cnt;
 static uint16_t soft_reboot;
 static char reboot_cnt_str[12];
 static char soft_reboot_str[12];


### PR DESCRIPTION
These particular items would be available through conf_get_value() interface, but access via direct symbol would be easier.