### PR TITLE
[STM32] syscfg hal choices

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32_common/src/hal_gpio.c
@@ -274,63 +274,63 @@ hal_gpio_clk_enable(uint32_t port_idx)
 {
     switch (port_idx) {
 #if defined GPIOA_BASE
-        case 0:
-            __HAL_RCC_GPIOA_CLK_ENABLE();
-            break;
+    case 0:
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOB_BASE
-        case 1:
-            __HAL_RCC_GPIOB_CLK_ENABLE();
-            break;
+    case 1:
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOC_BASE
-        case 2:
-            __HAL_RCC_GPIOC_CLK_ENABLE();
-            break;
+    case 2:
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOD_BASE
-        case 3:
-            __HAL_RCC_GPIOD_CLK_ENABLE();
-            break;
+    case 3:
+        __HAL_RCC_GPIOD_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOE_BASE
-        case 4:
-            __HAL_RCC_GPIOE_CLK_ENABLE();
-            break;
+    case 4:
+        __HAL_RCC_GPIOE_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOF_BASE
-        case 5:
-            __HAL_RCC_GPIOF_CLK_ENABLE();
-            break;
+    case 5:
+        __HAL_RCC_GPIOF_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOG_BASE
-        case 6:
-            __HAL_RCC_GPIOG_CLK_ENABLE();
-            break;
+    case 6:
+        __HAL_RCC_GPIOG_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOH_BASE
-        case 7:
-            __HAL_RCC_GPIOH_CLK_ENABLE();
-            break;
+    case 7:
+        __HAL_RCC_GPIOH_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOI_BASE
-        case 8:
-            __HAL_RCC_GPIOI_CLK_ENABLE();
-            break;
+    case 8:
+        __HAL_RCC_GPIOI_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOJ_BASE
-        case 9:
-            __HAL_RCC_GPIOJ_CLK_ENABLE();
-            break;
+    case 9:
+        __HAL_RCC_GPIOJ_CLK_ENABLE();
+        break;
 #endif
 #if defined GPIOK_BASE
-        case 10:
-            __HAL_RCC_GPIOK_CLK_ENABLE();
-            break;
+    case 10:
+        __HAL_RCC_GPIOK_CLK_ENABLE();
+        break;
 #endif
-        default:
-            assert(0);
-            break;
+    default:
+        assert(0);
+        break;
     }
 }
 

--- a/hw/mcu/stm/stm32_common/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32_common/src/hal_i2c.c
@@ -71,7 +71,7 @@ static struct stm32_hal_i2c *hal_i2c_devs[HAL_I2C_MAX_DEVS] = {
 #endif
 };
 
-#if defined(STM32F1)
+#if MYNEWT_VAL(MCU_STM32F1)
 static void
 i2c_reset(I2C_HandleTypeDef *hi2c)
 {
@@ -88,7 +88,7 @@ hal_i2c_init(uint8_t i2c_num, void *usercfg)
     struct stm32_hal_i2c_cfg *cfg = (struct stm32_hal_i2c_cfg *)usercfg;
     struct stm32_hal_i2c *dev;
     I2C_InitTypeDef *init;
-#if defined(STM32F1)
+#if MYNEWT_VAL(MCU_STM32F1)
     GPIO_InitTypeDef gpio;
 #endif
     int rc;
@@ -99,7 +99,7 @@ hal_i2c_init(uint8_t i2c_num, void *usercfg)
 
     init = &dev->hid_handle.Init;
     dev->hid_handle.Instance = cfg->hic_i2c;
-#if MYNEWT_VAL(MCU_STM32F3) || MYNEWT_VAL(MCU_STM32F7) || MYNEWT_VAL(MCU_STM32L4)
+#if !MYNEWT_VAL(STM32_HAL_I2C_HAS_CLOCKSPEED)
     init->Timing = cfg->hic_timingr;
 #else
     init->ClockSpeed = cfg->hic_speed;
@@ -116,7 +116,7 @@ hal_i2c_init(uint8_t i2c_num, void *usercfg)
      * Configure GPIO pins for I2C.
      * Enable clock routing for I2C.
      */
-#if !defined(STM32F1)
+#if !MYNEWT_VAL(MCU_STM32F1)
     rc = hal_gpio_init_af(cfg->hic_pin_sda, cfg->hic_pin_af, HAL_GPIO_PULL_UP,
                           1);
     if (rc) {
@@ -234,7 +234,7 @@ hal_i2c_master_probe(uint8_t i2c_num, uint8_t address, uint32_t timo)
 
     rc = HAL_I2C_IsDeviceReady(&dev->hid_handle, address << 1, 1, timo);
 
-#if defined(STM32F1)
+#if MYNEWT_VAL(MCU_STM32F1)
     if (rc == HAL_BUSY) {
         i2c_reset(&dev->hid_handle);
     }

--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -58,7 +58,7 @@ static struct hal_uart_irq uart_irqs[4];
 static struct hal_uart_irq uart_irqs[3];
 #endif
 
-#if MYNEWT_VAL(MCU_STM32F3) || MYNEWT_VAL(MCU_STM32F7) || MYNEWT_VAL(MCU_STM32L4)
+#if !MYNEWT_VAL(STM32_HAL_UART_HAS_SR)
 #  define STATUS(x)     ((x)->ISR)
 #  define RXNE          USART_ISR_RXNE
 #  define TXE           USART_ISR_TXE
@@ -140,7 +140,7 @@ uart_irq_handler(int num)
         }
         regs->CR1 = cr1;
     }
