### PR TITLE
kernel/sim-armv7: Fix os_arch_frame_init symbol type

### DIFF
--- a/kernel/os/src/arch/sim-armv7/os_arch_stack_frame.s
+++ b/kernel/os/src/arch/sim-armv7/os_arch_stack_frame.s
@@ -23,6 +23,7 @@
     .p2align 4, 0x90    /* align on 16-byte boundary and fill with NOPs */
 
     .globl os_arch_frame_init
+    .type  os_arch_frame_init, %function
     /*
      * void os_arch_frame_init(struct stack_frame *sf)
      */


### PR DESCRIPTION
Without symbol type GNU ld does not properly detect call to ARM code
from Thumb code and does not generate proper instruction to switch
modes which results in a crash.