### PR TITLE
log/modlog: Allow LOG_[...] macros to use modlog

### DIFF
--- a/sys/log/modlog/include/modlog/modlog.h
+++ b/sys/log/modlog/include/modlog/modlog.h
@@ -359,4 +359,29 @@ modlog_printf(uint8_t module, uint8_t level, const char *msg, ...)
 #define MODLOG_DFLT(ml_lvl_, ...) \
     MODLOG(ml_lvl_, LOG_MODULE_DEFAULT, __VA_ARGS__)
 
+/* If `MODLOG_LOG_MACROS` in enabled, retire the old `LOG_[...]` macros and
+ * redefine them to use modlog.
+ */
+#if MYNEWT_VAL(MODLOG_LOG_MACROS)
+
+#undef LOG_DEBUG
+#define LOG_DEBUG       MODLOG_DEBUG
+
+#undef LOG_INFO
+#define LOG_INFO        MODLOG_INFO
+
+#undef LOG_WARN
+#define LOG_WARN        MODLOG_WARN
+
+#undef LOG_ERROR
+#define LOG_ERROR       MODLOG_ERROR
+
+#undef LOG_CRITICAL
+#define LOG_CRITICAL    MODLOG_CRITICAL
+
+#undef LOG_DFLT
+#define LOG_DFLT        MODLOG_DFLT
+
+#endif
+
 #endif

--- a/sys/log/modlog/syscfg.yml
+++ b/sys/log/modlog/syscfg.yml
@@ -31,3 +31,13 @@ syscfg.defs:
         description: >
             Automatically create a default mapping to the console log.
         value: 1
+    MODLOG_LOG_MACROS:
+        description: >
+            Retires the old `LOG_[...]` macros and redefines them to use
+            modlog.  That is, if enabled, this setting allows the following
+            code:
+                LOG_DEBUG(LOG_MODULE_DFLT, "hello");
+            This line logs the string "hello" to the default module using
+            modlog.  This setting will be enabled by default in a future
+            release.
+        value: 0


### PR DESCRIPTION
Create a syscfg setting: `MODLOG_LOG_MACROS`.  If enabled, this setting retires the old `LOG_[...]` macros and redefines them to use modlog.