### PR TITLE
boot/split: Ensure conf loaded before status read

### DIFF
--- a/boot/split/src/split.c
+++ b/boot/split/src/split.c
@@ -21,6 +21,7 @@
 #include "os/mynewt.h"
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
+#include "config/config.h"
 #include "split/split.h"
 #include "split_priv.h"
 
@@ -111,6 +112,11 @@ split_app_go(void **entry, int toboot)
     split_mode_t split_mode;
     int run_app;
     int rc;
+
+    /* Make sure the configuration has been loaded.  We need the persisted
+     * `split/status` value to proceed.
+     */
+    conf_ensure_loaded();
 
     if (toboot) {
         split_mode = split_mode_get();

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -189,6 +189,13 @@ int conf_register(struct conf_handler *cf);
 int conf_load(void);
 
 /**
+ * @brief Loads the configuration if it hasn't been loaded since reboot.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int conf_ensure_loaded(void);
+
+/**
  * Save currently running configuration. All configuration which is different
  * from currently persisted values will be saved.
  *

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -89,7 +89,7 @@ conf_register(struct conf_handler *handler)
 static void
 conf_ev_fn_load(struct os_event *ev)
 {
-    conf_load();
+    conf_ensure_loaded();
 }
 
 /*

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -32,6 +32,7 @@ struct conf_dup_check_arg {
 
 struct conf_store_head conf_load_srcs;
 struct conf_store *conf_save_dst;
+static bool conf_loaded;
 
 void
 conf_src_register(struct conf_store *cs)
@@ -73,6 +74,7 @@ conf_load(void)
      *    commit all
      */
     conf_lock();
+    conf_loaded = true;
     SLIST_FOREACH(cs, &conf_load_srcs, cs_next) {
         cs->cs_itf->csi_load(cs, conf_load_cb, NULL);
         if (SLIST_NEXT(cs, cs_next)) {
@@ -81,6 +83,16 @@ conf_load(void)
     }
     conf_unlock();
     return conf_commit(NULL);
+}
+
+int
+conf_ensure_loaded(void)
+{
+    if (conf_loaded) {
+        return 0;
+    }
+
+    return conf_load();
 }
 
 static void
@@ -213,5 +225,6 @@ out:
 void
 conf_store_init(void)
 {
+    conf_loaded = false;
     SLIST_INIT(&conf_load_srcs);
 }


### PR DESCRIPTION
This removes the need for a manual call to `conf_load()` in `main()`, prior to the call to `split_app_go()`

`split_app_go()` is the function which decides whether to boot into the second app or to proceed with the current one).  This function requires that the configuration has been loaded, as the action it takes depends on the `split/status` config setting.
