### PR TITLE
mgmt/imgr: Add support to resume image upload

### DIFF
--- a/mgmt/imgmgr/src/imgmgr_priv.h
+++ b/mgmt/imgmgr/src/imgmgr_priv.h
@@ -31,6 +31,8 @@ extern "C" {
 
 #define IMGMGR_HASH_STR		48
 
+#define IMGMGR_DATA_HASH_LEN    32 /* SHA256 */
+
 /*
  * When accompanied by image, it's this structure followed by data.
  * Response contains just the offset.
@@ -92,6 +94,7 @@ struct imgr_state {
     struct {
         uint32_t off;
         uint32_t size;
+        uint8_t data_hash[IMGMGR_DATA_HASH_LEN];
         const struct flash_area *fa;
     } upload;
 };


### PR DESCRIPTION
1st chunk of data can include "datahash" field which is simply SHA256
computer over all data to be uploaded. This hash is stored in upload
state so in case transfer was interrupted we can detect this on next
attempt and simply resume transfer at previous location by replying
with latest offset from upload state.

"datahash" field is not mandatory so if it is missing we'll just start
new upload as usual.