### PR TITLE
time/timesched: Add package to create timers using clock time

### DIFF
--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -110,6 +110,19 @@ void os_time_delay(os_time_t osticks);
 #define OS_TIME_TICK_GT(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) > 0)
 #define OS_TIME_TICK_GEQ(__t1, __t2) ((os_stime_t) ((__t1) - (__t2)) >= 0)
 
+#define OS_TIMEVAL_LT(__t1, __t2) \
+    (((__t1).tv_sec < (__t2).tv_sec) || \
+     (((__t1).tv_sec == (__t2).tv_sec) && ((__t1).tv_usec < (__t2).tv_usec)))
+#define OS_TIMEVAL_LEQ(__t1, __t2) \
+    (((__t1).tv_sec < (__t2).tv_sec) || \
+     (((__t1).tv_sec == (__t2).tv_sec) && ((__t1).tv_usec <= (__t2).tv_usec)))
+#define OS_TIMEVAL_GT(__t1, __t2) \
+    (((__t1).tv_sec > (__t2).tv_sec) || \
+     (((__t1).tv_sec == (__t2).tv_sec) && ((__t1).tv_usec > (__t2).tv_usec)))
+#define OS_TIMEVAL_GEQ(__t1, __t2) \
+    (((__t1).tv_sec > (__t2).tv_sec) || \
+     (((__t1).tv_sec == (__t2).tv_sec) && ((__t1).tv_usec >= (__t2).tv_usec)))
+
 /**
  * Structure representing time since Jan 1 1970 with microsecond
  * granularity

--- a/time/timesched/include/timesched/timesched.h
+++ b/time/timesched/include/timesched/timesched.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TIMESCHED_H
+#define __TIMESCHED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "os/os_eventq.h"
+#include "os/os_time.h"
+#include "os/queue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct timesched_timer {
+    struct os_timeval expire;
+    struct os_eventq *evq;
+    struct os_event ev;
+
+    TAILQ_ENTRY(timesched_timer) link;
+};
+
+/**
+ * Initialize timer structure
+ *
+ * This function initializes a timer element with event queue and an event.
+ * After timer is initialized it can be started with timesched_timer_start() to
+ * expire at specified clock time. When this happens, an event will be sent to
+ * event queue as initialized here.
+ *
+ * @param timer   Timer to initialize
+ * @param evq     Event queue to post event on timer expire to
+ * @param ev_cb   Callback of event associated with timer
+ * @param ev_arg  Argument of event associated with timer
+ */
+void timesched_timer_init(struct timesched_timer *timer, struct os_eventq *evq,
+                          os_event_fn *ev_cb, void *ev_arg);
+
+/**
+ * Start timer
+ *
+ * This function starts a timer to expire at specified clock time.
+ *
+ * @param timer    Timer to start
+ * @param utctime  Time value (UTC) at which timer should expire
+ *
+ * @return OS_OK on success, error otherwise
+ */
+int timesched_timer_start(struct timesched_timer *timer,
+                          struct os_timeval *utctime);
+
+/**
+ * Stop timer
+ *
+ * This function stops a timer from expiring. If given timer was not started,
+ * this function has no effect.
+ *
+ * @param timer  Timer to stop
+ *
+ * @return OS_OK on success, error otherwise
+ */
+int timesched_timer_stop(struct timesched_timer *timer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __TIMESCHED_H */

--- a/time/timesched/pkg.yml
+++ b/time/timesched/pkg.yml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: time/timesched
+pkg.description: Scheduling on clock time
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - date 
+    - datetime
+
+pkg.deps:
+    - kernel/os
+
+pkg.init:
+    timesched_init: 500

--- a/time/timesched/src/timesched.c
+++ b/time/timesched/src/timesched.c
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "os/mynewt.h"
+#include "timesched/timesched.h"
+
+static TAILQ_HEAD(timesched_q, timesched_timer) g_timesched_q;
+
+static struct os_callout g_timesched_co;
+
+void
+timesched_resched(void)
+{
+    struct timesched_timer *timer;
+    os_time_t ticks;
+    struct os_timeval time;
+    uint64_t msec;
+
+    os_callout_stop(&g_timesched_co);
+
+    timer = TAILQ_FIRST(&g_timesched_q);
+    if (!timer) {
+        /* No timer was started, no need to start callout */
+        return;
+    }
+
+    os_gettimeofday(&time, NULL);
+
+    os_timersub(&timer->expire, &time, &time);
+
+    if (time.tv_sec < 0) {
+        /* We're already past expiry time - fire callout "immediately" */
+        ticks = 0;
+    } else {
+        msec = time.tv_sec * 1000 + time.tv_usec / 1000;
+
+        /*
+         * We could just schedule next callout to expire at calculated value,
+         * however we need to assume time may be adjusted on device in the
+         * meantime. Since there is no notification from OS that this happened,
+         * we'll just schedule callout at shorter interval to adjust callout if
+         * necessary. For now let's use 1 minute max.
+         */
+        msec = min(msec, 60 * 1000);
+
+        ticks = os_time_ms_to_ticks32(msec);
+    }
+
+    os_callout_reset(&g_timesched_co, ticks);
+}
+
+static void
+timesched_timer_co_cb(struct os_event *ev)
+{
+    struct timesched_timer *timer;
+    struct os_timeval time;
+    os_sr_t sr;
+
+    os_gettimeofday(&time, NULL);
+
+    OS_ENTER_CRITICAL(sr);
+
+    timer = TAILQ_FIRST(&g_timesched_q);
+    while (timer && OS_TIMEVAL_LEQ(timer->expire, time)) {
+        os_eventq_put(timer->evq, &timer->ev);
+
+        TAILQ_REMOVE(&g_timesched_q, timer, link);
+        timer = TAILQ_FIRST(&g_timesched_q);
+    }
+
+    OS_EXIT_CRITICAL(sr);
+
+    timesched_resched();
+}
+
+void
+timesched_timer_init(struct timesched_timer *timer, struct os_eventq *evq,
+                     os_event_fn *ev_cb, void *ev_arg)
+{
+    memset(timer, 0, sizeof(*timer));
+
+    timer->evq = evq;
+    timer->ev.ev_cb = ev_cb;
+    timer->ev.ev_arg = ev_arg;
+}
+
+int
+timesched_timer_start(struct timesched_timer *timer, struct os_timeval *utctime)
+{
+    struct timesched_timer *entry;
+    os_sr_t sr;
+
+    timer->expire = *utctime;
+
+    OS_ENTER_CRITICAL(sr);
+
+    if (TAILQ_EMPTY(&g_timesched_q)) {
+        TAILQ_INSERT_HEAD(&g_timesched_q, timer, link);
+    } else {
+        TAILQ_FOREACH(entry, &g_timesched_q, link) {
+            if (OS_TIMEVAL_LT(timer->expire, entry->expire)) {
+                TAILQ_INSERT_BEFORE(entry, timer, link);
+                break;
+            }
+        }
+
+        if (!entry) {
+            TAILQ_INSERT_TAIL(&g_timesched_q, timer, link);
+        }
+    }
+
+    OS_EXIT_CRITICAL(sr);
+
+    timesched_resched();
+
+    return OS_OK;
+}
+
+int
+timesched_timer_stop(struct timesched_timer *timer)
+{
+    os_sr_t sr;
+
+    OS_ENTER_CRITICAL(sr);
+
+    TAILQ_REMOVE(&g_timesched_q, timer, link);
+
+    OS_EXIT_CRITICAL(sr);
+
+    return OS_OK;
+}
+
+void
+timesched_init(void)
+{
+    os_callout_init(&g_timesched_co, os_eventq_dflt_get(),
+                    timesched_timer_co_cb, NULL);
+}


### PR DESCRIPTION
This patch adds new package which implements timer operating on clock time. These timers do not replace e.g. `hal_timer` since they do not guarantee high accuracy, but are just a convenience wrapper over `os_callout` APIs to fire at specified clock time (`os_timeval`) instead of at ticks interval.
