### PR TITLE
use absolute pathing in core

### DIFF
--- a/apps/blecent/pkg.yml
+++ b/apps/blecent/pkg.yml
@@ -23,15 +23,15 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - kernel/os 
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/util
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/util"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/blecsc/pkg.yml
+++ b/apps/blecsc/pkg.yml
@@ -25,17 +25,17 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/config
-    - net/nimble/transport
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/sysinit
-    - sys/id
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/config"
+    - "@apache-mynewt-core/net/nimble/transport"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/id"

--- a/apps/blehci/pkg.yml
+++ b/apps/blehci/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - sys/console/stub
-    - sys/stats/full
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/transport/uart
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/transport/uart"

--- a/apps/blehr/pkg.yml
+++ b/apps/blehr/pkg.yml
@@ -25,17 +25,17 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/config
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/sysinit
-    - sys/id
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/config"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/id"

--- a/apps/blemesh/pkg.yml
+++ b/apps/blemesh/pkg.yml
@@ -23,15 +23,15 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os 
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/shell
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/shell"

--- a/apps/blemesh_light/pkg.yml
+++ b/apps/blemesh_light/pkg.yml
@@ -23,15 +23,15 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/shell
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/shell"

--- a/apps/blemesh_shell/pkg.yml
+++ b/apps/blemesh_shell/pkg.yml
@@ -23,15 +23,15 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os 
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/shell
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/shell"

--- a/apps/bleprph/pkg.yml
+++ b/apps/bleprph/pkg.yml
@@ -23,22 +23,22 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - boot/split
-    - boot/bootutil
-    - kernel/os 
-    - mgmt/imgmgr
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/ble
-    - net/nimble/host
-    - net/nimble/host/services/ans
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/config
-    - net/nimble/host/util
-    - net/nimble/transport
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/sysinit
-    - sys/id
+    - "@apache-mynewt-core/boot/split"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/ans"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/config"
+    - "@apache-mynewt-core/net/nimble/host/util"
+    - "@apache-mynewt-core/net/nimble/transport"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/id"

--- a/apps/bleprph_oic/pkg.yml
+++ b/apps/bleprph_oic/pkg.yml
@@ -23,19 +23,19 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - boot/bootutil
-    - kernel/os 
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - mgmt/oicmgr
-    - sys/sysinit
-    - sys/shell
-    - sys/id
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/mgmt/oicmgr"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/id"

--- a/apps/blesplit/pkg.yml
+++ b/apps/blesplit/pkg.yml
@@ -25,23 +25,23 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - boot/split
-    - boot/split_app
-    - kernel/os
-    - mgmt/imgmgr
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/ble
-    - net/nimble/host
-    - net/nimble/host/util
-    - net/nimble/host/services/ans
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/id
-    - sys/log/full
-    - sys/log/modlog
-    - sys/shell
-    - sys/stats/full
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/boot/split"
+    - "@apache-mynewt-core/boot/split_app"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/util"
+    - "@apache-mynewt-core/net/nimble/host/services/ans"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/bletest/pkg.yml
+++ b/apps/bletest/pkg.yml
@@ -25,14 +25,14 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/transport/ram
-    - kernel/os
-    - sys/console/full
-    - sys/shell
-    - sys/config
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
 pkg.cflags: -DBLETEST

--- a/apps/bleuart/pkg.yml
+++ b/apps/bleuart/pkg.yml
@@ -23,19 +23,19 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - libc/baselibc
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/ble
-    - net/nimble/host/services/bleuart
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+    - "@apache-mynewt-core/net/nimble/host/services/bleuart"

--- a/apps/boot/pkg.yml
+++ b/apps/boot/pkg.yml
@@ -26,9 +26,9 @@ pkg.keywords:
     - loader
 
 pkg.deps:
-    - boot/bootutil
-    - kernel/os
-    - sys/console/stub
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/stub"
 
 pkg.deps.BOOT_SERIAL:
-    - boot/boot_serial
+    - "@apache-mynewt-core/boot/boot_serial"

--- a/apps/bsncent/pkg.yml
+++ b/apps/bsncent/pkg.yml
@@ -23,14 +23,14 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/bsnprph/pkg.yml
+++ b/apps/bsnprph/pkg.yml
@@ -23,22 +23,22 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - boot/split
-    - kernel/os
-    - mgmt/imgmgr
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/ble
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/ans
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/sysinit
-    - sys/id
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/boot/split"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/ans"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/id"

--- a/apps/btshell/pkg.yml
+++ b/apps/btshell/pkg.yml
@@ -23,17 +23,17 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - sys/console/full
-    - sys/shell
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.deps.BTSHELL_ANS:
-    - net/nimble/host/services/ans
+    - "@apache-mynewt-core/net/nimble/host/services/ans"

--- a/apps/ffs2native/pkg.yml
+++ b/apps/ffs2native/pkg.yml
@@ -25,9 +25,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - fs/nffs
-    - hw/hal
-    - sys/console/full
-    - sys/log/full
-    - sys/stats/stub
-    - kernel/os
+    - "@apache-mynewt-core/fs/nffs"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/stub"
+    - "@apache-mynewt-core/kernel/os"

--- a/apps/iptest/pkg.yml
+++ b/apps/iptest/pkg.yml
@@ -25,22 +25,22 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - boot/bootutil
-    - sys/shell
-    - sys/config
-    - sys/console/full
-    - sys/id
-    - sys/log/full
-    - sys/stats/full
-    - net/ip/inet_def_service
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/net/ip/inet_def_service"
 
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"
 
 pkg.deps.BUILD_WITH_OIC:
-    - net/oic
-    - encoding/cborattr
+    - "@apache-mynewt-core/net/oic"
+    - "@apache-mynewt-core/encoding/cborattr"

--- a/apps/lora_app_shell/pkg.yml
+++ b/apps/lora_app_shell/pkg.yml
@@ -32,5 +32,5 @@ pkg.deps:
     - "@apache-mynewt-core/sys/shell"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/util/parse"
-    - "mgmt/oicmgr"
-    - "mgmt/newtmgr/nmgr_os"
+    - "@apache-mynewt-core/mgmt/oicmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/nmgr_os"

--- a/apps/loraping/pkg.yml
+++ b/apps/loraping/pkg.yml
@@ -40,7 +40,7 @@ pkg.deps:
     - "@apache-mynewt-core/test/flash_test"
 
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"

--- a/apps/ocf_sample/pkg.yml
+++ b/apps/ocf_sample/pkg.yml
@@ -25,19 +25,19 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - net/oic
-    - encoding/cborattr
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/oic"
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
 
 pkg.deps.OC_TRANSPORT_SERIAL:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.deps.OC_TRANSPORT_GATT:
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"

--- a/apps/pwm_test/pkg.yml
+++ b/apps/pwm_test/pkg.yml
@@ -25,7 +25,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - sys/console/full
-    - hw/drivers/pwm
-    - util/easing
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/hw/drivers/pwm"
+    - "@apache-mynewt-core/util/easing"

--- a/apps/sensors_test/pkg.yml
+++ b/apps/sensors_test/pkg.yml
@@ -25,34 +25,34 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - hw/sensor
-    - boot/bootutil
-    - sys/console/full
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - hw/sensor/creator
-    - sys/reboot
-    - mgmt/newtmgr/transport/ble
-    - sys/id
-    - mgmt/imgmgr
-    - test/flash_test
-    - test/i2c_scan
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/sensor"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/hw/sensor/creator"
+    - "@apache-mynewt-core/sys/reboot"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/test/flash_test"
+    - "@apache-mynewt-core/test/i2c_scan"
 
 pkg.deps.SENSOR_OIC:
    #- mgmt/oicmgr
 
 pkg.deps.SENSOR_BLE:
-    - net/nimble/controller
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/ram
-    - net/nimble/transport/ram
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
+    - "@apache-mynewt-core/net/nimble/host/store/ram"
+    - "@apache-mynewt-core/net/nimble/transport/ram"
 
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"

--- a/apps/slinky/pkg.yml
+++ b/apps/slinky/pkg.yml
@@ -25,27 +25,27 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - test/flash_test
-    - mgmt/imgmgr
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/nmgr_shell
-    - kernel/os
-    - boot/bootutil
-    - sys/shell
-    - sys/config
-    - sys/console/full
-    - sys/id
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - boot/split
+    - "@apache-mynewt-core/test/flash_test"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/nmgr_shell"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/boot/split"
 
 pkg.deps.I2C_0: test/i2c_scan
 pkg.deps.I2C_1: test/i2c_scan
 pkg.deps.I2C_2: test/i2c_scan
 
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"

--- a/apps/slinky_oic/pkg.yml
+++ b/apps/slinky_oic/pkg.yml
@@ -25,21 +25,21 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - mgmt/imgmgr
-    - mgmt/oicmgr
-    - kernel/os
-    - boot/bootutil
-    - sys/shell
-    - sys/config
-    - sys/console/full
-    - sys/id
-    - sys/log/full
-    - sys/log/modlog
-    - sys/stats/full
-    - boot/split
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/oicmgr"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/boot/split"
 
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"

--- a/apps/spitest/pkg.yml
+++ b/apps/spitest/pkg.yml
@@ -25,9 +25,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - sys/console/full
-    - kernel/os
-    - sys/shell
-    - sys/config
-    - sys/log/full
-    - sys/stats/full
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/splitty/pkg.yml
+++ b/apps/splitty/pkg.yml
@@ -25,17 +25,17 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/bootutil
-    - boot/split
-    - boot/split_app
-    - kernel/os
-    - mgmt/imgmgr
-    - mgmt/newtmgr
-    - mgmt/newtmgr/transport/nmgr_shell
-    - sys/config
-    - sys/console/full
-    - sys/id
-    - sys/log/full
-    - sys/log/modlog
-    - sys/shell
-    - sys/stats/full
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/boot/split"
+    - "@apache-mynewt-core/boot/split_app"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/nmgr_shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/timtest/pkg.yml
+++ b/apps/timtest/pkg.yml
@@ -25,9 +25,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - sys/console/full
-    - kernel/os
-    - sys/shell
-    - sys/config
-    - sys/log/full
-    - sys/stats/full
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/apps/trng_test/pkg.yml
+++ b/apps/trng_test/pkg.yml
@@ -23,6 +23,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - sys/console/full
-    - hw/drivers/trng
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/hw/drivers/trng"

--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -26,12 +26,12 @@ pkg.keywords:
     - bootloader
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
-    - encoding/tinycbor
-    - encoding/base64
-    - sys/flash_map
-    - util/crc
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/encoding/base64"
+    - "@apache-mynewt-core/sys/flash_map"
+    - "@apache-mynewt-core/util/crc"
 
 pkg.req_apis:
     - bootloader

--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/boot_serial
-    - boot/bootutil
-    - test/testutil
+    - "@apache-mynewt-core/boot/boot_serial"
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -29,11 +29,11 @@ pkg.apis:
     - bootloader
 
 pkg.deps: 
-    - hw/hal
-    - crypto/mbedtls
-    - kernel/os 
-    - sys/defs
-    - sys/flash_map
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/crypto/mbedtls"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/defs"
+    - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.BOOTUTIL_SIGN_EC256:
-    - crypto/tinycrypt
+    - "@apache-mynewt-core/crypto/tinycrypt"

