### PR TITLE
hw/drivers/spiflash: Fix write over page boundary

### DIFF
--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -265,7 +265,7 @@ spiflash_write(const struct hal_flash *hal_flash_dev, uint32_t addr,
 
         spiflash_cs_activate(dev);
         hal_spi_txrx(dev->spi_num, cmd, NULL, sizeof cmd);
-        hal_spi_txrx(dev->spi_num, (void *)buf, NULL, to_write);
+        hal_spi_txrx(dev->spi_num, (void *)u8buf, NULL, to_write);
         spiflash_cs_deactivate(dev);
 
         addr += to_write;


### PR DESCRIPTION
A typo... we were using invalid buffer pointer so each write operation
would write from the beginning of input buffer.