### PR TITLE
pwm_nrf52: fix crash on close not checking playing status

### DIFF
--- a/hw/drivers/pwm/include/pwm/pwm.h
+++ b/hw/drivers/pwm/include/pwm/pwm.h
@@ -67,7 +67,7 @@ typedef int (*pwm_config_channel_func_t)(struct pwm_dev *,
  * @param cnum The channel to configure.
  * @param fraction The fraction value.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 typedef int (*pwm_set_duty_cycle_func_t)(struct pwm_dev *,
                                          uint8_t,
@@ -79,7 +79,7 @@ typedef int (*pwm_set_duty_cycle_func_t)(struct pwm_dev *,
  *
  * @param dev The PWM device to be enabled.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 typedef int (*pwm_enable_func_t)(struct pwm_dev *dev);
 
@@ -100,7 +100,7 @@ typedef bool (*pwm_is_enabled_func_t)(struct pwm_dev *);
  * @param dev The device to configure.
  * @param freq_hz The frequency value in Hz.
  *
- * @return 0 on success, negative on error.
+ * @return A value is in Hz on success, negative error code on failure.
  */
 typedef int (*pwm_set_frequency_func_t) (struct pwm_dev *, uint32_t);
 
@@ -109,7 +109,7 @@ typedef int (*pwm_set_frequency_func_t) (struct pwm_dev *, uint32_t);
  *
  * @param dev
  *
- * @return value is in Hz on success, negative on error.
+ * @return value is in Hz on success, negative error code on failure.
  */
 typedef int (*pwm_get_clock_freq_func_t) (struct pwm_dev *);
 
@@ -119,7 +119,7 @@ typedef int (*pwm_get_clock_freq_func_t) (struct pwm_dev *);
  *
  * @param dev
  *
- * @return value in cycles on success, negative on error.
+ * @return value in cycles on success, negative error code on failure.
  */
 typedef int (*pwm_get_top_value_funct_t) (struct pwm_dev *dev);
 
@@ -128,7 +128,7 @@ typedef int (*pwm_get_top_value_funct_t) (struct pwm_dev *dev);
  *
  * @param dev The device to query.
  *
- * @return The value in bits on success, negative on error.
+ * @return The value in bits on success, negative error code on failure.
  */
 typedef int (*pwm_get_resolution_bits_func_t) (struct pwm_dev *);
 
@@ -137,7 +137,7 @@ typedef int (*pwm_get_resolution_bits_func_t) (struct pwm_dev *);
  *
  * @param dev The device to disable.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 typedef int (*pwm_disable_func_t) (struct pwm_dev *);
 

--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -339,7 +339,10 @@ nrf52_pwm_close(struct os_dev *odev)
         return (EINVAL);
     }
 
-    nrfx_pwm_uninit(&instances[inst_id].drv_instance);
+    if(instances[inst_id].playing) {
+        nrfx_pwm_uninit(&instances[inst_id].drv_instance);
+    }
+
     cleanup_instance(inst_id);
 
     if (os_started()) {
@@ -545,8 +548,13 @@ nrf52_pwm_disable(struct pwm_dev *dev)
         return (-EINVAL);
     }
 
+    if (!instances[inst_id].playing) {
+        return (-EINVAL);
+    }
+
     nrfx_pwm_uninit(&instances[inst_id].drv_instance);
     instances[inst_id].playing = false;
+
     return (0);
 }
 

--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -280,7 +280,7 @@ cleanup_instance(int inst_id)
  *             it can be a nrf_drv_pwm_config_t, to override the default
  *             configuration.
  *
- * @return 0 on success, non-zero on failure.
+ * @return 0 on success, non-zero error code on failure.
  */
 static int
 nrf52_pwm_open(struct os_dev *odev, uint32_t wait, void *arg)
@@ -324,7 +324,7 @@ nrf52_pwm_open(struct os_dev *odev, uint32_t wait, void *arg)
  *
  * @param odev The device to close.
  *
- * @return 0 on success, non-zero on failure.
+ * @return 0 on success, non-zero error code on failure.
  */
 static int
 nrf52_pwm_close(struct os_dev *odev)
@@ -470,7 +470,7 @@ nrf52_pwm_configure_channel(struct pwm_dev *dev,
  * @param cnum The channel number. This channel should be already configured.
  * @param fraction The fraction value.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 static int
 nrf52_pwm_set_duty_cycle(struct pwm_dev *dev, uint8_t cnum, uint16_t fraction)
@@ -480,12 +480,12 @@ nrf52_pwm_set_duty_cycle(struct pwm_dev *dev, uint8_t cnum, uint16_t fraction)
     bool inverted;
 
     if (!instances[inst_id].in_use) {
-        return (-EINVAL);
+        return (EINVAL);
     }
 
     config = &instances[inst_id].config;
     if (config->output_pins[cnum] == NRFX_PWM_PIN_NOT_USED) {
-        return (-EINVAL);
+        return (EINVAL);
     }
 
     inverted = ((config->output_pins[cnum] & NRFX_PWM_PIN_INVERTED) != 0);
@@ -502,7 +502,7 @@ nrf52_pwm_set_duty_cycle(struct pwm_dev *dev, uint8_t cnum, uint16_t fraction)
  *
  * @param dev The PWM device to be enabled.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 int
 nrf52_pwm_enable(struct pwm_dev *dev)
@@ -538,18 +538,18 @@ nrf52_pwm_is_enabled(struct pwm_dev *dev)
  *
  * @param dev The device to disable.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 static int
 nrf52_pwm_disable(struct pwm_dev *dev)
 {
     int inst_id = dev->pwm_instance_id;
     if (!instances[inst_id].in_use) {
-        return (-EINVAL);
+        return (EINVAL);
     }
 
     if (!instances[inst_id].playing) {
-        return (-EINVAL);
+        return (EINVAL);
     }
 
     nrfx_pwm_uninit(&instances[inst_id].drv_instance);
@@ -559,14 +559,15 @@ nrf52_pwm_disable(struct pwm_dev *dev)
 }
 
 /**
+ * Set the frequency for the device's clock.
  * This frequency must be between 1/2 the clock frequency and
- * the clock divided by the resolution. NOTE: This may affect
- * other PWM channels.
+ * the clock divided by the resolution. NOTE: This will affect
+ * all PWM channels belonging to the device.
  *
  * @param dev The device to configure.
  * @param freq_hz The frequency value in Hz.
  *
- * @return A value is in Hz on success, negative on error.
+ * @return A value is in Hz on success, negative error code on failure.
  */
 static int
 nrf52_pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
@@ -628,7 +629,7 @@ nrf52_pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
  *
  * @param dev
  *
- * @return value is in Hz on success, negative on error.
+ * @return value is in Hz on success, error code on failure.
  */
 static int
 nrf52_pwm_get_clock_freq(struct pwm_dev *dev)
@@ -665,7 +666,7 @@ nrf52_pwm_get_clock_freq(struct pwm_dev *dev)
  *
  * @param dev
  *
- * @return value in cycles on success, negative on error.
+ * @return value in cycles on success, negative error code on failure.
  */
 int
 nrf52_pwm_get_top_value(struct pwm_dev *dev)
@@ -683,7 +684,7 @@ nrf52_pwm_get_top_value(struct pwm_dev *dev)
  *
  * @param dev The device to query.
  *
- * @return The value in bits on success, negative on error.
+ * @return The value in bits on success, negative error code on failure.
  */
 static int
 nrf52_pwm_get_resolution_bits(struct pwm_dev *dev)

--- a/hw/drivers/pwm/pwm_stm32/include/pwm_stm32/pwm_stm32.h
+++ b/hw/drivers/pwm/pwm_stm32/include/pwm_stm32/pwm_stm32.h
@@ -51,12 +51,12 @@ extern "C" {
  */
 
 #define STM32_PWM_ERR_OK       0
-#define STM32_PWM_ERR_NODEV   -1
-#define STM32_PWM_ERR_NOTIM   -2
-#define STM32_PWM_ERR_CHAN    -3
-#define STM32_PWM_ERR_FREQ    -4
-#define STM32_PWM_ERR_GPIO    -5
-#define STM32_PWM_ERR_NOIRQ   -6
+#define STM32_PWM_ERR_NODEV    1
+#define STM32_PWM_ERR_NOTIM    2
+#define STM32_PWM_ERR_CHAN     3
+#define STM32_PWM_ERR_FREQ     4
+#define STM32_PWM_ERR_GPIO     5
+#define STM32_PWM_ERR_NOIRQ    6
 
 typedef struct stm32_pwm_conf {
     TIM_TypeDef   *tim;

--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -318,7 +318,7 @@ stm32_pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
     uint32_t div, div1, div2;
 
     if (!freq_hz) {
-        return STM32_PWM_ERR_FREQ;
+        return -STM32_PWM_ERR_FREQ;
     }
 
     id = dev->pwm_instance_id;
@@ -329,7 +329,7 @@ stm32_pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
 
     div  = timer_clock / freq_hz;
     if (!div) {
-        return STM32_PWM_ERR_FREQ;
+        return -STM32_PWM_ERR_FREQ;
     }
 
     div1 = div >> 16;

--- a/hw/drivers/pwm/src/pwm.c
+++ b/hw/drivers/pwm/src/pwm.c
@@ -75,7 +75,7 @@ pwm_configure_channel(struct pwm_dev *dev,
  * @param cnum The channel number. This channel should be already configured.
  * @param fraction The fraction value.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 int
 pwm_set_duty_cycle(struct pwm_dev *dev, uint8_t cnum, uint16_t fraction)
@@ -95,7 +95,7 @@ pwm_set_duty_cycle(struct pwm_dev *dev, uint8_t cnum, uint16_t fraction)
  *
  * @param dev The PWM device to be enabled.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, non-zero error code on failure.
  */
 int
 pwm_enable(struct pwm_dev *dev)
@@ -130,7 +130,7 @@ pwm_is_enabled(struct pwm_dev *dev)
  * @param dev The device to configure.
  * @param freq_hz The frequency value in Hz.
  *
- * @return A value is in Hz on success, negative on error.
+ * @return A value is in Hz on success, negative error code on failure.
  */
 int
 pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
@@ -146,7 +146,7 @@ pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
  *
  * @param dev
  *
- * @return value is in Hz on success, negative on error.
+ * @return value is in Hz on success, negative error code on failure.
  */
 int
 pwm_get_clock_freq(struct pwm_dev *dev)
@@ -163,7 +163,7 @@ pwm_get_clock_freq(struct pwm_dev *dev)
  *
  * @param dev
  *
- * @return value in cycles on success, negative on error.
+ * @return value in cycles on success, negative error code on failure.
  */
 int
 pwm_get_top_value(struct pwm_dev *dev)
@@ -179,7 +179,7 @@ pwm_get_top_value(struct pwm_dev *dev)
  *
  * @param dev The device to query.
  *
- * @return The value in bits on success, negative on error.
+ * @return The value in bits on success, negative error code on failure.
  */
 int
 pwm_get_resolution_bits(struct pwm_dev *dev)
@@ -195,7 +195,7 @@ pwm_get_resolution_bits(struct pwm_dev *dev)
  *
  * @param dev The device to disable.
  *
- * @return 0 on success, negative on error.
+ * @return 0 on success, negative error code on failure.
  */
 int
 pwm_disable(struct pwm_dev *dev)


### PR DESCRIPTION
If you disable pwm and then close the device, it attempts to nrfx_pwm_uninit the same device twice and assert crashes.

Now we check if a device is 'playing' before we nrfx_pwm_uninit