### PR TITLE
kernel/os: Fix APIs to use os_time_t for ticks arguments

### DIFF
--- a/kernel/os/include/os/os_callout.h
+++ b/kernel/os/include/os/os_callout.h
@@ -44,7 +44,7 @@ struct os_callout {
     /** Pointer to the event queue to post the event to */
     struct os_eventq *c_evq;
     /** Number of ticks in the future to expire the callout */
-    uint32_t c_ticks;
+    os_time_t c_ticks;
 
 
     TAILQ_ENTRY(os_callout) c_next;
@@ -97,7 +97,7 @@ void os_callout_stop(struct os_callout *);
  *
  * @return 0 on success, non-zero on failure
  */
-int os_callout_reset(struct os_callout *, int32_t);
+int os_callout_reset(struct os_callout *, os_time_t);
 
 /**
  * Returns the number of ticks which remains to callout.

--- a/kernel/os/include/os/os_mutex.h
+++ b/kernel/os/include/os/os_mutex.h
@@ -90,9 +90,9 @@ os_error_t os_mutex_release(struct os_mutex *mu);
  * Pend (wait) for a mutex.
  *
  * @param mu Pointer to mutex.
- * @param timeout Timeout, in os ticks. A timeout of 0 means do
- *                not wait if not available. A timeout of
- *                0xFFFFFFFF means wait forever.
+ * @param timeout Timeout, in os ticks.
+ *                A timeout of 0 means do not wait if not available.
+ *                A timeout of OS_TIMEOUT_NEVER means wait forever.
  *
  *
  * @return os_error_t
@@ -100,7 +100,7 @@ os_error_t os_mutex_release(struct os_mutex *mu);
  *      OS_TIMEOUT          Mutex was owned by another task and timeout=0
  *      OS_OK               no error.
  */
-os_error_t os_mutex_pend(struct os_mutex *mu, uint32_t timeout);
+os_error_t os_mutex_pend(struct os_mutex *mu, os_time_t timeout);
 
 #ifdef __cplusplus
 }

--- a/kernel/os/include/os/os_sem.h
+++ b/kernel/os/include/os/os_sem.h
@@ -83,9 +83,9 @@ os_error_t os_sem_release(struct os_sem *sem);
  * Pend (wait) for a semaphore.
  *
  * @param mu Pointer to semaphore.
- * @param timeout Timeout, in os ticks. A timeout of 0 means do
- *                not wait if not available. A timeout of
- *                0xFFFFFFFF means wait forever.
+ * @param timeout Timeout, in os ticks.
+ *                A timeout of 0 means do not wait if not available.
+ *                A timeout of OS_TIMEOUT_NEVER means wait forever.
  *
  *
  * @return os_error_t
@@ -93,7 +93,7 @@ os_error_t os_sem_release(struct os_sem *sem);
  *      OS_TIMEOUT          Semaphore was owned by another task and timeout=0
  *      OS_OK               no error.
  */
-os_error_t os_sem_pend(struct os_sem *sem, uint32_t timeout);
+os_error_t os_sem_pend(struct os_sem *sem, os_time_t timeout);
 
 /**
  * Get current semaphore's count

--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -81,7 +81,7 @@ typedef int32_t os_stime_t;
 #define OS_STIME_MAX INT32_MAX
 
 /* Used to wait forever for events and mutexs */
-#define OS_TIMEOUT_NEVER    (UINT32_MAX)
+#define OS_TIMEOUT_NEVER    (OS_TIME_MAX)
 
 
 /**
@@ -100,11 +100,11 @@ void os_time_advance(int ticks);
 
 /**
  * Puts the current task to sleep for the specified number of os ticks. There
- * is no delay if ticks is <= 0.
+ * is no delay if ticks is 0.
  *
- * @param osticks Number of ticks to delay (<= 0 means no delay).
+ * @param osticks Number of ticks to delay (0 means no delay).
  */
-void os_time_delay(int32_t osticks);
+void os_time_delay(os_time_t osticks);
 
 #define OS_TIME_TICK_LT(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) < 0)
 #define OS_TIME_TICK_GT(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) > 0)
