### PR TITLE
log/modlog - Module-mapped logging

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -256,6 +256,11 @@ int log_append_typed(struct log *, uint8_t, uint8_t, uint8_t, void *, uint16_t);
 int log_append_mbuf_typed(struct log *, uint8_t, uint8_t, uint8_t,
                           struct os_mbuf *);
 
+#if MYNEWT_VAL(LOG_CONSOLE)
+struct log *log_console_get(void);
+void log_console_init(void);
+#endif
+
 static inline int
 log_append(struct log *log, uint8_t module, uint8_t level, void *data,
            uint16_t len)

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -83,6 +83,10 @@ log_init(void)
     rc = log_nmgr_register_group();
     SYSINIT_PANIC_ASSERT(rc == 0);
 #endif
+
+#if MYNEWT_VAL(LOG_CONSOLE)
+    log_console_init();
+#endif
 }
 
 struct log *

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -34,7 +34,6 @@ struct log_info g_log_info;
 
 static STAILQ_HEAD(, log) g_log_list = STAILQ_HEAD_INITIALIZER(g_log_list);
 static const char *g_log_module_list[ MYNEWT_VAL(LOG_MAX_USER_MODULES) ];
-static uint8_t log_inited;
 static uint8_t log_written;
 
 #if MYNEWT_VAL(LOG_CLI)
@@ -63,12 +62,9 @@ log_init(void)
 
     (void)rc;
 
-    if (log_inited) {
-        return;
-    }
-    log_inited = 1;
     log_written = 0;
 
+    STAILQ_INIT(&g_log_list);
     g_log_info.li_version = MYNEWT_VAL(LOG_VERSION);
     g_log_info.li_next_index = 0;
 

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -25,6 +25,14 @@
 #include <console/console.h>
 #include "log/log.h"
 