--- a/boot/bootutil/test/pkg.yml
+++ b/boot/bootutil/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - boot/bootutil
-    - test/testutil
+    - "@apache-mynewt-core/boot/bootutil"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/boot/split/pkg.yml
+++ b/boot/split/pkg.yml
@@ -25,7 +25,7 @@ pkg.keywords:
     - split
 
 pkg.deps:
-    - sys/config
+    - "@apache-mynewt-core/sys/config"
 
 pkg.req_apis:
     - bootloader

--- a/boot/split_app/pkg.yml
+++ b/boot/split_app/pkg.yml
@@ -22,8 +22,8 @@ pkg.description: Required by the application half of a split image.  The split i
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 pkg.keywords:
-    - split
-    - boot
-    - image
+    - "@apache-mynewt-core/split"
+    - "@apache-mynewt-core/boot"
+    - "@apache-mynewt-core/image"

--- a/compiler/xc32/pkg.yml
+++ b/compiler/xc32/pkg.yml
@@ -27,4 +27,4 @@ pkg.keywords:
     - compiler
 
 pkg.deps:
-    - libc/baselibc
+    - "@apache-mynewt-core/libc/baselibc"

--- a/crypto/mbedtls/test/pkg.yml
+++ b/crypto/mbedtls/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - crypto/mbedtls
-    - test/testutil
+    - "@apache-mynewt-core/crypto/mbedtls"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/crypto/tinycrypt/pkg.yml
+++ b/crypto/tinycrypt/pkg.yml
@@ -27,7 +27,7 @@ pkg.cflags:
     - "-std=c99"
 
 pkg.deps.TINYCRYPT_UECC_RNG_USE_TRNG:
-    - hw/drivers/trng
+    - "@apache-mynewt-core/hw/drivers/trng"
 
 pkg.init.TINYCRYPT_UECC_RNG_USE_TRNG:
     mynewt_tinycrypt_pkg_init: 200

--- a/docs/os/modules/console/console.rst
+++ b/docs/os/modules/console/console.rst
@@ -60,10 +60,10 @@ file:
 
     pkg.name: sys/shell
     pkg.deps:
-        - kernel/os
-        - encoding/base64
-        - time/datetime
-        - util/crc
+        - "@apache-mynewt-core/kernel/os"
+        - "@apache-mynewt-core/encoding/base64"
+        - "@apache-mynewt-core/time/datetime"
+        - "@apache-mynewt-core/util/crc"
     pkg.req_apis:
         - console
 
@@ -83,16 +83,16 @@ capability and has the following ``pkg.yml`` file:
 
     pkg.name: apps/slinky
     pkg.deps:
-        - test/flash_test
-        - mgmt/imgmgr
-        - mgmt/newtmgr
-        - mgmt/newtmgr/transport/nmgr_shell
-        - kernel/os
-        - boot/bootutil
-        - sys/shell
-        - sys/console/full
+        - "@apache-mynewt-core/test/flash_test"
+        - "@apache-mynewt-core/mgmt/imgmgr"
+        - "@apache-mynewt-core/mgmt/newtmgr"
+        - "@apache-mynewt-core/mgmt/newtmgr/transport/nmgr_shell"
+        - "@apache-mynewt-core/kernel/os"
+        - "@apache-mynewt-core/boot/bootutil"
+        - "@apache-mynewt-core/sys/shell"
+        - "@apache-mynewt-core/sys/console/full"
            ...
-        - sys/id
+        - "@apache-mynewt-core/sys/id"
 
 Using the Stub Console Package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,9 +127,9 @@ project boot pkg looks like the following:
 
     pkg.name: apps/boot
     pkg.deps:
-        - boot/bootutil
-        - kernel/os
-        - sys/console/stub
+        - "@apache-mynewt-core/boot/bootutil"
+        - "@apache-mynewt-core/kernel/os"
+        - "@apache-mynewt-core/sys/console/stub"
 
 Using the Minimal Console Package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -151,13 +151,13 @@ has the following ``pkg.yml`` file:
         - loader
 
     pkg.deps:
-        - boot/bootutil
-        - kernel/os
-        - sys/console/stub
+        - "@apache-mynewt-core/boot/bootutil"
+        - "@apache-mynewt-core/kernel/os"
+        - "@apache-mynewt-core/sys/console/stub"
 
     pkg.deps.BOOT_SERIAL.OVERWRITE:
-        - sys/console/minimal
-        - boot/boot_serial
+        - "@apache-mynewt-core/sys/console/minimal"
+        - "@apache-mynewt-core/boot/boot_serial"
 
 Output to the Console
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/os/modules/drivers/flash.rst
+++ b/docs/os/modules/drivers/flash.rst
@@ -70,7 +70,7 @@ dependency in your pkg.yml:
 ::
 
     pkg.deps:
-        - hw/drivers/flash/at45db
+        - "@apache-mynewt-core/hw/drivers/flash/at45db"
 
 Header file
 ^^^^^^^^^^^

--- a/docs/os/modules/drivers/mmc.rst
+++ b/docs/os/modules/drivers/mmc.rst
@@ -28,7 +28,7 @@ dependency in your pkg.yml:
 ::
 
     pkg.deps:
-        - hw/drivers/mmc
+        - "@apache-mynewt-core/hw/drivers/mmc"
 
 Returned values
 ^^^^^^^^^^^^^^^

--- a/docs/os/modules/fs/fatfs.rst
+++ b/docs/os/modules/fs/fatfs.rst
@@ -40,7 +40,7 @@ your project:
 ::
 
     pkg.deps:
-        - fs/fatfs
+        - "@apache-mynewt-core/fs/fatfs"
 
 It can now be used through the standard file system abstraction
 functions as described in `FS API </os/modules/fs/fs/fs#API>`__.

--- a/docs/os/modules/fs/fs.rst
+++ b/docs/os/modules/fs/fs.rst
@@ -40,8 +40,8 @@ used.
 
     pkg.name: repos/apache-mynewt-core/apps/slinky
     pkg.deps:
-        - fs/fs         # include the file operations interfaces
-        - fs/nffs       # include the NFFS filesystem implementation
+        - "@apache-mynewt-core/fs/fs"         # include the file operations interfaces
+        - "@apache-mynewt-core/fs/nffs"       # include the NFFS filesystem implementation
 
 ::
 
@@ -70,7 +70,7 @@ package.
     # repos/apache-mynewt-core/libs/imgmgr/pkg.yml
     pkg.name: libs/imgmgr
     pkg.deps:
-        - fs/fs
+        - "@apache-mynewt-core/fs/fs"
 
     # [...]
 

--- a/docs/os/modules/fs/otherfs.rst
+++ b/docs/os/modules/fs/otherfs.rst
@@ -19,11 +19,11 @@ the first item in the ``pkg.deps`` list.
 
     pkg.name: fs/nffs
     pkg.deps:
-        - fs/fs
-        - hw/hal
-        - libs/os
-        - libs/testutil
-        - sys/log
+        - "@apache-mynewt-core/fs/fs"
+        - "@apache-mynewt-core/hw/hal"
+        - "@apache-mynewt-core/libs/os"
+        - "@apache-mynewt-core/libs/testutil"
+        - "@apache-mynewt-core/sys/log"
 
 2. Register your package's API with the ``fs/fs`` interface.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/os/modules/logs/logs.rst
+++ b/docs/os/modules/logs/logs.rst
@@ -36,7 +36,7 @@ file:
 .. code-block:: console
 
     pkg.deps:
-        - sys/log/full
+        - "@apache-mynewt-core/sys/log/full"
 
 You can use the ``sys/log/stub`` package if you want to build your
 application without logging to reduce code size.

--- a/docs/os/modules/sensor_framework/sensor_create.rst
+++ b/docs/os/modules/sensor_framework/sensor_create.rst
@@ -149,7 +149,7 @@ For example:
 
 
     pkg.deps.LIS2DH12_ONB:
-        - hw/drivers/sensors/lis2dh12
+        - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 
     pkg.init:
         config_lis2dh12_sensor: 400
@@ -225,7 +225,7 @@ For example:
 
 
     pkg.deps.BNO055_OFB:
-        - hw/drivers/sensors/bno055
+        - "@apache-mynewt-core/hw/drivers/sensors/bno055"
 
 Reconfiguring A Sensor Device by an Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/os/modules/shell/shell.rst
+++ b/docs/os/modules/shell/shell.rst
@@ -49,7 +49,7 @@ setting to enable the log command in the shell:
 
     # sys/log/full pkg.yml
     pkg.deps.LOG_CLI:
-        - sys/shell
+        - "@apache-mynewt-core/sys/shell"
 
 Description
 -----------

--- a/docs/os/modules/sysinitconfig/sysinitconfig.rst
+++ b/docs/os/modules/sysinitconfig/sysinitconfig.rst
@@ -660,11 +660,11 @@ value is non-zero. Here is an example from the ``libs/os`` package
 .. code-block:: yaml
 
     pkg.deps:
-        - sys/sysinit
-        - util/mem
+        - "@apache-mynewt-core/sys/sysinit"
+        - "@apache-mynewt-core/util/mem"
 
     pkg.deps.OS_CLI
-        - sys/shell
+        - "@apache-mynewt-core/sys/shell"
 
 This example specifies that the ``os`` package depends on the
 ``sysinit`` and ``mem`` packages, and also depends on the ``shell``

--- a/encoding/base64/test/pkg.yml
+++ b/encoding/base64/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - encoding/base64
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/encoding/base64"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/encoding/cborattr/pkg.yml
+++ b/encoding/cborattr/pkg.yml
@@ -24,6 +24,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "encoding/tinycbor"
+    - "@apache-mynewt-core/encoding/tinycbor"
 
 pkg.cflags.FLOAT_USER: -DFLOAT_SUPPORT

--- a/encoding/cborattr/test/pkg.yml
+++ b/encoding/cborattr/test/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - encoding/tinycbor
-    - encoding/cborattr
-    - test/testutil
+    - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/encoding/json/test/pkg.yml
+++ b/encoding/json/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - encoding/json
-    - test/testutil
+    - "@apache-mynewt-core/encoding/json"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/fs/disk/pkg.yml
+++ b/fs/disk/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/fs/fatfs/pkg.yml
+++ b/fs/fatfs/pkg.yml
@@ -26,12 +26,12 @@ pkg.keywords:
     - filesystem
 
 pkg.deps:
-    - fs/fs
-    - util/crc
-    - hw/hal
-    - kernel/os
-    - test/testutil
-    - sys/flash_map
+    - "@apache-mynewt-core/fs/fs"
+    - "@apache-mynewt-core/util/crc"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/flash_map"
 pkg.req_apis:
     - log
     - stats

--- a/fs/fcb/pkg.yml
+++ b/fs/fcb/pkg.yml
@@ -25,6 +25,6 @@ pkg.keywords:
     - log
 
 pkg.deps:
-    - kernel/os
-    - util/crc
-    - sys/flash_map
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/util/crc"
+    - "@apache-mynewt-core/sys/flash_map"

--- a/fs/fcb/test/pkg.yml
+++ b/fs/fcb/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - fs/fcb
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/fs/fcb"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/fs/fs/pkg.yml
+++ b/fs/fs/pkg.yml
@@ -27,7 +27,7 @@ pkg.keywords:
     - ffs
 
 pkg.deps:
-    - fs/disk
+    - "@apache-mynewt-core/fs/disk"
 
 pkg.deps.FS_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"

--- a/fs/nffs/pkg.yml
+++ b/fs/nffs/pkg.yml
@@ -27,13 +27,13 @@ pkg.keywords:
     - ffs
 
 pkg.deps:
