### PR TITLE
hw/drivers: Initial bq27z561 driver

### DIFF
--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -1,0 +1,467 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * resarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __BQ27Z561_H__
+#define __BQ27Z561_H__
+
+#include "os/mynewt.h"
+
+#ifdef __cplusplus
+#extern "C" {
+#endif
+
+/* The i2c address of the device */
+#define BQ27Z561_I2C_ADDR       (0x55)
+
+/*
+ * The maximum length of data allowed to write to any AltMfrgAccess command
+ * XXX: no idea what the real size is yet.
+ */
+#define BQ27Z561_MAX_ALT_MFG_CMD_LEN    (32)
+
+/* Maximum amount of bytes we will allow to read/write from flash in one call */
+#define BQ27Z561_MAX_FLASH_RW_LEN       (64)
+
+/* Flash address start/end */
+#define BQ27Z561_FLASH_BEG_ADDR (0x4000)
+#define BQ27Z561_FLASH_END_ADDR (0x4600)
+
+/* Standard Data Commands */
+#define BQ27Z561_REG_CNTL       (0x00)
+#define BQ27Z561_REG_AR         (0x02)
+#define BQ27Z561_REG_ARTTE      (0x04)
+#define BQ27Z561_REG_TEMP       (0x06)
+#define BQ27Z561_REG_VOLT       (0x08)
+#define BQ27Z561_REG_FLAGS      (0x0A)
+#define BQ27Z561_REG_INSTCURR   (0x0C)
+#define BQ27Z561_REG_IMAX       (0x0E)
+#define BQ27Z561_REG_RM         (0x10)
+#define BQ27Z561_REG_FCC        (0x12)
+#define BQ27Z561_REG_AI         (0x14)
+#define BQ27Z561_REG_TTE        (0x16)
+#define BQ27Z561_REG_TTF        (0x18)
+#define BQ27Z561_REG_MLI        (0x1E)
+#define BQ27Z561_REG_MLTTE      (0x20)
+#define BQ27Z561_REG_AP         (0x22)
+#define BQ27Z561_REG_INT_TEMP   (0x28)
+#define BQ27Z561_REG_CC         (0x2A)
+#define BQ27Z561_REG_RSOC       (0x2C)
+#define BQ27Z561_REG_SOH        (0x2E)
+#define BQ27Z561_REG_CV         (0x30)
+#define BQ27Z561_REG_CHGC       (0x32)
+#define BQ27Z561_REG_DCAP       (0x3C)
+#define BQ27Z561_REG_MFRG_ACC   (0x3E)
+#define BQ27Z561_REG_CHKSUM     (0x60)
+
+
+/* Alt Manufacturer Command List */
+#define BQ27Z561_CMD_DEV_TYPE               (0x0001)
+#define BQ27Z561_CMD_FW_VER                 (0x0002)
+#define BQ27Z561_CMD_HW_VER                 (0x0003)
+#define BQ27Z561_CMD_IF_CHKSUM              (0x0004)
+#define BQ27Z561_CMD_DF_SIG                 (0x0005)
+#define BQ27Z561_CMD_CHEM_ID                (0x0006)
+#define BQ27Z561_CMD_PREV_WR                (0x0007)
+#define BQ27Z561_CMD_CHEM_DF_SIG            (0x0008)
+#define BQ27Z561_CMD_ALL_DF_SIG             (0x0009)
+#define BQ27Z561_CMD_RESET                  (0x0012)
+#define BQ27Z561_CMD_GAUGING                (0x0021)
+#define BQ27Z561_CMD_LIFETIME_DATA_COLLECT  (0x0023)
+#define BQ27Z561_CMD_LIFETIME_DATA_RESET    (0x0028)
+#define BQ27Z561_CMD_CALIBRATION_MODE       (0x002D)
+#define BQ27Z561_CMD_LIFETIME_DATA_FLUSH    (0x002E)
+#define BQ27Z561_CMD_SEAL_DEVICE            (0x0030)
+#define BQ27Z561_CMD_SEC_KEYS               (0x0035)
+#define BQ27Z561_CMD_RESET_DEV              (0x0041)
+#define BQ27Z561_CMD_SET_DEEP_SLEEP         (0x0044)
+#define BQ27Z561_CMD_CLR_DEEP_SLEEP         (0x0045)
+#define BQ27Z561_CMD_PULSE_GPIO             (0x0046)
+#define BQ27Z561_CMD_TAMBIENT_SYNC          (0x0047)
+#define BQ27Z561_CMD_DEV_NAME               (0x004A)
+#define BQ27Z561_CMD_DEV_CHEM               (0x004B)
+#define BQ27Z561_CMD_MFG_NAME               (0x004C)
+#define BQ27Z561_CMD_MFG_DATE               (0x004D)
+#define BQ27Z561_CMD_SERIAL_NUM             (0x004E)
+#define BQ27Z561_CMD_OP_STATUS              (0x0054)
+#define BQ27Z561_CMD_CHG_STATUS             (0x0055)
+#define BQ27Z561_CMD_GAUGING_STATUS         (0x0056)
+#define BQ27Z561_CMD_MFG_STATUS             (0x0057)
+#define BQ27Z561_CMD_LIFETIME_DATA_BLOCK1   (0x0060)
+#define BQ27Z561_CMD_MFRG_DATA              (0x0070)
+#define BQ27Z561_CMD_DA_STATUS1             (0x0071)
+#define BQ27Z561_CMD_DA_STATUS2             (0x0072)
+#define BQ27Z561_CMD_IT_STATUS1             (0x0073)
+#define BQ27Z561_CMD_IT_STATUS2             (0x0074)
+#define BQ27Z561_CMD_IT_STATUS3             (0x0075)
+#define BQ27Z561_CMD_FCC_SOH                (0x0077)
+#define BQ27Z561_CMD_FILT_CAP               (0x0078)
+#define BQ27Z561_CMD_ROM_MODE               (0x0F00)
+#define BQ27Z561_CMD_EXIT_CAL_MODE          (0xF080)
+#define BQ27Z561_CMD_OUT_CC_ADC_CAL         (0xF081)
+#define BQ27Z561_CMD_OUT_SHORT_CC_ADC_CAL   (0xF082)
+
+/* Errors returned from some commands */
+typedef enum
+{
+    BQ27Z561_OK = 0,
+    BQ27Z561_ERR_CHKSUM_FAIL = 1,
+    BQ27Z561_ERR_CMD_MISMATCH = 2,
+    BQ27Z561_ERR_I2C_ERR = 3,
+    BQ27Z561_ERR_CMD_LEN = 4,
+    BQ27Z561_ERR_INV_PARAMS = 5,
+    BQ27Z561_ERR_ALT_MFG_LEN = 6,
+    BQ27Z561_ERR_INV_FLASH_ADDR = 7,
+    BQ27Z561_ERR_FLASH_ADDR_MISMATCH = 8,
+} bq27z561_err_t;
+
+/* Config strucutre */
+struct bq27z561_cfg
+{
+    /* XXX: not sure what config is as of yet */
+    int foo;
+};
+
+/* Peripheral interface structure */
+struct bq27z561_itf
+{
+    uint8_t itf_num;
+    uint8_t itf_addr;
+};
+
+/* BQ27Z561 device */
+struct bq27z561
+{
+    /* Underlying OS device */
+    struct os_dev dev;
+
+    /* Configuration values */
+    struct bq27z561_cfg bq27_cfg;
+
+    /* Interface */
+    struct bq27z561_itf bq27_itf;
+};
+
+/**
+ * bq27z561 set at rate
+ *
+ * Sets the value used in calculating the "at rate time to empty".
+ *
+ * @param dev pointer to device
+ * @param current current rate, in mA
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_at_rate(struct bq27z561 *dev, int16_t current);
+
+/**
+ * bq27z561 get at rate
+ *
+ * Gets the value used in calculating the "at rate time to empty".
+ *
+ * @param dev pointer to device
+ * @param current current rate, in mA
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_at_rate(struct bq27z561 *dev, int16_t *current);
+
+/**
+ * bq27z561 get time to empty
+ *
+ * Gets amount of time until the battery is fully discharged based on at rate.
+ *
+ * @param dev pointer to device
+ * @param tte time until empty, in minutes
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_time_to_empty(struct bq27z561 *dev, uint16_t *tte);
+
+/**
+ * bq27z561 get temp
+ *
+ * Gets the temperature.
+ *
+ * @param dev pointer to device
+ * @param temp_c temperature in deg C
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_temp(struct bq27z561 *dev, float *temp_c);
+
+/**
+ * bq27z561 get voltage
+ *
+ * Gets the measured cell voltage
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_voltage(struct bq27z561 *dev, uint16_t *voltage);
+
+/**
+ * bq27z561 get batt status
+ *
+ * Gets the battery status
+ *
+ * @param dev pointer to device
+ * @param status battery status flags
+ *      0x0010 FD Fully dischargd (0 no 1 yes)
+ *      0x0020 FC Fully charged (0 no 1 yes)
+ *      0x0040 DSG Discharging (0 charging 1 discharging)
+ *      0x0080 INIT Initialization (0 complete 1 active)
+ *      0x0200 RCA Remaining capacity alarm (0 inactive 1 active)
+ *      0x0800 TDA Terminate discharge alarm (0 inactive 1 active)
+ *      0x4000 TCA Terminate charge alarm (0 inactive 1 active)
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_batt_status(struct bq27z561 *dev, uint16_t *status);
+
+/**
+ * bq27z561 get current
+ *
+ * Gets the measured current from the coulomb counter
+ *
+ * @param dev pointer to device
+ * @param current current, in mA
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_current(struct bq27z561 *dev, int16_t *current);
+
+/**
+ * bq27z561 get rem capacity
+ *
+ * Gets the predicted remaining capacity
+ *
+ * @param dev pointer to device
+ * @param capacity, in mAH
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_rem_capacity(struct bq27z561 *dev, uint16_t *capacity);
+
+/**
+ * bq27z561 get full chg capacity
+ *
+ * Gets predicted full charge capacity
+ *
+ * @param dev pointer to device
+ * @param capacity, in mAH
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_full_chg_capacity(struct bq27z561 *dev, uint16_t *capacity);
+
+/**
+ * bq27z561 get average current
+ *
+ * Gets average/filtered current
+ *
+ * @param dev pointer to device
+ * @param current, in mA
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_avg_current(struct bq27z561 *dev, int16_t *current);
+
+/**
+ * bq27z561 get average time to empty
+ *
+ * Gets the predicted remaining battery capacity based on average current.
+ *
+ * @param dev pointer to device
+ * @param tte average time to empty in minutes
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_avg_time_to_empty(struct bq27z561 *dev, uint16_t *tte);
+
+/**
+ * bq27z561 get average time to full
+ *
+ * Gets the predicted remaining time to full charge.
+ *
+ * @param dev pointer to device
+ * @param ttf average time to full in minutes
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_avg_time_to_full(struct bq27z561 *dev, uint16_t *ttf);
+
+/**
+ * bq27z561 get average power
+ *
+ * Gets the average power (voltage * avg current). It is negative due to
+ * discharge and positive due to charge. A zero value indicates battery not
+ * being discharged.
+ *
+ * @param dev pointer to device
+ * @param pwr average power in mW
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_avg_power(struct bq27z561 *dev, int16_t *pwr);
+
+/**
+ * bq27z561 get internal temp
+ *
+ * Gets the internal die temperature
+ *
+ * @param dev pointer to device
+ * @param temp_c temperature, in degrees C.
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_internal_temp(struct bq27z561 *dev, float *temp_c);
+
+/**
+ * bq27z561 get cycle count
+ *
+ * Gets the number of discharge cycles
+ *
+ * @param dev pointer to device
+ * @param cycles number of discharge cycles
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_discharge_cycles(struct bq27z561 *dev, uint16_t *cycles);
+
+/**
+ * bq27z561 get relatives state of charge
+ *
+ * Gets predicted remaining capacity as a percentage of full charge capacity
+ *
+ * @param dev pointer to device
+ * @param pcnt
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_relative_state_of_charge(struct bq27z561 *dev, uint8_t *pcnt);
+
+/**
+ * bq27z561 get state of health
+ *
+ * Returns the state of health as a percentage of the design capacity
+ *
+ * @param dev pointer to device
+ * @param pcnt % of design capacity
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_state_of_health(struct bq27z561 *dev, uint8_t *pcnt);
+
+/**
+ * bq27z561 get charging voltage
+ *
+ * Returns the desired charging voltage
+ *
+ * @param dev pointer to device
+ * @param voltage desired charging current, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_charging_voltage(struct bq27z561 *dev, uint16_t *voltage);
+
+/**
+ * bq27z561 get charging current
+ *
+ * Returns the desired charging current
+ *
+ * @param dev pointer to device
+ * @param current desired charging current, in mA
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_get_charging_current(struct bq27z561 *dev, uint16_t *current);
+
+/**
+ * bq27z561 read flash
+ *
+ * Reads 'buflen' bytes from flash at address 'addr'
+ *
+ * @param dev
+ * @param addr Flash address to read from.
+ * @param buf pointer to buffer where flash data will be stored. Cannot be NULL
+ * @param buflen Number of bytes to read. Cannot be 0 and it must be less than
+ *               or equal to BQ27Z561_MAX_FLASH_READ
+ *
+ * @return bq27z561_err_t
+ */
+bq27z561_err_t bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr,
+                                 uint8_t *buf, int buflen);
+
+bq27z561_err_t bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd,
+                                       uint8_t *val, int val_len);
+
+/**
+ * bq27z561 rd std reg word
+ *
+ * Allows reading of a standard "command" (register).
+ *
+ * NOTE: it is not expected that this api will be used by drivers or
+ * applications. Its use is intended to be internal but is provided for
+ * use by the shell.
+ *
+ * @param dev pointer to device
+ * @param reg register to read
+ * @param val returned value.
+ *
+ * @return int
+ */
+int bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val);
+
+
+/**
+ * Configure the bq27z561.
+ *
+ * @param ptr to bq27z561 device
+ * @param ptr to bq27z561 config
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int bq27z561_config(struct bq27z561 * bq27z561, struct bq27z561_cfg * cfg);
+
+/**
+ * Expects to be called back through os_dev_create().
+ *
+ * @param ptr to the device object associated with this accelerometer
+ * @param argument passed to OS device init
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int bq27z561_init(struct os_dev * dev, void * arg);
+
+#if MYNEWT_VAL(BQ27Z561_CLI)
+/**
+ * Initialize the BQ27Z561 shell extensions.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int bq27z561_shell_init(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/drivers/bq27z561/pkg.yml
+++ b/hw/drivers/bq27z561/pkg.yml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/bq27z561
+pkg.description: Driver for the BQ27Z561 fuel gauge
+pkg.keywords:
+    - bq27z561
+    - i2c
+    - fuel_gauge
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
+
+pkg.req_apis:
+    - stats
+    - log
+
+pkg.deps.BQ27Z561_CLI:
+    - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -1,0 +1,616 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * resarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+
+#include "os/mynewt.h"
+#include "bq27z561/bq27z561.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_i2c.h"
+
+#if MYNEWT_VAL(BQ27Z561_LOG)
+#include "log/log.h"
+#endif
+
+#if MYNEWT_VAL(BQ27Z561_LOG)
+static struct log bq27z561_log;
+#define LOG_MODULE_BQ27Z561 (253)
+#define BQ27Z561_ERROR(...) LOG_ERROR(&bq27z561_log, LOG_MODULE_BQ27Z561, __VA_ARGS__)
+#define BQ27Z561_INFO(...)  LOG_INFO(&bq27z561_log, LOG_MODULE_BQ27Z561, __VA_ARGS__)
+#else
+#define BQ27Z561_ERROR(...)
+#define BQ27Z561_INFO(...)
+#endif
+
+static uint8_t
+bq27z561_calc_chksum(uint8_t *tmpbuf, uint8_t len)
+{
+    uint8_t i;
+    uint8_t chksum;
+
+    chksum = 0;
+    if (len != 0) {
+        for (i = 0; i < len; ++i) {
+            chksum += tmpbuf[i];
+        }
+        chksum = 0xFF - chksum;
+    }
+    return chksum;
+}
+
+
+static float
+bq27z561_temp_to_celsius(uint16_t temp)
+{
+    float temp_c;
+
+    temp_c = ((float)temp * 0.1) - 273;
+    return temp_c;
+}
+
+static int
+bq27z561_open(struct os_dev *dev, uint32_t timeout, void *arg)
+{
+    return 0;
+}
+
+static int
+bq27z561_close(struct os_dev *dev)
+{
+    return 0;
+}
+
+int
+bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
+{
+    int rc;
+    struct hal_i2c_master_data i2c;
+
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.len = 1;
+    i2c.buffer = &reg;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        return rc;
+    }
+
+    i2c.len = 2;
+    i2c.buffer = (uint8_t *)val;
+    rc = hal_i2c_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
+        return rc;
+    }
+
+    /* XXX: add big-endian support */
+
+    return 0;
+}
+
+static int
+bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
+{
+    int rc;
+    uint8_t buf[3];
+    struct hal_i2c_master_data i2c;
+
+    buf[0] = reg;
+    buf[1] = (uint8_t)val;
+    buf[2] = (uint8_t)(val >> 8);
+
+    i2c.address = dev->bq27_itf.itf_num;
+    i2c.len     = 3;
+    i2c.buffer  = buf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg write 0x%02X failed\n", reg);
+        return rc;
+    }
+
+    return 0;
+}
+
+bq27z561_err_t
+bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
+                        int len)
+{
+    /* NOTE: add three here for register and two-byte command */
+    int rc;
+    uint8_t tmpbuf[BQ27Z561_MAX_ALT_MFG_CMD_LEN + 3];
+    struct hal_i2c_master_data i2c;
+
+    if ((len > 0) && (buf == NULL)) {
+        return BQ27Z561_ERR_INV_PARAMS;
+    }
+
+    /* Make sure length is not too long */
+    if (len > BQ27Z561_MAX_ALT_MFG_CMD_LEN) {
+        return BQ27Z561_ERR_CMD_LEN;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    tmpbuf[1] = (uint8_t)cmd;
+    tmpbuf[2] = (uint8_t)(cmd >> 8);
+
+    if (len > 0) {
+        memcpy(&tmpbuf[3], buf, len);
+    }
+
+    i2c.len = len + 3;
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        return BQ27Z561_ERR_I2C_ERR;
+    }
+
+    return BQ27Z561_OK;
+}
+
+bq27z561_err_t
+bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
+                        int val_len)
+{
+    bq27z561_err_t rc;
+    uint8_t tmpbuf[36];
+    uint8_t len;
+    uint16_t cmd_read;
+    uint8_t chksum;
+    struct hal_i2c_master_data i2c;
+
+    if ((val_len == 0) || (val == NULL)) {
+        return BQ27Z561_ERR_INV_PARAMS;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_CNTL;
+    tmpbuf[1] = (uint8_t)cmd;
+    tmpbuf[2] = (uint8_t)(cmd >> 8);
+
+    i2c.len = 3;
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    i2c.len = 1;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    i2c.len = 36;
+    i2c.buffer = tmpbuf;
+    rc = hal_i2c_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    /* Verify that first two bytes are the command */
+    cmd_read = tmpbuf[0];
+    cmd_read |= ((uint16_t)tmpbuf[1]) << 8;
+    if (cmd_read != cmd) {
+        BQ27Z561_ERROR("cmd mismatch (cmd=%x cmd_ret=%x\n", cmd, cmd_read);
+        rc = BQ27Z561_ERR_CMD_MISMATCH;
+        goto err;
+    }
+
+    /*
+     * Verify length. The length contains two bytes for the command and
+     * another two for the checksum and length bytes. Thus, there better
+     * be at least 5 bytes here
+     */
+    len = tmpbuf[35];
+    if (len < 5) {
+        rc = BQ27Z561_ERR_ALT_MFG_LEN;
+        goto err;
+    }
+
+    /* Subtract out checksum and length bytes from length */
+    len -= 2;
+    chksum = bq27z561_calc_chksum(tmpbuf, len);
+    if (chksum != tmpbuf[34]) {
+        BQ27Z561_ERROR("chksum failure for cmd %u (calc=%u read=%u)", cmd,
+                       chksum, tmpbuf[34]);
+        rc = BQ27Z561_ERR_CHKSUM_FAIL;
+    }
+
+    /* Now copy returned data. We subtract command from length */
+    len -= 2;
+    if (val_len < len) {
+        val_len = len;
+    }
+    memcpy(val, &tmpbuf[2], val_len);
+
+    rc = BQ27Z561_OK;
+
+err:
+    return rc;
+}
+
+bq27z561_err_t
+bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
+{
+    uint8_t tmpbuf[BQ27Z561_MAX_FLASH_RW_LEN + 2];
+    uint16_t addr_read;
+    bq27z561_err_t rc;
+    struct hal_i2c_master_data i2c;
+
+    if ((buflen == 0) || !buf || (buflen > BQ27Z561_MAX_FLASH_RW_LEN)) {
+        return BQ27Z561_ERR_INV_PARAMS;
+    }
+
+    if ((addr < BQ27Z561_FLASH_BEG_ADDR) || (addr > BQ27Z561_FLASH_END_ADDR)) {
+        return BQ27Z561_ERR_INV_FLASH_ADDR;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    tmpbuf[1] = (uint8_t)addr;
+    tmpbuf[2] = (uint8_t)(addr >> 8);
+
+    i2c.len = 3;
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    i2c.len = 1;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    i2c.len = buflen + 2;
+    i2c.buffer = tmpbuf;
+    rc = hal_i2c_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    /* Verify that first two bytes are the address*/
+    addr_read = tmpbuf[0];
+    addr_read |= ((uint16_t)tmpbuf[1]) << 8;
+    if (addr_read != addr) {
+        BQ27Z561_ERROR("addr mismatch (addr_read=%x addr_ret=%x\n", cmd,
+                        cmd_read);
+        rc = BQ27Z561_ERR_FLASH_ADDR_MISMATCH;
+        goto err;
+    }
+
+    /* Now copy returned data. */
+    memcpy(buf, &tmpbuf[2], buflen);
+
+    rc = BQ27Z561_OK;
+
+err:
+    return rc;
+}
+
+bq27z561_err_t
+bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
+{
+    uint8_t tmpbuf[BQ27Z561_MAX_FLASH_RW_LEN + 2];
+    uint8_t chksum;
+    bq27z561_err_t rc;
+    struct hal_i2c_master_data i2c;
+
+    if ((buflen == 0) || (!buf) || (buflen > BQ27Z561_MAX_FLASH_RW_LEN)) {
+        return BQ27Z561_ERR_INV_PARAMS;
+    }
+
+    if ((addr < BQ27Z561_FLASH_BEG_ADDR) || (addr > BQ27Z561_FLASH_END_ADDR)) {
+        return BQ27Z561_ERR_INV_FLASH_ADDR;
+    }
+
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    tmpbuf[1] = (uint8_t)addr;
+    tmpbuf[2] = (uint8_t)(addr >> 8);
+    memcpy(&tmpbuf[3], buf, buflen);
+
+    i2c.len = buflen + 3;
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    /* Calculate checksum */
+    chksum = bq27z561_calc_chksum(&tmpbuf[1], buflen + 2);
+
+    /* Write checksum and length */
+    tmpbuf[0] = BQ27Z561_REG_CHKSUM;
+    tmpbuf[1] = chksum;
+    tmpbuf[2] = buflen + 4;
+    i2c.len = 3;
+    i2c.buffer = tmpbuf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        rc = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    rc = BQ27Z561_OK;
+
+err:
+    return rc;
+}
+
+#if 0
+static int
+bq27z561_get_chip_id(struct bq27z561 *dev, uint8_t *chip_id)
+{
+    return 0;
+}
+#endif
+
+/* XXX: no support for control register yet */
+
+int
+bq27z561_set_at_rate(struct bq27z561 *dev, int16_t current)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_word(dev, BQ27Z561_REG_AR, (uint16_t)current);
+    return rc;
+}
+
+int
+bq27z561_get_at_rate(struct bq27z561 *dev, int16_t *current)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_AR, (uint16_t *)current);
+    return rc;
+}
+
+int
+bq27z561_get_time_to_empty(struct bq27z561 *dev, uint16_t *tte)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_ARTTE, tte);
+    return rc;
+}
+
+int
+bq27z561_get_temp(struct bq27z561 *dev, float *temp_c)
+{
+    int rc;
+    uint16_t val;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_TEMP, &val);
+    if (!rc) {
+        /* Kelvin to Celsius */
+        *temp_c = bq27z561_temp_to_celsius(val);
+    }
+    return rc;
+}
+
+int
+bq27z561_get_voltage(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT, voltage);
+    return rc;
+}
+
+int
+bq27z561_get_batt_status(struct bq27z561 *dev, uint16_t *status)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_FLAGS, status);
+    return rc;
+}
+
+int
+bq27z561_get_current(struct bq27z561 *dev, int16_t *current)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_INSTCURR,
+                                  (uint16_t *)current);
+    return rc;
+}
+
+/* XXX: no support for register IMAX */
+
+int
+bq27z561_get_rem_capacity(struct bq27z561 *dev, uint16_t *capacity)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_RM, capacity);
+    return rc;
+}
+
+int
+bq27z561_get_full_chg_capacity(struct bq27z561 *dev, uint16_t *capacity)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_FCC, capacity);
+    return rc;
+}
+
+int
+bq27z561_get_avg_current(struct bq27z561 *dev, int16_t *current)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_AI, (uint16_t *)current);
+    return rc;
+}
+
+int
+bq27z561_get_avg_time_to_empty(struct bq27z561 *dev, uint16_t *tte)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_TTE, tte);
+    return rc;
+}
+
+int
+bq27z561_get_avg_time_to_full(struct bq27z561 *dev, uint16_t *ttf)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_TTF, ttf);
+    return rc;
+}
+
+int
+bq27z561_get_avg_power(struct bq27z561 *dev, int16_t *pwr)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_AP, (uint16_t *)pwr);
+    return rc;
+}
+
+/* XXX: no support for max load current */
+/* XXX: no support for max load time to empty */
+
+int
+bq27z561_get_internal_temp(struct bq27z561 *dev, float *temp_c)
+{
+    int rc;
+    uint16_t val;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_INT_TEMP, &val);
+    if (!rc) {
+        *temp_c = bq27z561_temp_to_celsius(val);
+    }
+    return rc;
+}
+
+int
+bq27z561_get_discharge_cycles(struct bq27z561 *dev, uint16_t *cycles)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_CC, cycles);
+    return rc;
+}
+
+int
+bq27z561_get_relative_state_of_charge(struct bq27z561 *dev, uint8_t *pcnt)
+{
+    int rc;
+    uint16_t val;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_RSOC, &val);
+    if (!rc) {
+        *pcnt = (uint8_t)val;
+    }
+    return rc;
+}
+
+int
+bq27z561_get_state_of_health(struct bq27z561 *dev, uint8_t *pcnt)
+{
+    int rc;
+    uint16_t val;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_SOH, &val);
+    if (!rc) {
+        *pcnt = (uint8_t)val;
+    }
+    return rc;
+}
+
+int
+bq27z561_get_charging_voltage(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_CV, voltage);
+    return rc;
+}
+
+int
+bq27z561_get_charging_current(struct bq27z561 *dev, uint16_t *current)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_CHGC, current);
+    return rc;
+}
+
+int
+bq27z561_config(struct bq27z561 *dev, struct bq27z561_cfg *cfg)
+{
+    return 0;
+}
+
+int
+bq27z561_init(struct os_dev *dev, void *arg)
+{
+    struct bq27z561 *bq27;
+
+    if (!dev || !arg) {
+        return SYS_ENODEV;
+    }
+
+    OS_DEV_SETHANDLERS(dev, bq27z561_open, bq27z561_close);
+
+    /* Copy the interface struct */
+    bq27 = (struct bq27z561 *)dev;
+    memcpy(&bq27->bq27_itf, arg, sizeof(struct bq27z561_itf));
+
+    return 0;
+}

