### PR TITLE
Added stubs for I2C simulation

### DIFF
--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -29,6 +29,7 @@
 #include "uart_hal/uart_hal.h"
 #include "mcu/native_bsp.h"
 #include "mcu/mcu_hal.h"
+#include "hal/hal_i2c.h"
 
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
 #include "sim/sim_accel.h"
@@ -77,6 +78,11 @@ hal_bsp_init(void)
             OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *) NULL);
     assert(rc == 0);
 
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, NULL);
+    assert(rc == 0);
+#endif
+    
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
     rc = os_dev_create((struct os_dev *) &os_bsp_accel0, "simaccel0",
             OS_DEV_INIT_PRIMARY, 0, simaccel_init, (void *) NULL);

--- a/hw/hal/include/hal/hal_i2c_sim.h
+++ b/hw/hal/include/hal/hal_i2c_sim.h
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * @addtogroup HAL
+ * @{
+ *   @defgroup HALI2cSim HAL I2c sim
+ *   @{
+ */
+
+#ifndef H_HAL_I2C_SIM_
+#define H_HAL_I2C_SIM_
+
+#include <inttypes.h>
+#include <hal/hal_i2c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Sends a start condition and writes <len> bytes of data on the i2c bus.
+ * This API does NOT issue a stop condition unless `last_op` is set to `1`.
+ * You must stop the bus after successful or unsuccessful write attempts.
+ * This API is blocking until an error or NaK occurs. Timeout is platform
+ * dependent.
+ *
+ * @param i2c_num The number of the I2C device being written to
+ * @param pdata The data to write to the I2C bus
+ * @param timeout How long to wait for transaction to complete in ticks
+ * @param last_op Master should send a STOP at the end to signify end of
+ *        transaction.
+ *
+ * @return 0 on success, and non-zero error code on failure
+ */
+typedef int (*hal_i2c_sim_master_write_t)(uint8_t i2c_num,
+             struct hal_i2c_master_data *pdata, uint32_t timeout,
+             uint8_t last_op);
+
+/**
+* Sends a start condition and reads <len> bytes of data on the i2c bus.
+* This API does NOT issue a stop condition unless `last_op` is set to `1`.
+* You must stop the bus after successful or unsuccessful write attempts.
+* This API is blocking until an error or NaK occurs. Timeout is platform
+* dependent.
+*
+* @param i2c_num The number of the I2C device being written to
+* @param pdata The location to place read data
+* @param timeout How long to wait for transaction to complete in ticks
+* @param last_op Master should send a STOP at the end to signify end of
+*        transaction.
+*
+* @return 0 on success, and non-zero error code on failure
+*/
+typedef int (*hal_i2c_sim_master_read_t)(uint8_t i2c_num,
+             struct hal_i2c_master_data *pdata,
+             uint32_t timeout, uint8_t last_op);
+
+struct hal_i2c_sim_driver {
+    hal_i2c_sim_master_write_t sd_write;
+    hal_i2c_sim_master_read_t sd_read;
+
+    /* 7-bit I2C device address */
+    uint8_t addr;
+
+    /* Reserved for future use */
+    uint8_t rsvd[3];
+
+    /* The next simulated sensor in the global sim driver list. */
+    SLIST_ENTRY(hal_i2c_sim_driver) s_next;
+};
+
+/**
+* Register a driver simulator
+*
+* @param drv The simulated driver to register
+*
+* @return 0 on success, non-zero on failure.
+*/
+int hal_i2c_sim_register(struct hal_i2c_sim_driver *drv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_HAL_I2C_SIM_ */
+
+/**
+ *   @} HALI2cSim
+ * @} HAL
+ */

--- a/hw/mcu/native/include/mcu/mcu_sim_i2c.h
+++ b/hw/mcu/native/include/mcu/mcu_sim_i2c.h
@@ -18,15 +18,8 @@
  */
 
 
-/**
- * @addtogroup HAL
- * @{
- *   @defgroup HALI2cSim HAL I2c sim
- *   @{
- */
-
-#ifndef H_HAL_I2C_SIM_
-#define H_HAL_I2C_SIM_
+#ifndef H_MCU_SIM_I2C_
+#define H_MCU_SIM_I2C_
 
 #include <inttypes.h>
 #include <hal/hal_i2c.h>
@@ -100,9 +93,4 @@ int hal_i2c_sim_register(struct hal_i2c_sim_driver *drv);
 }
 #endif
 
-#endif /* H_HAL_I2C_SIM_ */
-
-/**
- *   @} HALI2cSim
- * @} HAL
- */
+#endif /* H_MCU_SIM_I2C_ */

--- a/hw/mcu/native/src/hal_i2c.c
+++ b/hw/mcu/native/src/hal_i2c.c
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <hal/hal_i2c.h>
+
+int
+hal_i2c_init(uint8_t i2c_num, void *cfg)
+{
+    return 0;
+}
+
+int
+hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                     uint32_t timeout, uint8_t last_op)
+{
+    return 0;
+}
+
+int
+hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                    uint32_t timeout, uint8_t last_op)
+{
+    return 0;
+}
+
+int
+hal_i2c_master_probe(uint8_t i2c_num, uint8_t address,
+                     uint32_t timeout)
+{
+    /* printf("I2C_%d probe at 0x%02X\n", i2c_num, address); */
+    /* fflush(stdout); */
+
+    return -1;
+}

