### PR TITLE
apps/btshell: Add cmd_set_scan_opts command

### DIFF
--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -81,6 +81,11 @@ struct btshell_conn {
     struct btshell_l2cap_coc_list coc_list;
 };
 
+struct btshell_scan_opts {
+    uint16_t limit;
+    uint8_t ignore_legacy:1;
+};
+
 extern struct btshell_conn btshell_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
 extern int btshell_num_conns;
 
@@ -134,12 +139,13 @@ int btshell_conn_cancel(void);
 int btshell_term_conn(uint16_t conn_handle, uint8_t reason);
 int btshell_wl_set(ble_addr_t *addrs, int addrs_count);
 int btshell_scan(uint8_t own_addr_type, int32_t duration_ms,
-                 const struct ble_gap_disc_params *disc_params);
+                 const struct ble_gap_disc_params *disc_params, void *cb_args);
 int btshell_ext_scan(uint8_t own_addr_type, uint16_t duration, uint16_t period,
                      uint8_t filter_duplicates, uint8_t filter_policy,
                      uint8_t limited,
                      const struct ble_gap_ext_disc_params *uncoded_params,
-                     const struct ble_gap_ext_disc_params *coded_params);
+                     const struct ble_gap_ext_disc_params *coded_params,
+                     void *cb_args);
 int btshell_scan_cancel(void);
 int btshell_update_conn(uint16_t conn_handle,
                          struct ble_gap_upd_params *params);

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -898,11 +898,17 @@ btshell_on_write_reliable(uint16_t conn_handle,
 }
 
 static void
-btshell_decode_adv_data(uint8_t *adv_data, uint8_t adv_data_len)
+btshell_decode_adv_data(uint8_t *adv_data, uint8_t adv_data_len, void *arg)
 {
+    struct btshell_scan_opts *scan_opts = arg;
     struct ble_hs_adv_fields fields;
 
     console_printf(" length_data=%d data=", adv_data_len);
+
+    if (scan_opts) {
+        adv_data_len = min(adv_data_len, scan_opts->limit);
+    }
+
     print_bytes(adv_data, adv_data_len);
     console_printf(" fields:\n");
     ble_hs_adv_parse_fields(&fields, adv_data, adv_data_len);
@@ -912,11 +918,16 @@ btshell_decode_adv_data(uint8_t *adv_data, uint8_t adv_data_len)
 
 #if MYNEWT_VAL(BLE_EXT_ADV)
 static void
-btshell_decode_event_type(struct ble_gap_ext_disc_desc *desc)
+btshell_decode_event_type(struct ble_gap_ext_disc_desc *desc, void *arg)
 {
+    struct btshell_scan_opts *scan_opts = arg;
     uint8_t directed = 0;
 
     if (desc->props & BLE_HCI_ADV_LEGACY_MASK) {
+        if (scan_opts && scan_opts->ignore_legacy) {
+            return;
+        }
+
         console_printf("Legacy PDU type %d", desc->legacy_event_type);
         if (desc->legacy_event_type == BLE_HCI_ADV_RPT_EVTYPE_DIR_IND) {
             directed = 1;
@@ -972,7 +983,7 @@ common_data:
         return;
     }
 
-    btshell_decode_adv_data(desc->data, desc->length_data);
+    btshell_decode_adv_data(desc->data, desc->length_data, arg);
 }
 #endif
 
@@ -1008,7 +1019,7 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 #if MYNEWT_VAL(BLE_EXT_ADV)
     case BLE_GAP_EVENT_EXT_DISC:
-        btshell_decode_event_type(&event->ext_disc);
+        btshell_decode_event_type(&event->ext_disc, arg);
         return 0;
 #endif
     case BLE_GAP_EVENT_DISC:
@@ -1026,7 +1037,7 @@ btshell_gap_event(struct ble_gap_event *event, void *arg)
                 return 0;
         }
 
-        btshell_decode_adv_data(event->disc.data, event->disc.length_data);
+        btshell_decode_adv_data(event->disc.data, event->disc.length_data, arg);
 
         return 0;
 
@@ -1528,12 +1539,12 @@ btshell_wl_set(ble_addr_t *addrs, int addrs_count)
 
 int
 btshell_scan(uint8_t own_addr_type, int32_t duration_ms,
-             const struct ble_gap_disc_params *disc_params)
+             const struct ble_gap_disc_params *disc_params, void *cb_args)
 {
     int rc;
 
     rc = ble_gap_disc(own_addr_type, duration_ms, disc_params,
-                      btshell_gap_event, NULL);
+                      btshell_gap_event, cb_args);
     return rc;
 }
 
@@ -1542,7 +1553,8 @@ btshell_ext_scan(uint8_t own_addr_type, uint16_t duration, uint16_t period,
                  uint8_t filter_duplicates, uint8_t filter_policy,
                  uint8_t limited,
                  const struct ble_gap_ext_disc_params *uncoded_params,
-                 const struct ble_gap_ext_disc_params *coded_params)
+                 const struct ble_gap_ext_disc_params *coded_params,
+                 void *cb_args)
 {
 #if !MYNEWT_VAL(BLE_EXT_ADV)
     console_printf("BLE extended advertising not supported.");
@@ -1553,7 +1565,7 @@ btshell_ext_scan(uint8_t own_addr_type, uint16_t duration, uint16_t period,
 
     rc = ble_gap_ext_disc(own_addr_type, duration, period, filter_duplicates,
                           filter_policy, limited, uncoded_params, coded_params,
-                          btshell_gap_event, NULL);
+                          btshell_gap_event, cb_args);
     return rc;
 #endif
 }


### PR DESCRIPTION
This patch extends btshell with cmd_set_scan_opts command, that
limit the data printed out to the serial console during
scanning. It has been noticed that the large amount of data
sent on UART might cause the LE Extended Adverising packets
to be truncated.

The command params are:
* ignore_legacy - to not print legacy advertisements
* decode_limit - to limit the data to be printed out to serial
console.