### PR TITLE
sys/console: Add proper flow control

### DIFF
--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -58,13 +58,17 @@ void console_echo(int on);
 int console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;
 
-void console_set_queues(struct os_eventq *avail_queue,
-                        struct os_eventq *cmd_queue);
 void console_set_completion_cb(completion_cb cb);
 int console_handle_char(uint8_t byte);
 
+/* Set queue to send console line events to */
+void console_line_queue_set(struct os_eventq *evq);
+/* Put (handled) line event to console */
+void console_line_event_put(struct os_event *ev);
+
 extern int console_is_midline;
 extern int console_out(int character);
+extern void console_rx_restart(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
sys/console: Add proper flow control
    
Flow control in console was pretty much non-existent since we always returned success from console_handle_char(). This means there was no way for "character source" to apply some kind of flow control.
    
To fix this console has to know when new line events are put back to queue which means queue of available line events has to be handled by console itself, not by the client. In case there is no free line event available to handle new character, RX is stalled in console and resumed when new line event is put back to queue. This automatically triggers flow control on UART, if enabled (otherwise we'll just drop characters, but this is "works as designed").
    
The above also works well with asynchronous UART RX since we no longer remove "oldest" character from queue in case of overflow, but just trigger UART flow control instead.