### PR TITLE
log/modlog: Use rwlock instead of mutex

### DIFF
--- a/sys/log/modlog/pkg.yml
+++ b/sys/log/modlog/pkg.yml
@@ -26,6 +26,7 @@ pkg.keywords:
 
 pkg.deps:
     - kernel/os
+    - util/rwlock
 
 pkg.req_apis:
     - log


### PR DESCRIPTION
Modlog (module-mapped logging) involves almost no writes compared to reads.  The modlog state is only written to when the application adds or changes a module mapping, but it is read every time a message is logged.

Using a regular mutex can cause some performance issues, as the logging task will be blocked until other tasks are done logging.  This commit replaces the regular mutex with a "readers-writer lock", which allows multiple tasks to log at the same time.