### PR TITLE
Fixed SPI Read in SX1272ReadBuffer

### DIFF
--- a/hw/drivers/lora/sx1272/src/sx1272.c
+++ b/hw/drivers/lora/sx1272/src/sx1272.c
@@ -1099,7 +1099,7 @@ SX1272ReadBuffer(uint16_t addr, uint8_t *buffer, uint8_t size)
     hal_gpio_write(RADIO_NSS, 0);
     hal_spi_tx_val(RADIO_SPI_IDX, addr & 0x7f);
     for(i = 0; i < size; i++) {
-        hal_spi_tx_val(RADIO_SPI_IDX, buffer[i]);
+        buffer[i] = hal_spi_tx_val(RADIO_SPI_IDX, 0);
     }
     hal_gpio_write(RADIO_NSS, 1);
 #endif


### PR DESCRIPTION
The code appears to have been copied from SX1272WriteBuffer without being modified. The original code was probably tested with BSP_USE_HAL_SPI = 1, which is why this bug was missed.