### PR TITLE
lis2dw12: Fix self testing function error

### DIFF
--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -1929,7 +1929,7 @@ int lis2dw12_run_self_test(struct sensor_itf *itf, int *result)
     int i;
     uint8_t prev_config[6];
     /* set config per datasheet, with positive self test mode enabled. */
-    uint8_t st_config[] = {0x44, 0x08, 0x40, 0x00, 0x00, 0x10};
+    uint8_t st_config[] = {0x44, 0x04, 0x40, 0x00, 0x00, 0x10};
 
     rc = lis2dw12_readlen(itf, LIS2DW12_REG_CTRL_REG1, prev_config, 6);
     if (rc) {


### PR DESCRIPTION
Per datasheet configuration that was supposed to switch on
positive self test mode, did it, but also turned off register
auto increment functionality.
This effectively disabled possibility to read
normal values from accelerometer since those reading are
done in blocks and not single registers.
After the self test, original configuration was meant to be restored,
alas it used multi register write that was just turned off,
so the configuration was not restored.

Now IF_ADD_INC is set in per-datasheet configuration.