### PR TITLE
Lis2dw12 fixes from lis2ds12 port

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -59,6 +59,9 @@
 #if MYNEWT_VAL(LIS2DS12_CLI)
 #include <lis2ds12/lis2ds12.h>
 #endif
+#if MYNEWT_VAL(LIS2DW12_CLI)
+#include <lis2dw12/lis2dw12.h>
+#endif
 
 #if MYNEWT_VAL(SENSOR_OIC)
 #include <oic/oc_api.h>
@@ -444,6 +447,10 @@ sensors_dev_shell_init(void)
 
 #if MYNEWT_VAL(LIS2DS12_CLI)
     lis2ds12_shell_init();
+#endif
+
+#if MYNEWT_VAL(LIS2DW12_CLI)
+    lis2dw12_shell_init();
 #endif
 }
 

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -559,7 +559,7 @@ int lis2dw12_get_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
  * Set freefall detection configuration
  *
  * @param itf The sensor interface
- * @param dur Freefall duration (5 bits LSB = 1/ODR)
+ * @param dur Freefall duration (6 bits LSB = 1/ODR)
  * @param ths Freefall threshold (3 bits)
  *
  * @return 0 on success, non-zero on failure
@@ -685,7 +685,7 @@ int lis2dw12_get_sixd_src(struct sensor_itf *itf, uint8_t *status);
  *
  * @param itf The sensor interface
  * @param mode FIFO mode to setup
- * @patam fifo_ths Threshold to set for FIFO
+ * @param fifo_ths Threshold to set for FIFO
  *
  * @return 0 on success, non-zero on failure
  */
@@ -695,7 +695,7 @@ int lis2dw12_set_fifo_cfg(struct sensor_itf *itf, enum lis2dw12_fifo_mode mode, 
  * Get Number of Samples in FIFO
  *
  * @param itf The sensor interface
- * @patam samples Ptr to return number of samples in
+ * @param samples Ptr to return number of samples in
  *
  * @return 0 on success, non-zero on failure
  */

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -823,24 +823,24 @@ int lis2dw12_set_stationary_en(struct sensor_itf *itf, uint8_t en);
 int lis2dw12_get_stationary_en(struct sensor_itf *itf, uint8_t *en);
 
 /**
- * Set whether interrupts are enabled
+ * Set whether interrupt 2 signals is mapped onto interrupt 1 pin
  *
  * @param itf The sensor interface
  * @param enable Value to set (0 = disabled, 1 = enabled)
  *
  * @return 0 on success, non-zero on failure
  */
-int lis2dw12_set_int1_on_int2_map(struct sensor_itf *itf, bool enable);
+int lis2dw12_set_int2_on_int1_map(struct sensor_itf *itf, bool enable);
 
 /**
- * Get whether interrupt 1 signals is mapped onto interrupt 2 pin
+ * Get whether interrupt 2 signals is mapped onto interrupt 1 pin
  *
  * @param itf The sensor interface
  * @param val Value to set (0 = disabled, 1 = enabled)
  *
  * @return 0 on success, non-zero on failure
  */
-int lis2dw12_get_int1_on_int2_map(struct sensor_itf *itf, uint8_t *val);
+int lis2dw12_get_int2_on_int1_map(struct sensor_itf *itf, uint8_t *val);
 
 /**
  * Run Self test on sensor

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -220,7 +220,6 @@ struct lis2dw12_cfg {
     uint8_t double_tap_event_enable     : 1;
 
     uint8_t slp_mode       : 1;
-    uint8_t self_test_mode : 3;
 
     /* Power mode */
     uint8_t power_mode     : 4;

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -1295,7 +1295,7 @@ int lis2dw12_get_tap_cfg(struct sensor_itf *itf, struct lis2dw12_tap_settings *c
  * Set freefall detection configuration
  *
  * @param the sensor interface
- * @param freefall duration (5 bits LSB = 1/ODR)
+ * @param freefall duration (6 bits LSB = 1/ODR)
  * @param freefall threshold (3 bits)
  * @return 0 on success, non-zero on failure
  */
@@ -1359,7 +1359,7 @@ int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths)
  *
  * @param the sensor interface
  * @param FIFO mode to setup
- * @patam Threshold to set for FIFO
+ * @param Threshold to set for FIFO
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_set_fifo_cfg(struct sensor_itf *itf, enum lis2dw12_fifo_mode mode, uint8_t fifo_ths)
@@ -1376,7 +1376,7 @@ int lis2dw12_set_fifo_cfg(struct sensor_itf *itf, enum lis2dw12_fifo_mode mode, 
  * Get Number of Samples in FIFO
  *
  * @param the sensor interface
- * @patam Pointer to return number of samples in
+ * @param Pointer to return number of samples in
  * @return 0 on success, non-zero on failure
  */
 int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples)
@@ -1397,8 +1397,8 @@ int lis2dw12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples)
 /**
  * Clear interrupt pin configuration for interrupt 1
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int1 config
  * @return 0 on success, non-zero on failure
  */
 int
