### PR TITLE
Add State of health for battery interface and fuel gauge driver

### DIFF
--- a/hw/battery/include/battery/battery_prop.h
+++ b/hw/battery/include/battery/battery_prop.h
@@ -95,6 +95,8 @@ typedef union battery_property_value {
     uint32_t bpv_capacity;
     /* SOC in % 0..100 */
     uint8_t bpv_soc;
+    /* SOH in % 0..100 */
+    uint8_t bpv_soh;
     /* Temperature in deg C */
     float bpv_temperature;
     /* Time in s */
@@ -144,6 +146,8 @@ typedef enum {
     BATTERY_PROP_CURRENT_AVG,
     /* State-Of-Charge, current capacity 0-100 % */
     BATTERY_PROP_SOC,
+    /* State-Of-Health, current battery state of health 0-100 % */
+    BATTERY_PROP_SOH,
     /* Predicted time to complete discharge in seconds */
     BATTERY_PROP_TIME_TO_EMPTY_NOW,
     /* Predicted time to full capacity when charging in seconds */

--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -161,7 +161,8 @@ static void print_property(const struct battery_property *prop)
         console_printf(" %s %ld s\n", name, prop->bp_value.bpv_time_in_s);
         break;
     case BATTERY_PROP_SOC:
-        console_printf(" %s %d %%\n", name, prop->bp_value.bpv_soc);
+    case BATTERY_PROP_SOH:
+        console_printf(" %s %d %%\n", name, prop->bp_value.bpv_u8);
         break;
     case BATTERY_PROP_STATUS:
         console_printf(" %s %s\n", name,

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -94,7 +94,7 @@ bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
     int rc;
     os_time_t ticks;
 
-    if (!bi->bi_lock) {
+    if (!bi->itf_lock) {
         return 0;
     }
 
@@ -121,7 +121,7 @@ bq27z561_itf_lock(struct bq27z561_itf *bi, uint32_t timeout)
 static void
 bq27z561_itf_unlock(struct bq27z561_itf *bi)
 {
-    if (!bi->bi_lock) {
+    if (!bi->itf_lock) {
         return;
     }
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -973,6 +973,11 @@ bq27z561_battery_property_get(struct battery_driver *driver,
         rc = bq27z561_get_relative_state_of_charge(
                 (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u8);
         property->bp_value.bpv_soc = val.bpv_u8;
+    } else if (property->bp_type == BATTERY_PROP_SOH &&
+               property->bp_flags == 0) {
+        rc = bq27z561_get_state_of_health(
+                (struct bq27z561 *) driver->bd_driver_data, &val.bpv_u8);
+        property->bp_value.bpv_soh = val.bpv_u8;
     } else if (property->bp_type == BATTERY_PROP_CYCLE_COUNT &&
                property->bp_flags == 0) {
         rc = bq27z561_get_discharge_cycles(
@@ -1106,6 +1111,7 @@ static const struct battery_driver_property bq27z561_battery_properties[] = {
     { BATTERY_PROP_VOLTAGE_NOW, 0, "Voltage" },
     { BATTERY_PROP_CURRENT_NOW, 0, "Current" },
     { BATTERY_PROP_SOC, 0, "SOC" },
+    { BATTERY_PROP_SOH, 0, "SOH" },
     { BATTERY_PROP_TIME_TO_EMPTY_NOW, 0, "TimeToEmpty" },
     { BATTERY_PROP_TIME_TO_FULL_NOW, 0, "TimeToFull" },
     { BATTERY_PROP_CYCLE_COUNT, 0, "CycleCount" },


### PR DESCRIPTION
* Battery state of health added to battery properties.

* Fuel gauge driver exposes this property.

* Battery shell can show SOH