--- a/hw/mcu/native/src/hal_i2c.c
+++ b/hw/mcu/native/src/hal_i2c.c
@@ -18,11 +18,20 @@
  */
 
 #include <stdio.h>
-#include <hal/hal_i2c.h>
+#include "os/mynewt.h"
+#include "hal/hal_i2c.h"
+#include "hal/hal_i2c_sim.h"
+
+struct {
+    struct os_mutex mgr_lock;
+    SLIST_HEAD(, hal_i2c_sim_driver) mgr_sim_list;
+} hal_i2c_sim_mgr;
 
 int
 hal_i2c_init(uint8_t i2c_num, void *cfg)
 {
+    os_mutex_init(&hal_i2c_sim_mgr.mgr_lock);
+
     return 0;
 }
 
@@ -30,15 +39,16 @@ int
 hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                      uint32_t timeout, uint8_t last_op)
 {
-    uint16_t i;
+    struct hal_i2c_sim_driver *cursor;
 
-    printf("hal_i2c wrote %d byte(s) on device 0x%02X (I2C_%d):",
-           pdata->len, pdata->address, i2c_num);
-    for (i=0; i<pdata->len; i++) {
-        printf(" %02X", pdata->buffer[i]);
+    cursor = NULL;
+    SLIST_FOREACH(cursor, &hal_i2c_sim_mgr.mgr_sim_list, s_next) {
+        if (cursor->addr == pdata->address) {
+            /* Forward the read request to the sim driver */
+            return cursor->sd_write(i2c_num, pdata, timeout, last_op);
+        }
     }
-    printf("\n");
-    fflush(stdout);
+
     return 0;
 }
 
@@ -46,15 +56,15 @@ int
 hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                     uint32_t timeout, uint8_t last_op)
 {
-    uint16_t i;
+    struct hal_i2c_sim_driver *cursor;
 
-    printf("hal_i2c read  %d byte(s) on device 0x%02X (I2C_%d):",
-           pdata->len, pdata->address, i2c_num);
-    for (i=0; i<pdata->len; i++) {
-        printf(" %02X", pdata->buffer[i]);
+    cursor = NULL;
+    SLIST_FOREACH(cursor, &hal_i2c_sim_mgr.mgr_sim_list, s_next) {
+        if (cursor->addr == pdata->address) {
+            /* Forward the read request to the sim driver */
+            return cursor->sd_read(i2c_num, pdata, timeout, last_op);
+        }
     }
-    printf("\n");
-    fflush(stdout);
 
     return 0;
 }
@@ -63,13 +73,79 @@ int
 hal_i2c_master_probe(uint8_t i2c_num, uint8_t address,
                      uint32_t timeout)
 {
-    int val;
+    struct hal_i2c_sim_driver *cursor;
 
-    /* ToDo: return '0' on any I2C address(es) you wish to match */
-    switch (address) {
-        default:
-          val = -1;
+    cursor = NULL;
+    SLIST_FOREACH(cursor, &hal_i2c_sim_mgr.mgr_sim_list, s_next) {
+        if (cursor->addr == address) {
+            return 0;
+        }
     }
 
-    return val;
+    return -1;
+}
+
+/**
+ * Lock sim manager to access the list of simulated drivers
+ */
+int
+hal_i2c_sim_mgr_lock(void)
+{
+    int rc;
+
+    rc = os_mutex_pend(&hal_i2c_sim_mgr.mgr_lock, OS_TIMEOUT_NEVER);
+    if (rc == 0 || rc == OS_NOT_STARTED) {
+        return (0);
+    }
+    return (rc);
+}
+
+/**
+ * Unlock sim manager once the list of simulated drivers has been accessed
+ */
+void
+hal_i2c_sim_mgr_unlock(void)
+{
+    (void) os_mutex_release(&hal_i2c_sim_mgr.mgr_lock);
+}
+
+/**
+ * Insert a simulated driver into the list
+ */
+static void
+hal_i2c_sim_mgr_insert(struct hal_i2c_sim_driver *driver)
+{
+    struct hal_i2c_sim_driver *cursor, *prev;
+
+    prev = cursor = NULL;
+    SLIST_FOREACH(cursor, &hal_i2c_sim_mgr.mgr_sim_list, s_next) {
+        prev = cursor;
+    }
+
+    if (prev == NULL) {
+        SLIST_INSERT_HEAD(&hal_i2c_sim_mgr.mgr_sim_list, driver, s_next);
+    } else {
+        SLIST_INSERT_AFTER(prev, driver, s_next);
+    }
+}
+
+int
+hal_i2c_sim_register(struct hal_i2c_sim_driver *drv)
+{
+    int rc;
+
+    rc = hal_i2c_sim_mgr_lock();
+    if (rc != 0) {
+        goto err;
+    }
+
+    printf("Registering I2C sim driver for 0x%02X\n", drv->addr);
+    fflush(stdout);
+    hal_i2c_sim_mgr_insert(drv);
+
+    hal_i2c_sim_mgr_unlock();
+
+    return (0);
+err:
+    return (rc);
 }

--- a/hw/mcu/native/src/hal_i2c.c
+++ b/hw/mcu/native/src/hal_i2c.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include "os/mynewt.h"
 #include "hal/hal_i2c.h"
-#include "hal/hal_i2c_sim.h"
+#include "mcu/mcu_sim_i2c.h"
 
 struct {
     struct os_mutex mgr_lock;
@@ -115,18 +115,7 @@ hal_i2c_sim_mgr_unlock(void)
 static void
 hal_i2c_sim_mgr_insert(struct hal_i2c_sim_driver *driver)
 {
-    struct hal_i2c_sim_driver *cursor, *prev;
-
-    prev = cursor = NULL;
-    SLIST_FOREACH(cursor, &hal_i2c_sim_mgr.mgr_sim_list, s_next) {
-        prev = cursor;
-    }
-
-    if (prev == NULL) {
-        SLIST_INSERT_HEAD(&hal_i2c_sim_mgr.mgr_sim_list, driver, s_next);
-    } else {
-        SLIST_INSERT_AFTER(prev, driver, s_next);
-    }
+    SLIST_INSERT_HEAD(&hal_i2c_sim_mgr.mgr_sim_list, driver, s_next);
 }
 
 int

--- a/hw/mcu/native/src/hal_i2c.c
+++ b/hw/mcu/native/src/hal_i2c.c
@@ -30,6 +30,15 @@ int
 hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                      uint32_t timeout, uint8_t last_op)
 {
+    uint16_t i;
+
+    printf("hal_i2c wrote %d byte(s) on device 0x%02X (I2C_%d):",
+           pdata->len, pdata->address, i2c_num);
+    for (i=0; i<pdata->len; i++) {
+        printf(" %02X", pdata->buffer[i]);
+    }
+    printf("\n");
+    fflush(stdout);
     return 0;
 }
 
@@ -37,6 +46,16 @@ int
 hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                     uint32_t timeout, uint8_t last_op)
 {
+    uint16_t i;
+
+    printf("hal_i2c read  %d byte(s) on device 0x%02X (I2C_%d):",
+           pdata->len, pdata->address, i2c_num);
+    for (i=0; i<pdata->len; i++) {
+        printf(" %02X", pdata->buffer[i]);
+    }
+    printf("\n");
+    fflush(stdout);
+
     return 0;
 }
 
@@ -44,8 +63,13 @@ int
 hal_i2c_master_probe(uint8_t i2c_num, uint8_t address,
                      uint32_t timeout)
 {
-    /* printf("I2C_%d probe at 0x%02X\n", i2c_num, address); */
-    /* fflush(stdout); */
+    int val;
 
-    return -1;
+    /* ToDo: return '0' on any I2C address(es) you wish to match */
+    switch (address) {
+        default:
+          val = -1;
+    }
+
+    return val;
 }

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -19,6 +19,10 @@
 # Package: hw/bsp/nrf52dk
 
 syscfg.defs:
+    I2C_0:
+        description: 'I2C interface 0'
+        value:  0
+
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.

--- a/test/i2c_scan/src/i2c_scan.c
+++ b/test/i2c_scan/src/i2c_scan.c
@@ -60,11 +60,7 @@ i2c_scan_cli_cmd(int argc, char **argv)
 
     /* Scan all valid I2C addresses (0x08..0x77) */
     for (addr = 0x08; addr < 0x78; addr++) {
-#ifndef ARCH_sim
         rc = hal_i2c_master_probe(i2cnum, addr, timeout);
-#else
-        (void)timeout;
-#endif
         /* Print addr header every 16 bytes */
         if (!(addr % 16)) {
             console_printf("\n%02x: ", addr);


### PR DESCRIPTION
This PR adds a **hal_i2c.c** file with stubs to the native MCU target to simulate I2C access. This can then be extended to simulate a specific device by listening for a dedicated I2C address, etc.

A minor change was also made to **test/i2c_scan/src/i2c_scan.c** since the simulator check is no longer required with the changes in this PR.

**NOTE**: Only `I2C_0` is implemented at present.