### PR TITLE
adp5061 - Fix build when CLI is not enabled

### DIFF
--- a/hw/drivers/chg_ctrl/adp5061/pkg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/pkg.yml
@@ -31,3 +31,4 @@ pkg.deps:
 
 pkg.deps.ADP5061_CLI:
     - '@apache-mynewt-core/sys/shell'
+    - '@apache-mynewt-core/util/parse'

--- a/hw/drivers/chg_ctrl/adp5061/src/adp5061_shell.c
+++ b/hw/drivers/chg_ctrl/adp5061/src/adp5061_shell.c
@@ -20,13 +20,14 @@
 #include <string.h>
 #include <errno.h>
 #include <os/mynewt.h>
+
+#if MYNEWT_VAL(ADP5061_CLI)
+
 #include <console/console.h>
 #include <shell/shell.h>
 #include <adp5061/adp5061.h>
 #include <parse/parse.h>
 #include "adp5061_priv.h"
-
-#if MYNEWT_VAL(ADP5061_CLI)
 
 static struct adp5061_dev *adp5061_dev;
 


### PR DESCRIPTION
* Make `#include` directives conditional along with the code.
* Depend on `util/parse` when the CLI is enabled.