### PR TITLE
[STM32F4] move flash sector and size configs to BSPs

### DIFF
--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -39,6 +39,31 @@
 #include "bsp/bsp.h"
 #include <assert.h>
 
+const uint32_t stm32f4_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 512 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 

--- a/hw/bsp/nucleo-f413re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413re/src/hal_bsp.c
@@ -40,6 +40,39 @@
 
 #include "bsp/bsp.h"
 
+const uint32_t stm32f4_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* 128kB */
+    0x08120000,     /* 128kB */
+    0x08140000,     /* 128kB */
+    0x08160000,     /* 128kB */
+    0x08180000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 1536 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -40,6 +40,39 @@
 
 #include "bsp/bsp.h"
 
+const uint32_t stm32f4_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* 128kB */
+    0x08120000,     /* 128kB */
+    0x08140000,     /* 128kB */
+    0x08160000,     /* 128kB */
+    0x08180000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 1536 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -52,6 +52,35 @@
 #include "mcu/stm32f4_bsp.h"
 #include "mcu/stm32f4xx_mynewt_hal.h"
 
+const uint32_t stm32f4_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 1024 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(TRNG)
 static struct trng_dev os_bsp_trng;
 #endif

--- a/hw/bsp/stm32f429discovery/include/bsp/bsp.h
+++ b/hw/bsp/stm32f429discovery/include/bsp/bsp.h
@@ -37,7 +37,7 @@ extern "C" {
 extern uint8_t _ram_start;
 extern uint8_t _ccram_start;
 
-#define RAM_SIZE        (128 * 1024)
+#define RAM_SIZE        (256 * 1024)
 #define CCRAM_SIZE      (64 * 1024)
 
 /* LED pins */

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -39,6 +39,49 @@
 
 #include <mcu/stm32f4_bsp.h>
 
+const uint32_t stm32f4_flash_sectors[] = {
+    /* Bank 1 */
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    /* Bank 2 */
+    0x08100000,     /* 16kB */
+    0x08104000,     /* 16kB */
+    0x08108000,     /* 16kB */
+    0x0810c000,     /* 16kB */
+    0x08110000,     /* 64kB */
+    0x08120000,     /* 128kB */
+    0x08140000,     /* 128kB */
+    0x08160000,     /* 128kB */
+    0x08180000,     /* 128kB */
+    0x081a0000,     /* 128kB */
+    0x081c0000,     /* 128kB */
+    0x081e0000,     /* 128kB */
+    0x08200000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 2048 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -41,6 +41,35 @@
 
 #include "bsp/bsp.h"
 
+const uint32_t stm32f4_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* End of flash */
+};
+
+const uint32_t STM32F4_FLASH_NUM_AREAS =
+    sizeof(stm32f4_flash_sectors) / sizeof(stm32f4_flash_sectors[0]);
+
+extern const struct hal_flash_funcs stm32f4_flash_funcs;
+
+const struct hal_flash stm32f4_flash_dev = {
+    .hf_itf = &stm32f4_flash_funcs,
+    .hf_base_addr = 0x08000000,
+    .hf_size = 1024 * 1024,
+    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
+    .hf_align = 1
+};
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 

--- a/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
@@ -49,7 +49,7 @@ int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
 od);
 
 struct hal_flash;
-extern struct hal_flash stm32f4_flash_dev;
+extern const struct hal_flash stm32f4_flash_dev;
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/stm/stm32f4xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f4xx/src/hal_flash.c
@@ -33,7 +33,7 @@ static int stm32f4_flash_sector_info(const struct hal_flash *dev, int idx,
         uint32_t *address, uint32_t *sz);
 static int stm32f4_flash_init(const struct hal_flash *dev);
 
-static const struct hal_flash_funcs stm32f4_flash_funcs = {
+const struct hal_flash_funcs stm32f4_flash_funcs = {
     .hff_read = stm32f4_flash_read,
     .hff_write = stm32f4_flash_write,
     .hff_erase_sector = stm32f4_flash_erase_sector,
@@ -41,33 +41,8 @@ static const struct hal_flash_funcs stm32f4_flash_funcs = {
     .hff_init = stm32f4_flash_init
 };
 
-static const uint32_t stm32f4_flash_sectors[] = {
-    0x08000000,     /* 16kB */
-    0x08004000,     /* 16kB */
-    0x08008000,     /* 16kB */
-    0x0800c000,     /* 16kB */
-    0x08010000,     /* 64kB */
-    0x08020000,     /* 128kB */
-    0x08040000,     /* 128kB */
-    0x08060000,     /* 128kB */
-    0x08080000,     /* 128kB */
-    0x080a0000,     /* 128kB */
-    0x080c0000,     /* 128kB */
-    0x080e0000,     /* 128kB */
-    0x08100000      /* End of flash */
-};
-
-#define STM32F4_FLASH_NUM_AREAS                                         \
-    (int)(sizeof(stm32f4_flash_sectors) /                               \
-      sizeof(stm32f4_flash_sectors[0]))
-
-const struct hal_flash stm32f4_flash_dev = {
-    .hf_itf = &stm32f4_flash_funcs,
-    .hf_base_addr = 0x08000000,
-    .hf_size = 1024 * 1024,
-    .hf_sector_cnt = STM32F4_FLASH_NUM_AREAS - 1,
-    .hf_align = 1
-};
+extern const uint32_t stm32f4_flash_sectors[];
+extern const uint32_t STM32F4_FLASH_NUM_AREAS;
 
 static int
 stm32f4_flash_read(const struct hal_flash *dev, uint32_t address, void *dst,
@@ -108,12 +83,12 @@ stm32f4_flash_erase_sector_id(int sector_id)
 {
     FLASH_EraseInitTypeDef eraseinit;
     uint32_t SectorError;
-    
+
     eraseinit.TypeErase = FLASH_TYPEERASE_SECTORS;
     eraseinit.Banks = 0;
     eraseinit.Sector = sector_id;
     eraseinit.NbSectors = 1;
-    eraseinit.VoltageRange = FLASH_VOLTAGE_RANGE_1; 
+    eraseinit.VoltageRange = FLASH_VOLTAGE_RANGE_1;
 
     HAL_FLASHEx_Erase(&eraseinit, &SectorError);
 }


### PR DESCRIPTION
All STM32F4 MCUs were sharing the same flash sector + size configs though it varies a lot between different parts so those configs are now being moved to the BSPs.