### PR TITLE
[WIP] NRF52810 Support

### DIFF
--- a/hw/mcu/nordic/include/nrfx_glue.h
+++ b/hw/mcu/nordic/include/nrfx_glue.h
@@ -84,7 +84,7 @@ extern "C" {
  * @retval true  If the IRQ is enabled.
  * @retval false Otherwise.
  */
-#define NRFX_IRQ_IS_ENABLED(irq_number) (NVIC_GetEnableIRQ(irq_number) == 1);
+#define NRFX_IRQ_IS_ENABLED(irq_number) (NVIC_GetEnableIRQ(irq_number) == 1)
 
 /**
  * @brief Macro for disabling a specific IRQ.

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -22,11 +22,7 @@
 
 #include "os/mynewt.h"
 
-#ifdef NRF52840_XXAA
-#include "nrf52840.h"
-#else
-#include "nrf52.h"
-#endif
+#include "nrf.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -29,3 +29,9 @@ pkg.deps:
     - hw/mcu/nordic
     - hw/cmsis-core 
     - hw/hal 
+
+# NRF52810 doesn't support SPI/I2C (Use SPIM/I2CM instead)
+pkg.ign_files.BSP_NRF52810:
+    - "hal_spi.c"
+    - "hal_i2c.c"
+

--- a/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
@@ -51,6 +51,14 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_sector_cnt = 256,	/* XXX read from factory info? */
     .hf_align = 1
 };
+#elif defined(NRF52810_XXAA)
+const struct hal_flash nrf52k_flash_dev = {
+    .hf_itf = &nrf52k_flash_funcs,
+    .hf_base_addr = 0x00000000,
+    .hf_size = 192 * 1024,  /* XXX read from factory info? */
+    .hf_sector_cnt = 48,   /* XXX read from factory info? */
+    .hf_align = 1
+};
 #elif defined(NRF52832_XXAA)
 const struct hal_flash nrf52k_flash_dev = {
     .hf_itf = &nrf52k_flash_funcs,

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -32,6 +32,35 @@
  *
  */
 
+/*
+ * GPIO pin mapping
+ *
+ * The logical GPIO pin numbers (0 to N) are mapped to ports in the following
+ * manner:
+ *  pins 0 - 31: Port 0
+ *  pins 32 - 48: Port 1.
+ *
+ *  The nrf52832 has only one port with 32 pins. The nrf52840 has 48 pins and
+ *  uses two ports.
+ *
+ *  NOTE: in order to save code space, there is no checking done to see if the
+ *  user specifies a pin that is not used by the processor. If an invalid pin
+ *  number is used unexpected and/or erroneous behavior will result.
+ */
+#if defined(NRF52832_XXAA) || defined(NRF52810_XXAA)
+#define HAL_GPIO_INDEX(pin)     (pin)
+#define HAL_GPIO_PORT(pin)      (NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << pin)
+#define HAL_GPIOTE_PIN_MASK     GPIOTE_CONFIG_PSEL_Msk
+#endif
+
+#ifdef NRF52840_XXAA
+#define HAL_GPIO_INDEX(pin)     ((pin) & 0x1F)
+#define HAL_GPIO_PORT(pin)      ((pin) > 31 ? NRF_P1 : NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << HAL_GPIO_INDEX(pin))
+#define HAL_GPIOTE_PIN_MASK     (0x3FUL << GPIOTE_CONFIG_PSEL_Pos)
+#endif
+
 /* GPIO interrupts */
 #define HAL_GPIO_MAX_IRQ        8
 

--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -35,8 +35,6 @@ pkg.ign_files.BSP_NRF52:
 pkg.ign_files.BSP_NRF52810:
     - "nrfx_power.c"
     - "nrfx_power_clock.c"
-    - "hal_spi.c"
-    - "hal_i2c.c"
 
 pkg.ign_files.BSP_NRF52840:
     - "nrfx_power.c"

--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -32,6 +32,12 @@ pkg.ign_files.BSP_NRF52:
     - "nrfx_power.c"
     - "nrfx_power_clock.c"
 
+pkg.ign_files.BSP_NRF52810:
+    - "nrfx_power.c"
+    - "nrfx_power_clock.c"
+    - "hal_spi.c"
+    - "hal_i2c.c"
+
 pkg.ign_files.BSP_NRF52840:
     - "nrfx_power.c"
     - "nrfx_power_clock.c"


### PR DESCRIPTION
This PR hopes to add support for the NRF52810 series.

It fixes the issues addressed in #845 (AFAIK)
It does require updating to the CMSIS 5 header, which are also included.

An example project with an NRF52810 BSP can be found here: https://github.com/alvarop/blemesh