### PR TITLE
Update repository dependencies

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -53,6 +53,9 @@ repo.newt_compatibility:
         0.0.0: good
 
     # Core 1.1.0+ requires newt 1.1.0+ (feature: self-overrides).
+    # Core 1.4.0+ requires newt 1.4.0+ (feature: sync repo deps).
+    1.4.0:
+        1.4.0: good
     1.3.0:
         1.1.0: good
     1.2.0:
@@ -66,4 +69,4 @@ repo.deps:
         user: apache
         repo: mynewt-nimble
         vers:
-            master: 1-latest
+            master: 0-dev


### PR DESCRIPTION
Core 1.4 requires newt 1.4 for repo dependencies. Also make -core
(on master branch only) depend on nimble 0-dev.