### PR TITLE
Add nimble dependency to 1.4.1.

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -72,3 +72,4 @@ repo.deps:
         vers:
             master: 0-dev
             mynewt_1_4_0_tag: 1.0.0
+            mynewt_1_4_1_tag: 1.0.0


### PR DESCRIPTION
mynewt-core 1.4.1 was missing a dependency on mynewt-nimble.  So, if the user gets 1.4.1, newt won't automatically install / upgrade / sync nimble.

This commit adds a dependency on mynewt-nimble 1.0.0 (the only version of mynewt-nimble).