### PR TITLE
tinycbor/oic; byte string encoding with data as iovec.

### DIFF
--- a/encoding/tinycbor/include/tinycbor/cbor.h
+++ b/encoding/tinycbor/include/tinycbor/cbor.h
@@ -166,10 +166,13 @@ typedef struct cbor_encoder_writer {
     int                 bytes_written;
 } cbor_encoder_writer;
 
+struct cbor_iovec {
+    void   *iov_base;
+    size_t iov_len;
+};
 
 /* Encoder API */
-struct CborEncoder
-{
+struct CborEncoder {
     cbor_encoder_writer *writer;
     void *writer_arg;
     size_t added;
@@ -190,6 +193,9 @@ CBOR_API CborError cbor_encode_text_string(CborEncoder *encoder, const char *str
 CBOR_INLINE_API CborError cbor_encode_text_stringz(CborEncoder *encoder, const char *string)
 { return cbor_encode_text_string(encoder, string, strlen(string)); }
 CBOR_API CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, size_t length);
+CBOR_API CborError cbor_encode_byte_iovec(CborEncoder *encoder,
+                                          const struct cbor_iovec iov[],
+                                          int iov_len);
 CBOR_API CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value);
 CBOR_INLINE_API CborError cbor_encode_bytes_written(CborEncoder *encoder)
 {   return encoder->writer->bytes_written; }

--- a/encoding/tinycbor/src/cborencoder.c
+++ b/encoding/tinycbor/src/cborencoder.c
@@ -411,6 +411,36 @@ CborError cbor_encode_byte_string(CborEncoder *encoder, const uint8_t *string, s
 }
 
 /**
+ * Appends the byte string passed as \a iov and \a iov_len to the CBOR
+ * stream provided by \a encoder. CBOR byte strings are arbitrary raw data.
+ *
+ * \sa CborError cbor_encode_text_stringz, cbor_encode_byte_string
+ */
+CborError cbor_encode_byte_iovec(CborEncoder *encoder,
+                                 const struct cbor_iovec iov[], int iov_len)
+{
+    CborError err;
+    size_t length;
+    int i;
+
+    length = 0;
+    for (i = 0; i < iov_len; i++) {
+        length += iov[i].iov_len;
+    }
+    err = encode_number(encoder, length, ByteStringType << MajorTypeShift);
+    if (err && !isOomError(err)) {
+        return err;
+    }
+    for (i = 0; i < iov_len; i++) {
+        err = append_to_buffer(encoder, iov[i].iov_base, iov[i].iov_len);
+        if (err && !isOomError(err)) {
+            return err;
+        }
+    }
+    return 0;
+}
+
+/**
  * Appends the byte string \a string of length \a length to the CBOR stream
  * provided by \a encoder. CBOR byte strings are arbitrary raw data.
  *

--- a/net/oic/include/oic/oc_rep.h
+++ b/net/oic/include/oic/oc_rep.h
@@ -76,6 +76,12 @@ int oc_rep_finalize(void);
     g_err |= cbor_encode_byte_string(&object##_map, value, length);            \
   } while (0)
 
+#define oc_rep_set_byte_string_iov(object, key, iov, iov_len)                  \
+  do {                                                                         \
+    g_err |= cbor_encode_text_string(&object##_map, #key, strlen(#key));       \
+    g_err |= cbor_encode_byte_iovec(&object##_map, iov, iov_len);              \
+  } while (0)
+
 #define oc_rep_start_array(parent, key)                                        \
   do {                                                                         \
     CborEncoder key##_array;                                                   \


### PR DESCRIPTION
This avoid memory copies when encoding byte strings where data is not contiguous in memory.