### PR TITLE
Stacktrace on crash

### DIFF
--- a/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
+++ b/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
+++ b/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/ble400/ble400_no_boot.ld
+++ b/hw/bsp/ble400/ble400_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/bmd200/nrf51dk_no_boot.ld
+++ b/hw/bsp/bmd200/nrf51dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
+++ b/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/ci40/uhi32.ld
+++ b/hw/bsp/ci40/uhi32.ld
@@ -176,6 +176,8 @@ SECTIONS
     . = ALIGN(8);
   } = 0
 
+  __text = .;
+
   .text : {
      _ftext = . ;
     PROVIDE (eprol  =  .);

--- a/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
+++ b/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/embarc_emsk/arc_core.ld
+++ b/hw/bsp/embarc_emsk/arc_core.ld
@@ -42,6 +42,8 @@ SECTIONS
          _e_vector = .;
     } > ICCM
 
+    __text = .;
+
     .init :
     {
         _f_init = .;
@@ -56,6 +58,8 @@ SECTIONS
         *(.text .text.* .gnu.linkonce.t.*)
         _e_text = .;
     } > ICCM
+
+    __etext = .;
 
     .rodata : ALIGN(4)
     {

--- a/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
@@ -73,6 +73,8 @@ SECTIONS
     . = . + 0x20;
   } > m_interrupts
 
+  __text = .;    /* define a global symbol for start of the code */
+
   /* The startup code goes first into internal flash */
   .interrupts :
   {

--- a/hw/bsp/hifive1/hifive1.ld
+++ b/hw/bsp/hifive1/hifive1.ld
@@ -29,6 +29,8 @@ SECTIONS
       . = . + _imghdr_size;
   } >flash
 
