### PR TITLE
hw/hal: Add hal_bsp_hw_id_len() function

### DIFF
--- a/hw/bsp/apollo2_evb/src/hal_bsp.c
+++ b/hw/bsp/apollo2_evb/src/hal_bsp.c
@@ -182,6 +182,12 @@ hal_bsp_init(void)
 }
 
 int
+hal_bsp_hw_id_len(void)
+{
+    return 0;
+}
+
+int
 hal_bsp_hw_id(uint8_t *id, int max_len)
 {
 #if 0

--- a/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
@@ -275,6 +275,12 @@ hal_bsp_init(void)
 }
 
 int
+hal_bsp_hw_id_len(void)
+{
+    return sizeof(DEVID);
+}
+
+int
 hal_bsp_hw_id(uint8_t *id, int max_len)
 {
     if (max_len > sizeof(DEVID)) {

--- a/hw/hal/include/hal/hal_bsp.h
+++ b/hw/hal/include/hal/hal_bsp.h
@@ -62,6 +62,14 @@ struct hal_bsp_mem_dump {
 const struct hal_bsp_mem_dump *hal_bsp_core_dump(int *area_cnt);
 
 #define HAL_BSP_MAX_ID_LEN  32
+
+/**
+ * Retrieves the length, in bytes, of the hardware ID.
+ *
+ * @return                      The length of the hardware ID.
+ */
+int hal_bsp_hw_id_len(void);
+
 /**
  * Get unique HW identifier/serial number for platform.
  * Returns the number of bytes filled in.

--- a/hw/mcu/native/src/hal_hw_id.c
+++ b/hw/mcu/native/src/hal_hw_id.c
@@ -31,6 +31,16 @@
 static uint8_t hal_hw_id[HAL_BSP_MAX_ID_LEN];
 static uint8_t hal_hw_id_len;
 
+int
+hal_bsp_hw_id_len(void)
+{
+    if (hal_hw_id_len != 0) {
+        return hal_hw_id_len;
+    } else {
+        return HAL_BSP_MAX_ID_LEN;
+    }
+}
+
 /*
  * This can be used as the unique hardware identifier for the platform, as
  * it's supposed to be unique for this particular MCU.

--- a/hw/mcu/nordic/nrf51xxx/src/nrf51_hw_id.c
+++ b/hw/mcu/nordic/nrf51xxx/src/nrf51_hw_id.c
@@ -28,6 +28,12 @@
 #define min(a, b) ((a)<(b)?(a):(b))
 #endif
 
+int
+hal_bsp_hw_id_len(void)
+{
+    return sizeof(NRF_FICR->DEVICEID) + sizeof(NRF_FICR->DEVICEADDR);
+}
+
 /*
  * These values are generated at random.
  * DEVICEID[0-1] and DEVICEADDR[0-1].

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_hw_id.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_hw_id.c
@@ -26,6 +26,12 @@
 #define min(a, b) ((a)<(b)?(a):(b))
 #endif
 
+int
+hal_bsp_hw_id_len(void)
+{
+    return sizeof(NRF_FICR->DEVICEID) + sizeof(NRF_FICR->DEVICEADDR);
+}
+
 /*
  * These values are generated at random.
  * DEVICEID[0-1] and DEVICEADDR[0-1].

--- a/hw/mcu/nxp/MK64F12/src/hal_hw_id.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_hw_id.c
@@ -28,12 +28,20 @@
 #define min(a, b) ((a)<(b)?(a):(b))
 #endif
 
+#define MK64F12_HW_ID_LEN     7
+
+int
+hal_bsp_hw_id_len(void)
+{
+    return MK64F12_HW_ID_LEN;
+}
+
 /*
  * TODO: Use serial# registers
  */
 int hal_bsp_hw_id(uint8_t *id, int max_len)
 {
-    memcpy(id, (void *)"ABCDEFG", 8);
+    memcpy(id, (void *)"ABCDEFG", MK64F12_HW_ID_LEN + 1);
 
-    return 7;
+    return MK64F12_HW_ID_LEN;
 }

--- a/hw/mcu/stm/stm32_common/src/stm32_hw_id.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_hw_id.c
@@ -27,12 +27,20 @@
 #define min(a, b) ((a)<(b)?(a):(b))
 #endif
 
+#define STM32_HW_ID_LEN     12
+
+int
+hal_bsp_hw_id_len(void)
+{
+    return STM32_HW_ID_LEN;
+}
+
 int
 hal_bsp_hw_id(uint8_t *id, int max_len)
 {
     int cnt;
 
-    cnt = min(12, max_len);
+    cnt = min(STM32_HW_ID_LEN, max_len);
     memcpy(id, (void *)UID_BASE, cnt);
 
     return cnt;


### PR DESCRIPTION
This function retrieves the length, in bytes, of the hardware ID.  The existing function, `hal_bsp_hw_id()`, retrieves the ID and truncates it to the size of the provided buffer, if necessary.  This new function is necessary for sizing your buffer to avoid truncation.
