### PR TITLE
fix os_callout_reset() parameter checking

### DIFF
--- a/kernel/os/src/os_callout.c
+++ b/kernel/os/src/os_callout.c
@@ -73,7 +73,7 @@ os_callout_reset(struct os_callout *c, os_time_t ticks)
 
     os_trace_api_u32x2(OS_TRACE_ID_CALLOUT_RESET, (uint32_t)c, (uint32_t)ticks);
 
-    if (ticks < 0) {
+    if (ticks > INT32_MAX) {
         ret = OS_EINVAL;
         goto err;
     }

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -36,8 +36,8 @@ struct oc_ep_hdr {
     uint8_t oe_flags:5;         /* OC_ENDPOINT flags */
 };
 
-#define OC_ENDPOINT_MULTICAST   1 << 0
-#define OC_ENDPOINT_SECURED     1 << 1
+#define OC_ENDPOINT_MULTICAST   (1 << 0)
+#define OC_ENDPOINT_SECURED     (1 << 1)
 
 /*
  * Use this when reserving memory for oc_endpoint of unknown type.

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -171,6 +171,7 @@ cursor_backward(unsigned int count)
     console_printf("\x1b[%uD", count);
 }
 
+#if MYNEWT_VAL(CONSOLE_HISTORY)
 static inline void
 cursor_clear_line(void)
 {
@@ -178,6 +179,7 @@ cursor_clear_line(void)
     console_out('[');
     console_out('K');
 }
+#endif
 
 static inline void
 cursor_save(void)

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -29,6 +29,13 @@
 #include "console/console.h"
 #include "console_priv.h"
 
+struct console_ring {
+    uint8_t head;
+    uint8_t tail;
+    uint16_t size;
+    uint8_t *buf;
+};
+
 static struct uart_dev *uart_dev;
 static struct console_ring cr_tx;
 static uint8_t cr_tx_buf[MYNEWT_VAL(CONSOLE_UART_TX_BUF_SIZE)];
@@ -41,13 +48,6 @@ static uint8_t cr_rx_buf[MYNEWT_VAL(CONSOLE_UART_RX_BUF_SIZE)];
 
 struct os_event rx_ev;
 #endif
-
-struct console_ring {
-    uint8_t head;
-    uint8_t tail;
-    uint16_t size;
-    uint8_t *buf;
-};
 
 static inline int
 inc_and_wrap(int i, int max)

--- a/test/crash_test/src/crash_test.c
+++ b/test/crash_test/src/crash_test.c
@@ -49,7 +49,7 @@ crash_device(char *how)
     } else if (!strcmp(how, "jump0")) {
         ((void (*)(void))0)();
     } else if (!strcmp(how, "ref0")) {
-        val1 = *(int *)0;
+        val1 = *(volatile int *)0;
     } else if (!strcmp(how, "assert")) {
         assert(0);
     } else if (!strcmp(how, "wdog")) {


### PR DESCRIPTION
Dangerously declared OIC macros were probably causing wrong code to be generated.
And other misc changes to compile slinky/blinky with llvm for native.