### PR TITLE
hw/native: Add hal_debugger_connected implementation

### DIFF
--- a/hw/mcu/native/src/hal_system.c
+++ b/hw/mcu/native/src/hal_system.c
@@ -136,3 +136,8 @@ mcu_sim_parse_args(int argc, char **argv)
     os_start();
 #endif
 }
+
+int hal_debugger_connected(void)
+{
+    return 0;
+}


### PR DESCRIPTION
This fix controller unit tests build failure.