### PR TITLE
sys/log/full: Allow min-level per module

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -62,7 +62,7 @@ struct log_offset {
 };
 
 typedef int (*log_walk_func_t)(struct log *, struct log_offset *log_offset,
-        void *offset, uint16_t len);
+        void *dptr, uint16_t len);
 
 typedef int (*lh_read_func_t)(struct log *, void *dptr, void *buf,
         uint16_t offset, uint16_t len);
@@ -279,6 +279,47 @@ int log_read_mbuf(struct log *log, void *dptr, struct os_mbuf *om, uint16_t off,
 int log_walk(struct log *log, log_walk_func_t walk_func,
         struct log_offset *log_offset);
 int log_flush(struct log *log);
+
+#if MYNEWT_VAL(LOG_MODULE_LEVELS)
+/**
+ * @brief Retrieves the globally configured minimum log level for the specified
+ * module ID.
+ *
+ * Writes with a level less than the module's minimum level are discarded.
+ *
+ * @param module                The module whose level should be retrieved.
+ *
+ * @return                      The configured minimum level, or 0
+ *                                  (LOG_LEVEL_DEBUG) if unconfigured.
+ */
+uint8_t log_level_get(uint8_t module);
+
+/**
+ * @brief Sets the globally configured minimum log level for the specified
+ * module ID.
+ *
+ * Writes with a level less than the module's minimum level are discarded.
+ *
+ * @param module                The module to configure.
+ * @param level                 The minimum level to assign to the module
+ *                                  (0-15, inclusive).
+ */
+int log_level_set(uint8_t module, uint8_t level);
+#else
+static inline uint8_t
+log_level_get(uint8_t module)
+{
+    /* All levels enabled. */
+    return 0;
+}
+
+static inline int
+log_level_set(uint8_t module, uint8_t level)
+{
+    return SYS_ENOTSUP;
+}
+#endif
+
 
 /* Handler exports */
 #if MYNEWT_VAL(LOG_CONSOLE)

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -312,6 +312,12 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level, uint8_t etype
         goto err;
     }
 
+    /* Check if this module has a minimum level. */
+    if (level < log_level_get(module)) {
+        rc = -1;
+        goto err;
+    }
+
     OS_ENTER_CRITICAL(sr);
     idx = g_log_info.li_next_index++;
     OS_EXIT_CRITICAL(sr);

--- a/sys/log/full/src/log_level.c
+++ b/sys/log/full/src/log_level.c
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(LOG_MODULE_LEVELS)
+
+#include "log/log.h"
+
+/**
+ * Contains the minimum log level for each of the 256 modules.  Two levels are
+ * packed into a single byte, one per nibble.
+ */
+static uint8_t log_level_map[(LOG_MODULE_MAX + 1) / 2];
+
+uint8_t
+log_level_get(uint8_t module)
+{
+    uint8_t byte;
+
+    byte = log_level_map[module / 2];
+    if (module % 2 == 0) {
+        return byte & 0x0f;
+    } else {
+        return byte >> 4;
+    }
+}
+
+int
+log_level_set(uint8_t module, uint8_t level)
+{
+    uint8_t *byte;
+
+    if (level > 0x0f) {
+        return SYS_EINVAL;
+    }
+
+    byte = &log_level_map[module / 2];
+    if (module % 2 == 0) {
+        *byte = (*byte & 0xf0) | level;
+    } else {
+        *byte = (*byte & 0x0f) | (level << 4);
+    }
+
+    return 0;
+}
+
+#endif

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -58,3 +58,10 @@ syscfg.defs:
     LOG_MAX_USER_MODULES:
         description: 'Maximum number of user modules to register'
         value: 1
+
+    LOG_MODULE_LEVELS:
+        description: >
+            Enables global configuration of minimum log level by module ID.
+            Writes with a level less than the module's minimum level are
+            discarded.  Enabling this setting requires 128 bytes of bss.
+        value: 1

--- a/sys/log/full/test/src/log_test.c
+++ b/sys/log/full/test/src/log_test.c
@@ -85,6 +85,7 @@ TEST_CASE_DECL(log_setup_fcb)
 TEST_CASE_DECL(log_append_fcb)
 TEST_CASE_DECL(log_walk_fcb)
 TEST_CASE_DECL(log_flush_fcb)
+TEST_CASE_DECL(log_level);
 
 TEST_SUITE(log_test_all)
 {
@@ -92,6 +93,7 @@ TEST_SUITE(log_test_all)
     log_append_fcb();
     log_walk_fcb();
     log_flush_fcb();
+    log_level();
 }
 
 #if MYNEWT_VAL(SELFTEST)

--- a/sys/log/full/test/src/testcases/log_level.c
+++ b/sys/log/full/test/src/testcases/log_level.c
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test.h"
+
+static int
+log_last_walk(struct log *log, struct log_offset *log_offset,
+              void *dptr, uint16_t len)
+{
+    uint32_t *idx;
+
+    idx = log_offset->lo_arg;
+    *idx = log_offset->lo_index;
+
+    return 0;
+}
+
+static uint32_t
+log_last(struct log *log)
+{
+    struct log_offset lo;
+    uint32_t idx;
+
+    idx = 0;
+
+    lo.lo_arg = &idx;
+    log_walk(log, log_last_walk, &lo);
+
+    return idx;
+}
+
+TEST_CASE(log_level)
+{
+    uint32_t idx;
+    int rc;
+    int i;
+
+    /* Ensure all modules initialized to 0. */
+    for (i = 0; i < 256; i++) {
+        TEST_ASSERT(log_level_get(i) == 0);
+    }
+
+    /* Level too great. */
+    rc = log_level_set(100, 16);
+    TEST_ASSERT(rc == SYS_EINVAL);
+
+    /* Ensure all modules can be configured. */
+    for (i = 0; i < 256; i++) {
+        rc = log_level_set(i, i % 16);
+        TEST_ASSERT(rc == 0);
+    }
+    for (i = 0; i < 256; i++) {
+        TEST_ASSERT(log_level_get(i) == i % 16);
+    }
+
+    /* Ensure no log write when level is too low. */
+    rc = log_level_set(100, 4);
+    TEST_ASSERT(rc == 0);
+
+    idx = log_last(&my_log);
+    log_printf(&my_log, 100, 1, "hello");
+    TEST_ASSERT(log_last(&my_log) == idx);
+
+    /* Ensure log write when level is equal. */
+    log_printf(&my_log, 100, 4, "hello");
+    TEST_ASSERT(log_last(&my_log) > idx);
+}


### PR DESCRIPTION
Defines a global map of per-module log levels.  Writes with a level less than the module's minimum level are discarded.

This allocates 128 bytes of bss.  To disable this feature, set `LOG_LEVEL_MAP` to 0.