### PR TITLE
battery/adc: Add activation pin support

### DIFF
--- a/hw/battery/include/battery/battery_adc.h
+++ b/hw/battery/include/battery/battery_adc.h
@@ -45,6 +45,12 @@ struct battery_adc_cfg
     int mul;
     /* divider for ADC reading */
     int div;
+    /* GPIO pin to activate for measurement */
+    int activation_pin;
+    /* GPIO activation needed for measurement */
+    uint8_t activation_pin_needed:1;
+    /* GPIO value needed for measurement */
+    uint8_t activation_pin_level:1;
 };
 
 /* battery_adc device */


### PR DESCRIPTION
Battery voltage reading often uses resistor divider that is
actiaved with GPIO pin for energy saving (divider is not powered
when not needed).
This change allows to specify GPIO pin that must be activated
before ADC can be used.
GPIO level also can be specified allowing divider activation with 0 and 1.