### PR TITLE
sys/config; add conf_set_from_storage().

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -196,6 +196,13 @@ int conf_load(void);
 int conf_ensure_loaded(void);
 
 /**
+ * Config setting comes as a result of conf_load().
+ *
+ * @return 1 if yes, 0 if not.
+ */
+int conf_set_from_storage(void);
+
+/**
  * Save currently running configuration. All configuration which is different
  * from currently persisted values will be saved.
  *
@@ -222,12 +229,6 @@ int conf_save_tree(char *name);
  * @return 0 on success, non-zero on failure.
  */
 int conf_save_one(const char *name, char *var);
-
-/*
-  XXXX for later
-  int conf_save_lib(char *name);
-  int conf_save_var(char *name, char *var);
-*/
 
 /**
  * Set configuration item identified by @p name to be value @p val_str.

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -32,6 +32,7 @@ struct conf_dup_check_arg {
 
 struct conf_store_head conf_load_srcs;
 struct conf_store *conf_save_dst;
+static bool conf_loading;
 static bool conf_loaded;
 
 void
@@ -75,12 +76,14 @@ conf_load(void)
      */
     conf_lock();
     conf_loaded = true;
+    conf_loading = true;
     SLIST_FOREACH(cs, &conf_load_srcs, cs_next) {
         cs->cs_itf->csi_load(cs, conf_load_cb, NULL);
         if (SLIST_NEXT(cs, cs_next)) {
             conf_commit(NULL);
         }
     }
+    conf_loading = false;
     conf_unlock();
     return conf_commit(NULL);
 }
@@ -93,6 +96,12 @@ conf_ensure_loaded(void)
     }
 
     return conf_load();
+}
+
+int
+conf_set_from_storage(void)
+{
+    return conf_loading;
 }
 
 static void


### PR DESCRIPTION
Using this handler can tell if value is coming from persisted storage
or from somewhere else.

Also remove obsolete XXX; functions mentioned there have been implemented.