@@ -205,7 +205,7 @@ void os_get_uptime(struct os_timeval *tvp);
  * @return                      0 on success; OS_EINVAL if the result is too
  *                                  large to fit in a uint32_t.
  */
-int os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks);
+int os_time_ms_to_ticks(uint32_t ms, os_time_t *out_ticks);
 
 /**
  * Converts OS ticks to milliseconds.
@@ -216,7 +216,7 @@ int os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks);
  * @return                      0 on success; OS_EINVAL if the result is too
  *                                  large to fit in a uint32_t.
  */
-int os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms);
+int os_time_ticks_to_ms(os_time_t ticks, uint32_t *out_ms);
 
 
 /**
@@ -229,7 +229,7 @@ int os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms);
  *
  * @return                      result on success
  */
-uint32_t os_time_ms_to_ticks32(uint32_t ms);
+os_time_t os_time_ms_to_ticks32(uint32_t ms);
 
 /**
  * Converts OS ticks to milliseconds.
@@ -241,7 +241,7 @@ uint32_t os_time_ms_to_ticks32(uint32_t ms);
  *
  * @return                      result on success
  */
-uint32_t os_time_ticks_to_ms32(uint32_t ticks);
+uint32_t os_time_ticks_to_ms32(os_time_t ticks);
 
 #ifdef __cplusplus
 }

--- a/kernel/os/src/os_callout.c
+++ b/kernel/os/src/os_callout.c
@@ -65,7 +65,7 @@ os_callout_stop(struct os_callout *c)
 }
 
 int
-os_callout_reset(struct os_callout *c, int32_t ticks)
+os_callout_reset(struct os_callout *c, os_time_t ticks)
 {
     struct os_callout *entry;
     os_sr_t sr;

--- a/kernel/os/src/os_mutex.c
+++ b/kernel/os/src/os_mutex.c
@@ -134,7 +134,7 @@ done:
 }
 
 os_error_t
-os_mutex_pend(struct os_mutex *mu, uint32_t timeout)
+os_mutex_pend(struct os_mutex *mu, os_time_t timeout)
 {
     os_sr_t sr;
     os_error_t ret;

--- a/kernel/os/src/os_sem.c
+++ b/kernel/os/src/os_sem.c
@@ -112,7 +112,7 @@ done:
 }
 
 os_error_t
-os_sem_pend(struct os_sem *sem, uint32_t timeout)
+os_sem_pend(struct os_sem *sem, os_time_t timeout)
 {
     os_sr_t sr;
     int sched;

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -104,7 +104,7 @@ os_time_advance(int ticks)
 #endif
 
 void
-os_time_delay(int32_t osticks)
+os_time_delay(os_time_t osticks)
 {
     os_sr_t sr;
 
@@ -189,7 +189,7 @@ os_get_uptime_usec(void)
 }
 
 int
-os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks)
+os_time_ms_to_ticks(uint32_t ms, os_time_t *out_ticks)
 {
     uint64_t ticks;
 
@@ -211,7 +211,7 @@ os_time_ms_to_ticks(uint32_t ms, uint32_t *out_ticks)
 }
 
 int
-os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms)
+os_time_ticks_to_ms(os_time_t ticks, uint32_t *out_ms)
 {
     uint64_t ms;
 
@@ -230,7 +230,7 @@ os_time_ticks_to_ms(uint32_t ticks, uint32_t *out_ms)
     return 0;
 }
 
-uint32_t
+os_time_t
 os_time_ms_to_ticks32(uint32_t ms)
 {
 #if OS_TICKS_PER_SEC == 1000
@@ -241,7 +241,7 @@ os_time_ms_to_ticks32(uint32_t ms)
 }
 
 uint32_t
-os_time_ticks_to_ms32(uint32_t ticks)
+os_time_ticks_to_ms32(os_time_t ticks)
 {
 #if OS_TICKS_PER_SEC == 1000
     return ticks;


### PR DESCRIPTION
This patch changes callout, mutex, sem and time APIs to use os_time_t
consistently in all APIs that take or return ticks as arguments/return
value. This way we define explicitly which parameters expect values in
ticks rather than other time units.

This should not affect any existing code since most args were uint32_t
anyway which is the same as os_time_t.