### PR TITLE
nrf52_pwm: catch NRFX_PWM_EVT_STOPPED events

### DIFF
--- a/apps/pwm_test/src/main.c
+++ b/apps/pwm_test/src/main.c
@@ -116,6 +116,9 @@ pwm_end_seq_handler(void* unused)
     } else {
         func_num++;
     }
+    rc = pwm_disable(pwm); /* Not needed but used for testing purposes. */
+    assert(rc == 0);
+
     rc = pwm_enable(pwm);
     assert(rc == 0);
 }

--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -123,9 +123,10 @@ static void handler_0(nrfx_pwm_evt_type_t event_type)
         break;
 
     case NRFX_PWM_EVT_FINISHED :
-        instances[0].playing = false;
-        nrfx_pwm_uninit(&instances[0].drv_instance);
         instances[0].seq_end_handler(instances[0].seq_end_data);
+        break;
+
+    case NRFX_PWM_EVT_STOPPED :
         break;
 
     default:
@@ -145,9 +146,10 @@ static void handler_1(nrfx_pwm_evt_type_t event_type)
         break;
 
     case NRFX_PWM_EVT_FINISHED :
-        instances[1].playing = false;
-        nrfx_pwm_uninit(&instances[1].drv_instance);
         instances[1].seq_end_handler(instances[1].seq_end_data);
+        break;
+
+    case NRFX_PWM_EVT_STOPPED :
         break;
 
     default:
@@ -167,9 +169,10 @@ static void handler_2(nrfx_pwm_evt_type_t event_type)
         break;
 
     case NRFX_PWM_EVT_FINISHED :
-        instances[2].playing = false;
-        nrfx_pwm_uninit(&instances[2].drv_instance);
         instances[2].seq_end_handler(instances[2].seq_end_data);
+        break;
+
+    case NRFX_PWM_EVT_STOPPED :
         break;
 
     default:
@@ -190,9 +193,10 @@ static void handler_3(nrfx_pwm_evt_type_t event_type)
         break;
 
     case NRFX_PWM_EVT_FINISHED :
-        instances[3].playing = false;
-        nrfx_pwm_uninit(&instances[3].drv_instance);
         instances[3].seq_end_handler(instances[3].seq_end_data);
+        break;
+
+    case NRFX_PWM_EVT_STOPPED :
         break;
 
     default:
@@ -335,9 +339,7 @@ nrf52_pwm_close(struct os_dev *odev)
         return (EINVAL);
     }
 
-    if (!instances[inst_id].playing) {
-        nrfx_pwm_uninit(&instances[inst_id].drv_instance);
-    }
+    nrfx_pwm_uninit(&instances[inst_id].drv_instance);
     cleanup_instance(inst_id);
 
     if (os_started()) {
@@ -543,12 +545,8 @@ nrf52_pwm_disable(struct pwm_dev *dev)
         return (-EINVAL);
     }
 
-    if (!nrfx_pwm_stop(&instances[inst_id].drv_instance, true)) {
-        return (-EINVAL);
-    }
-    instances[inst_id].playing = false;
-
     nrfx_pwm_uninit(&instances[inst_id].drv_instance);
+    instances[inst_id].playing = false;
     return (0);
 }
 


### PR DESCRIPTION
This PR makes pwm_stop not crash when called from seq_end_handler.