### PR TITLE
rtt: Mark old RTT settings as deprecated

### DIFF
--- a/hw/drivers/rtt/syscfg.yml
+++ b/hw/drivers/rtt/syscfg.yml
@@ -52,8 +52,10 @@ syscfg.defs:
 # Values below are deprecated and only used for backwards compatibility.
 # Please use new values instead.
     RTT_BUFFER_SIZE_UP:
-        description: 'Size of the output buffer'
+        description: 'Use RTT_TERMINAL_BUFFER_SIZE_UP instead'
+        deprecated: 1
         value: 1024
     RTT_BUFFER_SIZE_DOWN:
-        description: 'Size of the input buffer'
+        description: 'Use RTT_TERMINAL_BUFFER_SIZE_DOWN instead'
+        deprecated: 1
         value: 16


### PR DESCRIPTION
New "newt" can emit a warning when deprecated settings are overridden.