### PR TITLE
app/btshell: Increase block count if mesh enabled

### DIFF
--- a/apps/btshell/syscfg.yml
+++ b/apps/btshell/syscfg.yml
@@ -39,3 +39,6 @@ syscfg.vals:
 
     # Newtmgr is not supported in this app, so disable newtmgr-over-shell.
     SHELL_NEWTMGR: 0
+
+syscfg.vals.BLE_MESH:
+    MSYS_1_BLOCK_COUNT: 16


### PR DESCRIPTION
Memory error may occure while operating with enabled mesh and additional
instances of advertising. This update was tested agains initialized mesh
and one separate instance of advertising.