### PR TITLE
nrf51 bsps: deprecate old i2c flag names

### DIFF
--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -66,6 +66,9 @@ syscfg.defs:
     I2C_0_FREQ_KHZ:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
+    I2C_0_FREQ:
+        description: 'Use I2C_0_FREQ_KHZ instead'
+        deprecated: 1
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -49,6 +49,15 @@ syscfg.defs:
     I2C_0_FREQ_KHZ:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
+    I2C_0_FREQUENCY:
+        description: 'Use I2C_0_FREQ_KHZ instead'
+        deprecated: 1
+    I2C_0_SDA_PIN:
+        description: 'Use I2C_0_PIN_SDA instead'
+        deprecated: 1
+    I2C_0_SCL_PIN:
+        description: 'Use I2C_0_PIN_SCL instead'
+        deprecated: 1
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'
@@ -59,6 +68,16 @@ syscfg.defs:
     I2C_1_FREQ_KHZ:
         description: 'Frequency in khz for I2C_1 bus'
         value:  100
+    I2C_1_FREQUENCY:
+        description: 'Use I2C_1_FREQ_KHZ instead'
+        deprecated: 1
+    I2C_1_SDA_PIN:
+        description: 'Use I2C_1_PIN_SDA instead'
+        deprecated: 1
+    I2C_1_SCL_PIN:
+        description: 'Use I2C_1_PIN_SCL instead'
+        deprecated: 1
+
 
     TIMER_0:
         description: 'NRF51 Timer 0'

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -72,6 +72,15 @@ syscfg.defs:
     I2C_0_FREQ_KHZ:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
+    I2C_0_FREQUENCY:
+        description: 'Use I2C_0_FREQ_KHZ instead'
+        deprecated: 1
+    I2C_0_SDA_PIN:
+        description: 'Use I2C_0_PIN_SDA instead'
+        deprecated: 1
+    I2C_0_SCL_PIN:
+        description: 'Use I2C_0_PIN_SCL instead'
+        deprecated: 1
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -72,6 +72,15 @@ syscfg.defs:
     I2C_0_FREQ_KHZ:
         description: 'Frequency in khz for I2C_0 bus'
         value:  100
+    I2C_0_FREQUENCY:
+        description: 'Use I2C_0_FREQ_KHZ instead'
+        deprecated: 1
+    I2C_0_SDA_PIN:
+        description: 'Use I2C_0_PIN_SDA instead'
+        deprecated: 1
+    I2C_0_SCL_PIN:
+        description: 'Use I2C_0_PIN_SCL instead'
+        deprecated: 1
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'


### PR DESCRIPTION
Attempt to at least give some warnings about these recent my i2c changes in 
https://github.com/apache/mynewt-core/pull/1247