### PR TITLE
hw/mcu/nordic: Disconnect input buffer when gpio made an output.

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
@@ -97,7 +97,8 @@ hal_gpio_init_out(int pin, int val)
     } else {
         NRF_GPIO->OUTCLR = HAL_GPIO_MASK(pin);
     }
-    NRF_GPIO->PIN_CNF[pin] = GPIO_PIN_CNF_DIR_Output;
+    NRF_GPIO->PIN_CNF[pin] = GPIO_PIN_CNF_DIR_Output |
+        (GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
     NRF_GPIO->DIRSET = HAL_GPIO_MASK(pin);
     return 0;
 }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -132,7 +132,8 @@ hal_gpio_init_out(int pin, int val)
     } else {
         port->OUTCLR = HAL_GPIO_MASK(pin);
     }
-    port->PIN_CNF[pin_index] = GPIO_PIN_CNF_DIR_Output;
+    port->PIN_CNF[pin_index] = GPIO_PIN_CNF_DIR_Output |
+        (GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
     port->DIRSET = HAL_GPIO_MASK(pin);
 
     return 0;


### PR DESCRIPTION
This change disconnects the input buffer on a gpio when the gpio
is configured to be an output. This should save current.