@@ -1425,8 +1425,8 @@ err:
 /**
  * Clear interrupt pin configuration for interrupt 2
  *
- * @param the sensor interface
- * @param config
+ * @param itf The sensor interface
+ * @param cfg int2 config
  * @return 0 on success, non-zero on failure
  */
 int

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -2992,12 +2992,6 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
 
     lis2dw12->cfg.rate = cfg->rate;
 
-    rc = lis2dw12_set_self_test(itf, cfg->self_test_mode);
-    if (rc) {
-        goto err;
-    }
-    lis2dw12->cfg.self_test_mode = cfg->self_test_mode;
-
     rc = lis2dw12_set_power_mode(itf, cfg->power_mode);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -1351,7 +1351,7 @@ int lis2dw12_get_freefall(struct sensor_itf *itf, uint8_t *dur, uint8_t *ths)
 
     *dur = (ff_reg & LIS2DW12_FREEFALL_DUR) >> 3;
     *dur |= wake_reg & LIS2DW12_WAKE_DUR_FF_DUR ? (1 << 5) : 0;
-    *ths = wake_reg & LIS2DW12_FREEFALL_THS;
+    *ths = ff_reg & LIS2DW12_FREEFALL_THS;
 
     return 0;
 }

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -1863,13 +1863,13 @@ int lis2dw12_set_int_enable(struct sensor_itf *itf, uint8_t enabled)
 }
 
 /**
- * Set whether interrupt 1 signals is mapped onto interrupt 2 pin
+ * Set whether interrupt 2 signals is mapped onto interrupt 1 pin
  *
  * @param the sensor interface
  * @param value to set (false = disabled, true = enabled)
  * @return 0 on success, non-zero on failure
  */
-int lis2dw12_set_int1_on_int2_map(struct sensor_itf *itf, bool enable)
+int lis2dw12_set_int2_on_int1_map(struct sensor_itf *itf, bool enable)
 {
     uint8_t reg;
     int rc;
@@ -3092,7 +3092,7 @@ lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg)
     }
     lis2dw12->cfg.tap = cfg->tap;
 
-    rc = lis2dw12_set_int1_on_int2_map(itf, cfg->map_int2_to_int1);
+    rc = lis2dw12_set_int2_on_int1_map(itf, cfg->map_int2_to_int1);
     if(rc) {
         goto err;
     }

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -510,7 +510,8 @@ lis2dw12_set_full_scale(struct sensor_itf *itf, uint8_t fs)
         goto err;
     }
 
-    reg = (reg & ~LIS2DW12_CTRL_REG6_FS) | fs;
+    reg &= ~LIS2DW12_CTRL_REG6_FS;
+    reg |= (fs & LIS2DW12_CTRL_REG6_FS);
 
     rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG6, reg);
     if (rc) {
@@ -573,7 +574,8 @@ lis2dw12_set_rate(struct sensor_itf *itf, uint8_t rate)
         goto err;
     }
 