+  __text = .;
+
   .init           :
   {
     KEEP (*(SORT_NONE(.init)))

--- a/hw/bsp/nina-b1/nrf52dk_no_boot.ld
+++ b/hw/bsp/nina-b1/nrf52dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
+++ b/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
+++ b/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_no_boot.ld
+++ b/hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf51dk/nrf51dk_no_boot.ld
+++ b/hw/bsp/nrf51dk/nrf51dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf52-thingy/nrf52-thingy_no_boot.ld
+++ b/hw/bsp/nrf52-thingy/nrf52-thingy_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf52840pdk/nrf52840pdk_no_boot.ld
+++ b/hw/bsp/nrf52840pdk/nrf52840pdk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/nrf52dk/nrf52dk_no_boot.ld
+++ b/hw/bsp/nrf52dk/nrf52dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
+++ b/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
@@ -64,6 +64,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __vector_tbl_reloc__ = .;

--- a/hw/bsp/puckjs/puckjs_no_boot.ld
+++ b/hw/bsp/puckjs/puckjs_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
+++ b/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
+++ b/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/ruuvi_tag_revb2/nrf52dk_no_boot.ld
+++ b/hw/bsp/ruuvi_tag_revb2/nrf52dk_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/telee02/telee02_no_boot.ld
+++ b/hw/bsp/telee02/telee02_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/usbmkw41z/boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/boot-mkw41z512.ld
@@ -60,6 +60,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+    __text = .;
+
     .interrupts :
     {
         __isr_vector_start = .;

--- a/hw/bsp/usbmkw41z/mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/mkw41z512.ld
@@ -61,6 +61,8 @@ SECTIONS
       . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
@@ -60,6 +60,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+    __text = .;
+
     .interrupts :
     {
         __isr_vector_start = .;

--- a/hw/bsp/vbluno51/vbluno51_no_boot.ld
+++ b/hw/bsp/vbluno51/vbluno51_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/bsp/vbluno52/vbluno52_no_boot.ld
+++ b/hw/bsp/vbluno52/vbluno52_no_boot.ld
@@ -54,6 +54,8 @@ ENTRY(Reset_Handler)
 
 SECTIONS
 {
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/ambiq/apollo2/apollo2.ld
+++ b/hw/mcu/ambiq/apollo2/apollo2.ld
@@ -53,6 +53,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/nordic/nrf51xxx/nrf51.ld
+++ b/hw/mcu/nordic/nrf51xxx/nrf51.ld
@@ -53,6 +53,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/nordic/nrf52xxx/nrf52.ld
+++ b/hw/mcu/nordic/nrf52xxx/nrf52.ld
@@ -53,6 +53,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f1xx/stm32f103.ld
+++ b/hw/mcu/stm/stm32f1xx/stm32f103.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f3xx/stm32f303.ld
+++ b/hw/mcu/stm/stm32f3xx/stm32f303.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector = .;

--- a/hw/mcu/stm/stm32f4xx/stm32f401.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f401.ld
@@ -60,6 +60,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f4xx/stm32f407.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f407.ld
@@ -60,6 +60,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f4xx/stm32f413.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f413.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f4xx/stm32f427.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f427.ld
@@ -60,6 +60,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f4xx/stm32f429.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f429.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector = .;

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/hw/mcu/stm/stm32l1xx/stm32l152.ld
+++ b/hw/mcu/stm/stm32l1xx/stm32l152.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         __isr_vector_start = .;

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -147,6 +147,8 @@ os_default_irq(struct trap_frame *tf)
     console_printf("r12:0x%08lx  lr:0x%08lx  pc:0x%08lx psr:0x%08lx\n",
       tf->ef->r12, tf->ef->lr, tf->ef->pc, tf->ef->psr);
     console_printf("ICSR:0x%08lx\n", SCB->ICSR);
+
+    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -148,7 +148,7 @@ os_default_irq(struct trap_frame *tf)
       tf->ef->r12, tf->ef->lr, tf->ef->pc, tf->ef->psr);
     console_printf("ICSR:0x%08lx\n", SCB->ICSR);
 
-    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
+    os_stacktrace((uintptr_t)(tf->ef + 1));
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -163,7 +163,7 @@ os_default_irq(struct trap_frame *tf)
       SCB->ICSR, SCB->HFSR, SCB->CFSR);
     console_printf("BFAR:0x%08lx MMFAR:0x%08lx\n", SCB->BFAR, SCB->MMFAR);
 
-    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
+    os_stacktrace((uintptr_t)(tf->ef + 1));
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+#include <stdint.h>
+#include <unistd.h>
+
 #include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
@@ -25,9 +28,6 @@
 #if MYNEWT_VAL(OS_COREDUMP)
 #include "coredump/coredump.h"
 #endif
-
-#include <stdint.h>
-#include <unistd.h>
 
 struct exception_frame {
     uint32_t r0;
@@ -163,6 +163,7 @@ os_default_irq(struct trap_frame *tf)
       SCB->ICSR, SCB->HFSR, SCB->CFSR);
     console_printf("BFAR:0x%08lx MMFAR:0x%08lx\n", SCB->BFAR, SCB->MMFAR);
 
+    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -163,7 +163,7 @@ os_default_irq(struct trap_frame *tf)
       SCB->ICSR, SCB->HFSR, SCB->CFSR);
     console_printf("BFAR:0x%08lx MMFAR:0x%08lx\n", SCB->BFAR, SCB->MMFAR);
 
-    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
+    os_stacktrace((uintptr_t)(tf->ef + 1));
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+#include <stdint.h>
+#include <unistd.h>
+
 #include "os/mynewt.h"
 #include "console/console.h"
 #include "hal/hal_system.h"
@@ -25,9 +28,6 @@
 #if MYNEWT_VAL(OS_COREDUMP)
 #include "coredump/coredump.h"
 #endif
-
-#include <stdint.h>
-#include <unistd.h>
 
 struct exception_frame {
     uint32_t r0;
@@ -163,6 +163,7 @@ os_default_irq(struct trap_frame *tf)
       SCB->ICSR, SCB->HFSR, SCB->CFSR);
     console_printf("BFAR:0x%08lx MMFAR:0x%08lx\n", SCB->BFAR, SCB->MMFAR);
 
+    os_stacktrace((uintptr_t)(tf->ef + 1), 0xffffffff);
 #if MYNEWT_VAL(OS_COREDUMP)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));

--- a/kernel/os/src/os_priv.h
+++ b/kernel/os/src/os_priv.h
@@ -59,11 +59,10 @@ void os_msys_init(void);
  * the amount of stack it walks.
  *
  * @param sp Pointer to where stack starts.
- * @param sp Pointer to where stack ends.
  */
-void os_stacktrace(uintptr_t sp, uintptr_t end);
+void os_stacktrace(uintptr_t sp);
 #else
-#define os_stacktrace(sp, end)
+#define os_stacktrace(sp)
 #endif
 
 #ifdef __cplusplus

--- a/kernel/os/src/os_priv.h
+++ b/kernel/os/src/os_priv.h
@@ -52,6 +52,20 @@ void os_msys_init(void);
     }                                                                       \
 } while (0)
 