-    - fs/fs
-    - util/crc
-    - hw/hal
-    - kernel/os
-    - test/testutil
-    - sys/flash_map
-    - sys/log/modlog
+    - "@apache-mynewt-core/fs/fs"
+    - "@apache-mynewt-core/util/crc"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/flash_map"
+    - "@apache-mynewt-core/sys/log/modlog"
 
 pkg.req_apis:
     - stats

--- a/fs/nffs/test/pkg.yml
+++ b/fs/nffs/test/pkg.yml
@@ -23,10 +23,10 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - fs/nffs
-    - test/testutil
+    - "@apache-mynewt-core/fs/nffs"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
-    - sys/log/full
-    - sys/stats/stub
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/stub"

--- a/hw/battery/pkg.yml
+++ b/hw/battery/pkg.yml
@@ -22,7 +22,7 @@ pkg.description: Battery/Fuel Gauge Controller IC Interface
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 
 pkg.req_apis:
     - console

--- a/hw/bsp/ada_feather_nrf52/bsp.yml
+++ b/hw/bsp/ada_feather_nrf52/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/ada_feather_nrf52/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/ada_feather_nrf52/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/ada_feather_nrf52/split_ada_feather_nrf52.ld"
 bsp.downloadscript: "hw/bsp/ada_feather_nrf52/ada_feather_nrf52_download.sh"
 bsp.debugscript: "hw/bsp/ada_feather_nrf52/ada_feather_nrf52_debug.sh"

--- a/hw/bsp/ada_feather_nrf52/pkg.yml
+++ b/hw/bsp/ada_feather_nrf52/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/apollo2_evb/bsp.yml
+++ b/hw/bsp/apollo2_evb/bsp.yml
@@ -23,10 +23,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4 
 bsp.linkerscript:
     - "hw/bsp/apollo2_evb/apollo2.ld"
-    - "hw/mcu/ambiq/apollo2/apollo2.ld"
+    - "@apache-mynewt-core/hw/mcu/ambiq/apollo2/apollo2.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/apollo2_evb/boot-apollo2.ld"
-    - "hw/mcu/ambiq/apollo2/apollo2.ld"
+    - "@apache-mynewt-core/hw/mcu/ambiq/apollo2/apollo2.ld"
 bsp.downloadscript: "hw/bsp/apollo2_evb/apollo2_evb_download.sh"
 bsp.debugscript: "hw/bsp/apollo2_evb/apollo2_evb_debug.sh"
 

--- a/hw/bsp/apollo2_evb/pkg.yml
+++ b/hw/bsp/apollo2_evb/pkg.yml
@@ -31,8 +31,8 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/ambiq/apollo2
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/ambiq/apollo2"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/arduino_primo_nrf52/bsp.yml
+++ b/hw/bsp/arduino_primo_nrf52/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/arduino_primo_nrf52/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/arduino_primo_nrf52/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/arduino_primo_nrf52/split-primo.ld"
 bsp.downloadscript: "hw/bsp/arduino_primo_nrf52/primo_download.sh"
 bsp.debugscript: "hw/bsp/arduino_primo_nrf52/primo_debug.sh"

--- a/hw/bsp/arduino_primo_nrf52/pkg.yml
+++ b/hw/bsp/arduino_primo_nrf52/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/bbc_microbit/bsp.yml
+++ b/hw/bsp/bbc_microbit/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/bbc_microbit/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/bbc_microbit/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/bbc_microbit/split-microbit.ld"
 bsp.downloadscript: hw/bsp/bbc_microbit/microbit_download.sh
 bsp.debugscript: hw/bsp/bbc_microbit/microbit_debug.sh

--- a/hw/bsp/bbc_microbit/pkg.yml
+++ b/hw/bsp/bbc_microbit/pkg.yml
@@ -30,14 +30,14 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/ble400/bsp.yml
+++ b/hw/bsp/ble400/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/ble400/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/ble400/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/ble400/split-ble400.ld"
 bsp.downloadscript: "hw/bsp/ble400/ble400_download.sh"
 bsp.debugscript: "hw/bsp/ble400/ble400_debug.sh"

--- a/hw/bsp/ble400/pkg.yml
+++ b/hw/bsp/ble400/pkg.yml
@@ -31,17 +31,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/bmd200/bsp.yml
+++ b/hw/bsp/bmd200/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/bmd200/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/bmd200/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/bmd200/split-nrf51dk.ld"
 bsp.downloadscript: "hw/bsp/bmd200/nrf51dk_download.sh"
 bsp.debugscript: "hw/bsp/bmd200/nrf51dk_debug.sh"

--- a/hw/bsp/bmd200/pkg.yml
+++ b/hw/bsp/bmd200/pkg.yml
@@ -31,17 +31,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/bmd300eval/bsp.yml
+++ b/hw/bsp/bmd300eval/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/bmd300eval/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/bmd300eval/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/bmd300eval/split-bmd300eval.ld"
 bsp.downloadscript: "hw/bsp/bmd300eval/bmd300eval_download.sh"
 bsp.debugscript: "hw/bsp/bmd300eval/bmd300eval_debug.sh"

--- a/hw/bsp/bmd300eval/pkg.yml
+++ b/hw/bsp/bmd300eval/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/calliope_mini/bsp.yml
+++ b/hw/bsp/calliope_mini/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m0"
 bsp.linkerscript:
     - hw/bsp/calliope_mini/nrf51xxac.ld
-    - hw/mcu/nordic/nrf51xxx/nrf51.ld
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - hw/bsp/calliope_mini/boot-nrf51xxac.ld
-    - hw/mcu/nordic/nrf51xxx/nrf51.ld
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: hw/bsp/calliope_mini/split-calliope_mini.ld
 bsp.downloadscript: hw/bsp/calliope_mini/calliope_mini_download.sh
 bsp.debugscript: hw/bsp/calliope_mini/calliope_mini_debug.sh

--- a/hw/bsp/calliope_mini/pkg.yml
+++ b/hw/bsp/calliope_mini/pkg.yml
@@ -30,14 +30,14 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/ci40/pkg.yml
+++ b/hw/bsp/ci40/pkg.yml
@@ -30,14 +30,14 @@ pkg.keywords:
 
 pkg.cflags:
 pkg.deps:
-    - hw/mcu/mips/danube
-    - libc/baselibc
-    - hw/mips-hal
+    - "@apache-mynewt-core/hw/mcu/mips/danube"
+    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/hw/mips-hal"
 
 pkg.arch: mips
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/dwm1001-dev/bsp.yml
+++ b/hw/bsp/dwm1001-dev/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/dwm1001-dev/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/dwm1001-dev/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/dwm1001-dev/split-dwm1001-dev.ld"
 bsp.downloadscript: "hw/bsp/dwm1001-dev/dwm1001-dev_download.sh"
 bsp.debugscript: "hw/bsp/dwm1001-dev/dwm1001-dev_debug.sh"

--- a/hw/bsp/dwm1001-dev/pkg.yml
+++ b/hw/bsp/dwm1001-dev/pkg.yml
@@ -33,29 +33,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/embarc_emsk/pkg.yml
+++ b/hw/bsp/embarc_emsk/pkg.yml
@@ -27,7 +27,7 @@ pkg.keywords:
     - embarc_emsk
 
 pkg.deps:
-    - hw/mcu/arc/snps
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/arc/snps"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.cflags: -mcpu=em4_dmips -mlittle-endian -mcode-density -mdiv-rem -mswap -mbarrel-shifter

--- a/hw/bsp/frdm-k64f/pkg.yml
+++ b/hw/bsp/frdm-k64f/pkg.yml
@@ -42,23 +42,23 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nxp/MK64F12
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nxp/MK64F12"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_2:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_3:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_4:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_5:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/hifive1/pkg.yml
+++ b/hw/bsp/hifive1/pkg.yml
@@ -27,11 +27,11 @@ pkg.keywords:
     - riscv
 
 pkg.deps:
-    - hw/mcu/sifive/fe310
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/sifive/fe310"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.cflags: -march=rv32imac -mabi=ilp32
 

--- a/hw/bsp/native-armv7/pkg.yml
+++ b/hw/bsp/native-armv7/pkg.yml
@@ -27,9 +27,9 @@ pkg.keywords:
     - bsp
 
 pkg.deps:
-    - hw/mcu/native
-    - hw/drivers/uart/uart_hal
-    - net/ip/native_sockets
+    - "@apache-mynewt-core/hw/mcu/native"
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+    - "@apache-mynewt-core/net/ip/native_sockets"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/native
+    - "@apache-mynewt-core/hw/drivers/nimble/native"

--- a/hw/bsp/native-mips/pkg.yml
+++ b/hw/bsp/native-mips/pkg.yml
@@ -27,9 +27,9 @@ pkg.keywords:
     - bsp
 
 pkg.deps:
-    - hw/mcu/native
-    - hw/drivers/uart/uart_hal
-    - net/ip/native_sockets
+    - "@apache-mynewt-core/hw/mcu/native"
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+    - "@apache-mynewt-core/net/ip/native_sockets"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/native
+    - "@apache-mynewt-core/hw/drivers/nimble/native"

--- a/hw/bsp/native/pkg.yml
+++ b/hw/bsp/native/pkg.yml
@@ -27,9 +27,9 @@ pkg.keywords:
     - bsp
 
 pkg.deps:
-    - hw/mcu/native
-    - hw/drivers/uart/uart_hal
-    - net/ip/native_sockets
+    - "@apache-mynewt-core/hw/mcu/native"
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+    - "@apache-mynewt-core/net/ip/native_sockets"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/native
+    - "@apache-mynewt-core/hw/drivers/nimble/native"

--- a/hw/bsp/nina-b1/bsp.yml
+++ b/hw/bsp/nina-b1/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nina-b1/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nina-b1/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/nina-b1/split-nrf52dk.ld"
 bsp.downloadscript: "hw/bsp/nina-b1/nrf52dk_download.sh"
 bsp.debugscript: "hw/bsp/nina-b1/nrf52dk_debug.sh"

--- a/hw/bsp/nina-b1/pkg.yml
+++ b/hw/bsp/nina-b1/pkg.yml
@@ -33,35 +33,35 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nrf51-arduino_101/bsp.yml
+++ b/hw/bsp/nrf51-arduino_101/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/nrf51-arduino_101/nrf51xxaa.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf51-arduino_101/boot-nrf51xxaa.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.downloadscript: "hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_download.sh"
 bsp.debugscript: "hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_download.cmd"

--- a/hw/bsp/nrf51-arduino_101/pkg.yml
+++ b/hw/bsp/nrf51-arduino_101/pkg.yml
@@ -30,17 +30,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/nrf51-blenano/bsp.yml
+++ b/hw/bsp/nrf51-blenano/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/nrf51-blenano/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf51-blenano/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/nrf51-blenano/split-nrf51dk.ld"
 bsp.downloadscript: "hw/bsp/nrf51-blenano/nrf51dk_download.sh"
 bsp.debugscript: "hw/bsp/nrf51-blenano/nrf51dk_debug.sh"

--- a/hw/bsp/nrf51-blenano/pkg.yml
+++ b/hw/bsp/nrf51-blenano/pkg.yml
@@ -31,17 +31,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/nrf51dk-16kbram/bsp.yml
+++ b/hw/bsp/nrf51dk-16kbram/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/nrf51dk-16kbram/nrf51xxaa.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf51dk-16kbram/boot-nrf51xxaa.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/nrf51dk-16kbram/split-nrf51dk-16kbram.ld"
 bsp.downloadscript: "hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_download.sh"
 bsp.debugscript: "hw/bsp/nrf51dk-16kbram/nrf51dk-16kbram_debug.sh"