-#if MYNEWT_VAL(MCU_STM32F3) || MYNEWT_VAL(MCU_STM32F7) || MYNEWT_VAL(MCU_STM32L4)
+#if !MYNEWT_VAL(STM32_HAL_UART_HAS_SR)
     /* clear overrun */
     if (isr & USART_ISR_ORE) {
         regs->ICR |= USART_ICR_ORECF;
@@ -335,7 +335,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     struct hal_uart *u;
     const struct stm32_uart_cfg *cfg;
     uint32_t cr1, cr2, cr3;
-#if defined(STM32F1)
+#if MYNEWT_VAL(MCU_STM32F1)
     GPIO_InitTypeDef gpio;
 #endif
 
@@ -350,7 +350,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     cfg = u->u_cfg;
     assert(cfg);
 
-#if defined(STM32F1)
+#if MYNEWT_VAL(MCU_STM32F1)
     gpio.Mode = GPIO_MODE_AF_PP;
     gpio.Speed = GPIO_SPEED_FREQ_HIGH;
 
@@ -383,7 +383,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     cr3 = cfg->suc_uart->CR3;
 
     cr1 &= ~(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | USART_CR1_RE);
-#if !defined(STM32F1)
+#if !MYNEWT_VAL(MCU_STM32F1)
     cr1 &= ~(USART_CR1_OVER8);
 #endif
     cr2 &= ~(USART_CR2_STOP);
@@ -441,7 +441,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
         break;
     }
 
-#if !defined(STM32F1)
+#if !MYNEWT_VAL(MCU_STM32F1)
     cr1 |= (UART_MODE_RX | UART_MODE_TX | UART_OVERSAMPLING_16);
 #else
     cr1 |= (UART_MODE_TX_RX | UART_OVERSAMPLING_16);
@@ -449,7 +449,7 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
 
     *cfg->suc_rcc_reg |= cfg->suc_rcc_dev;
 
-#if !defined(STM32F1)
+#if !MYNEWT_VAL(MCU_STM32F1)
     hal_gpio_init_af(cfg->suc_pin_tx, cfg->suc_pin_af, 0, 0);
     hal_gpio_init_af(cfg->suc_pin_rx, cfg->suc_pin_af, 0, 0);
     if (flow_ctl == HAL_UART_FLOW_CTL_RTS_CTS) {

--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v1.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v1.c
@@ -29,7 +29,7 @@
 #include <mcu/stm32_hal.h>
 #include <syscfg/syscfg.h>
 
-#if !MYNEWT_VAL(MCU_STM32F3) && !MYNEWT_VAL(MCU_STM32F7) && !MYNEWT_VAL(MCU_STM32L4)
+#if MYNEWT_VAL(STM32_HAL_I2C_HAS_CLOCKSPEED)
 
 #define I2C_TIMEOUT_BUSY_FLAG     25U         /*!< Timeout 25 ms             */
 #define I2C_NO_OPTION_FRAME       0xFFFF0000U /*!< XferOptions default value */
@@ -852,6 +852,6 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_Custom(I2C_HandleTypeDef *hi2c,
   }
 }
 
-#endif /* !defined(STM32F3) && !defined(STM32F7) */
+#endif /* MYNEWT_VAL(STM32_HAL_I2C_HAS_CLOCKSPEED) */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v2.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v2.c
@@ -30,7 +30,7 @@
 #include <mcu/stm32_hal.h>
 #include <syscfg/syscfg.h>
 
-#if MYNEWT_VAL(MCU_STM32F3) || MYNEWT_VAL(MCU_STM32F7) || MYNEWT_VAL(MCU_STM32L4)
+#if !MYNEWT_VAL(STM32_HAL_I2C_HAS_CLOCKSPEED)
 
 #define I2C_TIMEOUT_BUSY    (25U)          /*!< 25 ms */
 
