### PR TITLE
sys/log: Add log storage usage tracking and watermarking

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -84,6 +84,11 @@ int fcb_init(struct fcb *fcb);
 struct fcb_log {
     struct fcb fl_fcb;
     uint8_t fl_entries;
+
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    /* Internal - tracking storage use */
+    uint32_t fl_watermark_off;
+#endif
 };
 
 /**

--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -87,12 +87,13 @@ extern "C" {
 #endif
 
 /* Newtmgr Log opcodes */
-#define LOGS_NMGR_OP_READ         (0)
-#define LOGS_NMGR_OP_CLEAR        (1)
-#define LOGS_NMGR_OP_APPEND       (2)
-#define LOGS_NMGR_OP_MODULE_LIST  (3)
-#define LOGS_NMGR_OP_LEVEL_LIST   (4)
-#define LOGS_NMGR_OP_LOGS_LIST    (5)
+#define LOGS_NMGR_OP_READ         	(0)
+#define LOGS_NMGR_OP_CLEAR        	(1)
+#define LOGS_NMGR_OP_APPEND       	(2)
+#define LOGS_NMGR_OP_MODULE_LIST  	(3)
+#define LOGS_NMGR_OP_LEVEL_LIST   	(4)
+#define LOGS_NMGR_OP_LOGS_LIST    	(5)
+#define LOGS_NMGR_OP_SET_WATERMARK	(6)
 
 #define LOG_PRINTF_MAX_ENTRY_LEN (128)
 

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -568,9 +568,33 @@ log_level_set(uint8_t module, uint8_t level)
 #endif
 
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
+/**
+ * Return information about log storage
+ *
+ * This return information about size and usage of storage on top of which log
+ * instance is created.
+ *
+ * @param log   The log to query.
+ * @param info  The destination to write information to.
+ *
+ * @return 0 on success, error code otherwise
+ *
+ */
 int log_storage_info(struct log *log, struct log_storage_info *info);
 #endif
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+/**
+ * Set watermark on log
+ *
+ * This sets watermark on log item with given index. This information is used
+ * to calculate size of entries which were logged after watermark item, i.e.
+ * unread items. The watermark is stored persistently for each log.
+ *
+ * @param log    The log to set watermark on.
+ * @param index  The index of a watermarked item.
+ *
+ * @return 0 on success, error code otherwise.
+ */
 int log_set_watermark(struct log *log, uint32_t index);
 #endif
 

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -57,6 +57,9 @@ struct log_offset {
 struct log_storage_info {
     uint32_t size;
     uint32_t used;
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    uint32_t used_unread;
+#endif
 };
 #endif
 
@@ -85,6 +88,9 @@ typedef int (*lh_flush_func_t)(struct log *);
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 typedef int (*lh_storage_info_func_t)(struct log *, struct log_storage_info *);
 #endif
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+typedef int (*lh_set_watermark_func_t)(struct log *, uint32_t);
+#endif
 typedef int (*lh_registered_func_t)(struct log *);
 
 struct log_handler {
@@ -99,6 +105,9 @@ struct log_handler {
     lh_flush_func_t log_flush;
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
     lh_storage_info_func_t log_storage_info;
+#endif
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    lh_set_watermark_func_t log_set_watermark;
 #endif
     /* Functions called only internally (no API for apps) */
     lh_registered_func_t log_registered;
@@ -560,6 +569,9 @@ log_level_set(uint8_t module, uint8_t level)
 
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 int log_storage_info(struct log *log, struct log_storage_info *info);
+#endif
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+int log_set_watermark(struct log *log, uint32_t index);
 #endif
 
 /* Handler exports */

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -50,6 +50,16 @@ struct log_offset {
     void *lo_arg;
 };
 
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+/**
+ * Log storage information
+ */
+struct log_storage_info {
+    uint32_t size;
+    uint32_t used;
+};
+#endif
+
 typedef int (*log_walk_func_t)(struct log *, struct log_offset *log_offset,
         void *dptr, uint16_t len);
 
@@ -72,6 +82,9 @@ typedef int (*lh_append_mbuf_body_func_t)(struct log *log,
 typedef int (*lh_walk_func_t)(struct log *,
         log_walk_func_t walk_func, struct log_offset *log_offset);
 typedef int (*lh_flush_func_t)(struct log *);
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+typedef int (*lh_storage_info_func_t)(struct log *, struct log_storage_info *);
+#endif
 typedef int (*lh_registered_func_t)(struct log *);
 
 struct log_handler {
@@ -84,6 +97,9 @@ struct log_handler {
     lh_append_mbuf_body_func_t log_append_mbuf_body;
     lh_walk_func_t log_walk;
     lh_flush_func_t log_flush;
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+    lh_storage_info_func_t log_storage_info;
+#endif
     /* Functions called only internally (no API for apps) */
     lh_registered_func_t log_registered;
 };
@@ -542,6 +558,9 @@ log_level_set(uint8_t module, uint8_t level)
 }
 #endif
 
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+int log_storage_info(struct log *log, struct log_storage_info *info);
+#endif
 
 /* Handler exports */
 #if MYNEWT_VAL(LOG_CONSOLE)

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -40,6 +40,9 @@ pkg.deps.LOG_NEWTMGR:
     - "@apache-mynewt-core/encoding/cborattr"
     - "@apache-mynewt-core/encoding/tinycbor"
 
+pkg.deps.LOG_STORAGE_WATERMARK:
+    - sys/config
+
 pkg.apis:
     - log
 

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -50,6 +50,14 @@ struct shell_cmd g_shell_slot1_cmd = {
     .sc_cmd_func = shell_log_slot1_cmd,
 };
 #endif
+
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+int shell_log_storage_cmd(int, char **);
+struct shell_cmd g_shell_storage_cmd = {
+    .sc_cmd = "log-storage",
+    .sc_cmd_func = shell_log_storage_cmd,
+};
+#endif
 #endif
 
 void
@@ -72,6 +80,9 @@ log_init(void)
     shell_cmd_register(&g_shell_log_cmd);
 #if MYNEWT_VAL(LOG_FCB_SLOT1)
     shell_cmd_register(&g_shell_slot1_cmd);
+#endif
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+    shell_cmd_register(&g_shell_storage_cmd);
 #endif
 #endif
 

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -654,3 +654,25 @@ log_flush(struct log *log)
 err:
     return (rc);
 }
+
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+int
+log_storage_info(struct log *log, struct log_storage_info *info)
+{
+    int rc;
+
+    if (!log->l_log->log_storage_info) {
+        rc = OS_ENOENT;
+        goto err;
+    }
+
+    rc = log->l_log->log_storage_info(log, info);
+    if (rc != 0) {
+        goto err;
+    }
+
+    return (0);
+err:
+    return (rc);
+}
+#endif

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -25,6 +25,9 @@
 #include "os/mynewt.h"
 #include "cbmem/cbmem.h"
 #include "log/log.h"
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+#include "config/config.h"
+#endif
 
 #if MYNEWT_VAL(LOG_CLI)
 #include "shell/shell.h"
@@ -60,6 +63,51 @@ struct shell_cmd g_shell_storage_cmd = {
 #endif
 #endif
 
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+static int log_conf_set(int argc, char **argv, char *val);
+
+static struct conf_handler log_conf = {
+    .ch_name = "log",
+    .ch_get = NULL,
+    .ch_set = log_conf_set,
+    .ch_commit = NULL,
+    .ch_export = NULL,
+};
+
+static int
+log_conf_set(int argc, char **argv, char *val)
+{
+    struct log *cur;
+
+    if (argc < 2) {
+        return -1;
+    }
+
+    /* Only support log/<name>/mark entries for now */
+    if (strcmp("mark", argv[1])) {
+        return -1;
+    }
+
+    /* Find proper log */
+    STAILQ_FOREACH(cur, &g_log_list, l_next) {
+        if (!strcmp(argv[0], cur->l_name)) {
+            break;
+        }
+    }
+
+    if (!cur) {
+        return -1;
+    }
+
+    /* Set watermark if supported */
+    if (cur->l_log->log_set_watermark) {
+        cur->l_log->log_set_watermark(cur, atoi(val));
+    }
+
+    return 0;
+}
+#endif
+
 void
 log_init(void)
 {
@@ -93,6 +141,11 @@ log_init(void)
 
 #if MYNEWT_VAL(LOG_CONSOLE)
     log_console_init();
+#endif
+
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    rc = conf_register(&log_conf);
+    SYSINIT_PANIC_ASSERT(rc == 0);
 #endif
 }
 
@@ -681,6 +734,37 @@ log_storage_info(struct log *log, struct log_storage_info *info)
     if (rc != 0) {
         goto err;
     }
+
+    return (0);
+err:
+    return (rc);
+}
+#endif
+
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+int
+log_set_watermark(struct log *log, uint32_t index)
+{
+    char log_path[CONF_MAX_NAME_LEN];
+    char mark_val[10]; /* fits uint32_t + \0 */
+    int rc;
+
+    if (!log->l_log->log_set_watermark) {
+        rc = OS_ENOENT;
+        goto err;
+    }
+
+    rc = log->l_log->log_set_watermark(log, index);
+    if (rc != 0) {
+        goto err;
+    }
+
+    snprintf(log_path, CONF_MAX_NAME_LEN, "log/%s/mark", log->l_name);
+    log_path[CONF_MAX_NAME_LEN - 1] = '\0';
+
+    sprintf(mark_val, "%u", (unsigned)index);
+
+    conf_save_one(log_path, mark_val);
 
     return (0);
 err:

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -206,6 +206,31 @@ err:
     return (rc);
 }
 
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+static int
+log_cbmem_storage_info(struct log *log, struct log_storage_info *info)
+{
+    struct cbmem *cbmem;
+    uint32_t size;
+    uint32_t used;
+
+    cbmem = (struct cbmem *)log->l_arg;
+
+    size = cbmem->c_buf_end - cbmem->c_buf;
+
+    used = (uint32_t)cbmem->c_entry_end + cbmem->c_entry_end->ceh_len -
+           (uint32_t)cbmem->c_entry_start;
+    if ((int32_t)used < 0) {
+        used += size;
+    }
+
+    info->size = size;
+    info->used = used;
+
+    return 0;
+}
+#endif
+
 const struct log_handler log_cbmem_handler = {
     .log_type = LOG_TYPE_MEMORY,
     .log_read = log_cbmem_read,
@@ -216,4 +241,7 @@ const struct log_handler log_cbmem_handler = {
     .log_append_mbuf_body = log_cbmem_append_mbuf_body,
     .log_walk = log_cbmem_walk,
     .log_flush = log_cbmem_flush,
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+    .log_storage_info = log_cbmem_storage_info,
+#endif
 };

--- a/sys/log/full/src/log_fcb_slot1.c
+++ b/sys/log/full/src/log_fcb_slot1.c
@@ -126,6 +126,10 @@ log_fcb_slot1_registered(struct log *log)
         s1->l_current = NULL;
     }
 
+    if (s1->l_current && s1->l_current->l_log->log_registered) {
+        s1->l_current->l_log->log_registered(s1->l_current);
+    }
+
     os_mutex_release(&g_log_slot1_mutex);
 
     return 0;
@@ -205,6 +209,10 @@ log_fcb_slot1_lock(void)
             log_flush(s1->l_current);
         } else {
             s1->l_current = NULL;
+        }
+
+        if (s1->l_current && s1->l_current->l_log->log_registered) {
+            s1->l_current->l_log->log_registered(s1->l_current);
         }
 
         os_mutex_release(&s1->mutex);
@@ -292,6 +300,9 @@ log_fcb_slot1_unlock(void)
         }
 
         s1->l_current = &s1->l_fcb;
+        if (s1->l_current->l_log->log_registered) {
+            s1->l_current->l_log->log_registered(s1->l_current);
+        }
 
         os_mutex_release(&s1->mutex);
     }

