### PR TITLE
sys/log: Fix counting log entries

### DIFF
--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -245,7 +245,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     }
     return (0);
 err:
-    ed->counter++;
     return (rc);
 }
 


### PR DESCRIPTION
Skipped log entries should not be counted when encoding for nmgr.