### PR TITLE
shell: Fix crash on 'help' in shell/compat

### DIFF
--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -902,7 +902,7 @@ shell_register(const char *module_name, const struct shell_cmd *commands)
 
 #if MYNEWT_VAL(SHELL_COMPAT)
 #define SHELL_COMPAT_MODULE_NAME "compat"
-static struct shell_cmd compat_commands[MYNEWT_VAL(SHELL_MAX_COMPAT_COMMANDS)];
+static struct shell_cmd compat_commands[MYNEWT_VAL(SHELL_MAX_COMPAT_COMMANDS) + 1];
 static int num_compat_commands;
 static int module_registered;
 


### PR DESCRIPTION
Shell code expects last shell_cmd entry to be empty as it used
as a mark for the end of registered commands.

When number of registered commands reached maximum (SHELL_MAX_COMPAT_COMMANDS) then
'help' command triggred crash as below:

001632 compat> help
001837 help
001837 stat
001837 config
001837 log
001837 ln_log
001837 imgr
001837 tasks                         show os tasks
001837 mpool                         show system mpool
001837 date                          show system date
001837 lms
001837 rcc
001837                               Unhandled interrupt (3), exception sp 0x200016d0
001837  r0:0x200009ec  r1:0x20001728  r2:0x00f92005  r3:0x00f92004
001837  r4:0x00000000  r5:0x200009ec  r6:0x200009ec  r7:0x20001728
001837  r8:0x00000000  r9:0x00000000 r10:0x00000000 r11:0x00000000
001837 r12:0x00000000  lr:0x0001fbb1  pc:0x0001f670 psr:0x01000000
001837 ICSR:0x00421803 HFSR:0x40000000 CFSR:0x00008200
001837 BFAR:0x00f92004 MMFAR:0x00f92004