### PR TITLE
libc/baselibc: Add optimized memcpy() for Cortex-M

### DIFF
--- a/libc/baselibc/src/memcpy.c
+++ b/libc/baselibc/src/memcpy.c
@@ -19,6 +19,32 @@ void *memcpy(void *dst, const void *src, size_t n)
 	asm volatile ("cld ; rep ; movsq ; movl %3,%%ecx ; rep ; movsb":"+c"
 		      (nq), "+S"(p), "+D"(q)
 		      :"r"((uint32_t) (n & 7)));
+#elif defined(ARCH_cortex_m0) || defined(ARCH_cortex_m3) || defined(ARCH_cortex_m4) || defined(ARCH_cortex_m7)
+        (void)p;
+        (void)q;
+
+#if defined(ARCH_cortex_m3) || defined(ARCH_cortex_m4) || defined(ARCH_cortex_m7)
+        /*
+         * For Cortex-M3/4/7 we can speed up a bit by moving 32-bit words since
+         * it supports unaligned access.
+         */
+        asm (".syntax unified           \n"
+             "       b    test1         \n"
+             "loop1: ldr  r3, [r1, r2]  \n"
+             "       str  r3, [r0, r2]  \n"
+             "test1: subs r2, #4        \n"
+             "       bpl  loop1         \n"
+             "       add  r2, #4        \n"
+            );
+#endif
+
+        asm (".syntax unified           \n"
+             "       b    test2         \n"
+             "loop2: ldrb r3, [r1, r2]  \n"
+             "       strb r3, [r0, r2]  \n"
+             "test2: subs r2, #1        \n"
+             "       bpl  loop2         \n"
+            );
 #else
 	while (n--) {
 		*q++ = *p++;


### PR DESCRIPTION
This adds a bit more optimized version of memcpy() for Cortex-M written
in inline assembly.

Naive implementation optimized by GCC (7.2.1) takes 12 cycles per byte
on Cortex-M0:
```
          memcpy:
0000a706:   movs    r3, #0
 9        {
0000a708:   push    {r4, lr}
23        	while (n--) {
0000a70a:   cmp     r2, r3
0000a70c:   bee.n   0xa710 <memcpy+10>
29        }
0000a70e:   pop     {r4, pc}
24        		*q++ = *p++;
0000a710:   ldrb    r4, [r1, r3]
0000a712:   strb    r4, [r0, r3]
0000a714:   adds    r3, #1
0000a716:   b.n     0xa70a <memcpy+4>
29        }
```
Inline assembly version takes only 8 cycles per byte.

For Cortex-M3/4/7 we can make it even faster as they support unaligned
memory access so we can easily copy by word.