### PR TITLE
Fix cortex-m0 compilation on gcc 8.1

### DIFF
--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.default: -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -DCMSIS_VECTAB_VIRTUAL -DCMSIS_VECTAB_VIRTUAL_HEADER_FILE="mynewt_cm0_vectab.h"
+compiler.flags.default: -march=armv6s-m -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -DCMSIS_VECTAB_VIRTUAL -DCMSIS_VECTAB_VIRTUAL_HEADER_FILE="mynewt_cm0_vectab.h"
 compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
 compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
 


### PR DESCRIPTION
This must be added due to what seems to be a gcc regression: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606