### PR TITLE
blemesh: Remove bt_mesh_register_gatt from app code

### DIFF
--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -427,7 +427,6 @@ main(int argc, char **argv)
 
     hal_gpio_init_out(LED_2, 0);
 
-    bt_mesh_register_gatt();
     health_pub_init();
 
     while (1) {

--- a/apps/blemesh_shell/src/main.c
+++ b/apps/blemesh_shell/src/main.c
@@ -107,8 +107,6 @@ main(void)
 
     hal_gpio_init_out(LED_2, 0);
 
-    bt_mesh_register_gatt();
-
     while (1) {
         os_eventq_run(os_eventq_dflt_get());
     }


### PR DESCRIPTION
Since it is possible to have mesh along with regular BLE, lets allow to
make it use in btshell.