### PR TITLE
lis2ds12: fix modlog include

### DIFF
--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -30,7 +30,7 @@
 #include "lis2ds12/lis2ds12.h"
 #include "lis2ds12_priv.h"
 #include "hal/hal_gpio.h"
-#include "log/log.h"
+#include "modlog/modlog.h"
 #include "stats/stats.h"
 #include <syscfg/syscfg.h>
 


### PR DESCRIPTION
Looks like lis2ds missed an include in the modlog prs, without this:

```
Error: repos/apache-mynewt-core/hw/drivers/sensors/lis2ds12/src/lis2ds12.c: In function 'lis2ds12_i2c_writelen':
repos/apache-mynewt-core/hw/drivers/sensors/lis2ds12/src/lis2ds12.c:85:5: error: implicit declaration of function 'MODLOG_ERROR' [-Werror=implicit-function-declaration]
     MODLOG_ ## lvl_(MYNEWT_VAL(LIS2DS12_LOG_MODULE), __VA_ARGS__)
     ^
repos/apache-mynewt-core/hw/drivers/sensors/lis2ds12/src/lis2ds12.c:144:9: note: in expansion of macro 'LIS2DS12_LOG'
         LIS2DS12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
         ^
cc1: all warnings being treated as errors
```