### PR TITLE
Senesor error format fix

### DIFF
--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -251,7 +251,7 @@ adxl345_spi_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_ERR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+        ADXL345_ERR("SPI_%u write failed addr:0x%02X\n",
                    itf->si_num, reg);
         STATS_INC(g_adxl345stats, write_errors);
         goto err;

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -866,7 +866,7 @@ bmp280_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMP280_ERR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+            BMP280_ERR("SPI_%u write failed addr:0x%02X\n",
                        itf->si_num, addr);
             STATS_INC(g_bmp280stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -889,7 +889,7 @@ bno055_find_reg(sensor_type_t type, uint8_t *reg)
             *reg = BNO055_GRAVITY_DATA_X_LSB_ADDR;
             break;
         default:
-            BNO055_ERR("Not supported sensor type: %d\n", type);
+            BNO055_ERR("Not supported sensor type: %d\n", (int)type);
             rc = SYS_EINVAL;
             break;
     }

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -293,7 +293,7 @@ lis2dh12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DH12_ERR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+            LIS2DH12_ERR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2dh12stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -211,7 +211,7 @@ lis2dw12_spi_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DW12_ERR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+        LIS2DW12_ERR("SPI_%u write failed addr:0x%02X\n",
                    itf->si_num, reg);
         STATS_INC(g_lis2dw12stats, write_errors);
         goto err;

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -220,7 +220,7 @@ lps33hw_spi_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33HW_ERR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+        LPS33HW_ERR("SPI_%u write failed addr:0x%02X\n",
                    itf->si_num, reg);
         STATS_INC(g_lps33hwstats, write_errors);
         goto err;

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -108,7 +108,7 @@ lsm303dlhc_write8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
                               OS_TICKS_PER_SEC / 10, 1);
     if (rc) {
-        LSM303DLHC_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
+        LSM303DLHC_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
                        addr, reg, value);
         STATS_INC(g_lsm303dlhcstats, errors);
     }

--- a/hw/drivers/sensors/mpu6050/src/mpu6050.c
+++ b/hw/drivers/sensors/mpu6050/src/mpu6050.c
@@ -87,7 +87,7 @@ mpu6050_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
                               OS_TICKS_PER_SEC / 10, 1);
 
     if (rc) {
-        MPU6050_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
+        MPU6050_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
                        itf->si_addr, reg, value);
         STATS_INC(g_mpu6050stats, read_errors);
     }

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -97,7 +97,7 @@ tcs34725_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
                               OS_TICKS_PER_SEC / 10, 1);
     if (rc) {
-        TCS34725_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
+        TCS34725_ERR("Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
                        data_struct.address, reg, value);
         STATS_INC(g_tcs34725stats, errors);
     }

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -94,7 +94,7 @@ tsl2561_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
                               OS_TICKS_PER_SEC / 10, 1);
     if (rc) {
-        TSL2561_ERR("Failed to write 0x%02X:0x%02X with value 0x%02X\n",
+        TSL2561_ERR("Failed to write 0x%02X:0x%02X with value 0x%02lX\n",
                     data_struct.address, reg, value);
         STATS_INC(g_tsl2561stats, errors);
     }


### PR DESCRIPTION
Several sensor drivers has formating issues that would be detected if log_error() has __attribute((format..) added.
First commit removes errors with extra placeholders.
Second cleans up formating so no warning will pop up in the future.