### PR TITLE
Remove ADC sysdefs already present on nrf51xx MCU

### DIFF
--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 0
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  29

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  25

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 8
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  29

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 0
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/vbluno51/syscfg.yml
+++ b/hw/bsp/vbluno51/syscfg.yml
@@ -40,16 +40,6 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 13
 
-    ADC_0_REFMV_0:
-        description: 'reference mV in AREF0 if used'
-        value: 0
-    ADC_0_REFMV_1:
-        description: 'reference mV in AREF1 if used'
-        value: 0
-    ADC_0_REFMV_VDD:
-        description: 'reference mV in VDD if used'
-        value: 0
-
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value:  28


### PR DESCRIPTION
This removes sysdefs `ADC_0_REFMV_0`, `ADC_0_REFMV_1`, `ADC_0_REFMV_VDD` that are already present on `mcu/nordic/nrf51xxx/syscfg.yml`