### PR TITLE
Fix/nrf52 i2c hang

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -290,12 +290,14 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     int rc = -1;
     int i;
     uint32_t start;
+    int tries = 0;
 
     NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
     regs = i2c->nhi_regs;
 
     regs->ADDRESS = pdata->address;
 
+retry:
     regs->EVENTS_ERROR = 0;
     regs->EVENTS_STOPPED = 0;
     regs->EVENTS_SUSPENDED = 0;
@@ -311,7 +313,14 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
         while (!regs->EVENTS_TXDSENT && !regs->EVENTS_ERROR) {
             if (os_time_get() - start > timo) {
                 regs->TASKS_STOP = 1;
-                goto err;
+                if (tries++==0) {
+                    /* Disable/enable TWI and try one more time */
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
+                    goto retry;
+                } else {
+                    goto err;
+                }
             }
         }
         if (regs->EVENTS_ERROR) {
@@ -350,10 +359,12 @@ hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     int rc = -1;
     int i;
     uint32_t start;
+    int tries = 0;
 
     NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
     regs = i2c->nhi_regs;
 
+retry:
     start = os_time_get();
 
     if (regs->EVENTS_RXDREADY) {
@@ -379,12 +390,18 @@ hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 
     for (i = 0; i < pdata->len; i++) {
         regs->TASKS_RESUME = 1;
-
         while (!regs->EVENTS_RXDREADY && !regs->EVENTS_ERROR) {
             if (os_time_get() - start > timo) {
                 regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
                 regs->TASKS_STOP = 1;
-                goto err;
+                if (tries++==0) {
+                    /* Disable/enable TWI and try one more time */
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
+                    goto retry;
+                } else {
+                    goto err;
+                }
             }
         }
         if (regs->EVENTS_ERROR) {


### PR DESCRIPTION
The nRF52 TWI peripheral (I2C master) gets in a weird state when writing a reset byte out to the lp5523 (LED driver chip). Once in this state, the TWI will fail to output anything when I2C operations are attempted. A workaround is to reset the TWI by disabling and re-enabling it, after which it will function normally again. 
The issue may be related to an errata documented in nRF52832 Rev 2 Errata v1.1, "TWIS: Stopped event occurs twice if the STOP event is triggered during a transaction".
The attached image shows a Saleae capture of an offending frame that causes the issue. The first sign of trouble is a glitch on SDA at the end of the 2nd byte. Also note the double STOP condition at the end of the frame. 
![glitch during write to lp5523 reset register](https://user-images.githubusercontent.com/3791899/40212006-a8917e38-5a02-11e8-9557-b9b05cfc83ab.png)