--- a/hw/bsp/nrf51dk-16kbram/pkg.yml
+++ b/hw/bsp/nrf51dk-16kbram/pkg.yml
@@ -30,17 +30,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/nrf51dk/bsp.yml
+++ b/hw/bsp/nrf51dk/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/nrf51dk/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf51dk/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/nrf51dk/split-nrf51dk.ld"
 bsp.downloadscript: "hw/bsp/nrf51dk/nrf51dk_download.sh"
 bsp.debugscript: "hw/bsp/nrf51dk/nrf51dk_debug.sh"

--- a/hw/bsp/nrf51dk/pkg.yml
+++ b/hw/bsp/nrf51dk/pkg.yml
@@ -30,17 +30,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/nrf52-thingy/bsp.yml
+++ b/hw/bsp/nrf52-thingy/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nrf52-thingy/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf52-thingy/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/nrf52-thingy/split-nrf52-thingy.ld"
 bsp.downloadscript: "hw/bsp/nrf52-thingy/nrf52-thingy_download.sh"
 bsp.debugscript: "hw/bsp/nrf52-thingy/nrf52-thingy_debug.sh"

--- a/hw/bsp/nrf52-thingy/pkg.yml
+++ b/hw/bsp/nrf52-thingy/pkg.yml
@@ -34,35 +34,35 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"
 
 pkg.deps.LIS2DH12_ONB:
-    - hw/drivers/sensors/lis2dh12
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 
 pkg.init:
     config_lis2dh12_sensor: 400

--- a/hw/bsp/nrf52840pdk/bsp.yml
+++ b/hw/bsp/nrf52840pdk/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nrf52840pdk/nrf52840aa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf52840pdk/boot-nrf52840aa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/nrf52840pdk/split-nrf52840pdk.ld"
 bsp.downloadscript: "hw/bsp/nrf52840pdk/nrf52840pdk_download.sh"
 bsp.debugscript: "hw/bsp/nrf52840pdk/nrf52840pdk_debug.sh"

--- a/hw/bsp/nrf52840pdk/pkg.yml
+++ b/hw/bsp/nrf52840pdk/pkg.yml
@@ -33,36 +33,36 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
-    - sys/flash_map
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.TRNG:
-    - hw/drivers/trng/trng_nrf52
+    - "@apache-mynewt-core/hw/drivers/trng/trng_nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_3:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nrf52dk/bsp.yml
+++ b/hw/bsp/nrf52dk/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nrf52dk/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nrf52dk/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/nrf52dk/split-nrf52dk.ld"
 bsp.downloadscript: "hw/bsp/nrf52dk/nrf52dk_download.sh"
 bsp.debugscript: "hw/bsp/nrf52dk/nrf52dk_debug.sh"

--- a/hw/bsp/nrf52dk/pkg.yml
+++ b/hw/bsp/nrf52dk/pkg.yml
@@ -33,29 +33,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nucleo-f303k8/bsp.yml
+++ b/hw/bsp/nucleo-f303k8/bsp.yml
@@ -21,7 +21,7 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nucleo-f303k8/nucleo-f303k8.ld"
-    - "hw/mcu/stm/stm32f3xx/stm32f303.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx/stm32f303.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f303k8/nucleo-f303k8_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f303k8/nucleo-f303k8_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f303k8/nucleo-f303k8_download.cmd"

--- a/hw/bsp/nucleo-f303k8/pkg.yml
+++ b/hw/bsp/nucleo-f303k8/pkg.yml
@@ -33,21 +33,21 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f3xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 

--- a/hw/bsp/nucleo-f303re/bsp.yml
+++ b/hw/bsp/nucleo-f303re/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nucleo-f303re/nucleo-f303re.ld"
-    - "hw/mcu/stm/stm32f3xx/stm32f303.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx/stm32f303.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-f303re/boot-nucleo-f303re.ld"
-    - "hw/mcu/stm/stm32f3xx/stm32f303.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx/stm32f303.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f303re/nucleo-f303re_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f303re/nucleo-f303re_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f303re/nucleo-f303re_download.cmd"

--- a/hw/bsp/nucleo-f303re/pkg.yml
+++ b/hw/bsp/nucleo-f303re/pkg.yml
@@ -33,20 +33,20 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f3xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"

--- a/hw/bsp/nucleo-f401re/bsp.yml
+++ b/hw/bsp/nucleo-f401re/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nucleo-f401re/nucleo-f401re.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f401.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f401.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-f401re/boot-nucleo-f401re.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f401.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f401.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f401re/nucleo-f401re_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f401re/nucleo-f401re_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f401re/nucleo-f401re_download.cmd"

--- a/hw/bsp/nucleo-f401re/pkg.yml
+++ b/hw/bsp/nucleo-f401re/pkg.yml
@@ -34,10 +34,10 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nucleo-f413zh/bsp.yml
+++ b/hw/bsp/nucleo-f413zh/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nucleo-f413zh/nucleo-f413zh.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f413.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f413.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-f413zh/boot-nucleo-f413zh.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f413.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f413.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f413zh/nucleo-f413zh_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f413zh/nucleo-f413zh_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f413zh/nucleo-f413zh_download.cmd"

--- a/hw/bsp/nucleo-f413zh/pkg.yml
+++ b/hw/bsp/nucleo-f413zh/pkg.yml
@@ -35,8 +35,8 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nucleo-f746zg/bsp.yml
+++ b/hw/bsp/nucleo-f746zg/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:
     - "hw/bsp/nucleo-f746zg/nucleo-f746zg.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f746.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f746.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-f746zg/boot-nucleo-f746zg.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f746.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f746.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f746zg/nucleo-f746zg_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f746zg/nucleo-f746zg_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f746zg/nucleo-f746zg_download.cmd"

--- a/hw/bsp/nucleo-f746zg/pkg.yml
+++ b/hw/bsp/nucleo-f746zg/pkg.yml
@@ -33,20 +33,20 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f7xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ETH_0:
-    - hw/drivers/lwip/stm32_eth
+    - "@apache-mynewt-core/hw/drivers/lwip/stm32_eth"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"

--- a/hw/bsp/nucleo-f767zi/bsp.yml
+++ b/hw/bsp/nucleo-f767zi/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:
     - "hw/bsp/nucleo-f767zi/nucleo-f767zi.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f767.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f767.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-f767zi/boot-nucleo-f767zi.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f767.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f767.ld"
 bsp.downloadscript: "hw/bsp/nucleo-f767zi/nucleo-f767zi_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-f767zi/nucleo-f767zi_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-f767zi/nucleo-f767zi_download.cmd"

--- a/hw/bsp/nucleo-f767zi/pkg.yml
+++ b/hw/bsp/nucleo-f767zi/pkg.yml
@@ -33,20 +33,20 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f7xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ETH_0:
-    - hw/drivers/lwip/stm32_eth
+    - "@apache-mynewt-core/hw/drivers/lwip/stm32_eth"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"

--- a/hw/bsp/nucleo-l476rg/bsp.yml
+++ b/hw/bsp/nucleo-l476rg/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/nucleo-l476rg/nucleo-l476rg.ld"
-    - "hw/mcu/stm/stm32l4xx/stm32l476.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l4xx/stm32l476.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/nucleo-l476rg/boot-nucleo-l476rg.ld"
-    - "hw/mcu/stm/stm32l4xx/stm32l476.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l4xx/stm32l476.ld"
 bsp.downloadscript: "hw/bsp/nucleo-l476rg/nucleo-l476rg_download.sh"
 bsp.debugscript: "hw/bsp/nucleo-l476rg/nucleo-l476rg_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/nucleo-l476rg/nucleo-l476rg_download.cmd"

--- a/hw/bsp/nucleo-l476rg/pkg.yml
+++ b/hw/bsp/nucleo-l476rg/pkg.yml
@@ -34,10 +34,10 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32l4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/olimex-p103/bsp.yml
+++ b/hw/bsp/olimex-p103/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m3
 bsp.compiler: compiler/arm-none-eabi-m3
 bsp.linkerscript:
     - "hw/bsp/olimex-p103/olimex_p103.ld"
-    - "hw/mcu/stm/stm32f1xx/stm32f103.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f1xx/stm32f103.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/olimex-p103/boot-olimex_p103.ld"
-    - "hw/mcu/stm/stm32f1xx/stm32f103.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f1xx/stm32f103.ld"
 bsp.downloadscript: "hw/bsp/olimex-p103/olimex_p103_download.sh"
 bsp.debugscript: "hw/bsp/olimex-p103/olimex_p103_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/olimex-p103/olimex_p103_download.cmd"

--- a/hw/bsp/olimex-p103/pkg.yml
+++ b/hw/bsp/olimex-p103/pkg.yml
@@ -29,8 +29,8 @@ pkg.keywords:
 pkg.cflags: -DSTM32F103xB
 
 pkg.deps:
-    - hw/mcu/stm/stm32f1xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f1xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/olimex_stm32-e407_devboard/bsp.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f407.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/olimex_stm32-e407_devboard/boot-olimex_stm32-e407_devboard.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f407.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
 bsp.downloadscript: "hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard_download.sh"
 bsp.debugscript: "hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/olimex_stm32-e407_devboard/olimex_stm32-e407_devboard_download.cmd"

--- a/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
@@ -35,18 +35,18 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.ADC_1:
-    - hw/drivers/adc/adc_stm32f4
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
 pkg.deps.ADC_2:
-    - hw/drivers/adc/adc_stm32f4
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
 pkg.deps.ADC_3:
-    - hw/drivers/adc/adc_stm32f4
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ETH_0:
-    - hw/drivers/lwip/stm32_eth
+    - "@apache-mynewt-core/hw/drivers/lwip/stm32_eth"

--- a/hw/bsp/pic32mx470_6lp_clicker/pkg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/pkg.yml
@@ -33,17 +33,17 @@ pkg.lflags:
     - -Wl,--defsym=_min_heap_size=0x400
 
 pkg.deps:
-    - hw/mcu/microchip/pic32mx470f512h
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/microchip/pic32mx470f512h"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_2:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_3:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/pic32mz2048_wi-fire/pkg.yml
+++ b/hw/bsp/pic32mz2048_wi-fire/pkg.yml
@@ -33,23 +33,23 @@ pkg.lflags:
     - -Wl,--defsym=_min_heap_size=0x400
 
 pkg.deps:
-    - hw/mcu/microchip/pic32mz2048efg100
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/microchip/pic32mz2048efg100"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_2:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_3:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_4:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_5:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/puckjs/bsp.yml
+++ b/hw/bsp/puckjs/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/puckjs/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/puckjs/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/puckjs/split_puckjs.ld"
 bsp.downloadscript: "hw/bsp/puckjs/puckjs_download.sh"
 bsp.debugscript: "hw/bsp/puckjs/puckjs_debug.sh"

--- a/hw/bsp/puckjs/pkg.yml
+++ b/hw/bsp/puckjs/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/rb-blend2/bsp.yml
+++ b/hw/bsp/rb-blend2/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/rb-blend2/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/rb-blend2/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/rb-blend2/split-rb-blend2.ld"
 bsp.downloadscript: "hw/bsp/rb-blend2/rb-blend2_download.sh"
 bsp.debugscript: "hw/bsp/rb-blend2/rb-blend2_debug.sh"