@@ -661,4 +661,4 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_Custom(I2C_HandleTypeDef *hi2c,
   }
 }
 
-#endif /* defined(STM32F3) || defined(STM32F7) */
+#endif /* !MYNEWT_VAL(STM32_HAL_I2C_HAS_CLOCKSPEED) */

--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
@@ -32,7 +32,7 @@
 HAL_StatusTypeDef HAL_SPI_Slave_Queue_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_QueueTransmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
 
-#define SPI_HAS_FIFO (MYNEWT_VAL(MCU_STM32F3) || MYNEWT_VAL(MCU_STM32F7) || MYNEWT_VAL(MCU_STM32L4))
+#define SPI_HAS_FIFO MYNEWT_VAL(STM32_HAL_SPI_HAS_FIFO)
 
 #if SPI_HAS_FIFO && (MYNEWT_VAL(SPI_0_SLAVE) || \
                      MYNEWT_VAL(SPI_1_SLAVE) || \

--- a/hw/mcu/stm/stm32f1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f1xx/syscfg.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-# Package: hw/bsp/stm32l152discovery
+# Package: hw/mcu/stm/stm32f1xx
 
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
@@ -27,6 +27,18 @@ syscfg.defs:
 
     MCU_STM32F1:
         description: MCUs are of STM32F1xx family
+        value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI without FIFO
+        value: 0
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has a clock speed register
+        value: 1
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses SR register for status.
         value: 1
 
     I2C_0:

--- a/hw/mcu/stm/stm32f3xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f3xx/syscfg.yml
@@ -16,6 +16,8 @@
 # under the License.
 #
 
+# Package: hw/mcu/stm/stm32f3xx
+
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
@@ -26,6 +28,18 @@ syscfg.defs:
     MCU_STM32F3:
         description: MCUs are of STM32F3xx family
         value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI with FIFO
+        value: 1
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has no clock speed register (has TIMINGR)
+        value: 0
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses ISR register (not SR) for status.
+        value: 0
 
     MCU_SYSCLK_PLL_HSI:
         description: Configure PLL as sysclock driven by HSI.

--- a/hw/mcu/stm/stm32f4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f4xx/syscfg.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm32f4xx
+# Package: hw/mcu/stm/stm32f4xx
 
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
@@ -27,6 +27,18 @@ syscfg.defs:
 
     MCU_STM32F4:
         description: MCUs are of STM32F4xx family
+        value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI without FIFO
+        value: 0
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has a clock speed register
+        value: 1
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses SR register for status.
         value: 1
 
     I2C_0:

--- a/hw/mcu/stm/stm32f7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f7xx/syscfg.yml
@@ -16,6 +16,8 @@
 # under the License.
 #
 
+# Package: hw/mcu/stm/stm32f7xx
+
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
@@ -26,6 +28,18 @@ syscfg.defs:
     MCU_STM32F7:
         description: MCUs are of STM32F7xx family
         value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI with FIFO
+        value: 1
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has no clock speed register (has TIMINGR)
+        value: 0
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses ISR register (not SR) for status.
+        value: 0
 
     MCU_SYSCLK_PLL_HSI:
         description: Configure PLL as sysclock driven by HSI.

--- a/hw/mcu/stm/stm32l1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l1xx/syscfg.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-# Package: hw/bsp/stm32l152discovery
+# Package: hw/mcu/stm/stm32l1xx
 
 syscfg.defs:
     I2C_0:
@@ -31,6 +31,18 @@ syscfg.defs:
 
     MCU_STM32L1:
         description: MCUs are of STM32L1xx family
+        value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI without FIFO
+        value: 0
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has a clock speed register
+        value: 1
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses SR register for status.
         value: 1
 
     SPI_0_MASTER:

--- a/hw/mcu/stm/stm32l4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l4xx/syscfg.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm32l4xx
+# Package: hw/mcu/stm/stm32l4xx
 
 syscfg.defs:
     I2C_0:
@@ -32,6 +32,18 @@ syscfg.defs:
     MCU_STM32L4:
         description: MCUs are of STM32L4xx family
         value: 1
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI with FIFO
+        value: 1
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has no clock speed register (has TIMINGR)
+        value: 0
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses ISR register (not SR) for status.
+        value: 0
 
     SPI_0_MASTER:
         description: 'SPI 0 master'


### PR DESCRIPTION
This moves family specific `#ifdefs` to syscfg to avoid having to modify the driver sources every time a new family is added. Also `#ifdefery` was updated to use `MYNEWT_VAL` instead of SDK provided macros where possible.