### PR TITLE
syscfg to configure NFC pins to be GPIO

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -30,8 +30,5 @@ pkg.deps:
     - hw/cmsis-core 
     - hw/hal 
 
-# NRF52810 doesn't support SPI/I2C (Use SPIM/I2CM instead)
-pkg.ign_files.BSP_NRF52810:
-    - "hal_spi.c"
-    - "hal_i2c.c"
-
+pkg.cflags.NFC_PINS_AS_GPIO: 
+     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -180,6 +180,10 @@ syscfg.defs:
     QSPI_PIN_DIO3:
         description: 'DIO3 pin for QSPI'
         value: -1
+        
+    NFC_PINS_AS_GPIO:
+        description: 'Use NFC pins as GPIOs instead of NFC functionality'
+        value: 0
 
 
 # The XTAL_xxx definitions are used to set the clock source used for the low


### PR DESCRIPTION
Break out a syscfg value to configure the NFC pins as GPIOs