--- a/hw/bsp/rb-blend2/pkg.yml
+++ b/hw/bsp/rb-blend2/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/rb-nano2/bsp.yml
+++ b/hw/bsp/rb-nano2/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/rb-nano2/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/rb-nano2/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/rb-nano2/split-rb-nano2.ld"
 bsp.downloadscript: "hw/bsp/rb-nano2/rb-nano2_download.sh"
 bsp.debugscript: "hw/bsp/rb-nano2/rb-nano2_debug.sh"

--- a/hw/bsp/rb-nano2/pkg.yml
+++ b/hw/bsp/rb-nano2/pkg.yml
@@ -34,29 +34,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/ruuvi_tag_revb2/bsp.yml
+++ b/hw/bsp/ruuvi_tag_revb2/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/ruuvi_tag_revb2/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/ruuvi_tag_revb2/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/ruuvi_tag_revb2/split-nrf52dk.ld"
 bsp.downloadscript: "hw/bsp/ruuvi_tag_revb2/nrf52dk_download.sh"
 bsp.debugscript: "hw/bsp/ruuvi_tag_revb2/nrf52dk_debug.sh"

--- a/hw/bsp/ruuvi_tag_revb2/pkg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/pkg.yml
@@ -35,38 +35,38 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"
 
 pkg.deps.BME280_ONB:
-    - hw/drivers/sensors/bme280
+    - "@apache-mynewt-core/hw/drivers/sensors/bme280"
 
 pkg.deps.LIS2DH12_ONB:
-    - hw/drivers/sensors/lis2dh12
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 
 pkg.init:
     config_lis2dh12_sensor: 400

--- a/hw/bsp/sensorhub/bsp.yml
+++ b/hw/bsp/sensorhub/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/sensorhub/sensorhub.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f427.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f427.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/sensorhub/boot-sensorhub.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f427.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f427.ld"
 bsp.downloadscript: "hw/bsp/sensorhub/sensorhub_download.sh"
 bsp.debugscript: "hw/bsp/sensorhub/sensorhub_debug.sh"
 bsp.downloadscript.WINDOWS.OVERRIDE: "hw/bsp/sensorhub/sensorhub_download.cmd"

--- a/hw/bsp/sensorhub/pkg.yml
+++ b/hw/bsp/sensorhub/pkg.yml
@@ -33,8 +33,8 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/stm32f3discovery/bsp.yml
+++ b/hw/bsp/stm32f3discovery/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/stm32f3discovery/stm32f3discovery.ld"
-    - "hw/mcu/stm/stm32f3xx/stm32f303.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx/stm32f303.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/stm32f3discovery/boot-stm32f3discovery.ld"
-    - "hw/mcu/stm/stm32f3xx/stm32f303.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx/stm32f303.ld"
 bsp.downloadscript: "hw/bsp/stm32f3discovery/stm32f3discovery_download.sh"
 bsp.debugscript: "hw/bsp/stm32f3discovery/stm32f3discovery_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/stm32f3discovery/stm32f3discovery_download.cmd"

--- a/hw/bsp/stm32f3discovery/pkg.yml
+++ b/hw/bsp/stm32f3discovery/pkg.yml
@@ -33,11 +33,11 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f3xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/stm32f429discovery/bsp.yml
+++ b/hw/bsp/stm32f429discovery/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/stm32f429discovery/stm32f429discovery.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f429.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f429.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/stm32f429discovery/boot-stm32f429discovery.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f429.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f429.ld"
 
 bsp.downloadscript: "hw/bsp/stm32f429discovery/stm32f429discovery_download.sh"
 bsp.debugscript: "hw/bsp/stm32f429discovery/stm32f429discovery_debug.sh"

--- a/hw/bsp/stm32f429discovery/pkg.yml
+++ b/hw/bsp/stm32f429discovery/pkg.yml
@@ -33,8 +33,8 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/stm32f4discovery/bsp.yml
+++ b/hw/bsp/stm32f4discovery/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/stm32f4discovery/stm32f4discovery.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f407.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/stm32f4discovery/boot-stm32f4discovery.ld"
-    - "hw/mcu/stm/stm32f4xx/stm32f407.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
 bsp.downloadscript: "hw/bsp/stm32f4discovery/stm32f4discovery_download.sh"
 bsp.debugscript: "hw/bsp/stm32f4discovery/stm32f4discovery_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/stm32f4discovery/stm32f4discovery_download.cmd"

--- a/hw/bsp/stm32f4discovery/pkg.yml
+++ b/hw/bsp/stm32f4discovery/pkg.yml
@@ -33,8 +33,8 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f4xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/stm32f7discovery/bsp.yml
+++ b/hw/bsp/stm32f7discovery/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:
     - "hw/bsp/stm32f7discovery/stm32f7discovery.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f746.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f746.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/stm32f7discovery/boot-stm32f7discovery.ld"
-    - "hw/mcu/stm/stm32f7xx/stm32f746.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx/stm32f746.ld"
 bsp.downloadscript: "hw/bsp/stm32f7discovery/stm32f7discovery_download.sh"
 bsp.debugscript: "hw/bsp/stm32f7discovery/stm32f7discovery_debug.sh"
 

--- a/hw/bsp/stm32f7discovery/pkg.yml
+++ b/hw/bsp/stm32f7discovery/pkg.yml
@@ -33,20 +33,20 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/stm/stm32f7xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ETH_0:
-    - hw/drivers/lwip/stm32_eth
+    - "@apache-mynewt-core/hw/drivers/lwip/stm32_eth"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_stm32
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_stm32"

--- a/hw/bsp/stm32l152discovery/bsp.yml
+++ b/hw/bsp/stm32l152discovery/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m3
 bsp.compiler: compiler/arm-none-eabi-m3
 bsp.linkerscript:
     - "hw/bsp/stm32l152discovery/stm32l152discovery.ld"
-    - "hw/mcu/stm/stm32l1xx/stm32l152.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l1xx/stm32l152.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/stm32l152discovery/boot-stm32l152discovery.ld"
-    - "hw/mcu/stm/stm32l1xx/stm32l152.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l1xx/stm32l152.ld"
 bsp.downloadscript: "hw/bsp/stm32l152discovery/stm32l152discovery_download.sh"
 bsp.debugscript: "hw/bsp/stm32l152discovery/stm32l152discovery_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/stm32l152discovery/stm32l152discovery_download.cmd"

--- a/hw/bsp/stm32l152discovery/pkg.yml
+++ b/hw/bsp/stm32l152discovery/pkg.yml
@@ -30,8 +30,8 @@ pkg.keywords:
 pkg.cflags: -DSTM32L152xC
 
 pkg.deps:
-    - hw/mcu/stm/stm32l1xx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/stm/stm32l1xx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/telee02/bsp.yml
+++ b/hw/bsp/telee02/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/telee02/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/telee02/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/telee02/split-telee02.ld"
 bsp.downloadscript: "hw/bsp/telee02/telee02_download.sh"
 bsp.debugscript: "hw/bsp/telee02/telee02_debug.sh"

--- a/hw/bsp/telee02/pkg.yml
+++ b/hw/bsp/telee02/pkg.yml
@@ -34,32 +34,32 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.LORA_NODE:
-    - hw/drivers/lora/sx1276
+    - "@apache-mynewt-core/hw/drivers/lora/sx1276"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/usbmkw41z/pkg.yml
+++ b/hw/bsp/usbmkw41z/pkg.yml
@@ -29,7 +29,7 @@ pkg.keywords:
 
 # NOTE: boot/bootutil and sys/flash_map were here. Seeing if they can be removed
 pkg.deps:
-    - hw/mcu/nxp/mkw41z
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nxp/mkw41z"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.cflags: -DCPU_MKW41Z512VHT4

--- a/hw/bsp/vbluno51/bsp.yml
+++ b/hw/bsp/vbluno51/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:
     - "hw/bsp/vbluno51/nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/vbluno51/boot-nrf51xxac.ld"
-    - "hw/mcu/nordic/nrf51xxx/nrf51.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx/nrf51.ld"
 bsp.part2linkerscript: "hw/bsp/vbluno51/split-vbluno51.ld"
 bsp.downloadscript: "hw/bsp/vbluno51/vbluno51_download.sh"
 bsp.debugscript: "hw/bsp/vbluno51/vbluno51_debug.sh"

--- a/hw/bsp/vbluno51/pkg.yml
+++ b/hw/bsp/vbluno51/pkg.yml
@@ -30,17 +30,17 @@ pkg.cflags:
     - '-DNRF51'
 
 pkg.deps:
-    - hw/mcu/nordic/nrf51xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf51
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf51"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf51
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf51"

--- a/hw/bsp/vbluno52/bsp.yml
+++ b/hw/bsp/vbluno52/bsp.yml
@@ -21,10 +21,10 @@ bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/vbluno52/nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/vbluno52/boot-nrf52xxaa.ld"
-    - "hw/mcu/nordic/nrf52xxx/nrf52.ld"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld"
 bsp.part2linkerscript: "hw/bsp/vbluno52/split-vbluno52.ld"
 bsp.downloadscript: "hw/bsp/vbluno52/vbluno52_download.sh"
 bsp.debugscript: "hw/bsp/vbluno52/vbluno52_debug.sh"

--- a/hw/bsp/vbluno52/pkg.yml
+++ b/hw/bsp/vbluno52/pkg.yml
@@ -33,29 +33,29 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/mcu/nordic/nrf52xxx
-    - libc/baselibc
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:
-    - hw/drivers/nimble/nrf52
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
 
 pkg.deps.UART_0:
-    - hw/drivers/uart/uart_hal
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.UART_1:
-    - hw/drivers/uart/uart_bitbang
+    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
 
 pkg.deps.ADC_0:
-    - hw/drivers/adc/adc_nrf52
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
 
 pkg.deps.PWM_0:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_1:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.PWM_2:
-    - hw/drivers/pwm/pwm_nrf52
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
-    - hw/drivers/pwm/soft_pwm
+    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/charge-control/pkg.yml
+++ b/hw/charge-control/pkg.yml
@@ -22,11 +22,11 @@ pkg.description: Battery Charge Controller IC Interface
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 
 pkg.deps.CHARGE_CONTROL_CLI:
-    - sys/shell
-    - util/parse
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/util/parse"
 
 pkg.req_apis:
     - console

--- a/hw/drivers/adc/adc_nrf51/pkg.yml
+++ b/hw/drivers/adc/adc_nrf51/pkg.yml
@@ -25,5 +25,5 @@ pkg.keywords:
 pkg.apis:
     - ADC_HW_IMPL
 pkg.deps:
-   - hw/drivers/adc
-   - hw/mcu/nordic
+    - "@apache-mynewt-core/hw/drivers/adc"
+    - "@apache-mynewt-core/hw/mcu/nordic"

--- a/hw/drivers/adc/adc_nrf52/pkg.yml
+++ b/hw/drivers/adc/adc_nrf52/pkg.yml
@@ -25,5 +25,5 @@ pkg.keywords:
 pkg.apis:
     - ADC_HW_IMPL
 pkg.deps:
-   - hw/drivers/adc
-   - hw/mcu/nordic
+    - "@apache-mynewt-core/hw/drivers/adc"
+    - "@apache-mynewt-core/hw/mcu/nordic"

