### PR TITLE
btshell: Fix scan command in legacy mode

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1185,6 +1185,8 @@ cmd_scan(int argc, char **argv)
             console_printf("error scanning; rc=%d\n", rc);
             return rc;
         }
+
+        return 0;
     }
 
     /* Copy above parameters to uncoded params */


### PR DESCRIPTION
When starting legacy scan code was also trying to start extended scan
with garbage parameters.