-    reg = (reg & ~LIS2DW12_CTRL_REG1_ODR) | rate;
+    reg &= ~LIS2DW12_CTRL_REG1_ODR;
+    reg |= (rate & LIS2DW12_CTRL_REG1_ODR);
 
     rc = lis2dw12_write8(itf, LIS2DW12_REG_CTRL_REG1, reg);
     if (rc) {

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -796,7 +796,7 @@ config_lis2dw12_sensor(void)
 {
     int rc;
     struct os_dev *dev;
-    struct lis2dw12_cfg cfg;
+    struct lis2dw12_cfg cfg = {0};
 
     dev = (struct os_dev *) os_dev_open("lis2dw12_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -839,7 +839,6 @@ config_lis2dw12_sensor(void)
     cfg.int_latched = 0;
     cfg.int_active_low = 0;
     cfg.slp_mode = 0;
-    cfg.self_test_mode = LIS2DW12_ST_MODE_DISABLE;
 
     cfg.fifo_mode = LIS2DW12_FIFO_M_BYPASS;
     cfg.fifo_threshold = 32;

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -801,7 +801,8 @@ config_lis2dw12_sensor(void)
     dev = (struct os_dev *) os_dev_open("lis2dw12_0", OS_TIMEOUT_NEVER, NULL);
     assert(dev != NULL);
 
-    cfg.rate = LIS2DW12_DATA_RATE_200HZ;
+    /* Valid Tap ODRs are 400 Hz, 800 Hz and 1600 Hz  AN5038 5.6.3 */
+    cfg.rate = LIS2DW12_DATA_RATE_400HZ;
     cfg.fs = LIS2DW12_FS_2G;
 
     cfg.offset_x = 0;
@@ -819,12 +820,12 @@ config_lis2dw12_sensor(void)
     cfg.tap.en_4d = 0;
     cfg.tap.ths_6d = LIS2DW12_6D_THS_80_DEG;
     cfg.tap.tap_priority = LIS2DW12_TAP_PRIOR_XYZ;
-    cfg.tap.tap_ths_x = 0x3;
-    cfg.tap.tap_ths_y = 0x3;
-    cfg.tap.tap_ths_z = 0x3;
-    cfg.tap.latency = 8; /* 640ms */
-    cfg.tap.quiet = 0; /* 10ms */
-    cfg.tap.shock = 3; /* 120ms */
+    cfg.tap.tap_ths_x = 0x3; /* 1875mg = (3 * FS / 32) */
+    cfg.tap.tap_ths_y = 0x3; /* 1875mg = (3 * FS / 32) */
+    cfg.tap.tap_ths_z = 0x3; /* 1875mg = (3 * FS / 32) */
+    cfg.tap.latency = 8; /* 640ms (= 8 * 32 / ODR) */
+    cfg.tap.quiet = 0; /* 5 ms  (= 2 / ODR */
+    cfg.tap.shock = 3; /* 60 ms (= 3 * 8 / ODR) */
 
     cfg.double_tap_event_enable = 0;
 

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -829,8 +829,8 @@ config_lis2dw12_sensor(void)
 
     cfg.double_tap_event_enable = 0;
 
-    cfg.freefall_dur = 6;
-    cfg.freefall_ths = 3; /* ~312mg */
+    cfg.freefall_dur = 6; /* 15ms (= 6/ODR) */
+    cfg.freefall_ths = 3; /* ~312mg (= 31.25 mg * 10) */
 
     cfg.int1_pin_cfg = 0;
     cfg.int2_pin_cfg = 0;
@@ -844,9 +844,9 @@ config_lis2dw12_sensor(void)
     cfg.fifo_mode = LIS2DW12_FIFO_M_BYPASS;
     cfg.fifo_threshold = 32;
 
-    cfg.wake_up_ths = 0;
-    cfg.wake_up_dur = 0;
-    cfg.sleep_duration = 0;
+    cfg.wake_up_ths = 0; /* 0 mg (= 0 * FS / 64) */
+    cfg.wake_up_dur = 0; /* 0 ms (= 0 * 1 / ODR) */
+    cfg.sleep_duration = 0; /* 0 ms (= 0 * 512 / ODR) */
 
     cfg.stationary_detection_enable = 0;
 


### PR DESCRIPTION
Needs testing, I dont have this device this is just my set of notes from porting. Happy to rebase or remove any commits.

Id especially like to see if self test is still passing for people as it had a few problems still. I dont personally feel like its properly implemented even yet.

AN5038 Section 8 says

> The procedure consists of:
> 1. enabling the accelerometer
> 2. averaging five samples before enabling the self-test
> 3. averaging five samples after enabling the self-test
> 4. computing the difference in absolute value for each axis and verifying that it falls within
> a given range. The min and max values are provided in the datasheet.

And Im not sure I consider the current implementation following that quote
This https://github.com/apache/mynewt-core/pull/948/commits/787e2a2a915b9f3e4da2fce6ea60989b5e6cc1ba is passing for me and my current recommendation, but I dont have your board.