--- a/hw/drivers/adc/adc_stm32f4/pkg.yml
+++ b/hw/drivers/adc/adc_stm32f4/pkg.yml
@@ -27,8 +27,8 @@ pkg.features:
 pkg.apis:
     - ADC_HW_IMPL
 pkg.deps:
-   - hw/drivers/adc
+    - "@apache-mynewt-core/hw/drivers/adc"
 pkg.deps.TEST:
-   - hw/hal
-   - hw/mcu/stm/stm32f4xx
-   - test/testutil
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/test/testutil"

--- a/hw/drivers/debounce/pkg.yml
+++ b/hw/drivers/debounce/pkg.yml
@@ -23,4 +23,4 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-    - "hw/hal"
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/flash/at45db/pkg.yml
+++ b/hw/drivers/flash/at45db/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/flash/spiflash/pkg.yml
+++ b/hw/drivers/flash/spiflash/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/lwip/stm32_eth/pkg.yml
+++ b/hw/drivers/lwip/stm32_eth/pkg.yml
@@ -26,14 +26,14 @@ pkg.keywords:
     - lwip
     - ethernet
 pkg.deps:
-    - hw/hal
-    - net/ip/lwip_base
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/net/ip/lwip_base"
 
 pkg.deps.MCU_STM32F4:
-    - hw/mcu/stm/stm32f4xx
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
 
 pkg.deps.MCU_STM32F7:
-    - hw/mcu/stm/stm32f7xx
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
 
 pkg.req_apis: 
 

--- a/hw/drivers/mmc/pkg.yml
+++ b/hw/drivers/mmc/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/pwm/pwm_nrf52/pkg.yml
+++ b/hw/drivers/pwm/pwm_nrf52/pkg.yml
@@ -26,5 +26,5 @@ pkg.keywords:
 pkg.apis:
     - PWM_HW_IMPL
 pkg.deps:
-   - hw/drivers/pwm
-   - hw/mcu/nordic
+    - "@apache-mynewt-core/hw/drivers/pwm"
+    - "@apache-mynewt-core/hw/mcu/nordic"

--- a/hw/drivers/pwm/pwm_stm32/pkg.yml
+++ b/hw/drivers/pwm/pwm_stm32/pkg.yml
@@ -27,10 +27,10 @@ pkg.apis:
     - PWM_HW_IMPL
 
 pkg.deps:
-    - hw/drivers/pwm
+    - "@apache-mynewt-core/hw/drivers/pwm"
 
 pkg.deps.MCU_STM32F3:
-    - hw/mcu/stm/stm32f3xx
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
 
 pkg.deps.MCU_STM32F7:
-    - hw/mcu/stm/stm32f7xx
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"

--- a/hw/drivers/trng/trng_nrf52/pkg.yml
+++ b/hw/drivers/trng/trng_nrf52/pkg.yml
@@ -27,4 +27,4 @@ pkg.apis:
     - TRNG_HW_IMPL
 
 pkg.deps:
-   - hw/drivers/trng
+    - "@apache-mynewt-core/hw/drivers/trng"

--- a/hw/drivers/trng/trng_stm32/pkg.yml
+++ b/hw/drivers/trng/trng_stm32/pkg.yml
@@ -26,4 +26,4 @@ pkg.keywords:
 pkg.apis:
     - TRNG_HW_IMPL
 pkg.deps:
-   - hw/drivers/trng
+    - "@apache-mynewt-core/hw/drivers/trng"

--- a/hw/drivers/uart/uart_bitbang/pkg.yml
+++ b/hw/drivers/uart/uart_bitbang/pkg.yml
@@ -24,5 +24,5 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.apis:
 pkg.deps:
-   - hw/hal
-   - hw/drivers/uart
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/drivers/uart"

--- a/hw/drivers/uart/uart_hal/pkg.yml
+++ b/hw/drivers/uart/uart_hal/pkg.yml
@@ -24,5 +24,5 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.apis:
 pkg.deps:
-    - hw/hal
-    - hw/drivers/uart
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/drivers/uart"

--- a/hw/mcu/ambiq/apollo2/pkg.yml
+++ b/hw/mcu/ambiq/apollo2/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - apollo2
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/ambiq 
-    - hw/cmsis-core
-    - compiler/arm-none-eabi-m4 
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/ambiq"
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/compiler/arm-none-eabi-m4"

--- a/hw/mcu/ambiq/pkg.yml
+++ b/hw/mcu/ambiq/pkg.yml
@@ -36,5 +36,5 @@ pkg.cflags:
     - '-Wno-enum-compare'
 
 pkg.deps: 
-    - hw/hal 
-    - hw/cmsis-core 
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/arc/pkg.yml
+++ b/hw/mcu/arc/pkg.yml
@@ -36,4 +36,4 @@ pkg.src_dirs:
     - "src/ext/sdk/"
 
 pkg.deps: 
-    - hw/hal 
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/arc/snps/pkg.yml
+++ b/hw/mcu/arc/snps/pkg.yml
@@ -25,5 +25,5 @@ pkg.keywords:
     - arc
 
 pkg.deps: 
-    - hw/hal 
-    - hw/mcu/arc 
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/arc"

--- a/hw/mcu/microchip/pic32mx470f512h/pkg.yml
+++ b/hw/mcu/microchip/pic32mx470f512h/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
     - pic32
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/microchip/pic32mz2048efg100/pkg.yml
+++ b/hw/mcu/microchip/pic32mz2048efg100/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
     - pic32
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/mips/danube/pkg.yml
+++ b/hw/mcu/mips/danube/pkg.yml
@@ -26,4 +26,4 @@ pkg.keywords:
     - danube
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/native/pkg.yml
+++ b/hw/mcu/native/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - x86
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"
 
 pkg.req_apis:
     - console

--- a/hw/mcu/nordic/nrf51xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf51xxx/pkg.yml
@@ -26,6 +26,6 @@ pkg.keywords:
     - nrfx
 
 pkg.deps: 
-    - hw/mcu/nordic
-    - hw/cmsis-core 
-    - hw/hal 
+    - "@apache-mynewt-core/hw/mcu/nordic"
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -26,9 +26,9 @@ pkg.keywords:
     - nrfx
 
 pkg.deps: 
-    - hw/mcu/nordic
-    - hw/cmsis-core 
-    - hw/hal 
+    - "@apache-mynewt-core/hw/mcu/nordic"
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/hw/hal"
 
 # NRF52810 doesn't support SPI/I2C (Use SPIM/I2CM instead)
 pkg.ign_files.BSP_NRF52810:

--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -54,5 +54,5 @@ pkg.src_dirs:
 pkg.cflags: -std=gnu99 -DNRF52_PAN_28
 
 pkg.deps:
-    - hw/hal
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/nxp/MK64F12/pkg.yml
+++ b/hw/mcu/nxp/MK64F12/pkg.yml
@@ -23,6 +23,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 
 pkg.deps:
-    - hw/hal
-    - hw/cmsis-core
-    - hw/mcu/nxp
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/hw/mcu/nxp"

--- a/hw/mcu/nxp/mkw41z/pkg.yml
+++ b/hw/mcu/nxp/mkw41z/pkg.yml
@@ -26,5 +26,5 @@ pkg.keywords:
     - nxp
 
 pkg.deps:
-    - hw/cmsis-core
-    - hw/hal
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/nxp/pkg.yml
+++ b/hw/mcu/nxp/pkg.yml
@@ -40,5 +40,5 @@ pkg.src_dirs:
 pkg.cflags: -std=gnu99 -D__assert_func=__assert_func_nxp
 
 pkg.deps:
-    - hw/hal
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/sifive/fe310/pkg.yml
+++ b/hw/mcu/sifive/fe310/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - riscv64
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/sifive
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/sifive"
 
 pkg.cflags: -march=rv32imac -mabi=ilp32

--- a/hw/mcu/sifive/pkg.yml
+++ b/hw/mcu/sifive/pkg.yml
@@ -27,7 +27,7 @@ pkg.keywords:
     - riscv64
 
 pkg.deps:
-    - hw/hal
+    - "@apache-mynewt-core/hw/hal"
 
 pkg.src_dirs:
     - "src/ext/freedom-e-sdk_3235929/bsp"

--- a/hw/mcu/stm/stm32_common/pkg.yml
+++ b/hw/mcu/stm/stm32_common/pkg.yml
@@ -25,5 +25,5 @@ pkg.keywords:
     - stm32
 
 pkg.deps:
-    - hw/hal
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32f1xx/pkg.yml
+++ b/hw/mcu/stm/stm32f1xx/pkg.yml
@@ -34,6 +34,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32f3xx/pkg.yml
+++ b/hw/mcu/stm/stm32f3xx/pkg.yml
@@ -34,6 +34,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32f4xx/pkg.yml
+++ b/hw/mcu/stm/stm32f4xx/pkg.yml
@@ -40,6 +40,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32f7xx/pkg.yml
+++ b/hw/mcu/stm/stm32f7xx/pkg.yml
@@ -34,6 +34,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32l1xx/pkg.yml
+++ b/hw/mcu/stm/stm32l1xx/pkg.yml
@@ -34,6 +34,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/stm/stm32l4xx/pkg.yml
+++ b/hw/mcu/stm/stm32l4xx/pkg.yml
@@ -34,6 +34,6 @@ pkg.ign_dirs:
     - "Device"
 
 pkg.deps:
-    - hw/hal
-    - hw/mcu/stm/stm32_common
-    - hw/cmsis-core
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/sensor/creator/pkg.yml
+++ b/hw/sensor/creator/pkg.yml
@@ -25,34 +25,34 @@ pkg.keywords:
     - sensors
 
 pkg.deps.BME280_OFB:
-    - hw/drivers/sensors/bme280
+    - "@apache-mynewt-core/hw/drivers/sensors/bme280"
 pkg.deps.DRV2605_OFB:
-    - hw/drivers/drv2605
+    - "@apache-mynewt-core/hw/drivers/drv2605"
 pkg.deps.LSM303DLHC_OFB:
-    - hw/drivers/sensors/lsm303dlhc
+    - "@apache-mynewt-core/hw/drivers/sensors/lsm303dlhc"
 pkg.deps.MPU6050_OFB:
-    - hw/drivers/sensors/mpu6050
+    - "@apache-mynewt-core/hw/drivers/sensors/mpu6050"
 pkg.deps.TSL2561_OFB:
-    - hw/drivers/sensors/tsl2561
+    - "@apache-mynewt-core/hw/drivers/sensors/tsl2561"
 pkg.deps.BNO055_OFB:
-    - hw/drivers/sensors/bno055
+    - "@apache-mynewt-core/hw/drivers/sensors/bno055"
 pkg.deps.TCS34725_OFB:
-    - hw/drivers/sensors/tcs34725
+    - "@apache-mynewt-core/hw/drivers/sensors/tcs34725"
 pkg.deps.MS5837_OFB:
-    - hw/drivers/sensors/ms5837
+    - "@apache-mynewt-core/hw/drivers/sensors/ms5837"
 pkg.deps.MS5840_OFB:
-    - hw/drivers/sensors/ms5840
+    - "@apache-mynewt-core/hw/drivers/sensors/ms5840"
 pkg.deps.MCU_NATIVE:
-    - hw/drivers/sensors/sim
+    - "@apache-mynewt-core/hw/drivers/sensors/sim"
 pkg.deps.BMP280_OFB:
-    - hw/drivers/sensors/bmp280
+    - "@apache-mynewt-core/hw/drivers/sensors/bmp280"
 pkg.deps.BMA253_OFB:
