### PR TITLE
sys/console: Fix RTT input polling

### DIFF
--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -72,3 +72,12 @@ syscfg.defs:
     CONSOLE_UART_DEV:
         description: 'Console UART device.'
         value: '"uart0"'
+
+    CONSOLE_RTT_INPUT_POLL_INTERVAL_MAX:
+        description: >
+            Maximum interval (milliseconds) to poll for RTT input.
+            With no new data on RTT input, interval to poll for new data will
+            be gradually increased up to specified value. Using high interval
+            value may affect RTT console responsiveness, using small value may
+            affect device performance due to more frequent polling.
+        value: 250


### PR DESCRIPTION
Timeout counter was missing "static" keyword thus we always used 50ms
as polling interval for every single character in buffer. This commit
fixes the problem and also refactors polling code a bit to make RTT
input more responsive.

We will now read all available data on RTT in single run and then start
with polling interval of 10ms, increasing it by 10ms on every idle run
until it reaches max interval set by syscfg value (default 250ms). This
means there may be tiny delay when reading 1st character after longer
idle period, but then complete input can be processed in no time.