### PR TITLE
Move includes to avoid compile error when CLIs are not enabled

### DIFF
--- a/hw/drivers/sensors/bma253/src/bma253_shell.c
+++ b/hw/drivers/sensors/bma253/src/bma253_shell.c
@@ -23,9 +23,10 @@
 #include "bma253/bma253.h"
 #include "bma253_priv.h"
 #include "console/console.h"
-#include "shell/shell.h"
 
 #if MYNEWT_VAL(BMA253_CLI)
+
+#include "shell/shell.h"
 
 struct self_test_mode {
     const char * name;

--- a/hw/drivers/sensors/bmp280/src/bmp280_shell.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280_shell.c
@@ -21,13 +21,14 @@
 #include <errno.h>
 #include "os/mynewt.h"
 #include "console/console.h"
-#include "shell/shell.h"
 #include "hal/hal_gpio.h"
 #include "bmp280/bmp280.h"
 #include "bmp280_priv.h"
-#include "parse/parse.h"
 
 #if MYNEWT_VAL(BMP280_CLI)
+
+#include "shell/shell.h"
+#include "parse/parse.h"
 
 static int bmp280_shell_cmd(int argc, char **argv);
 

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
@@ -21,13 +21,14 @@
 #include <errno.h>
 #include "os/mynewt.h"
 #include "console/console.h"
-#include "shell/shell.h"
 #include "sensor/accel.h"
 #include "lis2dw12/lis2dw12.h"
 #include "lis2dw12_priv.h"
-#include "parse/parse.h"
 
 #if MYNEWT_VAL(LIS2DW12_CLI)
+
+#include "shell/shell.h"
+#include "parse/parse.h"
 
 #define LIS2DW12_CLI_FIRST_REGISTER 0x0D
 #define LIS2DW12_CLI_LAST_REGISTER 0x3F


### PR DESCRIPTION
Several sensor shell modules were including shell/shell.h and parse/parse.h even when the package CLI's are disable. The shell and/or parse packages are conditional dependencies that don't get included when the CLI is disabled, and this was resulting in a compile error. 