### PR TITLE
Interface lock for sensor_itf and led_itf

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -32,6 +32,10 @@
 #include <reboot/log_reboot.h>
 #include <id/id.h>
 
+#ifndef LED_BLINK_PIN
+#define LED_BLINK_PIN 15
+#endif
+
 #if MYNEWT_VAL(BNO055_CLI)
 #include <bno055/bno055.h>
 #endif

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -151,7 +151,6 @@ struct bq27z561_itf
 {
     uint8_t itf_num;
     uint8_t itf_addr;
-    struct os_mutex *itf_mutex;
 };
 
 struct bq27z561_init_arg

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -151,6 +151,7 @@ struct bq27z561_itf
 {
     uint8_t itf_num;
     uint8_t itf_addr;
+    struct os_mutex *itf_lock;
 };
 
 struct bq27z561_init_arg

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -151,6 +151,7 @@ struct bq27z561_itf
 {
     uint8_t itf_num;
     uint8_t itf_addr;
+    struct os_mutex *itf_mutex;
 };
 
 struct bq27z561_init_arg

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -452,14 +452,13 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         rc = BQ27Z561_ERR_I2C_ERR;
-        bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 
@@ -477,10 +476,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         rc = BQ27Z561_ERR_I2C_ERR;
-        goto err;
     }
-
-    rc = BQ27Z561_OK;
 
 err:
     bq27z561_itf_unlock(&dev->bq27_itf);

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -275,6 +275,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         rc = BQ27Z561_ERR_I2C_ERR;
+        bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 
@@ -377,6 +378,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         rc = BQ27Z561_ERR_I2C_ERR;
+        bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 
@@ -457,6 +459,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         rc = BQ27Z561_ERR_I2C_ERR;
+        bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -80,6 +80,43 @@ bq27z561_close(struct os_dev *dev)
     return 0;
 }
 
+/**
+ * Lock access to the bq27z561_itf specified by si. Blocks until lock acquired.
+ *
+ * @param The bq27z561_itf to lock
+ * @param The timeout
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+static int
+bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
+{
+    int rc;
+    os_time_t ticks;
+
+    os_time_ms_to_ticks(timeout, &ticks);
+
+    rc = os_mutex_pend(bi->itf_lock, ticks);
+    if (rc == 0 || rc == OS_NOT_STARTED) {
+        return (0);
+    }
+
+    return (rc);
+}
+
+/**
+ * Unlock access to the bq27z561_itf specified by bi.
+ *
+ * @param The bq27z561_itf to unlock access to
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+static void
+bq27z561_itf_unlock(struct bq27z561_itf *bi)
+{
+    os_mutex_release(bi->itf_lock);
+}
+
 int
 bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
 {
@@ -89,6 +126,11 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.len = 1;
     i2c.buffer = &reg;
+
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
 
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0);
     if (rc != 0) {
@@ -103,6 +145,8 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
         BQ27Z561_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
         return rc;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     /* XXX: add big-endian support */
 
@@ -124,11 +168,18 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
     i2c.len     = 3;
     i2c.buffer  = buf;
 
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg write 0x%02X failed\n", reg);
         return rc;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     return 0;
 }
@@ -163,11 +214,18 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.buffer = tmpbuf;
 
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         return BQ27Z561_ERR_I2C_ERR;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     return BQ27Z561_OK;
 }
@@ -195,6 +253,11 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.buffer = tmpbuf;
 
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
@@ -221,6 +284,8 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
         rc = BQ27Z561_ERR_I2C_ERR;
         goto err;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     /* Verify that first two bytes are the command */
     cmd_read = tmpbuf[0];
@@ -288,6 +353,11 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.buffer = tmpbuf;
 
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
@@ -314,6 +384,8 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         rc = BQ27Z561_ERR_I2C_ERR;
         goto err;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     /* Verify that first two bytes are the address*/
     addr_read = tmpbuf[0];
@@ -359,6 +431,11 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.buffer = tmpbuf;
 
+    rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     rc = hal_i2c_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1);
     if (rc != 0) {
         BQ27Z561_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
@@ -382,6 +459,8 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         rc = BQ27Z561_ERR_I2C_ERR;
         goto err;
     }
