### PR TITLE
nrf52840pdk: fix incorrect jtag configuration

### DIFF
--- a/hw/bsp/nrf52840pdk/nrf52840pdk_debug.sh
+++ b/hw/bsp/nrf52840pdk/nrf52840pdk_debug.sh
@@ -40,7 +40,7 @@ if [ $# -gt 2 ]; then
     EXTRA_GDB_CMDS="add-symbol-file $SPLIT_ELF_NAME 0xc000 -readnow"
 fi
 
-JLINK_DEV="nRF52"
+JLINK_DEV="nrf52840_xxaa"
 
 jlink_debug
 

--- a/hw/bsp/nrf52840pdk/nrf52840pdk_download.sh
+++ b/hw/bsp/nrf52840pdk/nrf52840pdk_download.sh
@@ -34,7 +34,7 @@ if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0x0
 fi
 
-JLINK_DEV="nRF52"
+JLINK_DEV="nrf52840_xxaa"
 
 common_file_to_load
 jlink_load


### PR DESCRIPTION
resulting in inability to program last half of flash. Closes #1192