### PR TITLE
native hal_flash; use mktemp() instead of tmpnam() to generate name for temp flash file.

### DIFF
--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -93,11 +93,11 @@ static void
 flash_native_file_open(char *name)
 {
     int created = 0;
-    extern char *tmpnam(char *s);
     extern int ftruncate(int fd, off_t length);
 
     if (!name) {
-        name = tmpnam(NULL);
+        char tmpl[] = "/tmp/native_flash.XXXXXX";
+        name = mktemp(tmpl);
     }
     file = open(name, O_RDWR);
     if (file < 0) {

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -95,19 +95,26 @@ flash_native_file_open(char *name)
     int created = 0;
     extern int ftruncate(int fd, off_t length);
 
-    if (!name) {
+    if (name) {
+        file = open(name, O_RDWR);
+        if (file < 0) {
+            file = open(name, O_RDWR | O_CREAT, 0660);
+            assert(file > 0);
+            created = 1;
+        }
+    } else {
         char tmpl[] = "/tmp/native_flash.XXXXXX";
-        name = mktemp(tmpl);
-    }
-    file = open(name, O_RDWR);
-    if (file < 0) {
-        file = open(name, O_RDWR | O_CREAT, 0660);
+        file = mkstemp(tmpl);
         assert(file > 0);
         created = 1;
+    }
+
+    if (created) {
         if (ftruncate(file, native_flash_dev.hf_size) < 0) {
             assert(0);
         }
     }
+
     file_loc = mmap(0, native_flash_dev.hf_size,
           PROT_READ | PROT_WRITE, MAP_SHARED, file, 0);
     assert(file_loc != MAP_FAILED);


### PR DESCRIPTION
New MacOS headers are complaining about tmpnam() being deprecated.