### PR TITLE
syscfg to enable nRF52 pin reset

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -37,3 +37,6 @@ pkg.ign_files.BSP_NRF52810:
 
 pkg.cflags.NFC_PINS_AS_GPIO: 
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
+
+pkg.cflags.GPIO_AS_PIN_RESET: 
+    - '-DCONFIG_GPIO_AS_PINRESET=1'

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -185,6 +185,10 @@ syscfg.defs:
         description: 'Use NFC pins as GPIOs instead of NFC functionality'
         value: 1
 
+    GPIO_AS_PIN_RESET:
+        description: 'Enable pin reset'
+        value: 0
+
 
 # The XTAL_xxx definitions are used to set the clock source used for the low
 # frequency clock. It is required that at least one of these sources is


### PR DESCRIPTION
A syscfg value to enable pin reset on the `nrf52xxx` instead of using it as a normal GPIO.