### PR TITLE
Add SVC IRQ name to mcu.h to avoid naming issues

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/include/mcu/mcu.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define SVC_IRQ_NUMBER SVCall_IRQn
+
 /*
  * Defines for naming GPIOs.
  */

--- a/hw/mcu/nxp/mkw41z/include/mcu/mcu.h
+++ b/hw/mcu/nxp/mkw41z/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define SVC_IRQ_NUMBER SVCall_IRQn
+
 /*
  * Defines for naming GPIOs.
  */

--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -22,6 +22,8 @@
 #include <hal/hal_os_tick.h>
 #include <mcu/cmsis_nvic.h>
 
+#include "mcu/mcu.h"
+
 #include "os_priv.h"
 
 /*
@@ -199,7 +201,7 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
-        NVIC_SetVector(SVCall_IRQn, (uint32_t)SVC_Handler);
+        NVIC_SetVector(SVC_IRQ_NUMBER, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
 
@@ -219,7 +221,7 @@ os_arch_os_init(void)
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);
 
         /* Set the SVC interrupt to priority 0 (highest configurable) */
-        NVIC_SetPriority(SVCall_IRQn, SVC_PRIO);
+        NVIC_SetPriority(SVC_IRQ_NUMBER, SVC_PRIO);
 
         /* Check if privileged or not */
         if ((__get_CONTROL() & 1) == 0) {


### PR DESCRIPTION
STM32L0 changed the naming as had previously happened on Cortex-M3 which was fixed on #851.