+static struct log log_console;
+
+struct log *
+log_console_get(void)
+{
+    return &log_console;
+}
+
 static int
 log_console_append(struct log *log, void *buf, int len)
 {
@@ -75,5 +83,18 @@ const struct log_handler log_console_handler = {
     .log_walk = log_console_walk,
     .log_flush = log_console_flush,
 };
+
+void
+log_console_init(void)
+{
+    int rc;
+
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    rc = log_register("console", &log_console, &log_console_handler, NULL,
+                      MYNEWT_VAL(LOG_LEVEL));
+    SYSINIT_PANIC_ASSERT(rc == 0);
+}
 
 #endif

--- a/sys/log/modlog/include/modlog/modlog.h
+++ b/sys/log/modlog/include/modlog/modlog.h
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @file
+ * @brief modlog - Module-mapped logging.
+ *
+ * The modlog facility allows log entries to be written to numeric modules
+ * identifiers.  In typical usage, startup code maps 8-bit module IDs to one or
+ * more log objects, while other parts of the application log events by write
+ * entries to modules IDs.  This usage differs from the underlying `sys/log`
+ * facility, which requires clients to provide a log object to write to
+ * rather than just a module identifier.
+ *
+ * Benefits provided by the modlog package are:
+ *     o Improved modularity - configuration and usage are distinct.
+ *     o Ability to write to several logs with a single function call.  If one
+ *       module ID is mapped to several logs, a write to that ID causes all
+ *       mapped logs to be written.
+ *     o Default mappings.  Writes to unmapped module IDs get written to an
+ *       optional set of default logs.
+ *     o Minimum log level per mapping.  Writes specifying a log level less
+ *       than the module's minimum level are discarded.
+ *
+ * Costs of using modlog rather than the bare `sys/log` facility are:
+ *     o Increased RAM usage (`MODLOG_MAX_MAPPINGS` * 12).
+ *     o Increased CPU usage - each log write requires a lookup in the set
+ *       of configured modlog mappings.
+ */
+
+#ifndef H_MODLOG_
+#define H_MODLOG_
+
+#include "os/mynewt.h"
+#include "log/log.h"
+
+#define MODLOG_MODULE_DFLT      255
+
+/**
+ * @brief Modlog mapping descriptor.
+ *
+ * Describes an individual mapping of module ID to log.
+ */
+struct modlog_desc {
+    /** The log being mapped. */
+    struct log *log;
+
+    /** Unique identifier for this mapping. */
+    uint8_t handle;
+
+    /** The numeric module ID being mapped. */
+    uint8_t module;
+
+    /** Log writes with a level less than this are discarded. */
+    uint8_t min_level;
+};
+
+/** @typedef modlog_foreach_fn
+ * @brief Function applied to each modlog mapping during a `modlog_foreach`
+ *        traversal.
+ *
+ * @param desc                  The modlog mapping to operate on.
+ * @param arg                   Optional user argument.
+ *
+ * @return                      0 if the traversal should continue;
+ *                              nonzero to abort the traversal with the
+ *                                  specified return code.
+ */
+typedef int modlog_foreach_fn(const struct modlog_desc *desc, void *arg);
+
+/**
+ * @brief Retrieves the modlog mapping with the specified handle.
+ *
+ * @param handle                The handle of the modlog mapping to retrieve.
+ * @param out_desc              On success, the retrieved mapping is written
+ *                                  here.  Pass NULL if you do not reqire this
+ *                                  information.
+ *
+ * @return                      0 on success;
+ *                              SYS_ENOENT if no mapping with the specified
+ *                                  handle exists;
+ *                              Other SYS_[...] error code on failure.
+ */
+int modlog_get(uint8_t handle, struct modlog_desc *out_desc);
+
+/**
+ * @brief Registers a new modlog mapping.
+ *
+ * @param module                The module to map to a log.
+ * @param log                   The log to map.
+ * @param min_level             Subsequent writes to this mapping with a level
+ *                                  less than this value are discarded.
+ * @param out_handle            On success, the new mapping's handle gets
+ *                                  written here.  Pass NULL if you do not
+ *                                  require this information.
+ * 
+ * @return                      0 on success;
+ *                              SYS_ENOMEM on memory exhaustion.
+ *                              Other SYS_[...] error on failure.
+ */
+int modlog_register(uint8_t module, struct log *log, uint8_t min_level,
+                    uint8_t *out_handle);
+
+/**
+ * @brief Deletes the configured modlog mapping with the specified handle.
+ *
+ * @param handle                The handle of the mapping to delete.
+ *
+ * @return                      0 on success;
+ *                              SYS_ENOENT if the specified handle is unmapped.
+ *                              Other SYS_[...] error on failure.
+ */
+int modlog_delete(uint8_t handle);
+
+/**
+ * @brief Deletes all configured modlog mappings.
+ */
+void modlog_clear(void);
+
+/**
+ * @brief Writes the contents of a flat buffer to the specified log module.
+ *
+ * NOTE: The flat buffer must have an initial padding of length
+ * `LOG_ENTRY_HDR_SIZE`.  This padding is *not* reflected in the specified
+ * length.  So, to log the string "abc", you should pass the following
+ * arguments to this function:
+ *
+ *     data: <padding>abc   (total of `LOG_ENTRY_HDR_SIZE`+3 bytes.)
+ *     len: 3
+ *
+ * @param module                The log module to write to.
+ * @param level                 The severity of the log entry to write.
+ * @param etype                 The type of data being written; one of the
+ *                                  `LOG_ETYPE_[...]` constants.
+ * @param data                  The flat buffer to write.
+ * @param len                   The number of bytes to write.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int modlog_append(uint8_t module, uint8_t level, uint8_t etype,
+                  void *data, uint16_t len);
+
+/**
+ * @brief Writes the contents of an mbuf to the specified log module.
+ *
+ * NOTE: The mbuf must have an initial padding of length
+ * `LOG_ENTRY_HDR_SIZE`.  So, to log the string "abc", you should pass an mbuf
+ * with the following characteristics:
+ *
+ *     om_data: <padding>abc
+ *     om_len: `LOG_ENTRY_HDR_SIZE` + 3
+ *
+ * @param module                The log module to write to.
+ * @param level                 The severity of the log entry to write.
+ * @param etype                 The type of data being written; one of the
+ *                                  `LOG_ETYPE_[...]` constants.
+ * @param om                    The mbuf to write.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int modlog_append_mbuf(uint8_t module, uint8_t level, uint8_t etype,
+                       struct os_mbuf *om);
+
+/**
+ * @brief Applies a function to each configured modlog mapping.
+ *
+ * The callback is permitted to delete the mapping under operation.  No other
+ * manipulations of the mapping list are allowed during the traversal.
+ *
+ * @param fn                    The function to apply to each modlog mapping.
+ * @param arg                   Optional argument to pass to the callback.
+ *
+ * @return                      0 if the full iteration completed;
+ *                              nonzero if the callback aborted the iteration.
+ */
+int modlog_foreach(modlog_foreach_fn *fn, void *arg);
+
+/**
+ * @brief Writes a formatted text entry to the specified log module.
+ *
+ * @param module                The log module to write to.
+ * @param level                 The severity of the log entry to write.
+ * @param msg                   The "printf" formatted string to write.
+ */
+void modlog_printf(uint16_t module, uint16_t level, const char *msg, ...);
+
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_DEBUG || defined __DOXYGEN__
+/**
+ * @brief Writes a formatted debug text entry to the specified log module.
+ *
+ * This expands to nothing if the global log level is greater than
+ * `LOG_LEVEL_DEBUG`.
+ *
+ * @param ml_mod_               The log module to write to.
+ * @param ml_msg_               The "printf" formatted string to write.
+ */
+#define MODLOG_DEBUG(ml_mod_, ml_msg_, ...) \
+    modlog_printf(ml_mod_, LOG_LEVEL_DEBUG, ml_msg_, ##__VA_ARGS__)
+#else
+#define MODLOG_DEBUG(ml_mod_, ...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_INFO || defined __DOXYGEN__
+/**
+ * @brief Writes a formatted info text entry to the specified log module.
+ *
+ * This expands to nothing if the global log level is greater than
+ * `LOG_LEVEL_INFO`.
+ *
+ * @param ml_mod_               The log module to write to.
+ * @param ml_msg_               The "printf" formatted string to write.
+ */
+#define MODLOG_INFO(ml_mod_, ml_msg_, ...) \
+    modlog_printf(ml_mod_, LOG_LEVEL_INFO, ml_msg_, ##__VA_ARGS__)
+#else
+#define MODLOG_INFO(ml_mod_, ...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_WARN || defined __DOXYGEN__
+/**
+ * @brief Writes a formatted warn text entry to the specified log module.
+ *
+ * This expands to nothing if the global log level is greater than
+ * `LOG_LEVEL_WARN`.
+ *
+ * @param ml_mod_               The log module to write to.
+ * @param ml_msg_               The "printf" formatted string to write.
+ */
+#define MODLOG_WARN(ml_mod_, ml_msg_, ...) \
+    modlog_printf(ml_mod_, LOG_LEVEL_WARN, ml_msg_, ##__VA_ARGS__)
+#else
+#define MODLOG_WARN(ml_mod_, ...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_ERROR || defined __DOXYGEN__
+/**
+ * @brief Writes a formatted error text entry to the specified log module.
+ *
+ * This expands to nothing if the global log level is greater than
+ * `LOG_LEVEL_ERROR`.
+ *
+ * @param ml_mod_               The log module to write to.
+ * @param ml_msg_               The "printf" formatted string to write.
+ */
+#define MODLOG_ERROR(ml_mod_, ml_msg_, ...) \
+    modlog_printf(ml_mod_, LOG_LEVEL_ERROR, ml_msg_, ##__VA_ARGS__)
+#else
+#define MODLOG_ERROR(ml_mod_, ...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MYNEWT_VAL(LOG_LEVEL) <= LOG_LEVEL_CRITICAL || defined __DOXYGEN__
+/**
+ * @brief Writes a formatted critical text entry to the specified log module.
+ *
+ * This expands to nothing if the global log level is greater than
+ * `LOG_LEVEL_CRITICAL`.
+ *
+ * @param ml_mod_               The log module to write to.
+ * @param ml_msg_               The "printf" formatted string to write.
+ */
+#define MODLOG_CRITICAL(ml_mod_, ml_msg_, ...) \
+    modlog_printf(ml_mod_, LOG_LEVEL_CRITICAL, ml_msg_, ##__VA_ARGS__)
+#else
+#define MODLOG_CRITICAL(ml_mod_, ...) IGNORE(__VA_ARGS__)
+#endif
+
+#endif

--- a/sys/log/modlog/pkg.yml
+++ b/sys/log/modlog/pkg.yml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: sys/log/modlog
+pkg.description: Module-mapped logging.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - logging
+
+pkg.deps:
+    - kernel/os
+
+pkg.req_apis:
+    - log
+
+pkg.init:
+    modlog_init: 100

--- a/sys/log/modlog/src/modlog.c
+++ b/sys/log/modlog/src/modlog.c
@@ -1,0 +1,509 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdarg.h>
+#include "os/mynewt.h"
+#include "log/log.h"
+#include "modlog/modlog.h"
+
+struct modlog_mapping {
+    SLIST_ENTRY(modlog_mapping) next;
+    struct modlog_desc desc;
+};
+
+struct os_mempool modlog_mapping_pool;
+static os_membuf_t modlog_mapping_buf[
+    OS_MEMPOOL_SIZE(MYNEWT_VAL(MODLOG_MAX_MAPPINGS),
+                    sizeof (struct modlog_mapping))
+];
+
+static struct os_mutex modlog_mtx;
+
+SLIST_HEAD(modlog_list, modlog_mapping);
+
+/** List of configured mappings; sorted by module. */
+static struct modlog_list modlog_mappings =
+    SLIST_HEAD_INITIALIZER(&modlog_mappings);
+
+/**
+ * Points to the first default mapping in the list.  Since 255 is the default
+ * module, the default mappings are guaranteed to come last.
+ */
+static struct modlog_mapping *modlog_first_dflt;
+
+static void
+modlog_lock(void)
+{
+    int rc;
+
+    rc = os_mutex_pend(&modlog_mtx, OS_TIMEOUT_NEVER);
+    assert(rc == 0 || rc == OS_NOT_STARTED);
+}
+
+static void
+modlog_unlock(void)
+{
+    int rc;
+
+    rc = os_mutex_release(&modlog_mtx);
+    assert(rc == 0 || rc == OS_NOT_STARTED);
+}
+
+static struct modlog_mapping *
+modlog_alloc(void)
+{
+    struct modlog_mapping *mm;
+
+    mm = os_memblock_get(&modlog_mapping_pool);
+    if (mm != NULL) {
+        *mm = (struct modlog_mapping) { 0 };
+    }
+
+    return mm;
+}
+
+static void
+modlog_free(struct modlog_mapping *mm)
+{
+    os_memblock_put(&modlog_mapping_pool, mm);
+}
+
+static uint8_t
+modlog_infer_handle(const struct modlog_mapping *mm)
+{
+    uintptr_t off;
+    size_t elem_sz;
+    int idx;
+
+    elem_sz = sizeof modlog_mapping_buf / MYNEWT_VAL(MODLOG_MAX_MAPPINGS);
+
+    off = (uintptr_t)mm - (uintptr_t)modlog_mapping_buf;
+    idx = off / elem_sz;
+
+    assert(idx >= 0 && idx < MYNEWT_VAL(MODLOG_MAX_MAPPINGS));
+    assert(off % elem_sz == 0);
+
+    return idx;
+}
+
+static struct modlog_mapping *
+modlog_find(uint8_t handle, struct modlog_mapping **out_prev)
+{
+    struct modlog_mapping *prev;
+    struct modlog_mapping *cur;
+
+    prev = NULL;
+    SLIST_FOREACH(cur, &modlog_mappings, next) {
+        if (cur->desc.handle == handle) {
+            break;
+        }
+
+        prev = cur;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+
+    return cur;
+}
+
+static struct modlog_mapping *
+modlog_find_by_module(uint8_t module, struct modlog_mapping **out_prev)
+{
+    struct modlog_mapping *prev;
+    struct modlog_mapping *cur;
+
+    prev = NULL;
+    SLIST_FOREACH(cur, &modlog_mappings, next) {
+        if (cur->desc.module == module) {
+            break;
+        }
+
+        if (cur->desc.module > module) {
+            cur = NULL;
+            break;
+        }
+
+        prev = cur;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+
+    return cur;
+}
+
+static void
+modlog_insert(struct modlog_mapping *mm)
+{
+    struct modlog_mapping *prev;
+
+    modlog_find_by_module(mm->desc.module, &prev);
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&modlog_mappings, mm, next);
+    } else {
+        SLIST_INSERT_AFTER(prev, mm, next);
+    }
+
+    if (mm->desc.module == MODLOG_MODULE_DFLT) {
+        modlog_first_dflt = mm;
+    }
+}
+
+static void
+modlog_remove(struct modlog_mapping *mm, struct modlog_mapping *prev)
+{
+    if (mm == modlog_first_dflt) {
+        modlog_first_dflt = SLIST_NEXT(mm, next);
+    }
+        
+    if (prev == NULL) {
+        SLIST_REMOVE_HEAD(&modlog_mappings, next);
+    } else {
+        SLIST_NEXT(prev, next) = SLIST_NEXT(mm, next);
+    }
+}
+
+static int
+modlog_register_no_lock(uint8_t module, struct log *log, uint8_t min_level,
+                        uint8_t *out_handle)
+{
+    struct modlog_mapping *mm;
+
+    if (log == NULL) {
+        return SYS_EINVAL;
+    }
+
+    mm = modlog_alloc();
+    if (mm == NULL) {
+        return SYS_ENOMEM;
+    }
+
+    mm->desc = (struct modlog_desc) {
+        .log = log,
+        .handle = modlog_infer_handle(mm),
+        .module = module,
+        .min_level = min_level,
+    };
+
+    modlog_insert(mm);
+
+    if (out_handle != NULL) {
+        *out_handle = mm->desc.handle;
+    }
+
+    return 0;
+}
+
+static int
+modlog_delete_no_lock(uint8_t handle)
+{
+    struct modlog_mapping *prev;
+    struct modlog_mapping *mm;
+
+    mm = modlog_find(handle, &prev);
+    if (mm == NULL) {
+        return SYS_ENOENT;
+    }
+
+    modlog_remove(mm, prev);
+    modlog_free(mm);
+
+    return 0;
+}
+
+static int
+modlog_append_one(struct modlog_mapping *mm, uint8_t module, uint8_t level,
+                  uint8_t etype, void *data, uint16_t len)
+{
+    int rc;
+
+    if (level >= mm->desc.min_level) {
+        rc = log_append_typed(mm->desc.log, module,
+                              level, etype, data, len);
+        if (rc != 0) {
+            return SYS_EIO;
+        }
+    }
+
+    return 0;
+}
+
+static int
+modlog_append_no_lock(uint8_t module, uint8_t level, uint8_t etype,
+                      void *data, uint16_t len)
+{
+    struct modlog_mapping *mm;
+    int rc;
+
+    if (module == MODLOG_MODULE_DFLT) {
+        return SYS_EINVAL;
+    }
+
+    mm = modlog_find_by_module(module, NULL);
+    if (mm != NULL) {
+        while (mm != NULL && mm->desc.module == module) {
+            rc = modlog_append_one(mm, module, level, etype, data, len);
+            if (rc != 0) {
+                return rc;
+            }
+
+            mm = SLIST_NEXT(mm, next);
+        }
+        return 0;
+    }
+
+    /* No mappings match the specified module; write to the default set. */
+    for (mm = modlog_first_dflt;
+         mm != NULL;
+         mm = SLIST_NEXT(mm, next)) {
+
+        rc = modlog_append_one(mm, module, level, etype, data, len);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    return 0;
+}
+
+static int
+modlog_append_mbuf_one(struct modlog_mapping *mm, uint8_t module,
+                       uint8_t level, uint8_t etype, struct os_mbuf **om)
+{
+    int rc;
+
+    if (level >= mm->desc.min_level) {
+        rc = log_append_mbuf_typed_no_free(mm->desc.log, module,
+                                           level, etype, om);
+        if (rc != 0) {
+            return SYS_EIO;
+        }
+    }
+
+    return 0;
+}
+
+static int
+modlog_append_mbuf_no_lock(uint8_t module, uint8_t level, uint8_t etype,
+                           struct os_mbuf *om)
+{
+    struct modlog_mapping *mm;
+    bool found;
+    int rc;
+
+    found = false;
+    SLIST_FOREACH(mm, &modlog_mappings, next) {
+        if (mm->desc.module == module) {
+            found = true;
+
+            rc = modlog_append_mbuf_one(mm, module, level, etype, &om);
+            if (rc != 0) {
+                return rc;
+            }
+        } else if (mm->desc.module > module) {
+            break;
+        }
+    }
+
+    /* If no mappings match the specified module, write to the default set. */
+    if (!found) {
+        for (mm = modlog_first_dflt;
+             mm != NULL;
+             mm = SLIST_NEXT(mm, next)) {
+
+            rc = modlog_append_mbuf_one(mm, module, level, etype, &om);
+            if (rc != 0) {
+                return rc;
+            }
+        }
+    }
+
+    os_mbuf_free_chain(om);
+
+    return 0;
+}
+
+static int
+modlog_foreach_no_lock(modlog_foreach_fn *fn, void *arg)
+{
+    struct modlog_mapping *next;
+    struct modlog_mapping *cur;
+    int rc;
+
+    cur = SLIST_FIRST(&modlog_mappings);
+    while (cur != NULL) {
+        next = SLIST_NEXT(cur, next);
+
+        rc = fn(&cur->desc, arg);
+        if (rc != 0) {
+            return rc;
+        }
+
+        cur = next;
+    }
+
+    return 0;
+}
+
+int
+modlog_get(uint8_t handle, struct modlog_desc *out_desc)
+{
+    struct modlog_mapping *mm;
+    int rc;
+
+    modlog_lock();
+
+    mm = modlog_find(handle, NULL);
+    if (mm == NULL) {
+        rc = SYS_ENOENT;
+    } else {
+        if (out_desc != NULL) {
+            *out_desc = mm->desc;
+        }
+        rc = 0;
+    }
+
+    modlog_unlock();
+
+    return rc;
+}
+
+int
+modlog_register(uint8_t module, struct log *log, uint8_t min_level,
+                uint8_t *out_handle)
+{
+    int rc;
+
+    modlog_lock();
+    rc = modlog_register_no_lock(module, log, min_level, out_handle);
+    modlog_unlock();
+
+    return rc;
+}
+
+int
+modlog_delete(uint8_t handle)
+{
+    int rc;
+
+    modlog_lock();
+    rc = modlog_delete_no_lock(handle);
+    modlog_unlock();
+
+    return rc;
+}
+
+void
+modlog_clear(void)
+{
+    struct modlog_mapping *mm;
+
+    modlog_lock();
+
+    while ((mm = SLIST_FIRST(&modlog_mappings)) != NULL) {
+        modlog_remove(mm, NULL);
+        modlog_free(mm);
+    }
+
+    modlog_unlock();
+}
+
+int
+modlog_append(uint8_t module, uint8_t level, uint8_t etype,
+              void *data, uint16_t len)
+{
+    int rc;
+
+    modlog_lock();
+    rc = modlog_append_no_lock(module, level, etype, data, len);
+    modlog_unlock();
+
+    return rc;
+}
+
+int
+modlog_append_mbuf(uint8_t module, uint8_t level, uint8_t etype,
+                   struct os_mbuf *om)
+{
+    int rc;
+
+    modlog_lock();
+    rc = modlog_append_mbuf_no_lock(module, level, etype, om);
+    modlog_unlock();
+
+    return rc;
+}
+
+int
+modlog_foreach(modlog_foreach_fn *fn, void *arg)
+{
+    int rc;
+
+    modlog_lock();
+    rc = modlog_foreach_no_lock(fn, arg);
+    modlog_unlock();
+
+    return rc;
+}
+
+void
+modlog_printf(uint16_t module, uint16_t level, const char *msg, ...)
+{
+    va_list args;
+    char buf[LOG_ENTRY_HDR_SIZE + MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)];
+    int len;
+
+    va_start(args, msg);
+    len = vsnprintf(buf + LOG_ENTRY_HDR_SIZE,
+                    MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN),
+                    msg, args);
+    va_end(args);
+
+    if (len >= MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)) {
+        len = MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - 1;
+    }
+
+    modlog_append(module, level, LOG_ETYPE_STRING, buf, len);
+}
+
+void
+modlog_init(void)
+{
+    int rc;
+
+    SYSINIT_ASSERT_ACTIVE();
+
+    rc = os_mempool_init(&modlog_mapping_pool, MYNEWT_VAL(MODLOG_MAX_MAPPINGS),
+                         sizeof (struct modlog_mapping), modlog_mapping_buf,
+                         "modlog_mapping_pool");
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
+    SLIST_INIT(&modlog_mappings);
+    modlog_first_dflt = NULL;
+
+    /* Register the default console mapping if configured. */
+#if MYNEWT_VAL(MODLOG_CONSOLE_DFLT)
+    rc = modlog_register(MODLOG_MODULE_DFLT, log_console_get(),
+                         LOG_LEVEL_DEBUG, NULL);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+#endif
+}

--- a/sys/log/modlog/syscfg.yml
+++ b/sys/log/modlog/syscfg.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    MODLOG_MAX_MAPPINGS:
+        description: >
+            Maximum number of log module mappings that can be configured.
+        value: 16
+    MODLOG_MAX_PRINTF_LEN:
+        description: >
+            Maximum length of data that can be logged with `modlog_printf()`
+            (after format specifiers are expanded).
+        value: 128
+    MODLOG_CONSOLE_DFLT:
+        description: >
+            Automatically create a default mapping to the console log.
+        value: 1

--- a/sys/log/modlog/test/pkg.yml
+++ b/sys/log/modlog/test/pkg.yml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/modlog/test
+pkg.type: unittest
+pkg.description: "Module-mapped log unit tests."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps: 
+    - '@apache-mynewt-core/test/testutil'
+    - '@apache-mynewt-core/sys/log/modlog'
+
+pkg.deps.SELFTEST:
+    - '@apache-mynewt-core/sys/console/stub'
+    - '@apache-mynewt-core/sys/log/full'

--- a/sys/log/modlog/test/src/modlog_test.c
+++ b/sys/log/modlog/test/src/modlog_test.c
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "modlog_test.h"
+
+TEST_SUITE(modlog_test_suite_all)
+{
+    modlog_test_case_append();
+    modlog_test_case_basic();
+    modlog_test_case_printf();
+    modlog_test_case_prio();
+}
+
+#if MYNEWT_VAL(SELFTEST)
+
+int
+main(int argc, char **argv)
+{
+    sysinit();
+
+    modlog_test_suite_all();
+
+    return tu_any_failed;
+}
+
+#endif

--- a/sys/log/modlog/test/src/modlog_test.h
+++ b/sys/log/modlog/test/src/modlog_test.h
@@ -1,0 +1,35 @@
+#ifndef H_MODLOG_TEST_
+#define H_MODLOG_TEST_
+
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+#include "log/log.h"
+#include "modlog/modlog.h"
+#include "modlog_test_util.h"
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+TEST_SUITE_DECL(modlog_test_suite_all);
+TEST_CASE_DECL(modlog_test_case_append);
+TEST_CASE_DECL(modlog_test_case_basic);
+TEST_CASE_DECL(modlog_test_case_printf);
+TEST_CASE_DECL(modlog_test_case_prio);
+
+#endif

--- a/sys/log/modlog/test/src/modlog_test_util.c
+++ b/sys/log/modlog/test/src/modlog_test_util.c
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "os/mynewt.h"
+#include "modlog_test.h"
+
+static int
+mltu_log_append(struct log *log, void *buf, int len)
+{
+    struct mltu_log_entry *entry;
+    struct log_entry_hdr *hdr;
+    struct mltu_log_arg *mla;
+    int body_len;
+
+    mla = log->l_arg;
+
+    body_len = len - sizeof *hdr;
+
+    TEST_ASSERT_FATAL(mla->num_entries < MLTU_LOG_ARG_MAX_ENTRIES);
+    TEST_ASSERT_FATAL(body_len <= MLTU_LOG_ENTRY_MAX_LEN);
+
+    entry = mla->entries + mla->num_entries++;
+
+    hdr = buf;
+    entry->hdr = *hdr;
+    entry->len = body_len;
+    memcpy(entry->body, hdr + 1, body_len);
+
+    return 0;
+}
+
+static int
+mltu_log_append_mbuf(struct log *log, struct os_mbuf *om)
+{
+    struct mltu_log_entry *entry;
+    struct mltu_log_arg *mla;
+    int body_len;
+    int rc;
+
+    mla = log->l_arg;
+
+    body_len = OS_MBUF_PKTLEN(om) - sizeof entry->hdr;
+
+    TEST_ASSERT_FATAL(mla->num_entries < MLTU_LOG_ARG_MAX_ENTRIES);
+    TEST_ASSERT_FATAL(body_len <= MLTU_LOG_ENTRY_MAX_LEN);
+
+    entry = mla->entries + mla->num_entries++;
+
+    rc = os_mbuf_copydata(om, 0, sizeof entry->hdr, &entry->hdr);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    entry->len = body_len;
+    rc = os_mbuf_copydata(om, sizeof entry->hdr, body_len, entry->body);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    return 0;
+}
+
+static const struct log_handler mltu_handler = {
+    .log_type = LOG_TYPE_MEMORY,
+    .log_append = mltu_log_append,
+    .log_append_mbuf = mltu_log_append_mbuf,
+};
+
+void
+mltu_register_log(struct log *lg, struct mltu_log_arg *arg, const char *name,
+                  uint8_t level)
+{
+    int rc;
+
+    rc = log_register((char *)name, lg, &mltu_handler, arg, level);
+    TEST_ASSERT_FATAL(rc == 0);
+}
+
+struct os_mbuf *
+mltu_alloc_buf(void)
+{
+    struct os_mbuf *om;
+    uint8_t *u8p;
+
+    om = os_msys_get_pkthdr(0, 0);
+    TEST_ASSERT_FATAL(om != NULL);
+
+    u8p = os_mbuf_extend(om, sizeof (struct log_entry_hdr));
+    TEST_ASSERT_FATAL(u8p != NULL);
+
+    return om;
+}
+
+void
+mltu_append(uint8_t module, uint8_t level, uint8_t etype, void *data,
+            int len, bool mbuf)
+{
+    uint8_t buf[1024];
+    struct os_mbuf *om;
+    int rc;
+
+    if (!mbuf) {
+        TEST_ASSERT_FATAL(len + sizeof (struct log_entry_hdr) <= sizeof buf);
+        memcpy(buf + sizeof (struct log_entry_hdr), data, len);
+
+        rc = modlog_append(module, level, etype, buf, len);
+    } else {
+        om = mltu_alloc_buf();
+        rc = os_mbuf_append(om, data, len);
+        TEST_ASSERT_FATAL(rc == 0);
+
+        rc = modlog_append_mbuf(module, level, etype, om);
+    }
+    TEST_ASSERT_FATAL(rc == 0);
+}

--- a/sys/log/modlog/test/src/modlog_test_util.h
+++ b/sys/log/modlog/test/src/modlog_test_util.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_MODLOG_TEST_UTIL_
+#define H_MODLOG_TEST_UTIL_
+
+#define MLTU_LOG_ENTRY_MAX_LEN      256
+#define MLTU_LOG_ARG_MAX_ENTRIES    32
+
+struct mltu_log_entry {
+    struct log_entry_hdr hdr;
+    int len;
+    uint8_t body[MLTU_LOG_ENTRY_MAX_LEN];
+};
+
+struct mltu_log_arg {
+    struct mltu_log_entry entries[MLTU_LOG_ARG_MAX_ENTRIES];
+    int num_entries;
+};
+
+void mltu_register_log(struct log *lg, struct mltu_log_arg *arg,
+                       const char *name, uint8_t level);
+void mltu_append(uint8_t module, uint8_t level, uint8_t etype,
+                 void *data, int len, bool mbuf);
+
+#endif

--- a/sys/log/modlog/test/src/testcases/modlog_test_case_append.c
+++ b/sys/log/modlog/test/src/testcases/modlog_test_case_append.c
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "modlog_test.h"
+
+static void
+mltca_run(bool use_mbufs)
+{
+    struct mltu_log_arg mla1;
+    struct mltu_log_arg mla2;
+    struct mltu_log_arg mla3;
+    struct log log1;
+    struct log log2;
+    struct log log3;
+    uint8_t handle1;
+    uint8_t handle2;
+    uint8_t handle3;
+    uint8_t byte;
+    int rc;
+
+    sysinit();
+
+    /* Initialize three logs. */
+    memset(&mla1, 0, sizeof mla1);
+    mltu_register_log(&log1, &mla1, "log1", 0);
+
+    memset(&mla2, 0, sizeof mla2);
+    mltu_register_log(&log2, &mla2, "log2", 0);
+
+    memset(&mla3, 0, sizeof mla3);
+    mltu_register_log(&log3, &mla3, "log3", 0);
+
+    /* Map a different module to each log. */
+    rc = modlog_register(1, &log1, 1, &handle1);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(2, &log2, 2, &handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(3, &log3, 3, &handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Ensure unmapped module with no default causes no write. */
+    mltu_append(100, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    TEST_ASSERT(mla1.num_entries == 0);
+    TEST_ASSERT(mla2.num_entries == 0);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    /* Write a different entry to each module */
+    byte = '1';
+    mltu_append(1, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+
+    byte = '2';
+    mltu_append(2, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+
+    byte = '3';
+    mltu_append(3, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 1);
+    TEST_ASSERT(mla1.entries[0].len == 1);
+    TEST_ASSERT(mla1.entries[0].body[0] == '1');
+    TEST_ASSERT(mla1.entries[0].hdr.ue_module == 1);
+
+    TEST_ASSERT(mla2.num_entries == 1);
+    TEST_ASSERT(mla2.entries[0].len == 1);
+    TEST_ASSERT(mla2.entries[0].body[0] == '2');
+    TEST_ASSERT(mla2.entries[0].hdr.ue_module == 2);
+
+    TEST_ASSERT(mla3.num_entries == 1);
+    TEST_ASSERT(mla3.entries[0].len == 1);
+    TEST_ASSERT(mla3.entries[0].body[0] == '3');
+    TEST_ASSERT(mla3.entries[0].hdr.ue_module == 3);
+
+    /* Clear logs. */
+    mla1.num_entries = 0;
+    mla2.num_entries = 0;
+    mla3.num_entries = 0;
+
+    /* Point module 3 at log 2. */
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+    rc = modlog_register(3, &log2, 3, &handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Write to modules 2 and 3; verify log 2 written twice. */
+    mltu_append(2, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    mltu_append(3, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 0);
+    TEST_ASSERT(mla2.num_entries == 2);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    /* Clear logs. */
+    mla1.num_entries = 0;
+    mla2.num_entries = 0;
+    mla3.num_entries = 0;
+
+    /* Point module 1 at all three logs. */
+    rc = modlog_delete(handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(1, &log2, 2, &handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(1, &log3, 3, &handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Write a single entry to module 1; ensure all logs written. */
+    mltu_append(1, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    TEST_ASSERT(mla1.num_entries == 1);
+    TEST_ASSERT(mla2.num_entries == 1);
+    TEST_ASSERT(mla3.num_entries == 1);
+
+    /* Clear logs. */
+    mla1.num_entries = 0;
+    mla2.num_entries = 0;
+    mla3.num_entries = 0;
+
+    /* Make mapping1 a default entry. */
+    rc = modlog_delete(handle1);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(MODLOG_MODULE_DFLT, &log1, 1, &handle1);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    mltu_append(99, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    mltu_append(123, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(mla1.num_entries == 2);
+    TEST_ASSERT(mla2.num_entries == 0);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    TEST_ASSERT(mla1.entries[0].hdr.ue_module == 99);
+    TEST_ASSERT(mla1.entries[1].hdr.ue_module == 123);
+
+    /* Clear logs. */
+    mla1.num_entries = 0;
+    mla2.num_entries = 0;
+    mla3.num_entries = 0;
+
+    /* Make all three descs default entries. */
+    rc = modlog_delete(handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(MODLOG_MODULE_DFLT, &log2, 2, &handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(MODLOG_MODULE_DFLT, &log3, 3, &handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    mltu_append(103, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    mltu_append(144, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(mla1.num_entries == 2);
+    TEST_ASSERT(mla2.num_entries == 2);
+    TEST_ASSERT(mla3.num_entries == 2);
+
+    /* Clear logs. */
+    mla1.num_entries = 0;
+    mla2.num_entries = 0;
+    mla3.num_entries = 0;
+
+    /* Remove all default entries. */
+    rc = modlog_delete(handle1);
+    TEST_ASSERT_FATAL(rc == 0);
+    rc = modlog_delete(handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Ensure an append has no effect. */
+    mltu_append(234, 4, LOG_ETYPE_STRING, &byte, 1, use_mbufs);
+    TEST_ASSERT(mla1.num_entries == 0);
+    TEST_ASSERT(mla2.num_entries == 0);
+    TEST_ASSERT(mla3.num_entries == 0);
+}
+
+TEST_CASE(modlog_test_case_append)
+{
+    mltca_run(false);
+    mltca_run(true);
+}

--- a/sys/log/modlog/test/src/testcases/modlog_test_case_basic.c
+++ b/sys/log/modlog/test/src/testcases/modlog_test_case_basic.c
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "modlog_test.h"
+
+struct mltcb_foreach_arg {
+    struct modlog_desc descs[16];
+    int num_descs;
+};
+
+static int
+mltcb_foreach_fn(const struct modlog_desc *desc, void *arg)
+{
+    struct mltcb_foreach_arg *lfa;
+
+    lfa = arg;
+    TEST_ASSERT_FATAL(lfa->num_descs <
+                      sizeof lfa->descs / sizeof lfa->descs[0]);
+
+    lfa->descs[lfa->num_descs++] = *desc;
+    return 0;
+}
+
+static bool
+mltcb_desc_has_contents(const struct modlog_desc *desc, uint8_t module,
+                        const struct log *log, uint8_t min_level)
+{
+    return desc->log ==         log     &&
+           desc->module ==      module  &&
+           desc->min_level ==   min_level;
+}
+
+TEST_CASE(modlog_test_case_basic)
+{
+    struct mltcb_foreach_arg lfa;
+    struct log log1;
+    struct log log2;
+    struct log log3;
+    uint8_t handle1;
+    uint8_t handle2;
+    uint8_t handle3;
+    int rc;
+    int i;
+
+    sysinit();
+
+    /* NULL log. */
+    rc = modlog_register(1, NULL, LOG_LEVEL_DEBUG, NULL);
+    TEST_ASSERT(rc == SYS_EINVAL);
+
+    /* Ensure no mappings initially. */
+    for (i = 0; i < 256; i++) {
+        rc = modlog_get(i, NULL);
+        TEST_ASSERT(rc == SYS_ENOENT);
+    }
+
+    /* Insert three entries. */
+    rc = modlog_register(1, &log1, LOG_LEVEL_DEBUG, &handle1);
+    TEST_ASSERT(rc == 0);
+
+    rc = modlog_register(2, &log2, LOG_LEVEL_DEBUG, &handle2);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(handle2 != handle1);
+
+    rc = modlog_register(3, &log3, LOG_LEVEL_DEBUG, &handle3);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(handle3 != handle1);
+    TEST_ASSERT(handle3 != handle2);
+
+    /* Ensure foreach applies to all entries in the expected order. */
+    memset(&lfa, 0, sizeof lfa);
+    rc = modlog_foreach(mltcb_foreach_fn, &lfa);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(lfa.num_descs == 3);
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[0], 1, &log1, LOG_LEVEL_DEBUG));
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[1], 2, &log2, LOG_LEVEL_DEBUG));
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[2], 3, &log3, LOG_LEVEL_DEBUG));
+
+    /* Delete the first entry. */
+    rc = modlog_delete(handle1);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    memset(&lfa, 0, sizeof lfa);
+    rc = modlog_foreach(mltcb_foreach_fn, &lfa);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(lfa.num_descs == 2);
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[0], 2, &log2, LOG_LEVEL_DEBUG));
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[1], 3, &log3, LOG_LEVEL_DEBUG));
+
+    /* Modify entry 3 to point to log1. */
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+    rc = modlog_register(3, &log1, LOG_LEVEL_DEBUG, &handle3);
+    TEST_ASSERT(rc == 0);
+
+    memset(&lfa, 0, sizeof lfa);
+    rc = modlog_foreach(mltcb_foreach_fn, &lfa);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(lfa.num_descs == 2);
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[0], 2, &log2, LOG_LEVEL_DEBUG));
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[1], 3, &log1, LOG_LEVEL_DEBUG));
+
+    /* Delete entry 3. */
+    rc = modlog_delete(handle3);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    memset(&lfa, 0, sizeof lfa);
+    rc = modlog_foreach(mltcb_foreach_fn, &lfa);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(lfa.num_descs == 1);
+    TEST_ASSERT(mltcb_desc_has_contents(&lfa.descs[0], 2, &log2, LOG_LEVEL_DEBUG));
+
+    /* Delete last entry. */
+    rc = modlog_delete(handle2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    memset(&lfa, 0, sizeof lfa);
+    rc = modlog_foreach(mltcb_foreach_fn, &lfa);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(lfa.num_descs == 0);
+
+    /* Repeatedly add and remove entries; verify no leaks. */
+    for (i = 0; i < 100; i++) {
+        rc = modlog_register(1, &log1, LOG_LEVEL_DEBUG, &handle1);
+        TEST_ASSERT(rc == 0);
+
+        rc = modlog_delete(handle1);
+        TEST_ASSERT(rc == 0);
+    }
+}

--- a/sys/log/modlog/test/src/testcases/modlog_test_case_printf.c
+++ b/sys/log/modlog/test/src/testcases/modlog_test_case_printf.c
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "modlog_test.h"
+
+TEST_CASE(modlog_test_case_printf)
+{
+    struct mltu_log_arg mla;
+    struct log log;
+    char buf[MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) * 2];
+    int rc;
+    int i;
+
+    sysinit();
+
+    memset(&mla, 0, sizeof mla);
+    mltu_register_log(&log, &mla, "log", 0);
+
+    rc = modlog_register(1, &log, 1, NULL);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    modlog_printf(1, 1, "hello %d %s %c", 99, "abc", 'x');
+
+    TEST_ASSERT_FATAL(mla.num_entries == 1);
+    TEST_ASSERT(strcmp((char *)mla.entries[0].body, "hello 99 abc x") == 0);
+
+    /* Ensure oversized write gets truncated. */
+    for (i = 0; i < sizeof buf - 1; i++) {
+        buf[i] = '0' + i % 10;
+    }
+    buf[sizeof buf - 1] = '\0';
+
+    modlog_printf(1, 1, "%s", buf);
+    TEST_ASSERT_FATAL(mla.num_entries == 2);
+    TEST_ASSERT(mla.entries[1].len == MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - 1);
+    TEST_ASSERT(memcmp(mla.entries[1].body, buf,
+                       MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - 1) == 0);
+}

--- a/sys/log/modlog/test/src/testcases/modlog_test_case_prio.c
+++ b/sys/log/modlog/test/src/testcases/modlog_test_case_prio.c
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "modlog_test.h"
+
+static void
+mltcp_run(bool use_mbufs)
+{
+    struct mltu_log_arg mla1;
+    struct mltu_log_arg mla2;
+    struct mltu_log_arg mla3;
+    struct log log1;
+    struct log log2;
+    struct log log3;
+    uint8_t buf[sizeof (struct log_entry_hdr) + 16];
+    int rc;
+
+    sysinit();
+
+    /* Initialize three logs. */
+    memset(&mla1, 0, sizeof mla1);
+    mltu_register_log(&log1, &mla1, "log1", 0);
+
+    memset(&mla2, 0, sizeof mla2);
+    mltu_register_log(&log2, &mla2, "log2", 0);
+
+    memset(&mla3, 0, sizeof mla3);
+    mltu_register_log(&log3, &mla3, "log3", 0);
+
+    /* Map a different module to each log. */
+    rc = modlog_register(1, &log1, 1, NULL);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(2, &log2, 2, NULL);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    rc = modlog_register(3, &log3, 3, NULL);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Ensure too-low priorities are discarded. */
+    mltu_append(1, 0, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(2, 0, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(3, 0, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 0);
+    TEST_ASSERT(mla2.num_entries == 0);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    mltu_append(1, 1, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(2, 1, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(3, 1, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 1);
+    TEST_ASSERT(mla2.num_entries == 0);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    mltu_append(1, 2, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(2, 2, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(3, 2, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 2);
+    TEST_ASSERT(mla2.num_entries == 1);
+    TEST_ASSERT(mla3.num_entries == 0);
+
+    mltu_append(1, 3, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(2, 3, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+    mltu_append(3, 3, LOG_ETYPE_STRING, buf, 1, use_mbufs);
+
+    TEST_ASSERT(mla1.num_entries == 3);
+    TEST_ASSERT(mla2.num_entries == 2);
+    TEST_ASSERT(mla3.num_entries == 1);
+}
+
+TEST_CASE(modlog_test_case_prio)
+{
+    mltcp_run(false);
+    mltcp_run(true);
+}

--- a/sys/log/modlog/test/syscfg.yml
+++ b/sys/log/modlog/test/syscfg.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    MODLOG_CONSOLE_DFLT: 0

--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -85,6 +85,14 @@ const struct log_handler log_fcb_handler;
 const struct log_handler log_fcb_slot1_handler;
 #endif
 
+#if MYNEWT_VAL(LOG_CONSOLE)
+static inline struct log *
+log_console_get(void)
+{
+    return NULL;
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The modlog facility allows log entries to be written to numeric modules identifiers.  In typical usage, startup code maps 8-bit module IDs to one or more log objects, and other parts of the application log events by writing entries to module IDs.  This usage differs from the underlying `sys/log` facility, which requires clients to provide a log object to write to rather than just a module identifier.

Benefits provided by the modlog package are:
* Improved modularity - configuration and usage are distinct.
* Ability to write to several logs with a single function call.  If one module ID is mapped to several logs, a write to that ID causes all mapped logs to be written.
* Default mappings.  Writes to unmapped module IDs get written to an optional set of default logs.
* Minimum log level per mapping.  Writes specifying a log level less than the module's minimum level are discarded.
* Decreased RAM usage; multiple unrelated packages can share the same `struct log` object rather than defining their own (`sizeof (struct log)` is 20).


Costs of using modlog rather than the bare `sys/log` facility are:
* Increased RAM usage (`MODLOG_MAX_MAPPINGS` * 12).
* Increased CPU usage - each log write requires a lookup in the set of configured modlog mappings.

Example usage:

```
    /* Map module 100 to the console log. */
    rc = modlog_register(100, log_console_get(), LOG_LEVEL_DEBUG, NULL);
    assert(rc == 0);

    /* Log a message to module 100. */
    MODLOG_INFO(100, "hello from module %d\n", 100);
```
