### PR TITLE
net/lora: Add downlink counter to rx debug log

### DIFF
--- a/net/lora/node/src/lora_cli.c
+++ b/net/lora/node/src/lora_cli.c
@@ -646,8 +646,9 @@ lora_cli_log_cmd(int argc, char **argv)
                            g_lnd_log[i].lnd_p32);
             break;
         case LORA_NODE_LOG_RX_PORT:
-            console_printf("RX_PORT port=%u len=%u",
-                           g_lnd_log[i].lnd_p8, g_lnd_log[i].lnd_p16);
+            console_printf("RX_PORT port=%u len=%u dwnlink_cntr=%lu",
+                           g_lnd_log[i].lnd_p8, g_lnd_log[i].lnd_p16,
+                           g_lnd_log[i].lnd_p32);
             break;
         case LORA_NODE_LOG_RX_WIN2:
             console_printf("RX_WIN2 rxslot=%u cont=%u freq=%lu",

--- a/net/lora/node/src/mac/LoRaMac.c
+++ b/net/lora/node/src/mac/LoRaMac.c
@@ -1130,7 +1130,8 @@ lora_mac_process_radio_rx(struct os_event *ev)
 
                 rxi->port = port;
 
-                lora_node_log(LORA_NODE_LOG_RX_PORT, port, frameLen, 0);
+                lora_node_log(LORA_NODE_LOG_RX_PORT, port, frameLen,
+                              downLinkCounter);
 
                 /* If port is 0 it means frame has MAC commands in payload */
                 if (port == 0) {


### PR DESCRIPTION
Simple change to show the downlink counter when we receive a frame with an application port in it.