### PR TITLE
Fix build when charge_control is enabled

### DIFF
--- a/hw/charge-control/include/charge-control/charge_control.h
+++ b/hw/charge-control/include/charge-control/charge_control.h
@@ -379,6 +379,7 @@ struct charge_control {
 /* =================================================================
  * ====================== CHARGE CONTROL ===========================
  * =================================================================
+ */
 
 /**
  * Initialize charge control structure data and mutex and associate it with an

--- a/hw/charge-control/syscfg.yml
+++ b/hw/charge-control/syscfg.yml
@@ -21,7 +21,7 @@
 syscfg.defs:
     CHARGE_CONTROL_CLI:
         description: 'Whether or not to enable the charge control shell support'
-        value: 1
+        value: 0
 
     CHARGE_CONTROL_MGR_EVQ:
         description: >


### PR DESCRIPTION
There was missing end of comment that is now fixed.
By default function is called that is not defined in any place.
It may be that someone forgot to check in shell support files,
or it was planned and not finished.