### PR TITLE
Battery property write

### DIFF
--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -52,6 +52,13 @@ static const struct shell_cmd_help bat_read_help =
         .params = bat_read_params,
 };
 
+static const struct shell_cmd_help bat_write_help =
+{
+        .summary = "write battery properties",
+        .usage = "read <prop> <value>",
+        .params = NULL,
+};
+
 static const struct shell_cmd_help bat_list_help =
 {
         .summary = "list battery properties",
@@ -97,6 +104,7 @@ static void cmd_bat_help(void)
     console_printf("  monitor [<prop>] [off]\n");
     console_printf("  list\n");
     console_printf("  read [<prop>] | all\n");
+    console_printf("  write <prop> <value>\n");
 
     console_printf("Examples:\n");
     console_printf("  list\n");
@@ -104,6 +112,7 @@ static void cmd_bat_help(void)
     console_printf("  monitor off\n");
     console_printf("  read Voltage\n");
     console_printf("  read all\n");
+    console_printf("  write VoltageLoAlarmSet\n");
 }
 
 static const char *bat_status[] = {
@@ -215,6 +224,69 @@ err:
     return rc;
 }
 
+static int
+get_min_max(const struct battery_property *prop, long long *min, long long *max)
+{
+    int rc = 0;
+
+    if (prop->bp_type == BATTERY_PROP_VOLTAGE_NOW) {
+        *min = 0;
+        *max = 10000;
+    } else if (prop->bp_type == BATTERY_PROP_TEMP_NOW) {
+        *min = -128;
+        *max = 127;
+    } else {
+        rc = -1;
+    }
+    return rc;
+}
+
+static int
+cmd_bat_write(int argc, char ** argv)
+{
+    int rc = 0;
+    long long min;
+    long long max;
+    struct battery_property *prop;
+    long long int val;
+
+    if (argc < 3) {
+        console_printf("Invalid number of arguments, use write <prop> <value>\n");
+        goto err;
+    }
+
+    prop = battery_find_property_by_name(bat, argv[1]);
+    if (prop == NULL) {
+        console_printf("Invalid property name %s\n", argv[1]);
+        goto err;
+    }
+    if (get_min_max(prop, &min, &max)) {
+        console_printf("Property %s can not be set\n", argv[1]);
+        goto err;
+    }
+    val = parse_ll_bounds(argv[2], min, max, &rc);
+    if (rc) {
+        console_printf("Property value not in range <%lld, %lld>\n", min, max);
+        rc = 0;
+        goto err;
+    }
+    if (prop->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+            (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
+        battery_prop_set_value_uint32(prop, (uint32_t)val);
+    } else if (prop->bp_type == BATTERY_PROP_TEMP_NOW &&
+            (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
+        battery_prop_set_value_float(prop, val);
+    } else {
+        console_printf("Property %s can't be written!\n", argv[1]);
+    }
+    if (!prop->bp_valid) {
+        console_printf("Error writing property!\n");
+        goto err;
+    }
+err:
+    return rc;
+}
+
 static int cmd_bat_list(int argc, char **argv)
 {
     int i;
@@ -299,6 +371,7 @@ err:
 static const struct shell_cmd bat_cli_commands[] =
 {
         { "read", cmd_bat_read, HELP(bat_read_help) },
+        { "write", cmd_bat_write, HELP(bat_write_help) },
         { "list", cmd_bat_list, HELP(bat_list_help) },
         { "pollrate", cmd_bat_poll_rate, HELP(bat_poll_rate_help) },
         { "monitor", cmd_bat_monitor, HELP(bat_monitor_help) },

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -69,6 +69,14 @@
 #define BQ27Z561_REG_DCAP       (0x3C)
 #define BQ27Z561_REG_MFRG_ACC   (0x3E)
 #define BQ27Z561_REG_CHKSUM     (0x60)
+#define BQ27Z561_REG_VOLT_HI_SET_TH (0x62)
+#define BQ27Z561_REG_VOLT_HI_CLR_TH (0x64)
+#define BQ27Z561_REG_VOLT_LO_SET_TH (0x66)
+#define BQ27Z561_REG_VOLT_LO_CLR_TH (0x68)
+#define BQ27Z561_REG_TEMP_HI_SET_TH (0x6A)
+#define BQ27Z561_REG_TEMP_HI_CLR_TH (0x6B)
+#define BQ27Z561_REG_TEMP_LO_SET_TH (0x6C)
+#define BQ27Z561_REG_TEMP_LO_CLR_TH (0x6D)
 
 
 /* Alt Manufacturer Command List */
@@ -222,6 +230,60 @@ int bq27z561_get_time_to_empty(struct bq27z561 *dev, uint16_t *tte);
 int bq27z561_get_temp(struct bq27z561 *dev, float *temp_c);
 
 /**
+ * bq27z561 set low temperature set threshold
+ *
+ * Sets low temperature value that triggers interrupt
+ *
+ * @param dev pointer to device
+ * @param temp_c temperature, in C
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_temp_lo_set_threshold(struct bq27z561 *dev,
+        int8_t temp_c);
+
+/**
+ * bq27z561 set low temperature clear threshold
+ *
+ * When interrupt is active and temperature goes above this threshold interrupt
+ * is cleared.
+ *
+ * @param dev pointer to device
+ * @param temp_c temperature, in C
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_temp_lo_clear_threshold(struct bq27z561 *dev,
+        int16_t temp_c);
+
+/**
+ * bq27z561 set high temperature set threshold
+ *
+ * Sets high temperature value that triggers interrupt
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_temp_hi_set_threshold(struct bq27z561 *dev,
+        int8_t temp_c);
+
+/**
+ * bq27z561 set high temperature clear threshold
+ *
+ * When interrupt is active and temperature goes below this threshold interrupt
+ * is cleared.
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_temp_hi_clear_threshold(struct bq27z561 *dev,
+        int16_t temp_c);
+
+/**
  * bq27z561 get voltage
  *
  * Gets the measured cell voltage
@@ -232,6 +294,60 @@ int bq27z561_get_temp(struct bq27z561 *dev, float *temp_c);
  * @return int 0: success, -1 error
  */
 int bq27z561_get_voltage(struct bq27z561 *dev, uint16_t *voltage);
+
+/**
+ * bq27z561 set low voltage set threshold
+ *
+ * Sets low voltage value that triggers interrupt
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_voltage_lo_set_threshold(struct bq27z561 *dev,
+        uint16_t voltage);
+
+/**
+ * bq27z561 set low voltage clear threshold
+ *
+ * When interrupt is active and voltage goes above this threshold interrupt
+ * is cleared.
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_voltage_lo_clr_threshold(struct bq27z561 *dev,
+        uint16_t voltage);
+
+/**
+ * bq27z561 set high voltage set threshold
+ *
+ * Sets high voltage value that triggers interrupt
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_voltage_hi_set_threshold(struct bq27z561 *dev,
+        uint16_t voltage);
+
+/**
+ * bq27z561 set high voltage clear threshold
+ *
+ * When interrupt is active and voltage goes below this threshold interrupt
+ * is cleared.
+ *
+ * @param dev pointer to device
+ * @param voltage voltage, in mV
+ *
+ * @return int 0: success, -1 error
+ */
+int bq27z561_set_voltage_hi_clr_threshold(struct bq27z561 *dev,
+        uint16_t voltage);
 
 /**
  * bq27z561 get batt status

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -129,6 +129,33 @@ bq27z561_itf_unlock(struct bq27z561_itf *bi)
 }
 
 int
+bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
+{
+    int rc;
+    struct hal_i2c_master_data i2c;
+
+    i2c.address = dev->bq27_itf.itf_addr;
+    i2c.len = 1;
+    i2c.buffer = &reg;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
+        return rc;
+    }
+
+    i2c.len = 1;
+    i2c.buffer = (uint8_t *)val;
+    rc = hal_i2c_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
+        return rc;
+    }
+
+    return 0;
+}
+
+int
 bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
 {
     int rc;
@@ -163,6 +190,29 @@ err:
     /* XXX: add big-endian support */
 
     return rc;
+}
+
+static int
+bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
+{
+    int rc;
+    uint8_t buf[2];
+    struct hal_i2c_master_data i2c;
+
+    buf[0] = reg;
+    buf[1] = val;
+
+    i2c.address = dev->bq27_itf.itf_num;
+    i2c.len     = 2;
+    i2c.buffer  = buf;
+
+    rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
+    if (rc != 0) {
+        BQ27Z561_ERROR("I2C reg write 0x%02X failed\n", reg);
+        return rc;
+    }
+
+    return 0;
 }
 
 static int

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -927,6 +927,26 @@ bq27z561_battery_property_get(struct battery_driver *driver,
         rc = bq27z561_get_voltage((struct bq27z561 *) driver->bd_driver_data,
                                   &val.bpv_u16);
         property->bp_value.bpv_voltage = val.bpv_u16;
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_get_voltage_lo_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u16);
+            property->bp_value.bpv_voltage = val.bpv_u16;
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_get_voltage_lo_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u16);
+            property->bp_value.bpv_voltage = val.bpv_u16;
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_get_voltage_hi_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u16);
+            property->bp_value.bpv_voltage = val.bpv_u16;
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_get_voltage_hi_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u16);
+            property->bp_value.bpv_voltage = val.bpv_u16;
     } else if (property->bp_type == BATTERY_PROP_STATUS &&
                property->bp_flags == 0) {
         rc = bq27z561_get_batt_status((struct bq27z561 *) driver->bd_driver_data,
@@ -973,6 +993,26 @@ bq27z561_battery_property_get(struct battery_driver *driver,
         rc = bq27z561_get_temp(
                 (struct bq27z561 *) driver->bd_driver_data, &val.bpv_flt);
         property->bp_value.bpv_temperature = val.bpv_flt;
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_get_temp_lo_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_i8);
+            property->bp_value.bpv_temperature = val.bpv_i8;
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_get_temp_lo_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_i8);
+            property->bp_value.bpv_temperature = val.bpv_i8;
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_get_temp_hi_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_i8);
+            property->bp_value.bpv_temperature = val.bpv_i8;
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_get_temp_hi_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data, &val.bpv_i8);
+            property->bp_value.bpv_temperature = val.bpv_i8;
     } else {
         rc = -1;
         assert(0);
@@ -992,7 +1032,50 @@ bq27z561_battery_property_set(struct battery_driver *driver,
 {
     int rc = 0;
 
-    /* TODO: Not yet implemented */
+    if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+        property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD) {
+        rc = bq27z561_set_voltage_lo_set_threshold(
+                (struct bq27z561 *)driver->bd_driver_data,
+                property->bp_value.bpv_voltage);
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+               property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD) {
+        rc = bq27z561_set_voltage_lo_clr_threshold(
+                (struct bq27z561 *)driver->bd_driver_data,
+                property->bp_value.bpv_voltage);
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+               property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD) {
+        rc = bq27z561_set_voltage_hi_set_threshold(
+                (struct bq27z561 *)driver->bd_driver_data,
+                property->bp_value.bpv_voltage);
+    } else if (property->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
+               property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD) {
+        rc = bq27z561_set_voltage_hi_clr_threshold(
+                (struct bq27z561 *)driver->bd_driver_data,
+                property->bp_value.bpv_voltage);
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+            property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_set_temp_lo_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data,
+                    (int8_t)property->bp_value.bpv_temperature);
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+                   property->bp_flags == BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_set_temp_lo_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data,
+                    (int16_t)property->bp_value.bpv_temperature);
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+                   property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD) {
+            rc = bq27z561_set_temp_hi_set_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data,
+                    (int16_t)property->bp_value.bpv_temperature);
+    } else if (property->bp_type == BATTERY_PROP_TEMP_NOW &&
+                   property->bp_flags == BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD) {
+            rc = bq27z561_set_temp_hi_clr_threshold(
+                    (struct bq27z561 *) driver->bd_driver_data,
+                    (int16_t)property->bp_value.bpv_temperature);
+    } else {
+        rc = -1;
+        assert(0);
+    }
     return rc;
 }
 
