### PR TITLE
lwip_base: Make IPv6 neighbor discovery cfgable

### DIFF
--- a/net/ip/include/lwipopts.h
+++ b/net/ip/include/lwipopts.h
@@ -49,6 +49,7 @@ extern "C" {
 #define LWIP_DHCP_AUTOIP_COOP           0
 
 #define LWIP_IPV6                       1
+#define LWIP_ND6                        0
 #define MEMP_NUM_ND6_QUEUE              4
 
 #ifndef LWIP_DEBUG

--- a/net/ip/lwip_base/include/lwip/opt.h
+++ b/net/ip/lwip_base/include/lwip/opt.h
@@ -2269,6 +2269,13 @@
  * @{
  */
 /**
+ * XXX
+ */
+#if !defined LWIP_ND6 || defined __DOXYGEN__
+#define LWIP_ND6                        (LWIP_IPV6)
+#endif
+
+/**
  * LWIP_ND6_QUEUEING==1: queue outgoing IPv6 packets while MAC address
  * is being resolved.
  */

--- a/net/ip/lwip_base/src/core/ipv6/icmp6.c
+++ b/net/ip/lwip_base/src/core/ipv6/icmp6.c
@@ -111,6 +111,7 @@ icmp6_input(struct pbuf *p, struct netif *inp)
 #endif /* CHECKSUM_CHECK_ICMP6 */
 
   switch (icmp6hdr->type) {
+#if LWIP_ND6
   case ICMP6_TYPE_NA: /* Neighbor advertisement */
   case ICMP6_TYPE_NS: /* Neighbor solicitation */
   case ICMP6_TYPE_RA: /* Router advertisement */
@@ -119,6 +120,7 @@ icmp6_input(struct pbuf *p, struct netif *inp)
     nd6_input(p, inp);
     return;
     break;
+#endif
   case ICMP6_TYPE_RS:
 #if LWIP_IPV6_FORWARD
     /* @todo implement router functionality */

--- a/net/ip/lwip_base/src/core/ipv6/ip6.c
+++ b/net/ip/lwip_base/src/core/ipv6/ip6.c
@@ -148,10 +148,12 @@ ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest)
   }
 
   /* Get the netif for a suitable router. */
+#if LWIP_ND6
   netif = nd6_find_route(dest);
   if ((netif != NULL) && netif_is_up(netif) && netif_is_link_up(netif)) {
     return netif;
   }
+#endif
 
   /* try with the netif that matches the source address. */
   if (!ip6_addr_isany(src)) {

--- a/net/ip/lwip_base/src/core/ipv6/nd6.c
+++ b/net/ip/lwip_base/src/core/ipv6/nd6.c
@@ -43,7 +43,7 @@
 
 #include "lwip/opt.h"
 
-#if LWIP_IPV6  /* don't build if not configured for use in lwipopts.h */
+#if LWIP_IPV6 && LWIP_ND6 /* don't build if not configured for use in lwipopts.h */
 
 #include "lwip/nd6.h"
 #include "lwip/priv/nd6_priv.h"
@@ -702,7 +702,6 @@ nd6_input(struct pbuf *p, struct netif *inp)
   pbuf_free(p);
 }
 
-
 /**
  * Periodic timer for Neighbor discovery functions:
  *
@@ -891,7 +890,6 @@ nd6_tmr(void)
     }
   }
 #endif /* LWIP_IPV6_SEND_ROUTER_SOLICIT */
-
 }
 
 /** Send a neighbor solicitation message for a specific neighbor cache entry

--- a/net/ip/lwip_base/src/core/netif.c
+++ b/net/ip/lwip_base/src/core/netif.c
@@ -691,7 +691,7 @@ netif_set_down(struct netif *netif)
     }
 #endif /* LWIP_IPV4 && LWIP_ARP */
 
-#if LWIP_IPV6
+#if LWIP_IPV6 && LWIP_ND6
     nd6_cleanup_netif(netif);
 #endif /* LWIP_IPV6 */
 
@@ -1098,7 +1098,7 @@ netif_ip6_addr_set_state(struct netif* netif, s8_t addr_idx, u8_t state)
     u8_t new_valid = state & IP6_ADDR_VALID;
     LWIP_DEBUGF(NETIF_DEBUG | LWIP_DBG_STATE, ("netif_ip6_addr_set_state: netif address state being changed\n"));
 
-#if LWIP_IPV6_MLD
+#if LWIP_ND6 && LWIP_IPV6_MLD
     /* Reevaluate solicited-node multicast group membership. */
     if (netif->flags & NETIF_FLAG_MLD6) {
       nd6_adjust_mld_membership(netif, addr_idx, state);

--- a/net/ip/lwip_base/src/core/tcp.c
+++ b/net/ip/lwip_base/src/core/tcp.c
@@ -1924,6 +1924,7 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
   s16_t mtu;
 
   outif = ip_route(src, dest);
+#if LWIP_ND6
 #if LWIP_IPV6
 #if LWIP_IPV4
   if (IP_IS_V6(dest))
@@ -1936,6 +1937,7 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
   else
 #endif /* LWIP_IPV4 */
 #endif /* LWIP_IPV6 */
+#endif /* LWIP_ND6 */
 #if LWIP_IPV4
   {
     if (outif == NULL) {

--- a/net/ip/lwip_base/src/core/tcp_in.c
+++ b/net/ip/lwip_base/src/core/tcp_in.c
@@ -1202,7 +1202,7 @@ tcp_receive(struct tcp_pcb *pcb)
 
       pcb->polltmr = 0;
 
-#if LWIP_IPV6 && LWIP_ND6_TCP_REACHABILITY_HINTS
+#if LWIP_IPV6 && LWIP_ND6 && LWIP_ND6_TCP_REACHABILITY_HINTS
       if (ip_current_is_v6()) {
         /* Inform neighbor reachability of forward progress. */
         nd6_reachability_hint(ip6_current_src_addr());
@@ -1534,7 +1534,7 @@ tcp_receive(struct tcp_pcb *pcb)
         /* Acknowledge the segment(s). */
         tcp_ack(pcb);
 
-#if LWIP_IPV6 && LWIP_ND6_TCP_REACHABILITY_HINTS
+#if LWIP_IPV6 && LWIP_ND6 && LWIP_ND6_TCP_REACHABILITY_HINTS
         if (ip_current_is_v6()) {
           /* Inform neighbor reachability of forward progress. */
           nd6_reachability_hint(ip6_current_src_addr());

--- a/net/ip/lwip_base/src/core/timeouts.c
+++ b/net/ip/lwip_base/src/core/timeouts.c
@@ -96,7 +96,9 @@ const struct lwip_cyclic_timer lwip_cyclic_timers[] = {
   {DNS_TMR_INTERVAL, HANDLER(dns_tmr)},
 #endif /* LWIP_DNS */
 #if LWIP_IPV6
+#if LWIP_ND6 
   {ND6_TMR_INTERVAL, HANDLER(nd6_tmr)},
+#endif
 #if LWIP_IPV6_REASS
   {IP6_REASS_TMR_INTERVAL, HANDLER(ip6_reass_tmr)},
 #endif /* LWIP_IPV6_REASS */


### PR DESCRIPTION
IPv6 neighbor discovery is enabled by default.  Define `LWIP_ND6` equal to 0 to disable it.

This is useful in case you don't want lwIP sending packets automatically.  If accepted, we will want to try to get this change upstreamed into lwIP.
