### PR TITLE
sys/config: Automatically restore on startup

### DIFF
--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -331,8 +331,6 @@ main(void)
     phy_init();
 #endif
 
-    conf_load();
-
     /* If this app is acting as the loader in a split image setup, jump into
      * the second stage application instead of starting the OS.
      */

--- a/apps/blesplit/src/main.c
+++ b/apps/blesplit/src/main.c
@@ -309,8 +309,6 @@ main(void)
     rc = ble_svc_gap_device_name_set("nimble-blesplit");
     assert(rc == 0);
 
-    conf_load();
-
     /*
      * As the last thing, process events from default event queue.
      */

--- a/apps/bsnprph/src/main.c
+++ b/apps/bsnprph/src/main.c
@@ -351,8 +351,6 @@ main(void)
     rc = ble_svc_gap_device_name_set(MYNEWT_VAL(BSNPRPH_BLE_NAME));
     assert(rc == 0);
 
-    conf_load();
-
     /* If this app is acting as the loader in a split image setup, jump into
      * the second stage application instead of starting the OS.
      */

--- a/apps/iptest/src/main.c
+++ b/apps/iptest/src/main.c
@@ -424,8 +424,6 @@ main(int argc, char **argv)
     cbmem_init(&cbmem, cbmem_buf, MAX_CBMEM_BUF);
     log_register("log", &my_log, &log_cbmem_handler, &cbmem, LOG_SYSLEVEL);
 
-    conf_load();
-
     shell_cmd_register(&net_test_cmd);
 
     /*

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -511,9 +511,6 @@ main(int argc, char **argv)
     /* Initialize BLE and OIC logs */
     ble_oic_log_init();
 
-    /* Load config */
-    conf_load();
-
     /* Initialize tasks */
     init_tasks();
 

--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -260,8 +260,6 @@ main(int argc, char **argv)
 
     stats_register("gpio_toggle", STATS_HDR(g_stats_gpio_toggle));
 
-    conf_load();
-
     reboot_start(hal_reset_cause());
 
     init_tasks();

--- a/apps/slinky_oic/src/main.c
+++ b/apps/slinky_oic/src/main.c
@@ -277,8 +277,6 @@ main(int argc, char **argv)
 
     stats_register("gpio_toggle", STATS_HDR(g_stats_gpio_toggle));
 
-    conf_load();
-
     reboot_start(hal_reset_cause());
 
 #if MYNEWT_VAL(SPLIT_LOADER)

--- a/apps/splitty/src/main.c
+++ b/apps/splitty/src/main.c
@@ -193,8 +193,6 @@ main(int argc, char **argv)
 
     stats_register("gpio_toggle", STATS_HDR(g_stats_gpio_toggle));
 
-    conf_load();
-
     reboot_start(hal_reset_cause());
 
     init_tasks();

--- a/apps/testbench/src/testbench.c
+++ b/apps/testbench/src/testbench.c
@@ -399,8 +399,6 @@ main(int argc, char **argv)
     oc_ble_coap_gatt_srv_init();
 #endif
 
-    conf_load();
-
     reboot_start(hal_reset_cause());
 
     /*

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -28,8 +28,6 @@
 
 struct conf_handler_head conf_handlers;
 
-static uint8_t conf_cmd_inited;
-
 static os_event_fn conf_ev_fn_load;
 
 /* OS event - causes persisted config values to be loaded at startup. */
@@ -44,10 +42,6 @@ conf_init(void)
 
     SLIST_INIT(&conf_handlers);
     conf_store_init();
-
-    if (conf_cmd_inited) {
-        return;
-    }
 
     (void)rc;
 
@@ -65,8 +59,6 @@ conf_init(void)
      * storage first.
      */
     os_eventq_put(os_eventq_dflt_get(), &conf_ev_load);
-
-    conf_cmd_inited = 1;
 }
 
 int


### PR DESCRIPTION
Before PR: the application needed to manually restore the persisted configuration via a call to `conf_load()`, typically from `main()`.

After PR: `conf_load()` gets called automatically at startup.  It doesn't get called directly from `sysinit()`, as the underlying storage hasn't been configured at that point.  Instead, values are loaded by an event which config init function enqueues to the default event queue.  When `main()` has completed its runtime configuration, including that of the sys/config storage, it processes the default eventq, at which point `conf_load()` gets called.

There is one danger here: some packages may try to use a configuration setting before `conf_load()` has been called.  However, this is not a new issue; high priority tasks, created by `sysinit()`, would already preempt `main()` before `conf_load()` could be called.  To address this problem, I believe we need a separate fix.