@@ -1026,7 +1109,22 @@ static const struct battery_driver_property bq27z561_battery_properties[] = {
     { BATTERY_PROP_TIME_TO_EMPTY_NOW, 0, "TimeToEmpty" },
     { BATTERY_PROP_TIME_TO_FULL_NOW, 0, "TimeToFull" },
     { BATTERY_PROP_CYCLE_COUNT, 0, "CycleCount" },
-    /* TODO: Add threshold properties supported by fuel gauge in hardware */
+    { BATTERY_PROP_VOLTAGE_NOW,
+            BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD, "LoVoltAlarmSet" },
+    { BATTERY_PROP_VOLTAGE_NOW,
+            BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD, "LoVoltAlarmClear" },
+    { BATTERY_PROP_VOLTAGE_NOW,
+            BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD, "HiVoltAlarmSet" },
+    { BATTERY_PROP_VOLTAGE_NOW,
+            BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD, "HiVoltAlarmClear" },
+    { BATTERY_PROP_TEMP_NOW,
+            BATTERY_PROPERTY_FLAGS_LOW_ALARM_SET_THRESHOLD, "LoTempAlarmSet" },
+    { BATTERY_PROP_TEMP_NOW,
+            BATTERY_PROPERTY_FLAGS_LOW_ALARM_CLEAR_THRESHOLD, "LoTempAlarmClear" },
+    { BATTERY_PROP_TEMP_NOW,
+            BATTERY_PROPERTY_FLAGS_HIGH_ALARM_SET_THRESHOLD, "LoTempAlarmSet" },
+    { BATTERY_PROP_TEMP_NOW,
+            BATTERY_PROPERTY_FLAGS_HIGH_ALARM_CLEAR_THRESHOLD, "HiTempAlarmClear" },
     { BATTERY_PROP_NONE },
 };
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -586,11 +586,180 @@ bq27z561_get_temp(struct bq27z561 *dev, float *temp_c)
 }
 
 int