-    - hw/drivers/sensors/bma253
+    - "@apache-mynewt-core/hw/drivers/sensors/bma253"
 pkg.deps.BMA2XX_OFB:
-    - hw/drivers/sensors/bma2xx
+    - "@apache-mynewt-core/hw/drivers/sensors/bma2xx"
 pkg.deps.LIS2DW12_OFB:
-    - hw/drivers/sensors/lis2dw12
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dw12"
 pkg.deps.LIS2DS12_OFB:
-    - hw/drivers/sensors/lis2ds12
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2ds12"
 pkg.init:
     sensor_dev_create: 500

--- a/hw/sensor/pkg.yml
+++ b/hw/sensor/pkg.yml
@@ -24,14 +24,14 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 
 pkg.deps.SENSOR_OIC:
-    - net/oic
+    - "@apache-mynewt-core/net/oic"
 
 pkg.deps.SENSOR_CLI:
-    - sys/shell
-    - util/parse
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/util/parse"
 
 pkg.req_apis:
     - console

--- a/hw/sensor/test/pkg.yml
+++ b/hw/sensor/test/pkg.yml
@@ -23,10 +23,10 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - hw/sensor
-    - test/testutil
+    - "@apache-mynewt-core/hw/sensor"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
-    - sys/log/full
-    - sys/stats/stub
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/stub"

--- a/hw/util/blinker/pkg.yml
+++ b/hw/util/blinker/pkg.yml
@@ -26,4 +26,4 @@ pkg.keywords:
     - led
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/hw/util/button/pkg.yml
+++ b/hw/util/button/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
     - button
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/kernel/os/pkg.yml
+++ b/kernel/os/pkg.yml
@@ -24,24 +24,24 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - sys/sysinit
-    - sys/sys
-    - util/mem
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/sys/sys"
+    - "@apache-mynewt-core/util/mem"
 
 pkg.req_apis:
     - console
 
 pkg.deps.OS_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.deps.OS_COREDUMP:
-    - sys/coredump
+    - "@apache-mynewt-core/sys/coredump"
 
 pkg.deps.BSP_SIMULATED:
     - "@apache-mynewt-core/kernel/sim"
 
 pkg.deps.OS_SYSVIEW:
-    - sys/sysview
+    - "@apache-mynewt-core/sys/sysview"
 
 pkg.init:
     os_pkg_init: 0

--- a/kernel/os/test/pkg.yml
+++ b/kernel/os/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - kernel/os
-    - test/testutil
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -24,6 +24,6 @@ pkg.homepage: "https://github.com/PetteriAimonen/Baselibc"
 pkg.keywords:
     - libc
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 pkg.req_apis:
     - console

--- a/mgmt/imgmgr/pkg.yml
+++ b/mgmt/imgmgr/pkg.yml
@@ -24,10 +24,10 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - boot/split
-    - encoding/base64
-    - mgmt/mgmt
-    - sys/flash_map
+    - "@apache-mynewt-core/boot/split"
+    - "@apache-mynewt-core/encoding/base64"
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/sys/flash_map"
 
 pkg.req_apis:
     - newtmgr
@@ -37,13 +37,13 @@ pkg.req_apis.LOG_FCB_SLOT1:
     - log
 
 pkg.deps.IMGMGR_FS:
-    - fs/fs
+    - "@apache-mynewt-core/fs/fs"
 
 pkg.deps.IMGMGR_COREDUMP:
-    - sys/coredump
+    - "@apache-mynewt-core/sys/coredump"
 
 pkg.deps.IMGMGR_SHELL:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.init:
     imgmgr_module_init: 500

--- a/mgmt/mgmt/pkg.yml
+++ b/mgmt/mgmt/pkg.yml
@@ -24,5 +24,5 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - encoding/tinycbor
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/encoding/tinycbor"

--- a/mgmt/newtmgr/nmgr_os/pkg.yml
+++ b/mgmt/newtmgr/nmgr_os/pkg.yml
@@ -24,12 +24,12 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
-    - time/datetime
-    - kernel/os
-    - mgmt/mgmt
-    - encoding/tinycbor
-    - encoding/cborattr
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/time/datetime"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/encoding/cborattr"
 
 pkg.deps.LOG_SOFT_RESET:
     - sys/reboot

--- a/mgmt/newtmgr/nmgr_os/pkg.yml
+++ b/mgmt/newtmgr/nmgr_os/pkg.yml
@@ -32,7 +32,7 @@ pkg.deps:
     - "@apache-mynewt-core/encoding/cborattr"
 
 pkg.deps.LOG_SOFT_RESET:
-    - sys/reboot
+    - "@apache-mynewt-core/sys/reboot"
 
 pkg.req_apis:
     - newtmgr

--- a/mgmt/newtmgr/pkg.yml
+++ b/mgmt/newtmgr/pkg.yml
@@ -24,14 +24,14 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - encoding/cborattr
-    - kernel/os
-    - mgmt/mgmt
-    - mgmt/newtmgr/nmgr_os
-    - util/mem
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/mgmt/newtmgr/nmgr_os"
+    - "@apache-mynewt-core/util/mem"
 
 pkg.deps.NEWTMGR_BLE_HOST:
-    - mgmt/newtmgr/transport/ble
+    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
 
 pkg.apis:
     - newtmgr

--- a/mgmt/newtmgr/transport/ble/pkg.yml
+++ b/mgmt/newtmgr/transport/ble/pkg.yml
@@ -26,10 +26,10 @@ pkg.keywords:
     - bluetooth
 
 pkg.deps:
-    - kernel/os
-    - mgmt/mgmt
-    - mgmt/newtmgr
-    - net/nimble/host
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/net/nimble/host"
 
 pkg.init:
     newtmgr_ble_pkg_init: 501

--- a/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
+++ b/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
@@ -26,9 +26,9 @@ pkg.keywords:
     - shell
 
 pkg.deps:
-    - kernel/os
-    - sys/shell
-    - mgmt/newtmgr
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/mgmt/newtmgr"
 
 pkg.init:
     nmgr_shell_pkg_init: 501

--- a/mgmt/newtmgr/transport/nmgr_uart/pkg.yml
+++ b/mgmt/newtmgr/transport/nmgr_uart/pkg.yml
@@ -26,10 +26,10 @@ pkg.keywords:
     - uart
 
 pkg.deps:
-    - kernel/os
-    - hw/drivers/uart
-    - mgmt/newtmgr
-    - util/crc
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/drivers/uart"
+    - "@apache-mynewt-core/mgmt/newtmgr"
+    - "@apache-mynewt-core/util/crc"
 
 pkg.init:
     nmgr_uart_pkg_init: 501

--- a/mgmt/oicmgr/pkg.yml
+++ b/mgmt/oicmgr/pkg.yml
@@ -24,10 +24,10 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - net/oic
-    - mgmt/mgmt
-    - mgmt/newtmgr/nmgr_os
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/oic"
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/mgmt/newtmgr/nmgr_os"
 
 pkg.apis:
     - newtmgr

--- a/net/ip/inet_def_service/pkg.yml
+++ b/net/ip/inet_def_service/pkg.yml
@@ -27,8 +27,8 @@ pkg.keywords:
     - test
 
 pkg.deps:
-    - net/ip/mn_socket
-    - kernel/os
+    - "@apache-mynewt-core/net/ip/mn_socket"
+    - "@apache-mynewt-core/kernel/os"
 
 pkg.reqs:
     - console

--- a/net/ip/lwip_base/pkg.yml
+++ b/net/ip/lwip_base/pkg.yml
@@ -28,7 +28,7 @@ pkg.keywords:
     - udp
 
 pkg.deps:
-    - net/ip
+    - "@apache-mynewt-core/net/ip"
 
 pkg.cflags:
     - -Wno-unused

--- a/net/ip/mn_socket/pkg.yml
+++ b/net/ip/mn_socket/pkg.yml
@@ -26,4 +26,4 @@ pkg.keywords:
     - IP
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/net/ip/mn_socket/test/pkg.yml
+++ b/net/ip/mn_socket/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - net/ip/mn_socket
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/net/ip/mn_socket"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/net/ip/native_sockets/pkg.yml
+++ b/net/ip/native_sockets/pkg.yml
@@ -26,8 +26,8 @@ pkg.keywords:
     - IP
 
 pkg.deps:
-    - kernel/os
-    - net/ip/mn_socket
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/ip/mn_socket"
 
 pkg.init:
     native_sock_init: 200

--- a/net/ip/pkg.yml
+++ b/net/ip/pkg.yml
@@ -28,12 +28,12 @@ pkg.keywords:
     - udp
 
 pkg.deps:
-    - kernel/os
-    - net/ip/lwip_base
-    - net/ip/mn_socket
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/net/ip/lwip_base"
+    - "@apache-mynewt-core/net/ip/mn_socket"
 
 pkg.deps.LWIP_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.init:
     ip_init: 200

--- a/net/mqtt/eclipse/pkg.yml
+++ b/net/mqtt/eclipse/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
     - mqtt
 
 pkg.deps:
-    - "kernel/os"
+    - "@apache-mynewt-core/kernel/os"

--- a/net/oic/pkg.yml
+++ b/net/oic/pkg.yml
@@ -24,27 +24,27 @@ pkg.homepage: "https://www.iotivity.org/"
 pkg.keywords:
 
 pkg.deps:
-    - encoding/cborattr
-    - encoding/tinycbor
-    - kernel/os
-    - sys/log/modlog
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/log/modlog"
 
 pkg.req_apis:
     - stats
 
 pkg.deps.OC_TRANSPORT_GATT:
-    - net/nimble/host
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
+    - "@apache-mynewt-core/net/nimble/host"
+    - "@apache-mynewt-core/net/nimble/host/services/gap"
+    - "@apache-mynewt-core/net/nimble/host/services/gatt"
 
 pkg.deps.OC_TRANSPORT_IP:
-    - net/ip/mn_socket
+    - "@apache-mynewt-core/net/ip/mn_socket"
 
 pkg.deps.OC_TRANSPORT_SERIAL:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.deps.OC_TRANSPORT_LORA:
-    - net/lora/node
+    - "@apache-mynewt-core/net/lora/node"
 
 # remove debug option to save logging
 pkg.cflags:

--- a/net/oic/test/pkg.yml
+++ b/net/oic/test/pkg.yml
@@ -23,12 +23,12 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - net/oic
-    - encoding/tinycbor
-    - encoding/cborattr
-    - test/testutil
+    - "@apache-mynewt-core/net/oic"
+    - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
-    - sys/log/full
-    - sys/stats/full
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"

--- a/net/wifi/wifi_mgmt/pkg.yml
+++ b/net/wifi/wifi_mgmt/pkg.yml
@@ -23,6 +23,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-    - "kernel/os"
+    - "@apache-mynewt-core/kernel/os"
 pkg.deps.WIFI_MGMT_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"

--- a/sys/config/pkg.yml
+++ b/sys/config/pkg.yml
@@ -24,16 +24,16 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - encoding/base64
+    - "@apache-mynewt-core/encoding/base64"
 pkg.deps.CONFIG_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 pkg.deps.CONFIG_NEWTMGR:
-    - encoding/cborattr
-    - mgmt/mgmt
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/mgmt/mgmt"
 pkg.deps.CONFIG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"
 pkg.deps.CONFIG_NFFS:
-    - fs/nffs
+    - "@apache-mynewt-core/fs/nffs"
 
 pkg.init:
     config_pkg_init: 50

