### PR TITLE
rtt: Disable spurious warning in optimized build

### DIFF
--- a/hw/drivers/rtt/pkg.yml
+++ b/hw/drivers/rtt/pkg.yml
@@ -27,3 +27,4 @@ pkg.req_apis:
 
 pkg.cflags:
     - -DSEGGER_RTT_SECTION=".rtt"
+    - -Wno-array-bounds


### PR DESCRIPTION
With only `CONSOLE_RTT` enabled (other RTT features disabled) there is
only single up/down buffer thus buffer index !=0 is invalid. When
building RTT target code with optimizations enabled GCC emits an "array
subscript is above array bounds" error (`-Werror=array-bounds`) at line
1422 below because this code is accessed only if `BufferIndex` is larger
than 0 (thus out of array bounds). However, this will not happen due to
check in line 1419 as `MaxNumUpBuffers` is set to array size.
```
1419   if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
1420     SEGGER_RTT_LOCK();
1421     if (BufferIndex > 0u) {
1422       _SEGGER_RTT.aUp[BufferIndex].sName        = sName;
```
Since there is external code which we don't want to modify and also
there is no error in code, let's just disable this warning for RTT
package.