### PR TITLE
Fix debug builds on Cortex-M7

### DIFF
--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -28,7 +28,7 @@ compiler.path.objcopy: arm-none-eabi-objcopy
 compiler.flags.base: -mcpu=cortex-m7 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
-compiler.flags.debug: [compiler.flags.base, -O0 -ggdb -fomit-frame-pointer]
+compiler.flags.debug: [compiler.flags.base, -O0 -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 


### PR DESCRIPTION
Debug builds were omitting the frame pointer in Cortex-M7 which broke the usage of `__set_MSP` since CMSIS was upgraded to 5.x.