--- a/hw/drivers/bq27z561/src/bq27z561_shell.c
+++ b/hw/drivers/bq27z561/src/bq27z561_shell.c
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "os/mynewt.h"
+#include "bq27z561/bq27z561.h"
+#include "console/console.h"
+#include "shell/shell.h"
+
+#if MYNEWT_VAL(BQ27Z561_CLI)
+
+static int
+bq27z561_std_read_cmd(struct bq27z561 * bq27z561, int argc, char * argv[])
+{
+    int rc;
+    uint8_t reg;
+    uint16_t val;
+
+    if (argc != 1) {
+        return EINVAL;
+    }
+
+    reg = atoi(argv[0]);
+    if (reg > BQ27Z561_REG_DCAP) {
+        console_printf("Unsupported or invalid regsiter %u\n", reg);
+    }
+    rc = bq27z561_rd_std_reg_word(bq27z561, reg, &val);
+    if (rc) {
+        console_printf("Error reading chip\n");
+    } else {
+        console_printf("Reg %u returned %u (0x%04x)\n", reg, val, val);
+    }
+    return 0;
+}
+
+struct subcmd {
+    const char * name;
+    const char * help;
+    int (*func)(struct bq27z561 * bq27z561, int argc, char * argv[]);
+};
+
+static const struct subcmd supported_subcmds[] = {
+    {
+        .name = "std_read",
+        .help = "<cmd>",
+        .func = bq27z561_std_read_cmd,
+    },
+};
+
+static int
+bq27z561_shell_cmd(int argc, char * argv[])
+{
+    struct os_dev * dev;
+    struct bq27z561 *bq27;
+    const struct subcmd * subcmd;
+    uint8_t i;
+
+    dev = os_dev_open(MYNEWT_VAL(BQ27Z561_SHELL_DEV_NAME), OS_TIMEOUT_NEVER,
+                      NULL);
+    if (dev == NULL) {
+        console_printf("failed to open bq27z561_0 device\n");
+        return ENODEV;
+    }
+
+    bq27 = (struct bq27z561 *)dev;
+
+    subcmd = NULL;
+    if (argc > 1) {
+        for (i = 0; i < sizeof(supported_subcmds) /
+                        sizeof(*supported_subcmds); i++) {
+            if (strcmp(supported_subcmds[i].name, argv[1]) == 0) {
+                subcmd = supported_subcmds + i;
+            }
+        }
+
+        if (subcmd == NULL) {
+            console_printf("unknown %s subcommand\n", argv[1]);
+        }
+    }
+
+    if (subcmd != NULL) {
+        if (subcmd->func(bq27, argc - 2, argv + 2) != 0) {
+            console_printf("could not run %s subcommand\n", argv[1]);
+            console_printf("%s %s\n", subcmd->name, subcmd->help);
+        }
+    } else {
+        for (i = 0; i < sizeof(supported_subcmds) /
+                        sizeof(*supported_subcmds); i++) {
+            subcmd = supported_subcmds + i;
+            console_printf("%s %s\n", subcmd->name, subcmd->help);
+        }
+    }
+
+    os_dev_close(dev);
+
+    return 0;
+}
+
+static const struct shell_cmd bq27z561_shell_cmd_desc = {
+    .sc_cmd      = "bq27z561",
+    .sc_cmd_func = bq27z561_shell_cmd,
+};
+
+int
+bq27z561_shell_init(void)
+{
+    return shell_cmd_register(&bq27z561_shell_cmd_desc);
+}
+
+#endif

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    BQ27Z561_CLI:
+        description: 'Enable shell support for BQ27Z561'
+        value: 0
+    BQ27Z561_INT_ENABLE:
+        description: 'Enable interrupt support, necessary for events'
+        value: 0
+    BQ27Z561_LOG:
+        description: 'Enable BQ27Z561 logging'
+        value: 0
+    BQ27Z561_SHELL_DEV_NAME:
+        description: 'BQ27Z561 Shell device name'
+        value: "\"bq27z561_0\""


### PR DESCRIPTION
This is the initial cut at a driver for the bq27z561 fuel
gauge. No interrupt support but basic functionality is present.
No security either; just supports basic reads/writes and flash
read/writes.