### PR TITLE
Fix nrf51 bsp i2c inconsistencies

### DIFF
--- a/hw/bsp/bbc_microbit/src/hal_bsp.c
+++ b/hw/bsp/bbc_microbit/src/hal_bsp.c
@@ -29,6 +29,7 @@
 #include "flash_map/flash_map.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
+#include "hal/hal_i2c.h"
 
 #if MYNEWT_VAL(ADC_0)
 #include <adc_nrf51/adc_nrf51.h>
@@ -66,6 +67,22 @@ static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
     .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
     .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
     .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
+};
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
 };
 #endif
 
@@ -192,6 +209,16 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
     rc = hal_spi_init(1, (void *)&os_bsp_spi1s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, (void *)&hal_i2c0_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -63,6 +63,26 @@ syscfg.defs:
         description: 'SS pin for SPI_1_SLAVE'
         value:  24
 
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  29
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  25
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  29
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  25
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/ble400/src/hal_bsp.c
+++ b/hw/bsp/ble400/src/hal_bsp.c
@@ -79,6 +79,14 @@ static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
 static struct nrf51_adc_dev_cfg os_bsp_adc0_config = {
@@ -208,6 +216,11 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -73,6 +73,16 @@ syscfg.defs:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
 
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  13
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  12
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -79,6 +79,14 @@ static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
 static struct nrf51_adc_dev_cfg os_bsp_adc0_config = {
@@ -208,6 +216,11 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -73,6 +73,16 @@ syscfg.defs:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
 
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  13
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  12
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -76,7 +76,7 @@ static const nrf_drv_spis_config_t os_bsp_spi1s_cfg = {
 static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
     .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL), 
     .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA), 
-    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ) // 100    /* 100 kHz */
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ) // 100    /* 100 kHz */
 };
 #endif
 

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -80,6 +80,14 @@ static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
 static struct nrf51_adc_dev_cfg os_bsp_adc0_config = {
@@ -205,9 +213,14 @@ hal_bsp_init(void)
     rc = hal_spi_init(1, (void *)&os_bsp_spi1s_cfg, HAL_SPI_TYPE_SLAVE);
     assert(rc == 0);
 #endif
+
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
     assert(rc == 0);
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
+    assert(rc == 0);
+#endif
 }

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -67,6 +67,16 @@ syscfg.defs:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
 
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  13
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  12
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     BUTTON_A:
         description: 'enable Button A'
         value: 0

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -57,23 +57,22 @@ syscfg.defs:
         description: 'Use Segger JLINK OBE firmware'
         value: 0
 
-    I2C_0_PIN_SDA:
-      description: 'DATA pin for I2C 0'
-      value: 20
     I2C_0_PIN_SCL:
-      description: 'CLOCK pin for I2C 0'
-      value: 19
-    I2C_0_FREQ:
-      description: 'Frequency in Khz for I2C 0'
-      value: 100
-
+        description: 'SCL pin for I2C_0'
+        value:  19
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  20
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
 
     BUTTON_A:
-      description: 'enable Button A'
-      value: 0
+        description: 'enable Button A'
+        value: 0
     BUTTON_B:
-      description: 'enable Button B'
-      value: 0
+        description: 'enable Button B'
+        value: 0
 
 syscfg.defs.BLE_LP_CLOCK: 
     TIMER_0:

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -31,6 +31,7 @@
 #include "mcu/cmsis_nvic.h"
 #include "nrf51_bitfields.h"
 #include "hal/hal_spi.h"
+#include "hal/hal_i2c.h"
 
 #if MYNEWT_VAL(UART_0)
 #include "uart/uart.h"
@@ -70,6 +71,22 @@ static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
     .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
     .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
     .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
+};
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
 };
 #endif
 
@@ -194,6 +211,16 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(SPI_1_SLAVE)
     rc = hal_spi_init(1, (void *)&os_bsp_spi1s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/nrf51-arduino_101/syscfg.yml
+++ b/hw/bsp/nrf51-arduino_101/syscfg.yml
@@ -63,6 +63,26 @@ syscfg.defs:
         description: 'SS pin for SPI_1_SLAVE'
         value:  24
 
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  29
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  25
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
+
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  29
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  25
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/nrf51-blenano/src/hal_bsp.c
+++ b/hw/bsp/nrf51-blenano/src/hal_bsp.c
@@ -75,17 +75,17 @@ static const struct nrf51_hal_spi_cfg os_bsp_spi1s_cfg = {
 
 #if MYNEWT_VAL(I2C_0)
 static const struct nrf51_hal_i2c_cfg os_bsp_i2c0_cfg = {
-    .sda_pin = MYNEWT_VAL(I2C_0_SDA_PIN),
-    .scl_pin = MYNEWT_VAL(I2C_0_SCL_PIN),
-    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQUENCY),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
 };
 #endif
 
 #if MYNEWT_VAL(I2C_1)
 static const struct nrf51_hal_i2c_cfg os_bsp_i2c1_cfg = {
-    .sda_pin = MYNEWT_VAL(I2C_1_SDA_PIN),
-    .scl_pin = MYNEWT_VAL(I2C_1_SCL_PIN),
-    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQUENCY),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
 };
 #endif
 

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -40,25 +40,25 @@ syscfg.defs:
         description: 'CTS pin for UART0'
         value: 10
 
