### PR TITLE
nrf51 bsps: defunct old i2c flags

### DIFF
--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -68,7 +68,8 @@ syscfg.defs:
         value:  100
     I2C_0_FREQ:
         description: 'Use I2C_0_FREQ_KHZ instead'
-        deprecated: 1
+        defunct: 1
+        value:  100
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -51,13 +51,16 @@ syscfg.defs:
         value:  100
     I2C_0_FREQUENCY:
         description: 'Use I2C_0_FREQ_KHZ instead'
-        deprecated: 1
+        defunct: 1
+        value:  100
     I2C_0_SDA_PIN:
         description: 'Use I2C_0_PIN_SDA instead'
-        deprecated: 1
+        defunct: 1
+        value:  6
     I2C_0_SCL_PIN:
         description: 'Use I2C_0_PIN_SCL instead'
-        deprecated: 1
+        defunct: 1
+        value:  7
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'
@@ -70,13 +73,16 @@ syscfg.defs:
         value:  100
     I2C_1_FREQUENCY:
         description: 'Use I2C_1_FREQ_KHZ instead'
-        deprecated: 1
+        defunct: 1
+        value:  100
     I2C_1_SDA_PIN:
         description: 'Use I2C_1_PIN_SDA instead'
-        deprecated: 1
+        defunct: 1
+        value:  28
     I2C_1_SCL_PIN:
         description: 'Use I2C_1_PIN_SCL instead'
-        deprecated: 1
+        defunct: 1
+        value:  29
 
 
     TIMER_0:

--- a/hw/bsp/nrf51dk-16kbram/syscfg.yml
+++ b/hw/bsp/nrf51dk-16kbram/syscfg.yml
@@ -74,13 +74,16 @@ syscfg.defs:
         value:  100
     I2C_0_FREQUENCY:
         description: 'Use I2C_0_FREQ_KHZ instead'
-        deprecated: 1
+        defunct: 1
+        value:  100
     I2C_0_SDA_PIN:
         description: 'Use I2C_0_PIN_SDA instead'
-        deprecated: 1
+        defunct: 1
+        value:  30
     I2C_0_SCL_PIN:
         description: 'Use I2C_0_PIN_SCL instead'
-        deprecated: 1
+        defunct: 1
+        value:  7
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'

--- a/hw/bsp/nrf51dk/syscfg.yml
+++ b/hw/bsp/nrf51dk/syscfg.yml
@@ -74,13 +74,16 @@ syscfg.defs:
         value:  100
     I2C_0_FREQUENCY:
         description: 'Use I2C_0_FREQ_KHZ instead'
-        deprecated: 1
+        defunct: 1
+        value:  100
     I2C_0_SDA_PIN:
         description: 'Use I2C_0_PIN_SDA instead'
-        deprecated: 1
+        defunct: 1
+        value:  30
     I2C_0_SCL_PIN:
         description: 'Use I2C_0_PIN_SCL instead'
-        deprecated: 1
+        defunct: 1
+        value:  7
 
     I2C_1_PIN_SCL:
         description: 'SCL pin for I2C_1'


### PR DESCRIPTION
Fix missing value flag and defunct instead of deprecated, relies on https://github.com/apache/mynewt-newt/pull/194


Looks like this:
```
Building target targets/boot-nrf51dk
Error: Override of defunct settings detected:
    I2C_0_FREQUENCY: Use I2C_0_FREQ_KHZ instead

Setting history (newest -> oldest):
    I2C_0_FREQUENCY: [targets/boot-nrf51dk:100, @apache-mynewt-core/hw/bsp/nrf51dk:100]
```