--- a/sys/config/test-fcb/pkg.yml
+++ b/sys/config/test-fcb/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/config
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/config"
 
 pkg.deps.SELFTEST:
-    - fs/fcb
-    - sys/console/stub
+    - "@apache-mynewt-core/fs/fcb"
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/config/test-nffs/pkg.yml
+++ b/sys/config/test-nffs/pkg.yml
@@ -23,11 +23,11 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/config
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/config"
 
 pkg.deps.SELFTEST:
-    - fs/nffs
-    - sys/console/stub
-    - sys/log/full
-    - sys/stats/stub
+    - "@apache-mynewt-core/fs/nffs"
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/stub"

--- a/sys/console/full/pkg.yml
+++ b/sys/console/full/pkg.yml
@@ -24,12 +24,12 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
 pkg.deps.CONSOLE_UART:
-    - hw/drivers/uart
+    - "@apache-mynewt-core/hw/drivers/uart"
 pkg.deps.CONSOLE_RTT:
-    - hw/drivers/rtt
+    - "@apache-mynewt-core/hw/drivers/rtt"
 pkg.apis: console
 
 pkg.init:

--- a/sys/console/minimal/pkg.yml
+++ b/sys/console/minimal/pkg.yml
@@ -24,12 +24,12 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
 pkg.deps.CONSOLE_UART:
-    - hw/drivers/uart
+    - "@apache-mynewt-core/hw/drivers/uart"
 pkg.deps.CONSOLE_RTT:
-    - hw/drivers/rtt
+    - "@apache-mynewt-core/hw/drivers/rtt"
 pkg.apis: console
 
 pkg.init:

--- a/sys/coredump/pkg.yml
+++ b/sys/coredump/pkg.yml
@@ -25,9 +25,9 @@ pkg.keywords:
     - crash
 
 pkg.deps:
-    - hw/hal
-    - mgmt/imgmgr
-    - sys/flash_map
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/sys/flash_map"
 
 pkg.req_apis:
     - bootloader

--- a/sys/flash_map/pkg.yml
+++ b/sys/flash_map/pkg.yml
@@ -26,8 +26,8 @@ pkg.keywords:
     - flash map
 
 pkg.deps:
-    - sys/defs
-    - sys/mfg
+    - "@apache-mynewt-core/sys/defs"
+    - "@apache-mynewt-core/sys/mfg"
 
 pkg.init:
     flash_map_init: 2

--- a/sys/flash_map/test/pkg.yml
+++ b/sys/flash_map/test/pkg.yml
@@ -23,7 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - test/testutil
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/id/pkg.yml
+++ b/sys/id/pkg.yml
@@ -27,11 +27,11 @@ pkg.keywords:
     - identifier
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
-    - sys/config
-    - sys/mfg
-    - encoding/base64
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/mfg"
+    - "@apache-mynewt-core/encoding/base64"
 
 pkg.init:
     id_init: 500

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -25,23 +25,23 @@ pkg.keywords:
     - logging
 
 pkg.deps:
-    - kernel/os
-    - sys/flash_map
-    - sys/log/common
-    - util/cbmem
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/flash_map"
+    - "@apache-mynewt-core/sys/log/common"
+    - "@apache-mynewt-core/util/cbmem"
 pkg.deps.LOG_FCB:
-    - hw/hal
-    - fs/fcb
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/fs/fcb"
 pkg.deps.LOG_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 
 pkg.deps.LOG_NEWTMGR:
-    - mgmt/mgmt
-    - encoding/cborattr
-    - encoding/tinycbor
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/encoding/tinycbor"
 
 pkg.apis:
-    - log
+    - "@apache-mynewt-core/log"
 
 pkg.init:
     log_init: 100

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -41,7 +41,7 @@ pkg.deps.LOG_NEWTMGR:
     - "@apache-mynewt-core/encoding/tinycbor"
 
 pkg.apis:
-    - "@apache-mynewt-core/log"
+    - log
 
 pkg.init:
     log_init: 100

--- a/sys/log/full/test/align1/pkg.yml
+++ b/sys/log/full/test/align1/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/log/full
-    - sys/log/full/test/util
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/test/util"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/log/full/test/align2/pkg.yml
+++ b/sys/log/full/test/align2/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/log/full
-    - sys/log/full/test/util
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/test/util"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/log/full/test/align4/pkg.yml
+++ b/sys/log/full/test/align4/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/log/full
-    - sys/log/full/test/util
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/test/util"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/log/full/test/align8/pkg.yml
+++ b/sys/log/full/test/align8/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/log/full
-    - sys/log/full/test/util
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/test/util"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/sys/log/full/test/util/pkg.yml
+++ b/sys/log/full/test/util/pkg.yml
@@ -23,5 +23,5 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - sys/log/full
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/log/full"

--- a/sys/log/modlog/pkg.yml
+++ b/sys/log/modlog/pkg.yml
@@ -25,8 +25,8 @@ pkg.keywords:
     - logging
 
 pkg.deps:
-    - kernel/os
-    - util/rwlock
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/util/rwlock"
 
 pkg.req_apis:
     - log

--- a/sys/log/stub/pkg.yml
+++ b/sys/log/stub/pkg.yml
@@ -25,7 +25,7 @@ pkg.keywords:
     - logging
 
 pkg.deps:
-    - sys/log/common
+    - "@apache-mynewt-core/sys/log/common"
 
 pkg.apis:
     - log

--- a/sys/mfg/pkg.yml
+++ b/sys/mfg/pkg.yml
@@ -25,8 +25,8 @@ pkg.keywords:
     - manufacturing
 
 pkg.deps:
-    - kernel/os
-    - sys/flash_map
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/flash_map"
 
 # sys/flash_map must get initialized before sys/mfg.
 pkg.init:

--- a/sys/reboot/pkg.yml
+++ b/sys/reboot/pkg.yml
@@ -26,14 +26,14 @@ pkg.keywords:
     - logging
 
 pkg.deps:
-    - kernel/os
-    - mgmt/imgmgr
-    - sys/config
-    - sys/flash_map
-    - sys/log/modlog
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/sys/config"
+    - "@apache-mynewt-core/sys/flash_map"
+    - "@apache-mynewt-core/sys/log/modlog"
 
 pkg.deps.REBOOT_LOG_FCB:
-    - fs/fcb
+    - "@apache-mynewt-core/fs/fcb"
 
 pkg.init:
     log_reboot_pkg_init: 200

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -24,12 +24,12 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - time/datetime
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/time/datetime"
 
 pkg.deps.SHELL_NEWTMGR:
-    - encoding/base64
-    - util/crc
+    - "@apache-mynewt-core/encoding/base64"
+    - "@apache-mynewt-core/util/crc"
 
 pkg.req_apis:
     - console

--- a/sys/stats/full/pkg.yml
+++ b/sys/stats/full/pkg.yml
@@ -25,13 +25,13 @@ pkg.keywords:
     - statistics
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 pkg.apis:
     - stats
 pkg.deps.STATS_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 pkg.deps.STATS_NEWTMGR:
-    - mgmt/mgmt
+    - "@apache-mynewt-core/mgmt/mgmt"
 
 pkg.init:
     stats_module_init: 10

--- a/sys/sysinit/pkg.yml
+++ b/sys/sysinit/pkg.yml
@@ -25,5 +25,5 @@ pkg.keywords:
     - init
 
 pkg.deps:
-    - kernel/os
-    - sys/flash_map
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/flash_map"

--- a/sys/sysview/pkg.yml
+++ b/sys/sysview/pkg.yml
@@ -23,6 +23,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-      - sys/sysview/vendor
+    - "@apache-mynewt-core/sys/sysview/vendor"
 pkg.init:
     sysview_init: 100

--- a/sys/sysview/vendor/pkg.yml
+++ b/sys/sysview/vendor/pkg.yml
@@ -23,5 +23,5 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-      - hw/drivers/rtt
+    - "@apache-mynewt-core/hw/drivers/rtt"
 

--- a/test/crash_test/pkg.yml
+++ b/test/crash_test/pkg.yml
@@ -23,14 +23,14 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps.CRASH_TEST_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 pkg.req_apis.CRASH_TEST_CLI:
     - console
 pkg.deps.CRASH_TEST_NEWTMGR:
-    - mgmt/mgmt
+    - "@apache-mynewt-core/mgmt/mgmt"
 
 pkg.deps.CRASH_TEST_NEWTMGR:
-    - encoding/json
+    - "@apache-mynewt-core/encoding/json"
 
 pkg.init:
     crash_test_init: 500

--- a/test/flash_test/pkg.yml
+++ b/test/flash_test/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - hw/hal
-    - sys/shell
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/sys/shell"
 pkg.req_apis:
     - console
 

--- a/test/i2c_scan/pkg.yml
+++ b/test/i2c_scan/pkg.yml
@@ -23,10 +23,10 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os
-    - hw/hal
-    - sys/shell
-    - util/parse
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/util/parse"
 
 pkg.req_apis:
     - console

--- a/test/runtest/pkg.yml
+++ b/test/runtest/pkg.yml
@@ -23,13 +23,13 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps.RUNTEST_CLI:
-    - sys/shell
+    - "@apache-mynewt-core/sys/shell"
 pkg.req_apis.RUNTEST_CLI:
     - console
 pkg.deps.RUNTEST_NEWTMGR:
-    - mgmt/mgmt
-    - encoding/json
-    - test/testutil
+    - "@apache-mynewt-core/mgmt/mgmt"
+    - "@apache-mynewt-core/encoding/json"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.init:
     runtest_init: 500

--- a/test/testutil/pkg.yml
+++ b/test/testutil/pkg.yml
@@ -26,9 +26,9 @@ pkg.keywords:
     - test
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
-    - sys/sysinit
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/sysinit"
 
 pkg.init:
     tu_init: 1

--- a/time/datetime/pkg.yml
+++ b/time/datetime/pkg.yml
@@ -26,4 +26,4 @@ pkg.keywords:
     - datetime
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/time/timesched/pkg.yml
+++ b/time/timesched/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - datetime
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"
 
 pkg.init:
     timesched_init: 500

--- a/util/cbmem/pkg.yml
+++ b/util/cbmem/pkg.yml
@@ -26,5 +26,5 @@ pkg.keywords:
     - circular buffer
 
 pkg.deps:
-    - hw/hal
-    - kernel/os
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"

--- a/util/cbmem/test/pkg.yml
+++ b/util/cbmem/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - test/testutil
-    - util/cbmem
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/util/cbmem"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/util/mem/pkg.yml
+++ b/util/mem/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
     - mempool
 
 pkg.deps:
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/util/rwlock/pkg.yml
+++ b/util/rwlock/pkg.yml
@@ -22,4 +22,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - kernel/os
+    - "@apache-mynewt-core/kernel/os"

--- a/util/rwlock/test/pkg.yml
+++ b/util/rwlock/test/pkg.yml
@@ -23,9 +23,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - kernel/os
-    - test/testutil
-    - util/rwlock
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/util/rwlock"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
After discussion on the list 
http://mail-archives.apache.org/mod_mbox/mynewt-dev/201806.mbox/%3cCADzm-FKbSW9g6BueZW8cjaVpMpvB8epp67gp5D=QM6fXoMvnoA@mail.gmail.com%3e

No one brought up a reason all pathing in core shouldnt be absolute, mostly aiding (indeed supporting) in the ability of people to easily fork upstream packages.