### PR TITLE
adc: Move function pointers from .data to .rodata

### DIFF
--- a/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
+++ b/hw/drivers/adc/adc_nrf51/src/adc_nrf51.c
@@ -367,6 +367,18 @@ nrf51_adc_size_buffer(struct adc_dev *dev, int chans, int samples)
     return (sizeof(nrf_adc_value_t) * chans * samples);
 }
 
+/**
+ * ADC device driver functions
+ */
+static const struct adc_driver_funcs nrf51_adc_funcs = {
+        .af_configure_channel = nrf51_adc_configure_channel,
+        .af_sample = nrf51_adc_sample,
+        .af_read_channel = nrf51_adc_read_channel,
+        .af_set_buffer = nrf51_adc_set_buffer,
+        .af_release_buffer = nrf51_adc_release_buffer,
+        .af_read_buffer = nrf51_adc_read_buffer,
+        .af_size_buffer = nrf51_adc_size_buffer,
+};
 
 /**
  * Callback to initialize an adc_dev structure from the os device
@@ -377,7 +389,6 @@ int
 nrf51_adc_dev_init(struct os_dev *odev, void *arg)
 {
     struct adc_dev *dev;
-    struct adc_driver_funcs *af;
 
     dev = (struct adc_dev *) odev;
 
@@ -391,15 +402,7 @@ nrf51_adc_dev_init(struct os_dev *odev, void *arg)
     assert(init_adc_config == NULL || init_adc_config == arg);
     init_adc_config = arg;
 
-    af = &dev->ad_funcs;
-
-    af->af_configure_channel = nrf51_adc_configure_channel;
-    af->af_sample = nrf51_adc_sample;
-    af->af_read_channel = nrf51_adc_read_channel;
-    af->af_set_buffer = nrf51_adc_set_buffer;
-    af->af_release_buffer = nrf51_adc_release_buffer;
-    af->af_read_buffer = nrf51_adc_read_buffer;
-    af->af_size_buffer = nrf51_adc_size_buffer;
+    dev->ad_funcs = &nrf51_adc_funcs;
 
     NVIC_SetVector(ADC_IRQn, (uint32_t) nrfx_adc_irq_handler);
 

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -365,6 +365,19 @@ saadc_irq_handler(void)
 #endif
 
 /**
+ * ADC device driver functions
+ */
+static const struct adc_driver_funcs nrf52_adc_funcs = {
+        .af_configure_channel = nrf52_adc_configure_channel,
+        .af_sample = nrf52_adc_sample,
+        .af_read_channel = nrf52_adc_read_channel,
+        .af_set_buffer = nrf52_adc_set_buffer,
+        .af_release_buffer = nrf52_adc_release_buffer,
+        .af_read_buffer = nrf52_adc_read_buffer,
+        .af_size_buffer = nrf52_adc_size_buffer,
+};
+
+/**
  * Callback to initialize an adc_dev structure from the os device
  * initialization callback.  This sets up a nrf52_adc_device(), so
  * that subsequent lookups to this device allow us to manipulate it.
@@ -373,7 +386,6 @@ int
 nrf52_adc_dev_init(struct os_dev *odev, void *arg)
 {
     struct adc_dev *dev;
-    struct adc_driver_funcs *af;
 
     dev = (struct adc_dev *) odev;
 
@@ -387,15 +399,7 @@ nrf52_adc_dev_init(struct os_dev *odev, void *arg)
     assert(init_adc_config == NULL || init_adc_config == arg);
     init_adc_config = arg;
 
-    af = &dev->ad_funcs;
-
-    af->af_configure_channel = nrf52_adc_configure_channel;
-    af->af_sample = nrf52_adc_sample;
-    af->af_read_channel = nrf52_adc_read_channel;
-    af->af_set_buffer = nrf52_adc_set_buffer;
-    af->af_release_buffer = nrf52_adc_release_buffer;
-    af->af_read_buffer = nrf52_adc_read_buffer;
-    af->af_size_buffer = nrf52_adc_size_buffer;
+    dev->ad_funcs = &nrf52_adc_funcs;
 
 #if MYNEWT_VAL(OS_SYSVIEW)
     NVIC_SetVector(SAADC_IRQn, (uint32_t) saadc_irq_handler);

--- a/hw/drivers/adc/adc_stm32f4/src/adc_stm32f4.c
+++ b/hw/drivers/adc/adc_stm32f4/src/adc_stm32f4.c
@@ -700,6 +700,19 @@ stm32f4_adc_size_buffer(struct adc_dev *dev, int chans, int samples)
 }
 
 /**
+ * ADC device driver functions
+ */
+static const struct adc_driver_funcs stm32f4_adc_funcs = {
+        .af_configure_channel = stm32f4_adc_configure_channel,
+        .af_sample = stm32f4_adc_sample,
+        .af_read_channel = stm32f4_adc_read_channel,
+        .af_set_buffer = stm32f4_adc_set_buffer,
+        .af_release_buffer = stm32f4_adc_release_buffer,
+        .af_read_buffer = stm32f4_adc_read_buffer,
+        .af_size_buffer = stm32f4_adc_size_buffer,
+};
+
+/**
  * Callback to initialize an adc_dev structure from the os device
  * initialization callback.  This sets up a stm32f4_adc_device(), so
  * that subsequent lookups to this device allow us to manipulate it.
@@ -713,7 +726,6 @@ stm32f4_adc_dev_init(struct os_dev *odev, void *arg)
 {
     struct stm32f4_adc_dev_cfg *sac;
     struct adc_dev *dev;
-    struct adc_driver_funcs *af;
 
     sac = (struct stm32f4_adc_dev_cfg *) arg;
 
@@ -728,15 +740,7 @@ stm32f4_adc_dev_init(struct os_dev *odev, void *arg)
 
     OS_DEV_SETHANDLERS(odev, stm32f4_adc_open, stm32f4_adc_close);
 
-    af = &dev->ad_funcs;
-
-    af->af_configure_channel = stm32f4_adc_configure_channel;
-    af->af_sample = stm32f4_adc_sample;
-    af->af_read_channel = stm32f4_adc_read_channel;
-    af->af_set_buffer = stm32f4_adc_set_buffer;
-    af->af_release_buffer = stm32f4_adc_release_buffer;
-    af->af_read_buffer = stm32f4_adc_read_buffer;
-    af->af_size_buffer = stm32f4_adc_size_buffer;
+    dev->ad_funcs = &stm32f4_adc_funcs;
 
     return (OS_OK);
 }

--- a/hw/drivers/adc/include/adc/adc.h
+++ b/hw/drivers/adc/include/adc/adc.h
@@ -156,7 +156,7 @@ struct adc_chan_config {
 struct adc_dev {
     struct os_dev ad_dev;
     struct os_mutex ad_lock;
-    struct adc_driver_funcs ad_funcs;
+    const struct adc_driver_funcs *ad_funcs;
     struct adc_chan_config *ad_chans;
     int ad_chan_count;
     adc_event_handler_func_t ad_event_handler_func;
@@ -179,7 +179,7 @@ int adc_event_handler_set(struct adc_dev *, adc_event_handler_func_t,
 static inline int
 adc_sample(struct adc_dev *dev)
 {
-    return (dev->ad_funcs.af_sample(dev));
+    return (dev->ad_funcs->af_sample(dev));
 }
 
 /**
@@ -195,7 +195,7 @@ adc_sample(struct adc_dev *dev)
 static inline int
 adc_read_channel(struct adc_dev *dev, uint8_t ch, int *result)
 {
-    return (dev->ad_funcs.af_read_channel(dev, ch, result));
+    return (dev->ad_funcs->af_read_channel(dev, ch, result));
 }
 
 /**
@@ -216,7 +216,7 @@ static inline int
 adc_buf_set(struct adc_dev *dev, void *buf1, void *buf2,
         int buf_len)
 {
-    return (dev->ad_funcs.af_set_buffer(dev, buf1, buf2, buf_len));
+    return (dev->ad_funcs->af_set_buffer(dev, buf1, buf2, buf_len));
 }
 
 /**
@@ -232,7 +232,7 @@ adc_buf_set(struct adc_dev *dev, void *buf1, void *buf2,
 static inline int
 adc_buf_release(struct adc_dev *dev, void *buf, int buf_len)
 {
-    return (dev->ad_funcs.af_release_buffer(dev, buf, buf_len));
+    return (dev->ad_funcs->af_release_buffer(dev, buf, buf_len));
 }
 
 /**
@@ -250,7 +250,7 @@ static inline int
 adc_buf_read(struct adc_dev *dev, void *buf, int buf_len, int entry,
         int *result)
 {
-    return (dev->ad_funcs.af_read_buffer(dev, buf, buf_len, entry, result));
+    return (dev->ad_funcs->af_read_buffer(dev, buf, buf_len, entry, result));
 }
 
 /**
@@ -265,7 +265,7 @@ adc_buf_read(struct adc_dev *dev, void *buf, int buf_len, int entry,
 static inline int
 adc_buf_size(struct adc_dev *dev, int chans, int samples)
 {
-    return (dev->ad_funcs.af_size_buffer(dev, chans, samples));
+    return (dev->ad_funcs->af_size_buffer(dev, chans, samples));
 }
 
 /**

--- a/hw/drivers/adc/src/adc.c
+++ b/hw/drivers/adc/src/adc.c
@@ -34,13 +34,13 @@
 int
 adc_chan_config(struct adc_dev *dev, uint8_t cnum, void *data)
 {
-    assert(dev->ad_funcs.af_configure_channel != NULL);
+    assert(dev->ad_funcs->af_configure_channel != NULL);
 
     if (cnum >= dev->ad_chan_count) {
         return (EINVAL);
     }
 
-    return (dev->ad_funcs.af_configure_channel(dev, cnum, data));
+    return (dev->ad_funcs->af_configure_channel(dev, cnum, data));
 }
 
 /**
@@ -55,7 +55,7 @@ adc_chan_config(struct adc_dev *dev, uint8_t cnum, void *data)
 int
 adc_chan_read(struct adc_dev *dev, uint8_t cnum, int *result)
 {
-    assert(dev->ad_funcs.af_read_channel != NULL);
+    assert(dev->ad_funcs->af_read_channel != NULL);
 
     if (cnum >= dev->ad_chan_count) {
         return (EINVAL);
@@ -65,7 +65,7 @@ adc_chan_read(struct adc_dev *dev, uint8_t cnum, int *result)
         return (EINVAL);
     }
 
-    return (dev->ad_funcs.af_read_channel(dev, cnum, result));
+    return (dev->ad_funcs->af_read_channel(dev, cnum, result));
 }
 
 /**


### PR DESCRIPTION
ADC driver function pointers do not need to be kept in
RAM. Moving them to read only section should reduce
RAM usage.