--- a/sys/log/full/src/log_fcb_slot1.c
+++ b/sys/log/full/src/log_fcb_slot1.c
@@ -109,6 +109,12 @@ log_fcb_slot1_storage_info(struct log *log, struct log_storage_info *info)
 }
 
 static int
+log_fcb_slot1_set_watermark(struct log *log, uint32_t index)
+{
+    return LOG_FCB_SLOT1_CALL(log, log_set_watermark, index);
+}
+
+static int
 log_fcb_slot1_registered(struct log *log)
 {
     struct log_fcb_slot1 *s1 = log->l_arg;
@@ -153,6 +159,9 @@ const struct log_handler log_fcb_slot1_handler = {
     .log_flush = log_fcb_slot1_flush,
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
     .log_storage_info = log_fcb_slot1_storage_info,
+#endif
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    .log_set_watermark = log_fcb_slot1_set_watermark,
 #endif
     .log_registered = log_fcb_slot1_registered,
 };

--- a/sys/log/full/src/log_fcb_slot1.c
+++ b/sys/log/full/src/log_fcb_slot1.c
@@ -103,6 +103,12 @@ log_fcb_slot1_flush(struct log *log)
 }
 
 static int
+log_fcb_slot1_storage_info(struct log *log, struct log_storage_info *info)
+{
+    return LOG_FCB_SLOT1_CALL(log, log_storage_info, info);
+}
+
+static int
 log_fcb_slot1_registered(struct log *log)
 {
     struct log_fcb_slot1 *s1 = log->l_arg;
@@ -145,6 +151,9 @@ const struct log_handler log_fcb_slot1_handler = {
     .log_append_mbuf_body = log_fcb_slot1_append_mbuf_body,
     .log_walk = log_fcb_slot1_walk,
     .log_flush = log_fcb_slot1_flush,
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+    .log_storage_info = log_fcb_slot1_storage_info,
+#endif
     .log_registered = log_fcb_slot1_registered,
 };
 

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -38,6 +38,7 @@ static int log_nmgr_clear(struct mgmt_cbuf *njb);
 static int log_nmgr_module_list(struct mgmt_cbuf *njb);
 static int log_nmgr_level_list(struct mgmt_cbuf *njb);
 static int log_nmgr_logs_list(struct mgmt_cbuf *njb);
+static int log_nmgr_set_watermark(struct mgmt_cbuf *njb);
 static struct mgmt_group log_nmgr_group;
 
 
@@ -49,7 +50,8 @@ static struct mgmt_handler log_nmgr_group_handlers[] = {
     [LOGS_NMGR_OP_CLEAR] = {log_nmgr_clear, log_nmgr_clear},
     [LOGS_NMGR_OP_MODULE_LIST] = {log_nmgr_module_list, NULL},
     [LOGS_NMGR_OP_LEVEL_LIST] = {log_nmgr_level_list, NULL},
-    [LOGS_NMGR_OP_LOGS_LIST] = {log_nmgr_logs_list, NULL}
+    [LOGS_NMGR_OP_LOGS_LIST] = {log_nmgr_logs_list, NULL},
+    [LOGS_NMGR_OP_SET_WATERMARK] = {log_nmgr_set_watermark, NULL},
 };
 
 struct log_encode_data {
@@ -579,6 +581,79 @@ log_nmgr_clear(struct mgmt_cbuf *cb)
     }
 
     return 0;
+}
+
+static int
+log_nmgr_set_watermark(struct mgmt_cbuf *cb)
+{
+    struct log *log;
+    int rc;
+    char name[LOG_NAME_MAX_LEN] = {0};
+    int name_len;
+    uint64_t index;
+
+    const struct cbor_attr_t attr[4] = {
+        [0] = {
+            .attribute = "log_name",
+            .type = CborAttrTextStringType,
+            .addr.string = name,
+            .len = sizeof(name)
+        },
+        [1] = {
+            .attribute = "index",
+            .type = CborAttrUnsignedIntegerType,
+            .addr.uinteger = &index
+        },
+        [2] = {
+            .attribute = NULL
+        }
+    };
+
+    rc = cbor_read_object(&cb->it, attr);
+    if (rc) {
+        return rc;
+    }
+
+    name_len = strlen(name);
+    log = NULL;
+    while (1) {
+        log = log_list_get_next(log);
+        if (!log) {
+            break;
+        }
+
+        if (log->l_log->log_type == LOG_TYPE_STREAM) {
+            continue;
+        }
+
+        /* Conditions for returning specific logs */
+        if ((name_len > 0) && strcmp(name, log->l_name)) {
+            continue;
+        }
+
+        rc = log_set_watermark(log, index);
+        if (rc) {
+            goto err;
+        }
+
+        /* If a log was found, encode and break */
+        if (name_len > 0) {
+            break;
+        }
+    }
+
+    /* Running out of logs list and we have a specific log to look for */
+    if (!log && name_len > 0) {
+        rc = OS_EINVAL;
+    }
+
+err:
+    rc = mgmt_cbuf_setoerr(cb, 0);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return (rc);
 }
 
 /**

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -151,6 +151,10 @@ shell_log_storage_cmd(int argc, char **argv)
         } else {
             console_printf("%s: %d of %d used\n", log->l_name,
                            (unsigned)info.used, (unsigned)info.size);
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+            console_printf("%s: %d of %d used by unread entries\n", log->l_name,
+                           (unsigned)info.used_unread, (unsigned)info.size);
+#endif
         }
     }
 

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -128,6 +128,36 @@ shell_log_slot1_cmd(int argc, char **argv)
 }
 #endif
 
+#if MYNEWT_VAL(LOG_STORAGE_INFO)
+int
+shell_log_storage_cmd(int argc, char **argv)
+{
+    struct log *log;
+    struct log_storage_info info;
+
+    log = NULL;
+    while (1) {
+        log = log_list_get_next(log);
+        if (log == NULL) {
+            break;
+        }
+
+        if (log->l_log->log_type == LOG_TYPE_STREAM) {
+            continue;
+        }
+
+        if (log_storage_info(log, &info)) {
+            console_printf("Storage info not supported for %s\n", log->l_name);
+        } else {
+            console_printf("%s: %d of %d used\n", log->l_name,
+                           (unsigned)info.used, (unsigned)info.size);
+        }
+    }
+
+    return (0);
+}
+#endif
+
 #endif
 
 

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -71,3 +71,10 @@ syscfg.defs:
             Writes with a level less than the module's minimum level are
             discarded.  Enabling this setting requires 128 bytes of bss.
         value: 1
+
+    LOG_STORAGE_INFO:
+        description: >
+            Enable "storage_info" API which keeps track of log storage usage and
+            can return total number of bytes available for log and number of
+            bytes used by entries in log.
+        value: 0

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -78,3 +78,12 @@ syscfg.defs:
             can return total number of bytes available for log and number of
             bytes used by entries in log.
         value: 0
+
+    LOG_STORAGE_WATERMARK:
+        description: >
+            Enable "set_watermark" API which can watermark log by entry index and
+            thus allow to e.g. keep track of read items in log e.g. (via newtmgr).
+            This also extends information returned by "storage_info" to number of
+            bytes used by entries above watermark.
+        value: 0
+        restrictions: LOG_STORAGE_INFO


### PR DESCRIPTION
This adds two new APIs to log subsystem:
- `storage_info` which allows to query log storage for total storage size and currently used storage
- `set_watermark` which allows to set watermark on log (by index) and thus mark e.g. last item read

watermark for each log is stored persistently in `config` and restored on reboot