-    I2C_0_SDA_PIN:
-        description: 'Data pin for I2C0'
-        value: 6
-    I2C_0_SCL_PIN:
-        description: 'Clock pin for I2C0'
-        value: 7
-    I2C_0_FREQUENCY:
-        description: 'Bus frequency in KHz for I2C0'
-        value: 100
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  7
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  6
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
 
-    I2C_1_SDA_PIN:
-        description: 'Data pin for I2C1'
-        value: 28
-    I2C_1_SCL_PIN:
-        description: 'Clock pin for I2C1'
-        value: 29
-    I2C_1_FREQUENCY:
-        description: 'Bus frequency in KHz for I2C1'
-        value: 100
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  29
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  28
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
 
     TIMER_0:
         description: 'NRF51 Timer 0'

--- a/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk-16kbram/src/hal_bsp.c
@@ -79,6 +79,14 @@ static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
 static struct nrf51_adc_dev_cfg os_bsp_adc0_config = {
@@ -210,6 +218,11 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -63,15 +63,15 @@ syscfg.defs:
         description: 'SS pin for SPI_1_SLAVE'
         value:  24
 
-    I2C_0_SDA_PIN:
-        description: 'Data pin for I2C0'
-        value: 30
-    I2C_0_SCL_PIN:
-        description: 'Clock pin for I2C0'
-        value: 7
-    I2C_0_FREQUENCY:
-        description: 'Bus frequency in KHz for I2C0'
-        value: 100
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  7
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  30
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
 
     TIMER_0:
         description: 'NRF51 Timer 0'

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -73,6 +73,16 @@ syscfg.defs:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
 
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  13
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  12
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1

--- a/hw/bsp/nrf51dk/src/hal_bsp.c
+++ b/hw/bsp/nrf51dk/src/hal_bsp.c
@@ -81,6 +81,14 @@ static const struct nrf51_hal_i2c_cfg hal_i2c_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf51_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 static struct adc_dev os_bsp_adc0;
 static struct nrf51_adc_dev_cfg os_bsp_adc0_config = {
@@ -210,6 +218,11 @@ hal_bsp_init(void)
 
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -63,15 +63,15 @@ syscfg.defs:
         description: 'SS pin for SPI_1_SLAVE'
         value:  24
 
-    I2C_0_SDA_PIN:
-        description: 'Data pin for I2C0'
-        value: 30
-    I2C_0_SCL_PIN:
-        description: 'Clock pin for I2C0'
-        value: 7
-    I2C_0_FREQUENCY:
-        description: 'Bus frequency in KHz for I2C0'
-        value: 100
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value:  7
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value:  30
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_0 bus'
+        value:  100
 
     TIMER_0:
         description: 'NRF51 Timer 0'

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -73,6 +73,16 @@ syscfg.defs:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
 
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value:  13
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value:  12
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency in khz for I2C_1 bus'
+        value:  100
+
     TIMER_0:
         description: 'NRF51 Timer 0'
         value:  1


### PR DESCRIPTION
First commit fixes a bunch of nrf51 bsp i2c inconsistencies 
I2C_0_FREQ -> I2C_0_FREQ_KHZ
I2C_0_FREQUENCY -> I2C_0_FREQ_KHZ
I2C_1_FREQUENCY -> I2C_1_FREQ_KHZ
I2C_1_SDA_PIN -> 	I2C_1_PIN_SDA
I2C_1_SCL_PIN -> I2C_1_PIN_SCL
I2C_0_SDA_PIN -> I2C_0_PIN_SDA
I2C_0_SCL_PIN  -> I2C_0_PIN_SCL

Second commit I added i2c1 (as well as i2c0 where necessary) no guarantees on pin choices as I dont have all these boards, but at least they can be overridden now.