### PR TITLE
sys/config; add a custom filtering option when compressing FCB config.

### DIFF
--- a/sys/config/include/config/config_fcb.h
+++ b/sys/config/include/config/config_fcb.h
@@ -60,7 +60,9 @@ int conf_fcb_dst(struct conf_fcb *cf);
  *                    should be skipped.
  */
 void conf_fcb_compress(struct conf_fcb *cf,
-                       int (*copy_or_not)(const char *name, const char *val));
+                       int (*copy_or_not)(const char *name, const char *val,
+                                          void *con_arg),
+                       void *con_arg);
 
 #ifdef __cplusplus
 }

--- a/sys/config/include/config/config_fcb.h
+++ b/sys/config/include/config/config_fcb.h
@@ -30,8 +30,37 @@ struct conf_fcb {
     struct fcb cf_fcb;
 };
 
-extern int conf_fcb_src(struct conf_fcb *cf);
-extern int conf_fcb_dst(struct conf_fcb *cf);
+/**
+ * Add FCB as a sourced of persisted configation
+ *
+ * @param cf Information regarding FCB area to add.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int conf_fcb_src(struct conf_fcb *cf);
+
+/**
+ * Set FCB as the destination for persisting configation
+ *
+ * @param cf Information regarding FCB area to add. This FCB area should have
+ *           been added using conf_fcb_src() previously.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int conf_fcb_dst(struct conf_fcb *cf);
+
+/**
+ * Do a custom compression cycle. Caller provides a callback function which
+ * returns whether value should be copied or not. Note that compression
+ * automatically filters out old configuration values.
+ *
+ * @param cf FCB source to compress.
+ * @param copy_or_not Function which gets called with key/value pair.
+ *                    Returns 0 if copy should happen, 1 if key/value pair
+ *                    should be skipped.
+ */
+void conf_fcb_compress(struct conf_fcb *cf,
+                       int (*copy_or_not)(const char *name, const char *val));
 
 #ifdef __cplusplus
 }

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -152,7 +152,9 @@ conf_fcb_var_read(struct fcb_entry *loc, char *buf, char **name, char **val)
 
 void
 conf_fcb_compress(struct conf_fcb *cf,
-                  int (*copy_or_not)(const char *name, const char *val))
+                  int (*copy_or_not)(const char *name, const char *val,
+                                     void *cn_arg),
+                  void *cn_arg)
 {
     int rc;
     char buf1[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
@@ -198,7 +200,7 @@ conf_fcb_compress(struct conf_fcb *cf,
         }
 
         if (copy_or_not) {
-            if (copy_or_not(name1, val1)) {
+            if (copy_or_not(name1, val1, cn_arg)) {
                 /* Copy rejected */
                 continue;
             }
@@ -244,7 +246,7 @@ conf_fcb_append(struct conf_fcb *cf, char *buf, int len)
         if (cf->cf_fcb.f_scratch_cnt == 0) {
             return OS_ENOMEM;
         }
-        conf_fcb_compress(cf, NULL);
+        conf_fcb_compress(cf, NULL, NULL);
     }
     if (rc) {
         return OS_EINVAL;

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -150,8 +150,9 @@ conf_fcb_var_read(struct fcb_entry *loc, char *buf, char **name, char **val)
     return rc;
 }
 
-static void
-conf_fcb_compress(struct conf_fcb *cf)
+void
+conf_fcb_compress(struct conf_fcb *cf,
+                  int (*copy_or_not)(const char *name, const char *val))
 {
     int rc;
     char buf1[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
@@ -196,6 +197,12 @@ conf_fcb_compress(struct conf_fcb *cf)
             continue;
         }
 
+        if (copy_or_not) {
+            if (copy_or_not(name1, val1)) {
+                /* Copy rejected */
+                continue;
+            }
+        }
         /*
          * Can't find one. Must copy.
          */
@@ -237,7 +244,7 @@ conf_fcb_append(struct conf_fcb *cf, char *buf, int len)
         if (cf->cf_fcb.f_scratch_cnt == 0) {
             return OS_ENOMEM;
         }
-        conf_fcb_compress(cf);
+        conf_fcb_compress(cf, NULL);
     }
     if (rc) {
         return OS_EINVAL;

--- a/sys/config/test-fcb/src/conf_test_fcb.c
+++ b/sys/config/test-fcb/src/conf_test_fcb.c
@@ -309,7 +309,7 @@ config_test_fill_area(
 {
       int i, j;
 
-      for (j = 0; j < 64; j++) {
+      for (j = 0; j < CONF_TEST_FCB_VAL_STR_CNT; j++) {
           for (i = 0; i < CONF_MAX_VAL_LEN; i++) {
               test_value[j][i] = ((j * 2) + i + iteration) % 10 + '0';
           }
@@ -332,6 +332,7 @@ TEST_CASE_DECL(config_test_insert3)
 TEST_CASE_DECL(config_test_save_3_fcb)
 TEST_CASE_DECL(config_test_compress_reset)
 TEST_CASE_DECL(config_test_save_one_fcb)
+TEST_CASE_DECL(config_test_custom_compress)
 
 TEST_SUITE(config_test_all)
 {
@@ -361,6 +362,7 @@ TEST_SUITE(config_test_all)
     config_test_save_3_fcb();
 
     config_test_compress_reset();
+    config_test_custom_compress();
 
     config_test_save_one_fcb();
 }

--- a/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
+++ b/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "conf_test_fcb.h"
+
+static int unique_val_cnt;
+
+static int
+config_test_custom_compress_filter1(const char *val, const char *name)
+{
+    unique_val_cnt++;
+    return 0;
+}
+
+static int
+config_test_custom_compress_filter2(const char *val, const char *name)
+{
+    if (!strcmp(val, "myfoo/mybar")) {
+        return 0;
+    }
+    return 1;
+}
+
+TEST_CASE(config_test_custom_compress)
+{
+    int rc;
+    struct conf_fcb cf;
+    char test_value[CONF_TEST_FCB_VAL_STR_CNT][CONF_MAX_VAL_LEN];
+    int elems[4];
+    int i;
+
+    config_wipe_srcs();
+    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+
+    cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
+    cf.cf_fcb.f_sectors = fcb_areas;
+    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+
+    rc = conf_fcb_src(&cf);
+    TEST_ASSERT(rc == 0);
+
+    rc = conf_fcb_dst(&cf);
+    TEST_ASSERT(rc == 0);
+
+    c2_var_count = 1;
+    test_export_block = 0;
+    val8 = 4;
+    val64 = 8;
+    memset(elems, 0, sizeof(elems));
+
+    for (i = 0; ; i++) {
+        config_test_fill_area(test_value, i);
+        memcpy(val_string, test_value, sizeof(val_string));
+
+        rc = conf_save();
+        TEST_ASSERT(rc == 0);
+
+        if (cf.cf_fcb.f_active.fe_area == &fcb_areas[2]) {
+            /*
+             * Started using space just before scratch.
+             */
+            break;
+        }
+        memset(val_string, 0, sizeof(val_string));
+
+        rc = conf_load();
+        TEST_ASSERT(rc == 0);
+        TEST_ASSERT(!memcmp(val_string, test_value, CONF_MAX_VAL_LEN));
+    }
+
+    for (i = 0; i < cf.cf_fcb.f_sector_cnt - 1; i++) {
+        conf_fcb_compress(&cf, config_test_custom_compress_filter1);
+    }
+    TEST_ASSERT(unique_val_cnt == 4); /* c2, c3 and ctest together */
+
+    test_export_block = 1;
+
+    /*
+     * Read values back, make sure they were carried over.
+     */
+    memset(val_string, 0, sizeof(val_string));
+    val8 = 0;
+    val64 = 0;
+    rc = conf_load();
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(!memcmp(val_string, test_value, CONF_MAX_VAL_LEN));
+    TEST_ASSERT(val8 == 4);
+    TEST_ASSERT(val64 == 8);
+
+    /*
+     * Only leave one var.
+     */
+    for (i = 0; i < cf.cf_fcb.f_sector_cnt - 1; i++) {
+        conf_fcb_compress(&cf, config_test_custom_compress_filter2);
+    }
+
+    memset(val_string, 0, sizeof(val_string));
+    val8 = 0;
+    val64 = 0;
+    rc = conf_load();
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(val_string[0][0] == 0);
+    TEST_ASSERT(val8 == 4);
+    TEST_ASSERT(val64 == 0);
+}

--- a/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
+++ b/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
@@ -21,14 +21,14 @@
 static int unique_val_cnt;
 
 static int
-config_test_custom_compress_filter1(const char *val, const char *name)
+test_custom_compress_filter1(const char *val, const char *name, void *arg)
 {
     unique_val_cnt++;
     return 0;
 }
 
 static int
-config_test_custom_compress_filter2(const char *val, const char *name)
+test_custom_compress_filter2(const char *val, const char *name, void *arg)
 {
     if (!strcmp(val, "myfoo/mybar")) {
         return 0;
@@ -84,7 +84,7 @@ TEST_CASE(config_test_custom_compress)
     }
 
     for (i = 0; i < cf.cf_fcb.f_sector_cnt - 1; i++) {
-        conf_fcb_compress(&cf, config_test_custom_compress_filter1);
+        conf_fcb_compress(&cf, test_custom_compress_filter1, NULL);
     }
     TEST_ASSERT(unique_val_cnt == 4); /* c2, c3 and ctest together */
 
@@ -106,7 +106,7 @@ TEST_CASE(config_test_custom_compress)
      * Only leave one var.
      */
     for (i = 0; i < cf.cf_fcb.f_sector_cnt - 1; i++) {
-        conf_fcb_compress(&cf, config_test_custom_compress_filter2);
+        conf_fcb_compress(&cf, test_custom_compress_filter2, NULL);
     }
 
     memset(val_string, 0, sizeof(val_string));


### PR DESCRIPTION
This allows user to pick and choose what persisted data they want
to keep.