+#if MYNEWT_VAL(OS_CRASH_STACKTRACE)
+/**
+ * Print addresses from stack which look like they might be instruction
+ * pointers. Expects to be called from assert/fault handler. Function limits
+ * the amount of stack it walks.
+ *
+ * @param sp Pointer to where stack starts.
+ * @param sp Pointer to where stack ends.
+ */
+void os_stacktrace(uintptr_t sp, uintptr_t end);
+#else
+#define os_stacktrace(sp, end)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_stacktrace.c
+++ b/kernel/os/src/os_stacktrace.c
@@ -73,18 +73,24 @@ os_addr_is_ram(uintptr_t addr)
  * pointers.
  */
 void
-os_stacktrace(uintptr_t sp, uintptr_t end)
+os_stacktrace(uintptr_t sp)
 {
     uintptr_t addr;
+    uintptr_t end;
+    struct os_task *t;
 
     sp &= ~(sizeof(uintptr_t) - 1);
-    if (end > sp + OS_STACK_DEPTH_MAX) {
-        /*
-         * Limit this, in case SP/end of stack are not right.
-         */
-        end = sp + OS_STACK_DEPTH_MAX;
+    end = sp + OS_STACK_DEPTH_MAX;
+
+    if (g_os_started && g_current_task) {
+        t = g_current_task;
+        if (sp > (uintptr_t)t->t_stacktop && end > (uintptr_t)t->t_stacktop) {
+            end = (uintptr_t)t->t_stacktop;
+        }
+    } else {
+        t = NULL;
     }
-    console_printf("Stack\n");
+    console_printf("task:%s\n", t ? t->t_name : "NA");
     for ( ; sp < end; sp += sizeof(uintptr_t)) {
         if (os_addr_is_ram(sp)) {
             addr = *(uintptr_t *)sp;

--- a/kernel/os/src/os_stacktrace.c
+++ b/kernel/os/src/os_stacktrace.c
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(OS_CRASH_STACKTRACE)
+#include <hal/hal_bsp.h>
+#include <console/console.h>
+
+#define OS_STACK_DEPTH_MAX      1024
+
+/*
+ * Is address within text region?
+ */
+static int
+os_addr_is_text(uintptr_t addr)
+{
+    extern void *__text;
+    extern void *__etext;
+    uintptr_t start = (uintptr_t)&__text;
+    uintptr_t end = (uintptr_t)&__etext;
+
+    /*
+     * Assumes all text is contiguous. XXX split images and architectures where
+     * this is not the case.
+     */
+    if (addr >= start && addr < end) {
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * Is address within area where stack could be?
+ */
+static int
+os_addr_is_ram(uintptr_t addr)
+{
+    const struct hal_bsp_mem_dump *mem;
+    const struct hal_bsp_mem_dump *cur;
+    int mem_cnt;
+    int i;
+
+    mem = hal_bsp_core_dump(&mem_cnt); /* this returns ram regions as array */
+    for (i = 0; i < mem_cnt; i++) {
+        cur = &mem[i];
+        if (addr >= (uintptr_t)cur->hbmd_start &&
+            addr < (uintptr_t)cur->hbmd_start + cur->hbmd_size) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * Print addresses from stack which look like they might be instruction
+ * pointers.
+ */
+void
+os_stacktrace(uintptr_t sp, uintptr_t end)
+{
+    uintptr_t addr;
+
+    sp &= ~(sizeof(uintptr_t) - 1);
+    if (end > sp + OS_STACK_DEPTH_MAX) {
+        /*
+         * Limit this, in case SP/end of stack are not right.
+         */
+        end = sp + OS_STACK_DEPTH_MAX;
+    }
+    console_printf("Stack\n");
+    for ( ; sp < end; sp += sizeof(uintptr_t)) {
+        if (os_addr_is_ram(sp)) {
+            addr = *(uintptr_t *)sp;
+            if (os_addr_is_text(addr)) {
+                console_printf(" 0x%08lx: 0x%08lx\n",
+                               (unsigned long)sp, (unsigned long)addr);
+            }
+        }
+    }
+}
+#endif
+
+

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -34,6 +34,9 @@ syscfg.defs:
     OS_COREDUMP:
         description: 'Attempt to dump corefile when system crashes'
         value: 0
+    OS_CRASH_STACKTRACE:
+        description: 'Attempt to print stack trace when system crashes.'
+        value: 0
     OS_SYSVIEW:
         description: 'Enable OS sysview tracing'
         value: 0


### PR DESCRIPTION
Initial implementation is to print a trivial implementation. This walks through the immediate stack printing out values which could conceivably belong to to call-chain. So there will be false positives. This can be improved for architectures which use frame pointers.
Another thing to add later is looking at current task, and limit stack walk until the end of it's stack.