+bq27z561_get_temp_lo_set_threshold(struct bq27z561 *dev, int8_t *temp_c)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_byte(dev, BQ27Z561_REG_TEMP_LO_SET_TH,
+            (uint8_t *)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_set_temp_lo_set_threshold(struct bq27z561 *dev, int8_t temp_c)
+{
+    int rc;
+    uint8_t temp = (uint8_t)(temp_c);
+
+    rc = bq27z561_wr_std_reg_byte(dev, BQ27Z561_REG_TEMP_LO_SET_TH, temp);
+
+    return rc;
+}
+
+int
+bq27z561_get_temp_lo_clr_threshold(struct bq27z561 *dev, int8_t *temp_c)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_byte(dev, BQ27Z561_REG_TEMP_LO_CLR_TH,
+            (uint8_t *)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_set_temp_lo_clr_threshold(struct bq27z561 *dev, int8_t temp_c)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_byte(dev, BQ27Z561_REG_TEMP_LO_CLR_TH,
+            (uint8_t)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_get_temp_hi_set_threshold(struct bq27z561 *dev, int8_t *temp_c)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_byte(dev, BQ27Z561_REG_TEMP_HI_SET_TH,
+            (uint8_t *)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_set_temp_hi_set_threshold(struct bq27z561 *dev, int8_t temp_c)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_byte(dev, BQ27Z561_REG_TEMP_HI_SET_TH,
+            (uint8_t)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_get_temp_hi_clr_threshold(struct bq27z561 *dev, int8_t *temp_c)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_byte(dev, BQ27Z561_REG_TEMP_HI_CLR_TH,
+            (uint8_t *)temp_c);
+
+    return rc;
+}
+
+int
+bq27z561_set_temp_hi_clr_threshold(struct bq27z561 *dev, int8_t temp_c)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_byte(dev, BQ27Z561_REG_TEMP_HI_CLR_TH,
+            (uint8_t)temp_c);
+
+    return rc;
+}
+
+int
 bq27z561_get_voltage(struct bq27z561 *dev, uint16_t *voltage)
 {
     int rc;
 
     rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_get_voltage_lo_set_threshold(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT_LO_SET_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_set_voltage_lo_set_threshold(struct bq27z561 *dev, uint16_t voltage)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_word(dev, BQ27Z561_REG_VOLT_LO_SET_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_get_voltage_lo_clr_threshold(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT_LO_CLR_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_set_voltage_lo_clr_threshold(struct bq27z561 *dev, uint16_t voltage)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_word(dev, BQ27Z561_REG_VOLT_LO_CLR_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_get_voltage_hi_set_threshold(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT_HI_SET_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_set_voltage_hi_set_threshold(struct bq27z561 *dev, uint16_t voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT_HI_SET_TH, &voltage);
+
+    return rc;
+}
+
+int
+bq27z561_get_voltage_hi_clr_threshold(struct bq27z561 *dev, uint16_t *voltage)
+{
+    int rc;
+
+    rc = bq27z561_rd_std_reg_word(dev, BQ27Z561_REG_VOLT_HI_CLR_TH, voltage);
+
+    return rc;
+}
+
+int
+bq27z561_set_voltage_hi_clr_threshold(struct bq27z561 *dev, uint16_t voltage)
+{
+    int rc;
+
+    rc = bq27z561_wr_std_reg_word(dev, BQ27Z561_REG_VOLT_HI_CLR_TH, voltage);
+
     return rc;
 }
 


### PR DESCRIPTION
Battery drivers can have writable properties (i.e. threshold values).

This extends bq27z561 driver with access to threshold values and also exposes those values to battery API.

Write command for battery properties was also added so property writes can be tested.