+
+    bq27z561_itf_unlock(&dev->bq27_itf);
 
     rc = BQ27Z561_OK;
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -94,6 +94,10 @@ bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
+    if (!bi->bi_lock) {
+        return 0;
+    }
+
     rc = os_time_ms_to_ticks(timeout, &ticks);
     if (rc) {
         return rc;
@@ -117,6 +121,10 @@ bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
 static void
 bq27z561_itf_unlock(struct bq27z561_itf *bi)
 {
+    if (!bi->bi_lock) {
+        return;
+    }
+
     os_mutex_release(bi->itf_lock);
 }
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -94,7 +94,10 @@ bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
-    os_time_ms_to_ticks(timeout, &ticks);
+    rc = os_time_ms_to_ticks(timeout, &ticks);
+    if (rc) {
+        return rc;
+    }
 
     rc = os_mutex_pend(bi->itf_lock, ticks);
     if (rc == 0 || rc == OS_NOT_STARTED) {

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -30,3 +30,6 @@ syscfg.defs:
     BQ27Z561_SHELL_DEV_NAME:
         description: 'BQ27Z561 Shell device name'
         value: "\"bq27z561_0\""
+    BQ27Z561_ITF_LOCK_TMO:
+        description: 'BQ27Z561 interface lock timeout in milliseconds'
+        value: 1000

--- a/hw/drivers/led/include/led/led_itf.h
+++ b/hw/drivers/led/include/led/led_itf.h
@@ -71,7 +71,10 @@ led_itf_lock(struct led_itf *li, uint32_t timeout)
         return 0;
     }
 
-    os_time_ms_to_ticks(timeout, &ticks);
+    rc = os_time_ms_to_ticks(timeout, &ticks);
+    if (rc) {
+        return rc;
+    }
 
     rc = os_mutex_pend(li->li_lock, ticks);
     if (rc == 0 || rc == OS_NOT_STARTED) {

--- a/hw/drivers/led/include/led/led_itf.h
+++ b/hw/drivers/led/include/led/led_itf.h
@@ -47,6 +47,38 @@ struct led_itf {
 
     /* LED chip address, only needed for I2C */
     uint16_t li_addr;
+
+    /* Mutex for shared interface access */
+    struct os_mutex li_lock;
 };
+
+static inline int
+led_itf_lock_init(struct led_itf *li)
+{
+    return os_mutex_init(&li->li_lock);
+}
+
+static inline int
+led_itf_lock(struct led_itf *li, uint32_t timeout)
+{
+
+    int rc;
+    os_time_t ticks;
+
+    os_time_ms_to_ticks(timeout, &ticks);
+
+    rc = os_mutex_pend(&li->li_lock, ticks);
+    if (rc == 0 || rc == OS_NOT_STARTED) {
+        return (0);
+    }
+
+    return (rc);
+}
+
+static inline void
+led_itf_unlock(struct led_itf *li)
+{
+    os_mutex_release(&li->li_lock);
+}
 
 #endif

--- a/hw/drivers/led/include/led/led_itf.h
+++ b/hw/drivers/led/include/led/led_itf.h
@@ -49,15 +49,17 @@ struct led_itf {
     uint16_t li_addr;
 
     /* Mutex for shared interface access */
-    struct os_mutex li_lock;
+    struct os_mutex *li_lock;
 };
 
-static inline int
-led_itf_lock_init(struct led_itf *li)
-{
-    return os_mutex_init(&li->li_lock);
-}
-
+/**
+ * Lock access to the led_itf specified by li.  Blocks until lock acquired.
+ *
+ * @param li The led_itf to lock
+ * @param timeout The timeout in milliseconds
+ *
+ * @return 0 on success, non-zero on failure.
+ */
 static inline int
 led_itf_lock(struct led_itf *li, uint32_t timeout)
 {
@@ -65,9 +67,13 @@ led_itf_lock(struct led_itf *li, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
+    if (!li->li_lock) {
+        return 0;
+    }
+
     os_time_ms_to_ticks(timeout, &ticks);
 
-    rc = os_mutex_pend(&li->li_lock, ticks);
+    rc = os_mutex_pend(li->li_lock, ticks);
     if (rc == 0 || rc == OS_NOT_STARTED) {
         return (0);
     }
@@ -75,10 +81,21 @@ led_itf_lock(struct led_itf *li, uint32_t timeout)
     return (rc);
 }
 
+/**
+ * Unlock access to the led_itf specified by li.
+ *
+ * @param li The led_itf to unlock access to
+ *
+ * @return 0 on success, non-zero on failure.
+ */
 static inline void
 led_itf_unlock(struct led_itf *li)
 {
-    os_mutex_release(&li->li_lock);
+    if (!li->li_lock) {
+        return;
+    }
+
+    os_mutex_release(li->li_lock);
 }
 
 #endif

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -65,7 +65,7 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     rc = led_itf_lock(itf, MYNEWT_VAL(LP5523_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->li_num, &data_struct,
@@ -79,7 +79,6 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     led_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -119,9 +118,9 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
          STATS_INC(g_lp5523stats, read_errors);
     }
 
+err:
     led_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -144,7 +143,7 @@ lp5523_set_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     rc = led_itf_lock(itf, MYNEWT_VAL(LP5523_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->li_num, &data_struct,
@@ -157,7 +156,6 @@ lp5523_set_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     led_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -177,7 +175,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     rc = led_itf_lock(itf, MYNEWT_VAL(LP5523_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->li_num, &data_struct,
@@ -186,7 +184,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
     if (rc) {
         LP5523_ERR("Failed to write to 0x%02X:0x%02X\n", itf->li_addr, addr_b);
         STATS_INC(g_lp5523stats, read_errors);
-        return rc;
+        goto err;
     }
 
     data_struct.len = len;
@@ -200,9 +198,9 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
          STATS_INC(g_lp5523stats, read_errors);
     }
 
+err:
     led_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -928,7 +928,6 @@ int
 lp5523_init(struct os_dev *dev, void *arg)
 {
     int rc;
-    struct led_itf *itf;
 
     if (!arg || !dev) {
         return SYS_ENODEV;
@@ -946,8 +945,6 @@ lp5523_init(struct os_dev *dev, void *arg)
     /* Register the entry with the stats registry */
     rc = stats_register(dev->od_name, STATS_HDR(g_lp5523stats));
     SYSINIT_PANIC_ASSERT(rc == 0);
-
-    itf = (struct led_itf *)arg;
 
     return rc;
 }

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -949,8 +949,6 @@ lp5523_init(struct os_dev *dev, void *arg)
 
     itf = (struct led_itf *)arg;
 
-    rc = led_itf_lock_init(itf);
-
     return rc;
 }
 

--- a/hw/drivers/led/lp5523/syscfg.yml
+++ b/hw/drivers/led/lp5523/syscfg.yml
@@ -35,4 +35,4 @@ syscfg.defs:
         value: 5
     LP5523_ITF_LOCK_TMO:
         description: 'LP5523 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/led/lp5523/syscfg.yml
+++ b/hw/drivers/led/lp5523/syscfg.yml
@@ -33,3 +33,6 @@ syscfg.defs:
     LP5523_LEDS_PER_DRIVER:
         description: 'LP5523 LEDs per driver'
         value: 5
+    LP5523_ITF_LOCK_TMO:
+        description: 'LP5523 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -385,7 +385,7 @@ adxl345_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -395,7 +395,7 @@ adxl345_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     }
 
     sensor_itf_unlock(itf);
-err:
+
     return rc;
 }
 
@@ -415,7 +415,7 @@ adxl345_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -426,7 +426,6 @@ adxl345_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -448,7 +447,7 @@ adxl345_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -459,7 +458,6 @@ adxl345_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -1071,11 +1071,6 @@ adxl345_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        return rc;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         return rc;

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -32,6 +32,7 @@
 #include "adxl345_priv.h"
 #include "log/log.h"
 #include "stats/stats.h"
+#include <syscfg/syscfg.h>
 
 static struct hal_spi_settings spi_adxl345_settings = {
     .data_order = HAL_SPI_MSB_FIRST,
@@ -382,12 +383,19 @@ adxl345_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = adxl345_i2c_write8(itf, reg, value);
     } else {
         rc = adxl345_spi_write8(itf, reg, value);
     }
 
+    sensor_itf_unlock(itf);
+err:
     return rc;
 }
 
@@ -405,12 +413,20 @@ adxl345_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = adxl345_i2c_read8(itf, reg, value);
     } else {
         rc = adxl345_spi_read8(itf, reg, value);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -430,12 +446,20 @@ adxl345_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(ADXL345_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = adxl345_i2c_readlen(itf, reg, buffer, len);
     } else {
         rc = adxl345_spi_readlen(itf, reg, buffer, len);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -1047,6 +1071,11 @@ adxl345_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
+    rc = sensor_itf_lock_init(arg);
+    if (rc) {
+        return rc;
+    }
+
     rc = sensor_mgr_register(sensor);
     if (rc) {
         return rc;
@@ -1057,12 +1086,12 @@ adxl345_init(struct os_dev *dev, void *arg)
         if (rc == EINVAL) {
             return rc;
         }
-        
+
         rc = hal_spi_enable(sensor->s_itf.si_num);
         if (rc) {
             return rc;
         }
-        
+
         rc = hal_gpio_init_out(sensor->s_itf.si_cs_pin, 1);
         if (rc) {
             return rc;

--- a/hw/drivers/sensors/adxl345/syscfg.yml
+++ b/hw/drivers/sensors/adxl345/syscfg.yml
@@ -47,3 +47,6 @@ syscfg.defs:
     ADXL345_INT_PIN_DEVICE:
         description: 'Interrupt pin number 1 or 2 on accelerometer device'
         value: 1
+    ADXL345_ITF_LOCK_TMO:
+        description: 'ADXL345 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/adxl345/syscfg.yml
+++ b/hw/drivers/sensors/adxl345/syscfg.yml
@@ -49,4 +49,4 @@ syscfg.defs:
         value: 1
     ADXL345_ITF_LOCK_TMO:
         description: 'ADXL345 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -275,7 +275,6 @@ set_register(struct bma253 * bma253,
         break;
     }
 
-err:
     sensor_itf_unlock(itf);
 
     return rc;

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -4759,11 +4759,6 @@ bma253_init(struct os_dev * dev, void * arg)
         return rc;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     sensor->s_next_run = OS_TIMEOUT_NEVER;
 
     rc = sensor_mgr_register(sensor);

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -4782,6 +4782,5 @@ bma253_init(struct os_dev * dev, void * arg)
 
     bma253->power = BMA253_POWER_MODE_NORMAL;
 
-err:
     return rc;
 }

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -158,7 +158,7 @@ get_register(struct bma253 * bma253,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA253_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     oper.address = itf->si_addr;
@@ -169,7 +169,7 @@ get_register(struct bma253 * bma253,
                               OS_TICKS_PER_SEC / 10, 1);
     if (rc != 0) {
         BMA253_ERROR("I2C access failed at address 0x%02X\n", addr);
-        return rc;
+        goto err;
     }
 
     oper.address = itf->si_addr;
@@ -181,13 +181,11 @@ get_register(struct bma253 * bma253,
     if (rc != 0) {
         BMA253_ERROR("I2C read failed at address 0x%02X single byte\n",
                      addr);
-        return rc;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -209,7 +207,7 @@ get_registers(struct bma253 * bma253,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA253_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->si_num, &oper,
@@ -229,13 +227,11 @@ get_registers(struct bma253 * bma253,
     if (rc != 0) {
         BMA253_ERROR("I2C read failed at address 0x%02X length %u\n",
                      addr, size);
-        goto err;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -253,7 +249,7 @@ set_register(struct bma253 * bma253,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA253_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     tuple[0] = addr;
@@ -268,7 +264,6 @@ set_register(struct bma253 * bma253,
     if (rc != 0) {
         BMA253_ERROR("I2C write failed at address 0x%02X single byte\n",
                      addr);
-        return rc;
     }
 
     switch (bma253->power) {
@@ -280,10 +275,9 @@ set_register(struct bma253 * bma253,
         break;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -53,4 +53,4 @@ syscfg.defs:
         value: "\"bma253_0\""
     BMA253_ITF_LOCK_TMO:
         description: 'BMA253 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -51,3 +51,6 @@ syscfg.defs:
     BMA253_SHELL_DEV_NAME:
         description: 'BMA253 Shell device name'
         value: "\"bma253_0\""
+    BMA253_ITF_LOCK_TMO:
+        description: 'BMA253 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -330,7 +330,7 @@ get_register(struct bma2xx *bma2xx,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
@@ -343,7 +343,6 @@ get_register(struct bma2xx *bma2xx,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -359,7 +358,7 @@ get_registers(struct bma2xx *bma2xx,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
@@ -372,7 +371,6 @@ get_registers(struct bma2xx *bma2xx,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -388,7 +386,7 @@ set_register(struct bma2xx *bma2xx,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
@@ -409,7 +407,7 @@ set_register(struct bma2xx *bma2xx,
     }
 
     sensor_itf_unlock(itf);
-err:
+
     return rc;
 }
 

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -4923,11 +4923,6 @@ bma2xx_init(struct os_dev * dev, void * arg)
         return rc;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        return rc;
-    }
-
     sensor->s_next_run = OS_TIMEOUT_NEVER;
 
     rc = sensor_mgr_register(sensor);

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -29,6 +29,7 @@
 #include "hal/hal_gpio.h"
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"
+#include <syscfg/syscfg.h>
 
 #if MYNEWT_VAL(BMA2XX_LOG)
 #include "log/log.h"
@@ -166,7 +167,7 @@ interrupt_handler(void * arg)
  * @return 0 on success, non-zero on failure
  */
 int
-spi_readlen(const struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
+spi_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
             uint8_t len)
 {
     int i;
@@ -218,7 +219,7 @@ spi_readlen(const struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
  * @return 0 on success, non-zero on failure
  */
 int
-spi_writereg(const struct sensor_itf * itf, uint8_t addr, uint8_t payload,
+spi_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t payload,
              uint8_t len)
 {
     int i;
@@ -260,7 +261,7 @@ spi_writereg(const struct sensor_itf * itf, uint8_t addr, uint8_t payload,
 }
 
 int
-i2c_readlen(const struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
+i2c_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
             uint8_t len)
 {
     struct hal_i2c_master_data oper;
@@ -294,7 +295,7 @@ i2c_readlen(const struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
 }
 
 int
-i2c_writereg(const struct sensor_itf * itf, uint8_t addr, uint8_t data)
+i2c_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t data)
 {
     uint8_t tuple[2];
     struct hal_i2c_master_data oper;
@@ -319,13 +320,18 @@ i2c_writereg(const struct sensor_itf * itf, uint8_t addr, uint8_t data)
 }
 
 static int
-get_register(const struct bma2xx * bma2xx,
+get_register(struct bma2xx *bma2xx,
              uint8_t addr,
              uint8_t * data)
 {
     int rc;
-    const struct sensor_itf * itf;
+    struct sensor_itf * itf;
     itf = SENSOR_GET_ITF(&bma2xx->sensor);
+
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
         rc = spi_readlen(itf, addr, data, 1);
@@ -335,18 +341,26 @@ get_register(const struct bma2xx * bma2xx,
         rc = SYS_EINVAL;
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
 static int
-get_registers(const struct bma2xx * bma2xx,
+get_registers(struct bma2xx *bma2xx,
               uint8_t addr,
               uint8_t * data,
               uint8_t size)
 {
     int rc;
-    const struct sensor_itf * itf;
+    struct sensor_itf * itf;
     itf = SENSOR_GET_ITF(&bma2xx->sensor);
+
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
         rc = spi_readlen(itf, addr, data, size);
@@ -356,18 +370,26 @@ get_registers(const struct bma2xx * bma2xx,
         rc = SYS_EINVAL;
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
 static int
-set_register(const struct bma2xx * bma2xx,
+set_register(struct bma2xx *bma2xx,
              uint8_t addr,
              uint8_t data)
 {
     int rc;
-    const struct sensor_itf * itf;
+    struct sensor_itf * itf;
 
     itf = SENSOR_GET_ITF(&bma2xx->sensor);
+
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(BMA2XX_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
 
     if (itf->si_type == SENSOR_ITF_SPI) {
         rc = spi_writereg(itf, addr, data, 1);
@@ -386,14 +408,16 @@ set_register(const struct bma2xx * bma2xx,
         break;
     }
 
+    sensor_itf_unlock(itf);
+err:
     return rc;
 }
 
 int
-bma2xx_get_chip_id(const struct bma2xx * bma2xx,
+bma2xx_get_chip_id(struct bma2xx *bma2xx,
                    uint8_t * chip_id)
 {
-    return get_register(bma2xx, REG_ADDR_BGW_CHIPID, chip_id);
+    return get_register((struct bma2xx *)bma2xx, REG_ADDR_BGW_CHIPID, chip_id);
 }
 
 static void
@@ -485,7 +509,7 @@ get_accel_scale(enum bma2xx_model model,
 }
 
 int
-bma2xx_get_accel(const struct bma2xx * bma2xx,
+bma2xx_get_accel(struct bma2xx *bma2xx,
                  enum bma2xx_g_range g_range,
                  enum axis axis,
                  struct accel_data * accel_data)
@@ -514,7 +538,7 @@ bma2xx_get_accel(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_registers(bma2xx, base_addr,
+    rc = get_registers((struct bma2xx *)bma2xx, base_addr,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -526,13 +550,13 @@ bma2xx_get_accel(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_temp(const struct bma2xx * bma2xx,
+bma2xx_get_temp(struct bma2xx *bma2xx,
                 float * temp_c)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_ACCD_TEMP, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_ACCD_TEMP, &data);
     if (rc != 0) {
         return rc;
     }
@@ -572,13 +596,13 @@ quad_to_axis_trigger(struct axis_trigger * axis_trigger,
 }
 
 int
-bma2xx_get_int_status(const struct bma2xx * bma2xx,
+bma2xx_get_int_status(struct bma2xx *bma2xx,
                       struct int_status * int_status)
 {
     uint8_t data[4];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_STATUS_0,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_STATUS_0,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -609,14 +633,14 @@ bma2xx_get_int_status(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_fifo_status(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_status(struct bma2xx *bma2xx,
                        bool * overrun,
                        uint8_t * frame_counter)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_FIFO_STATUS, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_FIFO_STATUS, &data);
     if (rc != 0) {
         return rc;
     }
@@ -628,13 +652,13 @@ bma2xx_get_fifo_status(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_g_range(const struct bma2xx * bma2xx,
+bma2xx_get_g_range(struct bma2xx *bma2xx,
                    enum bma2xx_g_range * g_range)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_PMU_RANGE, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_RANGE, &data);
     if (rc != 0) {
         return rc;
     }
@@ -662,7 +686,7 @@ bma2xx_get_g_range(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_g_range(const struct bma2xx * bma2xx,
+bma2xx_set_g_range(struct bma2xx *bma2xx,
                    enum bma2xx_g_range g_range)
 {
     uint8_t data;
@@ -684,17 +708,17 @@ bma2xx_set_g_range(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, REG_ADDR_PMU_RANGE, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_RANGE, data);
 }
 
 int
-bma2xx_get_filter_bandwidth(const struct bma2xx * bma2xx,
+bma2xx_get_filter_bandwidth(struct bma2xx *bma2xx,
                             enum bma2xx_filter_bandwidth * filter_bandwidth)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_PMU_BW, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_BW, &data);
     if (rc != 0) {
         return rc;
     }
@@ -730,7 +754,7 @@ bma2xx_get_filter_bandwidth(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_filter_bandwidth(const struct bma2xx * bma2xx,
+bma2xx_set_filter_bandwidth(struct bma2xx *bma2xx,
                             enum bma2xx_filter_bandwidth filter_bandwidth)
 {
     uint8_t data;
@@ -783,17 +807,17 @@ bma2xx_set_filter_bandwidth(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, REG_ADDR_PMU_BW, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_BW, data);
 }
 
 int
-bma2xx_get_power_settings(const struct bma2xx * bma2xx,
+bma2xx_get_power_settings(struct bma2xx *bma2xx,
                           struct power_settings * power_settings)
 {
     uint8_t data[2];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_PMU_LPW,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_PMU_LPW,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -872,8 +896,8 @@ bma2xx_get_power_settings(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_power_settings(const struct bma2xx * bma2xx,
-                          const struct power_settings * power_settings)
+bma2xx_set_power_settings(struct bma2xx *bma2xx,
+                          struct power_settings * power_settings)
 {
     uint8_t data[2];
     int rc;
@@ -957,11 +981,11 @@ bma2xx_set_power_settings(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = set_register(bma2xx, REG_ADDR_PMU_LOW_POWER, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_LOW_POWER, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_PMU_LPW, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_LPW, data[0]);
     if (rc != 0) {
         return rc;
     }
@@ -970,14 +994,14 @@ bma2xx_set_power_settings(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_data_acquisition(const struct bma2xx * bma2xx,
+bma2xx_get_data_acquisition(struct bma2xx *bma2xx,
                             bool * unfiltered_reg_data,
                             bool * disable_reg_shadow)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_ACCD_HBW, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_ACCD_HBW, &data);
     if (rc != 0) {
         return rc;
     }
@@ -989,7 +1013,7 @@ bma2xx_get_data_acquisition(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_data_acquisition(const struct bma2xx * bma2xx,
+bma2xx_set_data_acquisition(struct bma2xx *bma2xx,
                             bool unfiltered_reg_data,
                             bool disable_reg_shadow)
 {
@@ -998,15 +1022,15 @@ bma2xx_set_data_acquisition(const struct bma2xx * bma2xx,
     data = (unfiltered_reg_data << 7) |
            (disable_reg_shadow << 6);
 
-    return set_register(bma2xx, REG_ADDR_ACCD_HBW, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_ACCD_HBW, data);
 }
 
 int
-bma2xx_set_softreset(const struct bma2xx * bma2xx)
+bma2xx_set_softreset(struct bma2xx *bma2xx)
 {
     int rc;
 
-    rc = set_register(bma2xx, REG_ADDR_BGW_SOFTRESET, REG_VALUE_SOFT_RESET);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_BGW_SOFTRESET, REG_VALUE_SOFT_RESET);
     if (rc != 0) {
         return rc;
     }
@@ -1017,13 +1041,13 @@ bma2xx_set_softreset(const struct bma2xx * bma2xx)
 }
 
 int
-bma2xx_get_int_enable(const struct bma2xx * bma2xx,
+bma2xx_get_int_enable(struct bma2xx *bma2xx,
                       struct int_enable * int_enable)
 {
     uint8_t data[3];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_EN_0,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_EN_0,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1052,8 +1076,8 @@ bma2xx_get_int_enable(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_int_enable(const struct bma2xx * bma2xx,
-                      const struct int_enable * int_enable)
+bma2xx_set_int_enable(struct bma2xx *bma2xx,
+                      struct int_enable * int_enable)
 {
     uint8_t data[3];
     int rc;
@@ -1079,15 +1103,15 @@ bma2xx_set_int_enable(const struct bma2xx * bma2xx,
               (int_enable->slow_no_mot_y_int_enable << 1) |
               (int_enable->slow_no_mot_x_int_enable << 0);
 
-    rc = set_register(bma2xx, REG_ADDR_INT_EN_0, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_EN_0, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_EN_1, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_EN_1, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_EN_2, data[2]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_EN_2, data[2]);
     if (rc != 0) {
         return rc;
     }
@@ -1096,13 +1120,13 @@ bma2xx_set_int_enable(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_int_routes(const struct bma2xx * bma2xx,
+bma2xx_get_int_routes(struct bma2xx *bma2xx,
                       struct int_routes * int_routes)
 {
     uint8_t data[3];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_MAP_0,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_MAP_0,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1200,8 +1224,8 @@ bma2xx_get_int_routes(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_int_routes(const struct bma2xx * bma2xx,
-                      const struct int_routes * int_routes)
+bma2xx_set_int_routes(struct bma2xx *bma2xx,
+                      struct int_routes * int_routes)
 {
     uint8_t data[3];
     int rc;
@@ -1231,15 +1255,15 @@ bma2xx_set_int_routes(const struct bma2xx * bma2xx,
               (((int_routes->high_g_int_route & INT_ROUTE_PIN_2) != 0) << 1) |
               (((int_routes->low_g_int_route & INT_ROUTE_PIN_2) != 0) << 0);
 
-    rc = set_register(bma2xx, REG_ADDR_INT_MAP_0, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_MAP_0, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_MAP_1, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_MAP_1, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_MAP_2, data[2]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_MAP_2, data[2]);
     if (rc != 0) {
         return rc;
     }
@@ -1248,13 +1272,13 @@ bma2xx_set_int_routes(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_int_filters(const struct bma2xx * bma2xx,
+bma2xx_get_int_filters(struct bma2xx *bma2xx,
                        struct int_filters * int_filters)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_INT_SRC, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_INT_SRC, &data);
     if (rc != 0) {
         return rc;
     }
@@ -1270,8 +1294,8 @@ bma2xx_get_int_filters(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_int_filters(const struct bma2xx * bma2xx,
-                       const struct int_filters * int_filters)
+bma2xx_set_int_filters(struct bma2xx *bma2xx,
+                       struct int_filters * int_filters)
 {
     uint8_t data;
 
@@ -1282,17 +1306,17 @@ bma2xx_set_int_filters(const struct bma2xx * bma2xx,
            (int_filters->unfiltered_high_g_int << 1) |
            (int_filters->unfiltered_low_g_int << 0);
 
-    return set_register(bma2xx, REG_ADDR_INT_SRC, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_SRC, data);
 }
 
 int
-bma2xx_get_int_pin_electrical(const struct bma2xx * bma2xx,
+bma2xx_get_int_pin_electrical(struct bma2xx *bma2xx,
                               struct int_pin_electrical * electrical)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_INT_OUT_CTRL, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_INT_OUT_CTRL, &data);
     if (rc != 0) {
         return rc;
     }
@@ -1322,8 +1346,8 @@ bma2xx_get_int_pin_electrical(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_int_pin_electrical(const struct bma2xx * bma2xx,
-                              const struct int_pin_electrical * electrical)
+bma2xx_set_int_pin_electrical(struct bma2xx *bma2xx,
+                              struct int_pin_electrical * electrical)
 {
     uint8_t data;
 
@@ -1373,17 +1397,17 @@ bma2xx_set_int_pin_electrical(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, REG_ADDR_INT_OUT_CTRL, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_OUT_CTRL, data);
 }
 
 int
-bma2xx_get_int_latch(const struct bma2xx * bma2xx,
+bma2xx_get_int_latch(struct bma2xx *bma2xx,
                      enum int_latch * int_latch)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_INT_RST_LATCH, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_INT_RST_LATCH, &data);
     if (rc != 0) {
         return rc;
     }
@@ -1443,7 +1467,7 @@ bma2xx_get_int_latch(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_int_latch(const struct bma2xx * bma2xx,
+bma2xx_set_int_latch(struct bma2xx *bma2xx,
                      bool reset_ints,
                      enum int_latch int_latch)
 {
@@ -1499,17 +1523,17 @@ bma2xx_set_int_latch(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, REG_ADDR_INT_RST_LATCH, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_RST_LATCH, data);
 }
 
 int
-bma2xx_get_low_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_low_g_int_cfg(struct bma2xx *bma2xx,
                          struct low_g_int_cfg * low_g_int_cfg)
 {
     uint8_t data[3];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_0,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_0,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1524,8 +1548,8 @@ bma2xx_get_low_g_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_low_g_int_cfg(const struct bma2xx * bma2xx,
-                         const struct low_g_int_cfg * low_g_int_cfg)
+bma2xx_set_low_g_int_cfg(struct bma2xx *bma2xx,
+                         struct low_g_int_cfg * low_g_int_cfg)
 {
     uint8_t data[3];
     int rc;
@@ -1548,15 +1572,15 @@ bma2xx_set_low_g_int_cfg(const struct bma2xx * bma2xx,
     data[2] = (low_g_int_cfg->axis_summing << 2) |
               (((uint8_t)(low_g_int_cfg->hyster_g / 0.125) & 0x03) << 0);
 
-    rc = set_register(bma2xx, REG_ADDR_INT_0, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_0, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_1, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_1, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_2, data[2]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_2, data[2]);
     if (rc != 0) {
         return rc;
     }
@@ -1565,7 +1589,7 @@ bma2xx_set_low_g_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_high_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_high_g_int_cfg(struct bma2xx *bma2xx,
                           enum bma2xx_g_range g_range,
                           struct high_g_int_cfg * high_g_int_cfg)
 {
@@ -1595,7 +1619,7 @@ bma2xx_get_high_g_int_cfg(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_2,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_2,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1609,9 +1633,9 @@ bma2xx_get_high_g_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_high_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_high_g_int_cfg(struct bma2xx *bma2xx,
                           enum bma2xx_g_range g_range,
-                          const struct high_g_int_cfg * high_g_int_cfg)
+                          struct high_g_int_cfg * high_g_int_cfg)
 {
     float hyster_scale;
     float thresh_scale;
@@ -1656,15 +1680,15 @@ bma2xx_set_high_g_int_cfg(const struct bma2xx * bma2xx,
     data[1] = (high_g_int_cfg->delay_ms >> 1) - 1;
     data[2] = high_g_int_cfg->thresh_g / thresh_scale;
 
-    rc = set_register(bma2xx, REG_ADDR_INT_2, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_2, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_3, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_3, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_4, data[2]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_4, data[2]);
     if (rc != 0) {
         return rc;
     }
@@ -1673,7 +1697,7 @@ bma2xx_set_high_g_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slow_no_mot_int_cfg(struct bma2xx *bma2xx,
                                bool no_motion_select,
                                enum bma2xx_g_range g_range,
                                struct slow_no_mot_int_cfg * slow_no_mot_int_cfg)
@@ -1699,11 +1723,11 @@ bma2xx_get_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_register(bma2xx, REG_ADDR_INT_5, data + 0);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_INT_5, data + 0);
     if (rc != 0) {
         return rc;
     }
-    rc = get_register(bma2xx, REG_ADDR_INT_7, data + 1);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_INT_7, data + 1);
     if (rc != 0) {
         return rc;
     }
@@ -1731,10 +1755,10 @@ bma2xx_get_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_slow_no_mot_int_cfg(struct bma2xx *bma2xx,
                                bool no_motion_select,
                                enum bma2xx_g_range g_range,
-                               const struct slow_no_mot_int_cfg * slow_no_mot_int_cfg)
+                               struct slow_no_mot_int_cfg * slow_no_mot_int_cfg)
 {
     float thresh_scale;
     uint8_t data[2];
@@ -1794,11 +1818,11 @@ bma2xx_set_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
     }
     data[1] = slow_no_mot_int_cfg->thresh_g / thresh_scale;
 
-    rc = set_register(bma2xx, REG_ADDR_INT_5, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_5, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_7, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_7, data[1]);
     if (rc != 0) {
         return rc;
     }
@@ -1807,7 +1831,7 @@ bma2xx_set_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_slope_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slope_int_cfg(struct bma2xx *bma2xx,
                          enum bma2xx_g_range g_range,
                          struct slope_int_cfg * slope_int_cfg)
 {
@@ -1832,7 +1856,7 @@ bma2xx_get_slope_int_cfg(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_5,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_5,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1845,9 +1869,9 @@ bma2xx_get_slope_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_slope_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_slope_int_cfg(struct bma2xx *bma2xx,
                          enum bma2xx_g_range g_range,
-                         const struct slope_int_cfg * slope_int_cfg)
+                         struct slope_int_cfg * slope_int_cfg)
 {
     float thresh_scale;
     uint8_t data[2];
@@ -1882,11 +1906,11 @@ bma2xx_set_slope_int_cfg(const struct bma2xx * bma2xx,
     data[0] = (slope_int_cfg->duration_p - 1) & 0x03;
     data[1] = slope_int_cfg->thresh_g / thresh_scale;
 
-    rc = set_register(bma2xx, REG_ADDR_INT_5, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_5, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_6, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_6, data[1]);
     if (rc != 0) {
         return rc;
     }
@@ -1895,7 +1919,7 @@ bma2xx_set_slope_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_tap_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_tap_int_cfg(struct bma2xx *bma2xx,
                        enum bma2xx_g_range g_range,
                        struct tap_int_cfg * tap_int_cfg)
 {
@@ -1920,7 +1944,7 @@ bma2xx_get_tap_int_cfg(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_8,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_8,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -1985,9 +2009,9 @@ bma2xx_get_tap_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_tap_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_tap_int_cfg(struct bma2xx *bma2xx,
                        enum bma2xx_g_range g_range,
-                       const struct tap_int_cfg * tap_int_cfg)
+                       struct tap_int_cfg * tap_int_cfg)
 {
     float thresh_scale;
     uint8_t data[2];
@@ -2088,11 +2112,11 @@ bma2xx_set_tap_int_cfg(const struct bma2xx * bma2xx,
 
     data[1] |= (uint8_t)(tap_int_cfg->thresh_g / thresh_scale) & 0x1F;
 
-    rc = set_register(bma2xx, REG_ADDR_INT_8, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_8, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_9, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_9, data[1]);
     if (rc != 0) {
         return rc;
     }
@@ -2101,13 +2125,13 @@ bma2xx_set_tap_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_orient_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_orient_int_cfg(struct bma2xx *bma2xx,
                           struct orient_int_cfg * orient_int_cfg)
 {
     uint8_t data[2];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_A,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_A,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -2160,8 +2184,8 @@ bma2xx_get_orient_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_orient_int_cfg(const struct bma2xx * bma2xx,
-                          const struct orient_int_cfg * orient_int_cfg)
+bma2xx_set_orient_int_cfg(struct bma2xx *bma2xx,
+                          struct orient_int_cfg * orient_int_cfg)
 {
     uint8_t data[2];
     int rc;
@@ -2210,11 +2234,11 @@ bma2xx_set_orient_int_cfg(const struct bma2xx * bma2xx,
     data[1] = (orient_int_cfg->signal_up_dn << 6) |
               ((orient_int_cfg->blocking_angle & 0x3F) << 0);
 
-    rc = set_register(bma2xx, REG_ADDR_INT_A, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_A, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_B, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_B, data[1]);
     if (rc != 0) {
         return rc;
     }
@@ -2223,13 +2247,13 @@ bma2xx_set_orient_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_flat_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_flat_int_cfg(struct bma2xx *bma2xx,
                         struct flat_int_cfg * flat_int_cfg)
 {
     uint8_t data[2];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_INT_C,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_INT_C,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -2259,8 +2283,8 @@ bma2xx_get_flat_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_flat_int_cfg(const struct bma2xx * bma2xx,
-                        const struct flat_int_cfg * flat_int_cfg)
+bma2xx_set_flat_int_cfg(struct bma2xx *bma2xx,
+                        struct flat_int_cfg * flat_int_cfg)
 {
     uint8_t data[2];
     int rc;
@@ -2295,11 +2319,11 @@ bma2xx_set_flat_int_cfg(const struct bma2xx * bma2xx,
         data[1] |= flat_int_cfg->flat_hyster & 0x07;
     }
 
-    rc = set_register(bma2xx, REG_ADDR_INT_C, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_C, data[0]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_INT_D, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_INT_D, data[1]);
     if (rc != 0) {
         return rc;
     }
@@ -2308,13 +2332,13 @@ bma2xx_set_flat_int_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_fifo_wmark_level(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_wmark_level(struct bma2xx *bma2xx,
                             uint8_t * wmark_level)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_FIFO_CONFIG_0, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_FIFO_CONFIG_0, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2325,7 +2349,7 @@ bma2xx_get_fifo_wmark_level(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_fifo_wmark_level(const struct bma2xx * bma2xx,
+bma2xx_set_fifo_wmark_level(struct bma2xx *bma2xx,
                             uint8_t wmark_level)
 {
     uint8_t data;
@@ -2336,17 +2360,17 @@ bma2xx_set_fifo_wmark_level(const struct bma2xx * bma2xx,
 
     data = wmark_level & 0x3F;
 
-    return set_register(bma2xx, REG_ADDR_FIFO_CONFIG_0, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_FIFO_CONFIG_0, data);
 }
 
 int
-bma2xx_get_self_test_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_self_test_cfg(struct bma2xx *bma2xx,
                          struct self_test_cfg * self_test_cfg)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_PMU_SELF_TEST, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_SELF_TEST, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2385,8 +2409,8 @@ bma2xx_get_self_test_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_self_test_cfg(const struct bma2xx * bma2xx,
-                         const struct self_test_cfg * self_test_cfg)
+bma2xx_set_self_test_cfg(struct bma2xx *bma2xx,
+                         struct self_test_cfg * self_test_cfg)
 {
     uint8_t data;
 
@@ -2430,11 +2454,11 @@ bma2xx_set_self_test_cfg(const struct bma2xx * bma2xx,
         }
     }
 
-    return set_register(bma2xx, REG_ADDR_PMU_SELF_TEST, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_PMU_SELF_TEST, data);
 }
 
 int
-bma2xx_get_nvm_control(const struct bma2xx * bma2xx,
+bma2xx_get_nvm_control(struct bma2xx *bma2xx,
                        uint8_t * remaining_cycles,
                        bool * load_from_nvm,
                        bool * nvm_is_ready,
@@ -2443,7 +2467,7 @@ bma2xx_get_nvm_control(const struct bma2xx * bma2xx,
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_TRIM_NVM_CTRL, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_TRIM_NVM_CTRL, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2457,7 +2481,7 @@ bma2xx_get_nvm_control(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_nvm_control(const struct bma2xx * bma2xx,
+bma2xx_set_nvm_control(struct bma2xx *bma2xx,
                        bool load_from_nvm,
                        bool store_into_nvm,
                        bool nvm_unlocked)
@@ -2468,17 +2492,17 @@ bma2xx_set_nvm_control(const struct bma2xx * bma2xx,
            (store_into_nvm << 1) |
            (nvm_unlocked << 0);
 
-    return set_register(bma2xx, REG_ADDR_TRIM_NVM_CTRL, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_TRIM_NVM_CTRL, data);
 }
 
 int
-bma2xx_get_i2c_watchdog(const struct bma2xx * bma2xx,
+bma2xx_get_i2c_watchdog(struct bma2xx *bma2xx,
                         enum i2c_watchdog * i2c_watchdog)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_BGW_SPI3_WDT, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_BGW_SPI3_WDT, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2497,7 +2521,7 @@ bma2xx_get_i2c_watchdog(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_i2c_watchdog(const struct bma2xx * bma2xx,
+bma2xx_set_i2c_watchdog(struct bma2xx *bma2xx,
                         enum i2c_watchdog i2c_watchdog)
 {
     uint8_t data;
@@ -2516,11 +2540,11 @@ bma2xx_set_i2c_watchdog(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, REG_ADDR_BGW_SPI3_WDT, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_BGW_SPI3_WDT, data);
 }
 
 int
-bma2xx_get_fast_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_fast_ofc_cfg(struct bma2xx *bma2xx,
                         bool * fast_ofc_ready,
                         enum bma2xx_offset_comp_target * ofc_target_z,
                         enum bma2xx_offset_comp_target * ofc_target_y,
@@ -2529,7 +2553,7 @@ bma2xx_get_fast_ofc_cfg(const struct bma2xx * bma2xx,
     uint8_t data[2];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_OFC_CTRL,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_OFC_CTRL,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -2586,7 +2610,7 @@ bma2xx_get_fast_ofc_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_fast_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_fast_ofc_cfg(struct bma2xx *bma2xx,
                         enum axis fast_ofc_axis,
                         enum bma2xx_offset_comp_target fast_ofc_target,
                         bool trigger_fast_ofc)
@@ -2634,11 +2658,11 @@ bma2xx_set_fast_ofc_cfg(const struct bma2xx * bma2xx,
         data[0] |= axis_value << 5;
     }
 
-    rc = set_register(bma2xx, REG_ADDR_OFC_SETTING, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_OFC_SETTING, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_OFC_CTRL, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_OFC_CTRL, data[0]);
     if (rc != 0) {
         return rc;
     }
@@ -2647,13 +2671,13 @@ bma2xx_set_fast_ofc_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_get_slow_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slow_ofc_cfg(struct bma2xx *bma2xx,
                         struct slow_ofc_cfg * slow_ofc_cfg)
 {
     uint8_t data[2];
     int rc;
 
-    rc = get_registers(bma2xx, REG_ADDR_OFC_CTRL,
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_OFC_CTRL,
                        data, sizeof(data) / sizeof(*data));
     if (rc != 0) {
         return rc;
@@ -2668,8 +2692,8 @@ bma2xx_get_slow_ofc_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_slow_ofc_cfg(const struct bma2xx * bma2xx,
-                        const struct slow_ofc_cfg * slow_ofc_cfg)
+bma2xx_set_slow_ofc_cfg(struct bma2xx *bma2xx,
+                        struct slow_ofc_cfg * slow_ofc_cfg)
 {
     uint8_t data[2];
     int rc;
@@ -2679,11 +2703,11 @@ bma2xx_set_slow_ofc_cfg(const struct bma2xx * bma2xx,
               (slow_ofc_cfg->ofc_x_enabled << 0);
     data[1] = slow_ofc_cfg->high_bw_cut_off << 0;
 
-    rc = set_register(bma2xx, REG_ADDR_OFC_SETTING, data[1]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_OFC_SETTING, data[1]);
     if (rc != 0) {
         return rc;
     }
-    rc = set_register(bma2xx, REG_ADDR_OFC_CTRL, data[0]);
+    rc = set_register((struct bma2xx *)bma2xx, REG_ADDR_OFC_CTRL, data[0]);
     if (rc != 0) {
         return rc;
     }
@@ -2692,13 +2716,13 @@ bma2xx_set_slow_ofc_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_ofc_reset(const struct bma2xx * bma2xx)
+bma2xx_set_ofc_reset(struct bma2xx *bma2xx)
 {
-    return set_register(bma2xx, REG_ADDR_OFC_CTRL, 0x80);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_OFC_CTRL, 0x80);
 }
 
 int
-bma2xx_get_ofc_offset(const struct bma2xx * bma2xx,
+bma2xx_get_ofc_offset(struct bma2xx *bma2xx,
                       enum axis axis,
                       float * offset_g)
 {
@@ -2720,7 +2744,7 @@ bma2xx_get_ofc_offset(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_register(bma2xx, reg_addr, &data);
+    rc = get_register((struct bma2xx *)bma2xx, reg_addr, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2731,7 +2755,7 @@ bma2xx_get_ofc_offset(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_ofc_offset(const struct bma2xx * bma2xx,
+bma2xx_set_ofc_offset(struct bma2xx *bma2xx,
                       enum axis axis,
                       float offset_g)
 {
@@ -2754,11 +2778,11 @@ bma2xx_set_ofc_offset(const struct bma2xx * bma2xx,
 
     data = (int8_t)(offset_g / 0.00781);
 
-    return set_register(bma2xx, reg_addr, data);
+    return set_register((struct bma2xx *)bma2xx, reg_addr, data);
 }
 
 int
-bma2xx_get_saved_data(const struct bma2xx * bma2xx,
+bma2xx_get_saved_data(struct bma2xx *bma2xx,
                       enum saved_data_addr saved_data_addr,
                       uint8_t * saved_data_val)
 {
@@ -2775,11 +2799,11 @@ bma2xx_get_saved_data(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return get_register(bma2xx, reg_addr, saved_data_val);
+    return get_register((struct bma2xx *)bma2xx, reg_addr, saved_data_val);
 }
 
 int
-bma2xx_set_saved_data(const struct bma2xx * bma2xx,
+bma2xx_set_saved_data(struct bma2xx *bma2xx,
                       enum saved_data_addr saved_data_addr,
                       uint8_t saved_data_val)
 {
@@ -2796,17 +2820,17 @@ bma2xx_set_saved_data(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    return set_register(bma2xx, reg_addr, saved_data_val);
+    return set_register((struct bma2xx *)bma2xx, reg_addr, saved_data_val);
 }
 
 int
-bma2xx_get_fifo_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_cfg(struct bma2xx *bma2xx,
                     struct fifo_cfg * fifo_cfg)
 {
     uint8_t data;
     int rc;
 
-    rc = get_register(bma2xx, REG_ADDR_FIFO_CONFIG_1, &data);
+    rc = get_register((struct bma2xx *)bma2xx, REG_ADDR_FIFO_CONFIG_1, &data);
     if (rc != 0) {
         return rc;
     }
@@ -2844,8 +2868,8 @@ bma2xx_get_fifo_cfg(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_set_fifo_cfg(const struct bma2xx * bma2xx,
-                    const struct fifo_cfg * fifo_cfg)
+bma2xx_set_fifo_cfg(struct bma2xx *bma2xx,
+                    struct fifo_cfg * fifo_cfg)
 {
     uint8_t data;
 
@@ -2880,11 +2904,11 @@ bma2xx_set_fifo_cfg(const struct bma2xx * bma2xx,
         break;
     }
 
-    return set_register(bma2xx, REG_ADDR_FIFO_CONFIG_1, data);
+    return set_register((struct bma2xx *)bma2xx, REG_ADDR_FIFO_CONFIG_1, data);
 }
 
 int
-bma2xx_get_fifo(const struct bma2xx * bma2xx,
+bma2xx_get_fifo(struct bma2xx *bma2xx,
                 enum bma2xx_g_range g_range,
                 enum fifo_data fifo_data,
                 struct accel_data * accel_data)
@@ -2912,7 +2936,7 @@ bma2xx_get_fifo(const struct bma2xx * bma2xx,
         return SYS_EINVAL;
     }
 
-    rc = get_registers(bma2xx, REG_ADDR_FIFO_DATA, data, size);
+    rc = get_registers((struct bma2xx *)bma2xx, REG_ADDR_FIFO_DATA, data, size);
     if (rc != 0) {
         return rc;
     }
@@ -2928,9 +2952,9 @@ bma2xx_get_fifo(const struct bma2xx * bma2xx,
 }
 
 static int
-reset_and_recfg(struct bma2xx * bma2xx)
+reset_and_recfg(struct bma2xx *bma2xx)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     int rc;
     enum int_route int_route;
     struct int_routes int_routes;
@@ -3109,10 +3133,10 @@ reset_and_recfg(struct bma2xx * bma2xx)
 }
 
 static int
-change_power(struct bma2xx * bma2xx,
+change_power(struct bma2xx *bma2xx,
              enum bma2xx_power_mode target)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     int rc;
     bool step1_move;
     bool step2_move;
@@ -3196,7 +3220,7 @@ change_power(struct bma2xx * bma2xx,
 }
 
 static int
-interim_power(struct bma2xx * bma2xx,
+interim_power(struct bma2xx *bma2xx,
               const enum bma2xx_power_mode * reqs,
               uint8_t size)
 {
@@ -3216,9 +3240,9 @@ interim_power(struct bma2xx * bma2xx,
 }
 
 static int
-default_power(struct bma2xx * bma2xx)
+default_power(struct bma2xx *bma2xx)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
 
     cfg = &bma2xx->cfg;
 
@@ -3231,7 +3255,7 @@ default_power(struct bma2xx * bma2xx)
 
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
 static int
-init_intpin(struct bma2xx * bma2xx,
+init_intpin(struct bma2xx *bma2xx,
               hal_gpio_irq_handler_t handler,
               void * arg)
 {
@@ -3282,7 +3306,7 @@ init_intpin(struct bma2xx * bma2xx,
 }
 
 static void
-enable_intpin(struct bma2xx * bma2xx)
+enable_intpin(struct bma2xx *bma2xx)
 {
     struct bma2xx_private_driver_data *pdd = &bma2xx->pdd;
     enum bma2xx_int_num int_num = pdd->int_num;
@@ -3295,7 +3319,7 @@ enable_intpin(struct bma2xx * bma2xx)
 }
 
 static void
-disable_intpin(struct bma2xx * bma2xx)
+disable_intpin(struct bma2xx *bma2xx)
 {
     struct bma2xx_private_driver_data *pdd = &bma2xx->pdd;
     enum bma2xx_int_num int_num = pdd->int_num;
@@ -3313,7 +3337,7 @@ disable_intpin(struct bma2xx * bma2xx)
 #endif
 
 static int
-self_test_enable(const struct bma2xx * bma2xx,
+self_test_enable(struct bma2xx *bma2xx,
                  enum self_test_ampl ampl,
                  enum self_test_sign sign,
                  enum axis axis)
@@ -3329,7 +3353,7 @@ self_test_enable(const struct bma2xx * bma2xx,
 }
 
 static int
-self_test_disable(const struct bma2xx * bma2xx)
+self_test_disable(struct bma2xx *bma2xx)
 {
     struct self_test_cfg self_test_cfg;
 
@@ -3342,7 +3366,7 @@ self_test_disable(const struct bma2xx * bma2xx)
 }
 
 static int
-self_test_nudge(const struct bma2xx * bma2xx,
+self_test_nudge(struct bma2xx *bma2xx,
                 enum self_test_ampl ampl,
                 enum self_test_sign sign,
                 enum axis axis,
@@ -3374,7 +3398,7 @@ self_test_nudge(const struct bma2xx * bma2xx,
 }
 
 static int
-self_test_axis(const struct bma2xx * bma2xx,
+self_test_axis(struct bma2xx *bma2xx,
                enum axis axis,
                enum bma2xx_g_range g_range,
                float * delta_hi_g,
@@ -3430,12 +3454,12 @@ self_test_axis(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_self_test(struct bma2xx * bma2xx,
+bma2xx_self_test(struct bma2xx *bma2xx,
                  float delta_high_mult,
                  float delta_low_mult,
                  bool * self_test_fail)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     enum bma2xx_power_mode request_power;
     int rc;
     float delta_hi_x_g;
@@ -3528,7 +3552,7 @@ bma2xx_self_test(struct bma2xx * bma2xx,
 }
 
 static int
-axis_offset_compensation(const struct bma2xx * bma2xx,
+axis_offset_compensation(struct bma2xx *bma2xx,
                          enum axis axis,
                          enum bma2xx_offset_comp_target target)
 {
@@ -3582,12 +3606,12 @@ axis_offset_compensation(const struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_offset_compensation(struct bma2xx * bma2xx,
+bma2xx_offset_compensation(struct bma2xx *bma2xx,
                            enum bma2xx_offset_comp_target target_x,
                            enum bma2xx_offset_comp_target target_y,
                            enum bma2xx_offset_comp_target target_z)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     enum bma2xx_power_mode request_power;
     int rc;
 
@@ -3645,12 +3669,12 @@ bma2xx_offset_compensation(struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_query_offsets(struct bma2xx * bma2xx,
+bma2xx_query_offsets(struct bma2xx *bma2xx,
                      float * offset_x_g,
                      float * offset_y_g,
                      float * offset_z_g)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     enum bma2xx_power_mode request_power[5];
     int rc;
     float val_offset_x_g;
@@ -3717,12 +3741,12 @@ bma2xx_query_offsets(struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_write_offsets(struct bma2xx * bma2xx,
+bma2xx_write_offsets(struct bma2xx *bma2xx,
                      float offset_x_g,
                      float offset_y_g,
                      float offset_z_g)
 {
-    struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     enum bma2xx_power_mode request_power[5];
     int rc;
 
@@ -3762,12 +3786,12 @@ bma2xx_write_offsets(struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_stream_read(struct bma2xx * bma2xx,
+bma2xx_stream_read(struct bma2xx *bma2xx,
                    bma2xx_stream_read_func_t read_func,
                    void * read_arg,
                    uint32_t time_ms)
 {
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
     int rc;
     enum bma2xx_power_mode request_power;
     struct int_enable int_enable_org;
@@ -3903,7 +3927,7 @@ done:
 }
 
 int
-bma2xx_current_temp(struct bma2xx * bma2xx,
+bma2xx_current_temp(struct bma2xx *bma2xx,
                     float * temp_c)
 {
     enum bma2xx_power_mode request_power[3];
@@ -3934,7 +3958,7 @@ bma2xx_current_temp(struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_current_orient(struct bma2xx * bma2xx,
+bma2xx_current_orient(struct bma2xx *bma2xx,
                       struct bma2xx_orient_xyz * orient_xyz)
 {
     enum bma2xx_power_mode request_power[3];
@@ -3993,7 +4017,7 @@ bma2xx_current_orient(struct bma2xx * bma2xx,
 }
 
 int
-bma2xx_wait_for_orient(struct bma2xx * bma2xx,
+bma2xx_wait_for_orient(struct bma2xx *bma2xx,
                        struct bma2xx_orient_xyz * orient_xyz)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
@@ -4072,7 +4096,7 @@ done:
 }
 
 int
-bma2xx_wait_for_high_g(struct bma2xx * bma2xx)
+bma2xx_wait_for_high_g(struct bma2xx *bma2xx)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
     int rc;
@@ -4144,7 +4168,7 @@ done:
 }
 
 int
-bma2xx_wait_for_low_g(struct bma2xx * bma2xx)
+bma2xx_wait_for_low_g(struct bma2xx *bma2xx)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
     int rc;
@@ -4214,7 +4238,7 @@ done:
 }
 
 int
-bma2xx_wait_for_tap(struct bma2xx * bma2xx,
+bma2xx_wait_for_tap(struct bma2xx *bma2xx,
                     enum bma2xx_tap_type tap_type)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
@@ -4314,11 +4338,11 @@ done:
 }
 
 int
-bma2xx_power_settings(struct bma2xx * bma2xx,
+bma2xx_power_settings(struct bma2xx *bma2xx,
                       enum bma2xx_power_mode power_mode,
                       enum bma2xx_sleep_duration sleep_duration)
 {
-    struct bma2xx_cfg * cfg;
+    struct bma2xx_cfg *cfg;
 
     cfg = &bma2xx->cfg;
 
@@ -4335,8 +4359,8 @@ sensor_driver_read(struct sensor * sensor,
                    void * data_arg,
                    uint32_t timeout)
 {
-    struct bma2xx * bma2xx;
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx *bma2xx;
+    struct bma2xx_cfg *cfg;
     enum bma2xx_power_mode request_power[3];
     int rc;
     struct accel_data accel_data[AXIS_ALL];
@@ -4457,12 +4481,12 @@ sensor_driver_set_trigger_thresh(struct sensor * sensor,
                                  struct sensor_type_traits * stt)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
-    struct bma2xx * bma2xx;
-    const struct bma2xx_cfg * cfg;
+    struct bma2xx *bma2xx;
+    struct bma2xx_cfg *cfg;
     int rc;
     enum bma2xx_power_mode request_power[3];
-    const struct sensor_accel_data * low_thresh;
-    const struct sensor_accel_data * high_thresh;
+    struct sensor_accel_data * low_thresh;
+    struct sensor_accel_data * high_thresh;
     struct int_enable int_enable;
     float thresh;
     struct low_g_int_cfg low_g_int_cfg;
@@ -4593,7 +4617,7 @@ sensor_driver_unset_notification(struct sensor * sensor,
                                sensor_event_type_t sensor_event_type)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
-    struct bma2xx * bma2xx;
+    struct bma2xx *bma2xx;
     enum bma2xx_power_mode request_power[3];
     struct int_enable int_enable;
     struct int_routes int_routes;
@@ -4670,7 +4694,7 @@ sensor_driver_set_notification(struct sensor * sensor,
                                sensor_event_type_t sensor_event_type)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
-    struct bma2xx * bma2xx;
+    struct bma2xx *bma2xx;
     int rc;
     enum bma2xx_power_mode request_power[3];
     struct int_enable int_enable;
@@ -4759,7 +4783,7 @@ static int
 sensor_driver_handle_interrupt(struct sensor * sensor)
 {
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
-    struct bma2xx * bma2xx;
+    struct bma2xx *bma2xx;
     struct bma2xx_private_driver_data *pdd;
     struct int_status int_status;
     int rc;
@@ -4804,7 +4828,7 @@ static struct sensor_driver bma2xx_sensor_driver = {
 };
 
 int
-bma2xx_config(struct bma2xx * bma2xx, struct bma2xx_cfg * cfg)
+bma2xx_config(struct bma2xx *bma2xx, struct bma2xx_cfg *cfg)
 {
     struct sensor * sensor;
     int rc;
@@ -4856,7 +4880,7 @@ bma2xx_config(struct bma2xx * bma2xx, struct bma2xx_cfg * cfg)
 int
 bma2xx_init(struct os_dev * dev, void * arg)
 {
-    struct bma2xx * bma2xx;
+    struct bma2xx *bma2xx;
     struct sensor * sensor;
 #if MYNEWT_VAL(BMA2XX_INT_ENABLE)
     struct bma2xx_private_driver_data *pdd;
@@ -4896,6 +4920,11 @@ bma2xx_init(struct os_dev * dev, void * arg)
 
     rc = sensor_set_interface(sensor, arg);
     if (rc != 0) {
+        return rc;
+    }
+
+    rc = sensor_itf_lock_init(arg);
+    if (rc) {
         return rc;
     }
 

--- a/hw/drivers/sensors/bma2xx/src/bma2xx_priv.h
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx_priv.h
@@ -116,7 +116,7 @@
 
 /* Get the chip ID */
 int
-bma2xx_get_chip_id(const struct bma2xx * bma2xx,
+bma2xx_get_chip_id(struct bma2xx * bma2xx,
                    uint8_t * chip_id);
 
 /* All three axis types */
@@ -135,14 +135,14 @@ struct accel_data {
 
 /* Get an accelerometer measurement for a single axis */
 int
-bma2xx_get_accel(const struct bma2xx * bma2xx,
+bma2xx_get_accel(struct bma2xx * bma2xx,
                  enum bma2xx_g_range g_range,
                  enum axis axis,
                  struct accel_data * accel_data);
 
 /* Get a temperature measurement */
 int
-bma2xx_get_temp(const struct bma2xx * bma2xx,
+bma2xx_get_temp(struct bma2xx * bma2xx,
                 float * temp_c);
 
 /* Which direction in an axis was this interrupt triggered on */
@@ -181,29 +181,29 @@ struct int_status {
 
 /* Get the active status of all interrupts */
 int
-bma2xx_get_int_status(const struct bma2xx * bma2xx,
+bma2xx_get_int_status(struct bma2xx * bma2xx,
                       struct int_status * int_status);
 
 /* Get the status and size of the FIFO */
 int
-bma2xx_get_fifo_status(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_status(struct bma2xx * bma2xx,
                        bool * overrun,
                        uint8_t * frame_counter);
 
 /* Get/Set the accelerometer range */
 int
-bma2xx_get_g_range(const struct bma2xx * bma2xx,
+bma2xx_get_g_range(struct bma2xx * bma2xx,
                    enum bma2xx_g_range * g_range);
 int
-bma2xx_set_g_range(const struct bma2xx * bma2xx,
+bma2xx_set_g_range(struct bma2xx * bma2xx,
                    enum bma2xx_g_range g_range);
 
 /* Get/Set the filter output bandwidth */
 int
-bma2xx_get_filter_bandwidth(const struct bma2xx * bma2xx,
+bma2xx_get_filter_bandwidth(struct bma2xx * bma2xx,
                             enum bma2xx_filter_bandwidth * filter_bandwidth);
 int
-bma2xx_set_filter_bandwidth(const struct bma2xx * bma2xx,
+bma2xx_set_filter_bandwidth(struct bma2xx * bma2xx,
                             enum bma2xx_filter_bandwidth filter_bandwidth);
 
 /* Whether the sleep timer is locked to events or to time */
@@ -221,25 +221,25 @@ struct power_settings {
 
 /* Get/Set the power settings of the device */
 int
-bma2xx_get_power_settings(const struct bma2xx * bma2xx,
+bma2xx_get_power_settings(struct bma2xx * bma2xx,
                           struct power_settings * power_settings);
 int
-bma2xx_set_power_settings(const struct bma2xx * bma2xx,
-                          const struct power_settings * power_settings);
+bma2xx_set_power_settings(struct bma2xx * bma2xx,
+                          struct power_settings * power_settings);
 
 /* Get/Set the data register settings */
 int
-bma2xx_get_data_acquisition(const struct bma2xx * bma2xx,
+bma2xx_get_data_acquisition(struct bma2xx * bma2xx,
                             bool * unfiltered_reg_data,
                             bool * disable_reg_shadow);
 int
-bma2xx_set_data_acquisition(const struct bma2xx * bma2xx,
+bma2xx_set_data_acquisition(struct bma2xx * bma2xx,
                             bool unfiltered_reg_data,
                             bool disable_reg_shadow);
 
 /* Kick off a full soft reset of the device */
 int
-bma2xx_set_softreset(const struct bma2xx * bma2xx);
+bma2xx_set_softreset(struct bma2xx * bma2xx);
 
 /* Enable settings of all interupts */
 struct int_enable {
@@ -265,11 +265,11 @@ struct int_enable {
 
 /* Get/Set the enable settings of all interrupts */
 int
-bma2xx_get_int_enable(const struct bma2xx * bma2xx,
+bma2xx_get_int_enable(struct bma2xx * bma2xx,
                       struct int_enable * int_enable);
 int
-bma2xx_set_int_enable(const struct bma2xx * bma2xx,
-                      const struct int_enable * int_enable);
+bma2xx_set_int_enable(struct bma2xx * bma2xx,
+                      struct int_enable * int_enable);
 
 /* Which physical device pin is a given interrupt routed to */
 enum int_route {
@@ -301,11 +301,11 @@ struct int_routes {
 
 /* Get/Set the pin routing settings of all interrupts */
 int
-bma2xx_get_int_routes(const struct bma2xx * bma2xx,
+bma2xx_get_int_routes(struct bma2xx * bma2xx,
                       struct int_routes * int_routes);
 int
-bma2xx_set_int_routes(const struct bma2xx * bma2xx,
-                      const struct int_routes * int_routes);
+bma2xx_set_int_routes(struct bma2xx * bma2xx,
+                      struct int_routes * int_routes);
 
 /* Whether each interrupt uses filtered or unfiltered data */
 struct int_filters {
@@ -319,11 +319,11 @@ struct int_filters {
 
 /* Get/Set the filtered data settings of all interrupts */
 int
-bma2xx_get_int_filters(const struct bma2xx * bma2xx,
+bma2xx_get_int_filters(struct bma2xx * bma2xx,
                        struct int_filters * int_filters);
 int
-bma2xx_set_int_filters(const struct bma2xx * bma2xx,
-                       const struct int_filters * int_filters);
+bma2xx_set_int_filters(struct bma2xx * bma2xx,
+                       struct int_filters * int_filters);
 
 /* Drive mode of the interrupt pins */
 enum int_pin_output {
@@ -347,11 +347,11 @@ struct int_pin_electrical {
 
 /* Get/Set the electrical settings of both interrupt pins */
 int
-bma2xx_get_int_pin_electrical(const struct bma2xx * bma2xx,
+bma2xx_get_int_pin_electrical(struct bma2xx * bma2xx,
                               struct int_pin_electrical * electrical);
 int
-bma2xx_set_int_pin_electrical(const struct bma2xx * bma2xx,
-                              const struct int_pin_electrical * electrical);
+bma2xx_set_int_pin_electrical(struct bma2xx * bma2xx,
+                              struct int_pin_electrical * electrical);
 
 /* Length of time that an interrupt condition should be latched active */
 enum int_latch {
@@ -373,10 +373,10 @@ enum int_latch {
 
 /* Get/Set the interrupt condition latch time */
 int
-bma2xx_get_int_latch(const struct bma2xx * bma2xx,
+bma2xx_get_int_latch(struct bma2xx * bma2xx,
                      enum int_latch * int_latch);
 int
-bma2xx_set_int_latch(const struct bma2xx * bma2xx,
+bma2xx_set_int_latch(struct bma2xx * bma2xx,
                      bool reset_ints,
                      enum int_latch int_latch);
 
@@ -390,11 +390,11 @@ struct low_g_int_cfg {
 
 /* Get/Set the low-g interrupt settings */
 int
-bma2xx_get_low_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_low_g_int_cfg(struct bma2xx * bma2xx,
                          struct low_g_int_cfg * low_g_int_cfg);
 int
-bma2xx_set_low_g_int_cfg(const struct bma2xx * bma2xx,
-                         const struct low_g_int_cfg * low_g_int_cfg);
+bma2xx_set_low_g_int_cfg(struct bma2xx * bma2xx,
+                         struct low_g_int_cfg * low_g_int_cfg);
 
 /* Settings for the high-g interrupt */
 struct high_g_int_cfg {
@@ -405,13 +405,13 @@ struct high_g_int_cfg {
 
 /* Get/Set the high-g interrupt settings */
 int
-bma2xx_get_high_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_high_g_int_cfg(struct bma2xx * bma2xx,
                           enum bma2xx_g_range g_range,
                           struct high_g_int_cfg * high_g_int_cfg);
 int
-bma2xx_set_high_g_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_high_g_int_cfg(struct bma2xx * bma2xx,
                           enum bma2xx_g_range g_range,
-                          const struct high_g_int_cfg * high_g_int_cfg);
+                          struct high_g_int_cfg * high_g_int_cfg);
 
 /* Settings for the slow/no-motion interrupt */
 struct slow_no_mot_int_cfg {
@@ -421,15 +421,15 @@ struct slow_no_mot_int_cfg {
 
 /* Get/Set the slow/no-motion interrupt settings */
 int
-bma2xx_get_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slow_no_mot_int_cfg(struct bma2xx * bma2xx,
                                bool no_motion_select,
                                enum bma2xx_g_range g_range,
                                struct slow_no_mot_int_cfg * slow_no_mot_int_cfg);
 int
-bma2xx_set_slow_no_mot_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_slow_no_mot_int_cfg(struct bma2xx * bma2xx,
                                bool no_motion_select,
                                enum bma2xx_g_range g_range,
-                               const struct slow_no_mot_int_cfg * slow_no_mot_int_cfg);
+                               struct slow_no_mot_int_cfg * slow_no_mot_int_cfg);
 
 /* Settings for the slope interrupt */
 struct slope_int_cfg {
@@ -439,13 +439,13 @@ struct slope_int_cfg {
 
 /* Get/Set the slope interrupt settings */
 int
-bma2xx_get_slope_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slope_int_cfg(struct bma2xx * bma2xx,
                          enum bma2xx_g_range g_range,
                          struct slope_int_cfg * slope_int_cfg);
 int
-bma2xx_set_slope_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_slope_int_cfg(struct bma2xx * bma2xx,
                          enum bma2xx_g_range g_range,
-                         const struct slope_int_cfg * slope_int_cfg);
+                         struct slope_int_cfg * slope_int_cfg);
 
 /* Settings for the double/single tap interrupt */
 struct tap_int_cfg {
@@ -458,13 +458,13 @@ struct tap_int_cfg {
 
 /* Get/Set the double/single tap interrupt settings */
 int
-bma2xx_get_tap_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_tap_int_cfg(struct bma2xx * bma2xx,
                        enum bma2xx_g_range g_range,
                        struct tap_int_cfg * tap_int_cfg);
 int
-bma2xx_set_tap_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_tap_int_cfg(struct bma2xx * bma2xx,
                        enum bma2xx_g_range g_range,
-                       const struct tap_int_cfg * tap_int_cfg);
+                       struct tap_int_cfg * tap_int_cfg);
 
 /* Settings for the orientation interrupt */
 struct orient_int_cfg {
@@ -477,11 +477,11 @@ struct orient_int_cfg {
 
 /* Get/Set the orientation interrupt settings */
 int
-bma2xx_get_orient_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_orient_int_cfg(struct bma2xx * bma2xx,
                           struct orient_int_cfg * orient_int_cfg);
 int
-bma2xx_set_orient_int_cfg(const struct bma2xx * bma2xx,
-                          const struct orient_int_cfg * orient_int_cfg);
+bma2xx_set_orient_int_cfg(struct bma2xx * bma2xx,
+                          struct orient_int_cfg * orient_int_cfg);
 
 /* Hold time for flat condition */
 enum flat_hold {
@@ -501,18 +501,18 @@ struct flat_int_cfg {
 
 /* Get/Set the flat interrupt settings */
 int
-bma2xx_get_flat_int_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_flat_int_cfg(struct bma2xx * bma2xx,
                         struct flat_int_cfg * flat_int_cfg);
 int
-bma2xx_set_flat_int_cfg(const struct bma2xx * bma2xx,
-                        const struct flat_int_cfg * flat_int_cfg);
+bma2xx_set_flat_int_cfg(struct bma2xx * bma2xx,
+                        struct flat_int_cfg * flat_int_cfg);
 
 /* Get/Set the FIFO watermark level */
 int
-bma2xx_get_fifo_wmark_level(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_wmark_level(struct bma2xx * bma2xx,
                             uint8_t * wmark_level);
 int
-bma2xx_set_fifo_wmark_level(const struct bma2xx * bma2xx,
+bma2xx_set_fifo_wmark_level(struct bma2xx * bma2xx,
                             uint8_t wmark_level);
 
 /* Amplitude of a self-test induced acceleration */
@@ -537,21 +537,21 @@ struct self_test_cfg {
 
 /* Get/Set the self-test settings */
 int
-bma2xx_get_self_test_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_self_test_cfg(struct bma2xx * bma2xx,
                          struct self_test_cfg * self_test_cfg);
 int
-bma2xx_set_self_test_cfg(const struct bma2xx * bma2xx,
-                         const struct self_test_cfg * self_test_cfg);
+bma2xx_set_self_test_cfg(struct bma2xx * bma2xx,
+                         struct self_test_cfg * self_test_cfg);
 
 /* Get/Set the NVM reset/write control values */
 int
-bma2xx_get_nvm_control(const struct bma2xx * bma2xx,
+bma2xx_get_nvm_control(struct bma2xx * bma2xx,
                        uint8_t * remaining_cycles,
                        bool * load_from_nvm,
                        bool * nvm_is_ready,
                        bool * nvm_unlocked);
 int
-bma2xx_set_nvm_control(const struct bma2xx * bma2xx,
+bma2xx_set_nvm_control(struct bma2xx * bma2xx,
                        bool load_from_nvm,
                        bool store_into_nvm,
                        bool nvm_unlocked);
@@ -565,10 +565,10 @@ enum i2c_watchdog {
 
 /* Get/Set the I2C watchdog settings */
 int
-bma2xx_get_i2c_watchdog(const struct bma2xx * bma2xx,
+bma2xx_get_i2c_watchdog(struct bma2xx * bma2xx,
                         enum i2c_watchdog * i2c_watchdog);
 int
-bma2xx_set_i2c_watchdog(const struct bma2xx * bma2xx,
+bma2xx_set_i2c_watchdog(struct bma2xx * bma2xx,
                         enum i2c_watchdog i2c_watchdog);
 
 /* Offset compensation settings used in slow compensation mode */
@@ -582,32 +582,32 @@ struct slow_ofc_cfg {
 /* Get/Set the fast & slow offset compensation mode settings, and reset all
  * offset compensation values back to NVM defaults */
 int
-bma2xx_get_fast_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_fast_ofc_cfg(struct bma2xx * bma2xx,
                         bool * fast_ofc_ready,
                         enum bma2xx_offset_comp_target * ofc_target_z,
                         enum bma2xx_offset_comp_target * ofc_target_y,
                         enum bma2xx_offset_comp_target * ofc_target_x);
 int
-bma2xx_set_fast_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_set_fast_ofc_cfg(struct bma2xx * bma2xx,
                         enum axis fast_ofc_axis,
                         enum bma2xx_offset_comp_target fast_ofc_target,
                         bool trigger_fast_ofc);
 int
-bma2xx_get_slow_ofc_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_slow_ofc_cfg(struct bma2xx * bma2xx,
                         struct slow_ofc_cfg * slow_ofc_cfg);
 int
-bma2xx_set_slow_ofc_cfg(const struct bma2xx * bma2xx,
-                        const struct slow_ofc_cfg * slow_ofc_cfg);
+bma2xx_set_slow_ofc_cfg(struct bma2xx * bma2xx,
+                        struct slow_ofc_cfg * slow_ofc_cfg);
 int
-bma2xx_set_ofc_reset(const struct bma2xx * bma2xx);
+bma2xx_set_ofc_reset(struct bma2xx * bma2xx);
 
 /* Get/Set the offset compensation value for a specific axis */
 int
-bma2xx_get_ofc_offset(const struct bma2xx * bma2xx,
+bma2xx_get_ofc_offset(struct bma2xx * bma2xx,
                       enum axis axis,
                       float * offset_g);
 int
-bma2xx_set_ofc_offset(const struct bma2xx * bma2xx,
+bma2xx_set_ofc_offset(struct bma2xx * bma2xx,
                       enum axis axis,
                       float offset_g);
 
@@ -619,11 +619,11 @@ enum saved_data_addr {
 
 /* Get/Set the data stored in general purpose non-volatile registers */
 int
-bma2xx_get_saved_data(const struct bma2xx * bma2xx,
+bma2xx_get_saved_data(struct bma2xx * bma2xx,
                       enum saved_data_addr saved_data_addr,
                       uint8_t * saved_data_val);
 int
-bma2xx_set_saved_data(const struct bma2xx * bma2xx,
+bma2xx_set_saved_data(struct bma2xx * bma2xx,
                       enum saved_data_addr saved_data_addr,
                       uint8_t saved_data_val);
 
@@ -650,15 +650,15 @@ struct fifo_cfg {
 
 /* Get/Set the FIFO capture and behavior settings */
 int
-bma2xx_get_fifo_cfg(const struct bma2xx * bma2xx,
+bma2xx_get_fifo_cfg(struct bma2xx * bma2xx,
                     struct fifo_cfg * fifo_cfg);
 int
-bma2xx_set_fifo_cfg(const struct bma2xx * bma2xx,
-                    const struct fifo_cfg * fifo_cfg);
+bma2xx_set_fifo_cfg(struct bma2xx * bma2xx,
+                    struct fifo_cfg * fifo_cfg);
 
 /* Read a single multi-axis data frame from the FIFO */
 int
-bma2xx_get_fifo(const struct bma2xx * bma2xx,
+bma2xx_get_fifo(struct bma2xx * bma2xx,
                 enum bma2xx_g_range g_range,
                 enum fifo_data fifo_data,
                 struct accel_data * accel_data);

--- a/hw/drivers/sensors/bma2xx/syscfg.yml
+++ b/hw/drivers/sensors/bma2xx/syscfg.yml
@@ -45,3 +45,6 @@ syscfg.defs:
     BMA2XX_SHELL_DEV_NAME:
         description: 'BMA2XX Shell device name'
         value: "\"bma2xx_0\""
+    BMA2XX_ITF_LOCK_TMO:
+        description: 'BMA2XX interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/bma2xx/syscfg.yml
+++ b/hw/drivers/sensors/bma2xx/syscfg.yml
@@ -47,4 +47,4 @@ syscfg.defs:
         value: "\"bma2xx_0\""
     BMA2XX_ITF_LOCK_TMO:
         description: 'BMA2XX interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -36,6 +36,3 @@ syscfg.defs:
     BME280_SPEC_CALC:
         description: 'BME280 Spec calculation insetad of built in one'
         value : 1
-    BME280_ITF_LOCK_TMO:
-        description: 'BME280 interface lock timeout in milliseconds'
-        value: 1000

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -36,3 +36,6 @@ syscfg.defs:
     BME280_SPEC_CALC:
         description: 'BME280 Spec calculation insetad of built in one'
         value : 1
+    BME280_ITF_LOCK_TMO:
+        description: 'BME280 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -38,4 +38,4 @@ syscfg.defs:
         value : 1
     BME280_ITF_LOCK_TMO:
         description: 'BME280 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -156,11 +156,6 @@ bmp280_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc != 0) {
         goto err;

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -33,6 +33,7 @@
 #include "hal/hal_gpio.h"
 #include "log/log.h"
 #include "stats/stats.h"
+#include <syscfg/syscfg.h>
 
 #ifndef MATHLIB_SUPPORT
 static double NAN = 0.0/0.0;
@@ -151,6 +152,11 @@ bmp280_init(struct os_dev *dev, void *arg)
 
     /* Set the interface */
     rc = sensor_set_interface(sensor, arg);
+    if (rc) {
+        goto err;
+    }
+
+    rc = sensor_itf_lock_init(arg);
     if (rc) {
         goto err;
     }

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -902,11 +902,18 @@ bmp280_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(BMP280_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = bmp280_i2c_writelen(itf, addr, payload, len);
     } else {
         rc = bmp280_spi_writelen(itf, addr, payload, len);
     }
+
+    sensor_itf_unlock(itf);
 
     return rc;
 }
@@ -926,11 +933,18 @@ bmp280_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(BMP280_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = bmp280_i2c_readlen(itf, addr, payload, len);
     } else {
         rc = bmp280_spi_readlen(itf, addr, payload, len);
     }
+
+    sensor_itf_unlock(itf);
 
     return rc;
 }

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -41,4 +41,4 @@ syscfg.defs:
         value : 1
     BMP280_ITF_LOCK_TMO:
         description: 'BMP280 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -39,3 +39,6 @@ syscfg.defs:
     BMP280_SPEC_CALC:
         description: 'BMP280 Spec calculation instead of built in one'
         value : 1
+    BMP280_ITF_LOCK_TMO:
+        description: 'BMP280 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -509,11 +509,6 @@ bno055_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc != 0) {
         goto err;

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -121,15 +121,14 @@ bno055_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     };
 
     if (len > (sizeof(payload) - 1)) {
-        rc = OS_EINVAL;
-        goto err;
+        return OS_EINVAL;
     }
 
     memcpy(&payload[1], buffer, len);
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BNO055_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -145,14 +144,12 @@ bno055_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = hal_i2c_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, len);
     if (rc) {
         BNO055_ERR("Failed to read from 0x%02X:0x%02X\n", data_struct.address, reg);
-        STATS_INC(g_bno055stats, errors);
-        goto err;
+        STATS_INC(g_bno055stats, errors);;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -179,7 +176,7 @@ bno055_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BNO055_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -201,9 +198,9 @@ bno055_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
         STATS_INC(g_bno055stats, errors);
     }
 
+err:
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -237,7 +234,7 @@ bno055_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(BNO055_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -255,16 +252,14 @@ bno055_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     if (rc) {
         BNO055_ERR("Failed to read from 0x%02X:0x%02X\n", data_struct.address, reg);
         STATS_INC(g_bno055stats, errors);
-        goto err;
     }
 
     /* Copy the I2C results into the supplied buffer */
     memcpy(buffer, payload, len);
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -30,3 +30,6 @@ syscfg.defs:
     BNO055_SHELL_ITF_ADDR:
         description: 'BNO055 I2C Address'
         value: 0x28
+    BNO055_ITF_LOCK_TMO:
+        description: 'BNO055 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -32,4 +32,4 @@ syscfg.defs:
         value: 0x28
     BNO055_ITF_LOCK_TMO:
         description: 'BNO055 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -329,7 +329,7 @@ lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -340,7 +340,6 @@ lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -361,7 +360,7 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -372,7 +371,6 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -32,6 +32,7 @@
 #include "hal/hal_gpio.h"
 #include "log/log.h"
 #include "stats/stats.h"
+#include <syscfg/syscfg.h>
 
 static struct hal_spi_settings spi_lis2dh12_settings = {
     .data_order = HAL_SPI_MSB_FIRST,
@@ -326,12 +327,20 @@ lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = lis2dh12_i2c_writelen(itf, addr, payload, len);
     } else {
         rc = lis2dh12_spi_writelen(itf, addr, payload, len);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -350,12 +359,20 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = lis2dh12_i2c_readlen(itf, addr, payload, len);
     } else {
         rc = lis2dh12_spi_readlen(itf, addr, payload, len);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -896,6 +913,11 @@ lis2dh12_init(struct os_dev *dev, void *arg)
 
     /* Set the interface */
     rc = sensor_set_interface(sensor, arg);
+    if (rc) {
+        goto err;
+    }
+
+    rc = sensor_itf_lock_init(arg);
     if (rc) {
         goto err;
     }

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -917,11 +917,6 @@ lis2dh12_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -18,19 +18,6 @@
 #
 
 syscfg.defs:
-    TCS34725_CLI:
-        description: 'Enable shell support for the TCS34725'
-        value: 0
-    TCS34725_SHELL_ITF_TYPE:
-        description: 'TCS34725 interface type - I2C'
-        value: 1
-    TCS34725_SHELL_ITF_NUM:
-        description: 'TCS34725 interface number'
-        value: 0
-    TCS34725_SHELL_ITF_ADDR:
-        description: 'TCS34725 I2C address'
-        value : 0x29
-    TCS34725_ITF_LOCK_TMO:
-        description: 'TCS34725 interface lock timeout in milliseconds'
+    LIS2DH12_ITF_LOCK_TMO:
+        description: 'LIS2DH12 interface lock timeout in milliseconds'
         value: 30
-

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -20,4 +20,4 @@
 syscfg.defs:
     LIS2DH12_ITF_LOCK_TMO:
         description: 'LIS2DH12 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -2511,11 +2511,6 @@ lis2ds12_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -352,7 +352,7 @@ lis2ds12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -363,7 +363,6 @@ lis2ds12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -383,7 +382,7 @@ lis2ds12_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -394,7 +393,6 @@ lis2ds12_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -416,7 +414,7 @@ lis2ds12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -427,7 +425,6 @@ lis2ds12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -32,6 +32,7 @@
 #include "hal/hal_gpio.h"
 #include "log/log.h"
 #include "stats/stats.h"
+#include <syscfg/syscfg.h>
 
 /*
  * Max time to wait for interrupt.
@@ -305,7 +306,7 @@ lis2ds12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     /* Send the address */
     retval = hal_spi_tx_val(itf->si_num, reg | LIS2DS12_SPI_READ_CMD_BIT);
-    
+
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
         LIS2DS12_ERR("SPI_%u register write failed addr:0x%02X\n",
@@ -349,12 +350,20 @@ lis2ds12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = lis2ds12_i2c_writelen(itf, reg, &value, 1);
     } else {
         rc = lis2ds12_spi_writelen(itf, reg, &value, 1);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -372,12 +381,20 @@ lis2ds12_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = lis2ds12_i2c_readlen(itf, reg, value, 1);
     } else {
         rc = lis2ds12_spi_readlen(itf, reg, value, 1);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -397,12 +414,20 @@ lis2ds12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 {
     int rc;
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DS12_ITF_LOCK_TMO));
+    if (rc) {
+        goto err;
+    }
+
     if (itf->si_type == SENSOR_ITF_I2C) {
         rc = lis2ds12_i2c_readlen(itf, reg, buffer, len);
     } else {
         rc = lis2ds12_spi_readlen(itf, reg, buffer, len);
     }
 
+    sensor_itf_unlock(itf);
+
+err:
     return rc;
 }
 
@@ -2482,6 +2507,11 @@ lis2ds12_init(struct os_dev *dev, void *arg)
 
     /* Set the interface */
     rc = sensor_set_interface(sensor, arg);
+    if (rc) {
+        goto err;
+    }
+
+    rc = sensor_itf_lock_init(arg);
     if (rc) {
         goto err;
     }

--- a/hw/drivers/sensors/lis2ds12/syscfg.yml
+++ b/hw/drivers/sensors/lis2ds12/syscfg.yml
@@ -43,4 +43,4 @@ syscfg.defs:
         value: 0
     LIS2DS12_ITF_LOCK_TMO:
         description: 'LIS2DS12 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/lis2ds12/syscfg.yml
+++ b/hw/drivers/sensors/lis2ds12/syscfg.yml
@@ -41,3 +41,6 @@ syscfg.defs:
     LIS2DS12_CLI:
         description: 'Enable shell support for the LIS2DS12'
         value: 0
+    LIS2DS12_ITF_LOCK_TMO:
+        description: 'LIS2DS12 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -299,7 +299,7 @@ lis2dw12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DW12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -310,7 +310,6 @@ lis2dw12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -427,7 +426,7 @@ lis2dw12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DW12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -438,8 +437,6 @@ lis2dw12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -459,7 +456,7 @@ lis2dw12_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DW12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -470,8 +467,6 @@ lis2dw12_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -493,7 +488,7 @@ lis2dw12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DW12_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -504,7 +499,6 @@ lis2dw12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -3093,11 +3093,6 @@ lis2dw12_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -44,3 +44,6 @@ syscfg.defs:
     LIS2DW12_NOTIF_STATS:
         description: 'Enable notification stats'
         value: 1
+    LIS2DW12_ITF_LOCK_TMO:
+        description: 'LIS2DW12 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -46,4 +46,4 @@ syscfg.defs:
         value: 1
     LIS2DW12_ITF_LOCK_TMO:
         description: 'LIS2DW12 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -255,7 +255,7 @@ lps33hw_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33HW_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -265,7 +265,7 @@ lps33hw_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     }
 
     sensor_itf_unlock(itf);
-err:
+
     return rc;
 }
 
@@ -386,7 +386,7 @@ lps33hw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33HW_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     if (itf->si_type == SENSOR_ITF_I2C) {
@@ -397,7 +397,6 @@ lps33hw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -902,11 +902,6 @@ lps33hw_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        return rc;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         return rc;

--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -34,4 +34,4 @@ syscfg.defs:
         value: 0
     LPS33HW_ITF_LOCK_TMO:
         description: 'LPS33HW interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -32,3 +32,6 @@ syscfg.defs:
     LPS33HW_CLI:
         description: 'Enable shell support for the LPS33HW'
         value: 0
+    LPS33HW_ITF_LOCK_TMO:
+        description: 'LPS33HW interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -105,6 +105,11 @@ lsm303dlhc_write8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
         .buffer = payload
     };
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LSM303DLHC_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
                               OS_TICKS_PER_SEC / 10, 1);
     if (rc) {
@@ -112,6 +117,8 @@ lsm303dlhc_write8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
                        addr, reg, value);
         STATS_INC(g_lsm303dlhcstats, errors);
     }
+
+    sensor_itf_unlock(itf);
 
     return rc;
 }
@@ -139,6 +146,11 @@ lsm303dlhc_read8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
         .buffer = &payload
     };
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LSM303DLHC_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     /* Register write */
     payload = reg;
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
@@ -160,6 +172,8 @@ lsm303dlhc_read8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     }
 
 err:
+    sensor_itf_unlock(itf);
+
     return rc;
 }
 
@@ -189,6 +203,11 @@ lsm303dlhc_read48(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     /* Clear the supplied buffer */
     memset(buffer, 0, 6);
 
+    rc = sensor_itf_lock(itf, MYNEWT_VAL(LSM303DLHC_ITF_LOCK_TMO));
+    if (rc) {
+        return rc;
+    }
+
     /* Register write */
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
                               OS_TICKS_PER_SEC / 10, 1);
@@ -207,13 +226,14 @@ lsm303dlhc_read48(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     if (rc) {
         LSM303DLHC_ERR("Failed to read from 0x%02X:0x%02X\n", addr, reg);
         STATS_INC(g_lsm303dlhcstats, errors);
-        goto err;
     }
 
     /* Copy the I2C results into the supplied buffer */
     memcpy(buffer, payload, 6);
 
 err:
+    sensor_itf_unlock(itf);
+
     return rc;
 }
 

--- a/hw/drivers/sensors/lsm303dlhc/syscfg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/syscfg.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    LSM303DLHC_ITF_LOCK_TMO:
+        description: 'LSM303DLHC interface lock timeout in milliseconds'
+        value: 1000

--- a/hw/drivers/sensors/mpu6050/src/mpu6050.c
+++ b/hw/drivers/sensors/mpu6050/src/mpu6050.c
@@ -433,11 +433,6 @@ mpu6050_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        return rc;
-    }
-
     return sensor_mgr_register(sensor);
 }
 

--- a/hw/drivers/sensors/mpu6050/syscfg.yml
+++ b/hw/drivers/sensors/mpu6050/syscfg.yml
@@ -18,19 +18,6 @@
 #
 
 syscfg.defs:
-    TCS34725_CLI:
-        description: 'Enable shell support for the TCS34725'
-        value: 0
-    TCS34725_SHELL_ITF_TYPE:
-        description: 'TCS34725 interface type - I2C'
-        value: 1
-    TCS34725_SHELL_ITF_NUM:
-        description: 'TCS34725 interface number'
-        value: 0
-    TCS34725_SHELL_ITF_ADDR:
-        description: 'TCS34725 I2C address'
-        value : 0x29
-    TCS34725_ITF_LOCK_TMO:
-        description: 'TCS34725 interface lock timeout in milliseconds'
+    MPU6050_ITF_LOCK_TMO:
+        description: 'MPU6050 interface lock timeout in milliseconds'
         value: 30
-

--- a/hw/drivers/sensors/mpu6050/syscfg.yml
+++ b/hw/drivers/sensors/mpu6050/syscfg.yml
@@ -20,4 +20,4 @@
 syscfg.defs:
     MPU6050_ITF_LOCK_TMO:
         description: 'MPU6050 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -136,11 +136,6 @@ ms5837_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -335,7 +335,7 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(MS5837_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -344,13 +344,10 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
         MS5837_ERR("I2C write command write failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_ms5837stats, write_errors);
-        goto err;
     }
 
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -382,7 +379,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(MS5837_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Command write */
@@ -404,13 +401,12 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
         goto err;
     }
 
-    sensor_itf_unlock(itf);
-
     /* Copy the I2C results into the supplied buffer */
     memcpy(buffer, payload, len);
 
-    return 0;
 err:
+    sensor_itf_unlock(itf);
+
     return rc;
 }
 

--- a/hw/drivers/sensors/ms5837/syscfg.yml
+++ b/hw/drivers/sensors/ms5837/syscfg.yml
@@ -20,4 +20,4 @@
 syscfg.defs:
     MS5837_ITF_LOCK_TMO:
         description: 'MS5837 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/ms5837/syscfg.yml
+++ b/hw/drivers/sensors/ms5837/syscfg.yml
@@ -18,19 +18,6 @@
 #
 
 syscfg.defs:
-    TCS34725_CLI:
-        description: 'Enable shell support for the TCS34725'
-        value: 0
-    TCS34725_SHELL_ITF_TYPE:
-        description: 'TCS34725 interface type - I2C'
-        value: 1
-    TCS34725_SHELL_ITF_NUM:
-        description: 'TCS34725 interface number'
-        value: 0
-    TCS34725_SHELL_ITF_ADDR:
-        description: 'TCS34725 I2C address'
-        value : 0x29
-    TCS34725_ITF_LOCK_TMO:
-        description: 'TCS34725 interface lock timeout in milliseconds'
+    MS5837_ITF_LOCK_TMO:
+        description: 'MS5837 interface lock timeout in milliseconds'
         value: 30
-

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -336,7 +336,7 @@ ms5840_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(MS5840_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -345,13 +345,10 @@ ms5840_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
         MS5840_ERR("I2C write command write failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_ms5840stats, write_errors);
-        goto err;
     }
 
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -383,7 +380,7 @@ ms5840_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(MS5840_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Command write */

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -139,11 +139,6 @@ ms5840_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/ms5840/syscfg.yml
+++ b/hw/drivers/sensors/ms5840/syscfg.yml
@@ -20,4 +20,4 @@
 syscfg.defs:
     MS5840_ITF_LOCK_TMO:
         description: 'MS5840 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/drivers/sensors/ms5840/syscfg.yml
+++ b/hw/drivers/sensors/ms5840/syscfg.yml
@@ -18,19 +18,6 @@
 #
 
 syscfg.defs:
-    TCS34725_CLI:
-        description: 'Enable shell support for the TCS34725'
-        value: 0
-    TCS34725_SHELL_ITF_TYPE:
-        description: 'TCS34725 interface type - I2C'
-        value: 1
-    TCS34725_SHELL_ITF_NUM:
-        description: 'TCS34725 interface number'
-        value: 0
-    TCS34725_SHELL_ITF_ADDR:
-        description: 'TCS34725 I2C address'
-        value : 0x29
-    TCS34725_ITF_LOCK_TMO:
-        description: 'TCS34725 interface lock timeout in milliseconds'
+    MS5840_ITF_LOCK_TMO:
+        description: 'MS5840 interface lock timeout in milliseconds'
         value: 30
-

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -97,7 +97,7 @@ tcs34725_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TCS34725_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
@@ -110,7 +110,6 @@ tcs34725_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -137,7 +136,7 @@ tcs34725_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TCS34725_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -158,9 +157,9 @@ tcs34725_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
         STATS_INC(g_tcs34725stats, errors);
     }
 
+err:
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -190,7 +189,7 @@ tcs34725_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t l
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TCS34725_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -217,10 +216,9 @@ tcs34725_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t l
     /* Copy the I2C results into the supplied buffer */
     memcpy(buffer, payload, len);
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -254,7 +252,7 @@ tcs34725_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t 
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TCS34725_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -277,10 +275,9 @@ tcs34725_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t 
         goto err;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -396,11 +396,6 @@ tcs34725_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc != 0) {
         goto err;

--- a/hw/drivers/sensors/tcs34725/syscfg.yml
+++ b/hw/drivers/sensors/tcs34725/syscfg.yml
@@ -32,5 +32,5 @@ syscfg.defs:
         value : 0x29
     TCS34725_ITF_LOCK_TMO:
         description: 'TCS34725 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000
 

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -625,11 +625,6 @@ tsl2561_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
-    rc = sensor_itf_lock_init(arg);
-    if (rc) {
-        goto err;
-    }
-
     rc = sensor_mgr_register(sensor);
     if (rc) {
         goto err;

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -94,7 +94,7 @@ tsl2561_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TSL2561_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
@@ -107,7 +107,6 @@ tsl2561_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -125,7 +124,7 @@ tsl2561_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TSL2561_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     rc = hal_i2c_master_write(itf->si_num, &data_struct,
@@ -137,7 +136,6 @@ tsl2561_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
 
     sensor_itf_unlock(itf);
 
-err:
     return rc;
 }
 
@@ -155,7 +153,7 @@ tsl2561_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TSL2561_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -176,10 +174,9 @@ tsl2561_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
         TSL2561_ERR("Failed to read @0x%02X\n", reg);
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 
@@ -197,7 +194,7 @@ tsl2561_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
 
     rc = sensor_itf_lock(itf, MYNEWT_VAL(TSL2561_ITF_LOCK_TMO));
     if (rc) {
-        goto err;
+        return rc;
     }
 
     /* Register write */
@@ -219,10 +216,9 @@ tsl2561_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
         goto err;
     }
 
+err:
     sensor_itf_unlock(itf);
 
-    return 0;
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/tsl2561/syscfg.yml
+++ b/hw/drivers/sensors/tsl2561/syscfg.yml
@@ -33,3 +33,6 @@ syscfg.defs:
     TSL2561_SHELL_ITF_ADDR:
         description: 'TSL2561 I2C Addresss'
         value: 0x39
+    TSL2561_ITF_LOCK_TMO:
+        description: 'TSL2561 interface lock timeout in milliseconds'
+        value: 30

--- a/hw/drivers/sensors/tsl2561/syscfg.yml
+++ b/hw/drivers/sensors/tsl2561/syscfg.yml
@@ -35,4 +35,4 @@ syscfg.defs:
         value: 0x39
     TSL2561_ITF_LOCK_TMO:
         description: 'TSL2561 interface lock timeout in milliseconds'
-        value: 30
+        value: 1000

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -234,7 +234,7 @@ static struct sensor_itf i2c_0_itf_tcs = {
 #endif
 
 #if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(MS5837_OFB)
-static struct sensor_itf i2c_0_itf_ms = {
+static struct sensor_itf i2c_0_itf_ms37 = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
     /* HW I2C address for the MS5837 */
@@ -243,7 +243,7 @@ static struct sensor_itf i2c_0_itf_ms = {
 #endif
 
 #if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(MS5840_OFB)
-static struct sensor_itf i2c_0_itf_ms = {
+static struct sensor_itf i2c_0_itf_ms40 = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
     /* HW I2C address for the MS5840 */
@@ -1059,7 +1059,7 @@ sensor_dev_create(void)
 
 #if MYNEWT_VAL(MS5837_OFB)
     rc = os_dev_create((struct os_dev *) &ms5837, "ms5837_0",
-      OS_DEV_INIT_PRIMARY, 0, ms5837_init, (void *)&i2c_0_itf_ms);
+      OS_DEV_INIT_PRIMARY, 0, ms5837_init, (void *)&i2c_0_itf_ms37);
     assert(rc == 0);
 
     rc = config_ms5837_sensor();
@@ -1068,7 +1068,7 @@ sensor_dev_create(void)
 
 #if MYNEWT_VAL(MS5840_OFB)
     rc = os_dev_create((struct os_dev *) &ms5840, "ms5840_0",
-      OS_DEV_INIT_PRIMARY, 0, ms5840_init, (void *)&i2c_0_itf_ms);
+      OS_DEV_INIT_PRIMARY, 0, ms5840_init, (void *)&i2c_0_itf_ms40);
     assert(rc == 0);
 
     rc = config_ms5840_sensor();

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -501,6 +501,9 @@ struct sensor_itf {
     /* Sensor interface high int pin */
     uint8_t si_high_pin;
 
+    /* Mutex for interface access */
+    struct os_mutex si_lock;
+
     /* Sensor interface interrupts pins */
     /* XXX We should probably remove low/high pins and replace it with those
      */
@@ -587,6 +590,37 @@ struct sensor {
     /* The next sensor in the global sensor list. */
     SLIST_ENTRY(sensor) s_next;
 };
+
+/**
+ * Initializes a sensor_itf lock
+ *
+ * @param si The sensor_itf to initialize lock for
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int
+sensor_itf_lock_init(struct sensor_itf *si);
+
+/**
+ * Lock access to the sensor_itf specified by si.  Blocks until lock acquired.
+ *
+ * @param si The sensor_itf to lock
+ * @param timeout The timeout
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int
+sensor_itf_lock(struct sensor_itf *si, os_time_t timeout);
+
+/**
+ * Unlock access to the sensor_itf specified by si.
+ *
+ * @param si The sensor_itf to unlock access to
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+void
+sensor_itf_unlock(struct sensor_itf *si);
 
 /**
  * Initialize a sensor

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -502,7 +502,7 @@ struct sensor_itf {
     uint8_t si_high_pin;
 
     /* Mutex for interface access */
-    struct os_mutex si_lock;
+    struct os_mutex *si_lock;
 
     /* Sensor interface interrupts pins */
     /* XXX We should probably remove low/high pins and replace it with those
@@ -592,16 +592,6 @@ struct sensor {
 };
 
 /**
- * Initializes a sensor_itf lock
- *
- * @param si The sensor_itf to initialize lock for
- *
- * @return 0 on success, non-zero error code on failure.
- */
-int
-sensor_itf_lock_init(struct sensor_itf *si);
-
-/**
  * Lock access to the sensor_itf specified by si.  Blocks until lock acquired.
  *
  * @param si The sensor_itf to lock
@@ -626,7 +616,7 @@ sensor_itf_unlock(struct sensor_itf *si);
  * Initialize a sensor
  *
  * @param sensor The sensor to initialize
- * @param The device to associate with this sensor.
+ * @param dev The device to associate with this sensor.
  *
  * @return 0 on success, non-zero error code on failure.
  */
@@ -644,7 +634,7 @@ int sensor_lock(struct sensor *sensor);
 /**
  * Unlock access to the sensor specified by sensor.
  *
- * @param The sensor to unlock access to.
+ * @param sensor The sensor to unlock access to.
  */
 void sensor_unlock(struct sensor *sensor);
 

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -853,22 +853,7 @@ sensor_pkg_init(void)
 }
 
 /**
- * Initializes a sensor_itf lock
- *
- * @param The sensor_itf to initialize lock for
- *
- * @return 0 on success, non-zero error code on failure.
- */
-int
-sensor_itf_lock_init(struct sensor_itf *si)
-{
-    return os_mutex_init(&si->si_lock);
-
-}
-
-
-/**
- * Lock access to the sensor_itf specified by si.  Blocks until lock acquired.
+ * Lock access to the sensor_itf specified by si. Blocks until lock acquired.
  *
  * @param The sensor_itf to lock
  * @param The timeout
@@ -883,7 +868,7 @@ sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
 
     os_time_ms_to_ticks(timeout, &ticks);
 
-    rc = os_mutex_pend(&si->si_lock, ticks);
+    rc = os_mutex_pend(si->si_lock, ticks);
     if (rc == 0 || rc == OS_NOT_STARTED) {
         return (0);
     }
@@ -901,7 +886,7 @@ sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
 void
 sensor_itf_unlock(struct sensor_itf *si)
 {
-    os_mutex_release(&si->si_lock);
+    os_mutex_release(si->si_lock);
 }
 
 

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -866,7 +866,10 @@ sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
-    os_time_ms_to_ticks(timeout, &ticks);
+    rc = os_time_ms_to_ticks(timeout, &ticks);
+    if (rc) {
+        return rc;
+    }
 
     rc = os_mutex_pend(si->si_lock, ticks);
     if (rc == 0 || rc == OS_NOT_STARTED) {

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -866,6 +866,10 @@ sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
+    if (!si->si_lock) {
+        return 0;
+    }
+
     rc = os_time_ms_to_ticks(timeout, &ticks);
     if (rc) {
         return rc;
@@ -889,6 +893,10 @@ sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
 void
 sensor_itf_unlock(struct sensor_itf *si)
 {
+    if (!si->si_lock) {
+        return;
+    }
+
     os_mutex_release(si->si_lock);
 }
 

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -852,6 +852,58 @@ sensor_pkg_init(void)
 #endif
 }
 
+/**
+ * Initializes a sensor_itf lock
+ *
+ * @param The sensor_itf to initialize lock for
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+int
+sensor_itf_lock_init(struct sensor_itf *si)
+{
+    return os_mutex_init(&si->si_lock);
+
+}
+
+
+/**
+ * Lock access to the sensor_itf specified by si.  Blocks until lock acquired.
+ *
+ * @param The sensor_itf to lock
+ * @param The timeout
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int
+sensor_itf_lock(struct sensor_itf *si, uint32_t timeout)
+{
+    int rc;
+    os_time_t ticks;
+
+    os_time_ms_to_ticks(timeout, &ticks);
+
+    rc = os_mutex_pend(&si->si_lock, ticks);
+    if (rc == 0 || rc == OS_NOT_STARTED) {
+        return (0);
+    }
+
+    return (rc);
+}
+
+/**
+ * Unlock access to the sensor_itf specified by si.
+ *
+ * @param The sensor_itf to unlock access to
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+void
+sensor_itf_unlock(struct sensor_itf *si)
+{
+    os_mutex_release(&si->si_lock);
+}
+
 
 /**
  * Lock access to the sensor specified by sensor.  Blocks until lock acquired.
@@ -882,7 +934,6 @@ sensor_unlock(struct sensor *sensor)
 {
     os_mutex_release(&sensor->s_lock);
 }
-
 
 /**
  * Initialize a sensor


### PR DESCRIPTION
Introducing an interface lock for the `sensor_itf` and `led_itf` or interface structures for any drivers. If a BSP shares an interface particularly I2C, it can initialize a mutex set it in the interface.