### PR TITLE
checking device initialization register for init completed

### DIFF
--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -179,6 +179,9 @@ struct bq27z561
 
     /* Interface */
     struct bq27z561_itf bq27_itf;
+
+    /* Device initialization complete flag */
+    uint8_t bq27_initialized;
 };
 
 /**
@@ -349,6 +352,15 @@ int bq27z561_set_voltage_hi_set_threshold(struct bq27z561 *dev,
 int bq27z561_set_voltage_hi_clr_threshold(struct bq27z561 *dev,
         uint16_t voltage);
 
+/* Check if bq27z561 is initialized and sets bq27z561 initialized flag */
+/**
+ * Check if bq27z561 is initialized and sets bq27z561 initialized flag
+ * @param dev pointer to device
+ * @param initialized device initialized flag
+ * @return int 0: success, -1 error
+ */
+int
+bq27z561_get_init_status(struct bq27z561 *dev, uint8_t *initialized);
 /**
  * bq27z561 get batt status
  *

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -352,7 +352,6 @@ int bq27z561_set_voltage_hi_set_threshold(struct bq27z561 *dev,
 int bq27z561_set_voltage_hi_clr_threshold(struct bq27z561 *dev,
         uint16_t voltage);
 
-/* Check if bq27z561 is initialized and sets bq27z561 initialized flag */
 /**
  * Check if bq27z561 is initialized and sets bq27z561 initialized flag
  * @param dev pointer to device

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -938,13 +938,17 @@ bq27z561_battery_property_get(struct battery_driver *driver,
     int rc = 0;
     struct bq27z561 * bq_dev;
     bq_dev = (struct bq27z561 *)&driver->dev;
-    rc = bq27z561_get_init_status((struct bq27z561 *) driver->bd_driver_data,
-                                      &bq_dev->bq27_initialized);
+
     if (!bq_dev->bq27_initialized)
     {
-        rc = -2;
-        property->bp_valid = 0;
-        return rc;
+        rc = bq27z561_get_init_status((struct bq27z561 *) driver->bd_driver_data,
+                                          &bq_dev->bq27_initialized);
+        if (!bq_dev->bq27_initialized)
+        {
+            rc = -2;
+            property->bp_valid = 0;
+            return rc;
+        }
     }
 
     battery_property_value_t val;
@@ -1173,6 +1177,9 @@ bq27z561_init(struct os_dev *dev, void *arg)
     OS_DEV_SETHANDLERS(dev, bq27z561_open, bq27z561_close);
 
     bq27 = (struct bq27z561 *)dev;
+
+    bq27->bq27_initialized = 0;
+
     /* Copy the interface struct */
     bq27->bq27_itf = init_arg->itf;
 


### PR DESCRIPTION
@vrahane @wes3 @kasjer 
bq27z561 changes to look at battery_status initialization bit.

bp_valid bit is not set depending on a valid read based on successful register read AND init bit set.

Without this change the listeners can return invalid values if polling occurs when fuel gauge is still initializing.