### PR TITLE
tinycbor: Fix cmp return value from readers

### DIFF
--- a/encoding/tinycbor/src/cbor_buf_reader.c
+++ b/encoding/tinycbor/src/cbor_buf_reader.c
@@ -55,7 +55,7 @@ cbor_buf_reader_cmp(struct cbor_decoder_reader *d, char *dst, int src_offset,
                     size_t len)
 {
     struct cbor_buf_reader *cb = (struct cbor_buf_reader *) d;
-    return memcmp(dst, cb->buffer + src_offset, len);
+    return memcmp(dst, cb->buffer + src_offset, len) == 0;
 }
 
 static uintptr_t

--- a/encoding/tinycbor/src/cbor_mbuf_reader.c
+++ b/encoding/tinycbor/src/cbor_mbuf_reader.c
@@ -66,7 +66,7 @@ cbor_mbuf_reader_cmp(struct cbor_decoder_reader *d, char *buf, int offset,
                      size_t len)
 {
     struct cbor_mbuf_reader *cb = (struct cbor_mbuf_reader *) d;
-    return os_mbuf_cmpf(cb->m, offset + cb->init_off, buf, len);
+    return os_mbuf_cmpf(cb->m, offset + cb->init_off, buf, len) == 0;
 }
 
 static uintptr_t


### PR DESCRIPTION
cmp functions are used as IteratorFunc and expected behaviour is to
return non-zero value on success so the opposite of what memcmp-like
function do.