### PR TITLE
kernel/os: Preempt when high priority task created

### DIFF
--- a/kernel/os/src/os_task.c
+++ b/kernel/os/src/os_task.c
@@ -114,6 +114,13 @@ os_task_init(struct os_task *t, const char *name, os_task_func_t func,
     os_trace_task_create(t);
     os_trace_task_info(t);
 
+    /* Allow a preemption in case the new task has a higher priority than the
+     * current one.
+     */
+    if (os_started()) {
+        os_sched(NULL);
+    }
+
     return (0);
 err:
     return (rc);


### PR DESCRIPTION
Before this change, a newly-created high-priority task would not immediately preempt the current one.  Preemption would not occur until the next call to `os_sched()` (e.g., via a mutex unlock).

This PR causes `os_sched()` to be called whenever a new task is created (so long as the OS has been started).

The motivation for this change is to facilitate running of multi-task unit tests.  When a unit test creates a high priority task, the new task needs to start running immediately so that it can process events generated by the main test task.