### PR TITLE
Lora spi fix

### DIFF
--- a/hw/drivers/lora/sx1272/include/radio/radio.h
+++ b/hw/drivers/lora/sx1272/include/radio/radio.h
@@ -339,31 +339,13 @@ struct Radio_s
      * \retval time Radio plus board wakeup time in ms.
      */
     uint32_t  ( *GetWakeupTime )( void );
+
     /*!
-     * \brief Process radio irq
-     */
-    void ( *IrqProcess )( void );
-    /*
-     * The next functions are available only on SX126x radios.
-     */
-    /*!
-     * \brief Sets the radio in reception mode with Max LNA gain for the given time
+     * \brief Disables receive irq, puts chip in standby and clears any pending
+     * rx interrupts
      *
-     * \remark Available on SX126x radios only.
-     *
-     * \param [IN] timeout Reception timeout [ms]
-     *                     [0: continuous, others timeout]
      */
-    void    ( *RxBoosted )( uint32_t timeout );
-    /*!
-     * \brief Sets the Rx duty cycle management parameters
-     *
-     * \remark Available on SX126x radios only.
-     *
-     * \param [in]  rxTime        Structure describing reception timeout value
-     * \param [in]  sleepTime     Structure describing sleep timeout value
-     */
-    void ( *SetRxDutyCycle ) ( uint32_t rxTime, uint32_t sleepTime );
+    void  ( *RxDisable )( void );
 };
 
 /*!

--- a/hw/drivers/lora/sx1272/src/sx1272-board.c
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.c
@@ -349,3 +349,21 @@ SX1272GetBoardTcxoWakeupTime(void)
 {
     return 0;
 }
+
+void
+SX1272RxIoIrqDisable(void)
+{
+    hal_gpio_irq_disable(SX1272_DIO0);
+    hal_gpio_irq_disable(SX1272_DIO1);
+    hal_gpio_irq_disable(SX1272_DIO2);
+    hal_gpio_irq_disable(SX1272_DIO3);
+}
+
+void
+SX1272RxIoIrqEnable(void)
+{
+    hal_gpio_irq_enable(SX1272_DIO0);
+    hal_gpio_irq_enable(SX1272_DIO1);
+    hal_gpio_irq_enable(SX1272_DIO2);
+    hal_gpio_irq_enable(SX1272_DIO3);
+}

--- a/hw/drivers/lora/sx1272/src/sx1272-board.c
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.c
@@ -63,7 +63,8 @@ const struct Radio_s Radio =
     SX1272ReadBuffer,
     SX1272SetMaxPayloadLength,
     SX1272SetPublicNetwork,
-    SX1272GetWakeupTime
+    SX1272GetWakeupTime,
+    SX1272RxDisable
 };
 
 void
@@ -348,4 +349,3 @@ SX1272GetBoardTcxoWakeupTime(void)
 {
     return 0;
 }
-

--- a/hw/drivers/lora/sx1272/src/sx1272-board.h
+++ b/hw/drivers/lora/sx1272/src/sx1272-board.h
@@ -152,6 +152,17 @@ bool SX1272CheckRfFrequency(uint32_t frequency);
 uint32_t SX1272GetBoardTcxoWakeupTime( void );
 
 /*!
+ * \brief Disables all receive related IO Irqs
+ */
+void SX1272RxIoIrqDisable( void );
+
+/*!
+ * \brief Enables all receive related IO Irqs
+ */
+void SX1272RxIoIrqEnable( void );
+
+
+/*!
  * Radio hardware and global parameters
  */
 extern SX1272_t SX1272;

--- a/hw/drivers/lora/sx1272/src/sx1272.c
+++ b/hw/drivers/lora/sx1272/src/sx1272.c
@@ -1569,6 +1569,9 @@ void
 SX1272RxDisable(void)
 {
     if (SX1272.Settings.Modem == MODEM_LORA) {
+        /* Disable GPIO interrupts */
+        SX1272RxIoIrqDisable();
+
         /* Disable RX interrupts */
         SX1272Write(REG_LR_IRQFLAGSMASK, RFLR_IRQFLAGS_RXTIMEOUT_MASK       |
                                          RFLR_IRQFLAGS_RXDONE_MASK          |
@@ -1585,5 +1588,7 @@ SX1272RxDisable(void)
                                      RFLR_IRQFLAGS_PAYLOADCRCERROR_MASK |
                                      RFLR_IRQFLAGS_CADDONE_MASK         |
                                      RFLR_IRQFLAGS_CADDETECTED_MASK);
+        /* Enable GPIO interrupts */
+        SX1272RxIoIrqEnable();
     }
 }

--- a/hw/drivers/lora/sx1272/src/sx1272.c
+++ b/hw/drivers/lora/sx1272/src/sx1272.c
@@ -1564,3 +1564,26 @@ SX1272OnDio5Irq(void *unused)
         break;
     }
 }
+
+void
+SX1272RxDisable(void)
+{
+    if (SX1272.Settings.Modem == MODEM_LORA) {
+        /* Disable RX interrupts */
+        SX1272Write(REG_LR_IRQFLAGSMASK, RFLR_IRQFLAGS_RXTIMEOUT_MASK       |
+                                         RFLR_IRQFLAGS_RXDONE_MASK          |
+                                         RFLR_IRQFLAGS_PAYLOADCRCERROR_MASK |
+                                         RFLR_IRQFLAGS_CADDONE_MASK         |
+                                         RFLR_IRQFLAGS_CADDETECTED_MASK);
+
+        /* Put radio into standby */
+        SX1272SetStby();
+
+        /* Clear any pending interrupts */
+        SX1272Write(REG_LR_IRQFLAGS, RFLR_IRQFLAGS_RXTIMEOUT            |
+                                     RFLR_IRQFLAGS_RXDONE               |
+                                     RFLR_IRQFLAGS_PAYLOADCRCERROR_MASK |
+                                     RFLR_IRQFLAGS_CADDONE_MASK         |
+                                     RFLR_IRQFLAGS_CADDETECTED_MASK);
+    }
+}

--- a/hw/drivers/lora/sx1272/src/sx1272.h
+++ b/hw/drivers/lora/sx1272/src/sx1272.h
@@ -398,4 +398,6 @@ void SX1272SetPublicNetwork(bool enable);
  */
 uint32_t SX1272GetWakeupTime(void);
 
+void SX1272RxDisable(void);
+
 #endif // __SX1272_H__

--- a/hw/drivers/lora/sx1276/include/radio/radio.h
+++ b/hw/drivers/lora/sx1276/include/radio/radio.h
@@ -339,31 +339,13 @@ struct Radio_s
      * \retval time Radio plus board wakeup time in ms.
      */
     uint32_t  ( *GetWakeupTime )( void );
+
     /*!
-     * \brief Process radio irq
-     */
-    void ( *IrqProcess )( void );
-    /*
-     * The next functions are available only on SX126x radios.
-     */
-    /*!
-     * \brief Sets the radio in reception mode with Max LNA gain for the given time
+     * \brief Disables receive irq, puts chip in standby and clears any pending
+     * rx interrupts
      *
-     * \remark Available on SX126x radios only.
-     *
-     * \param [IN] timeout Reception timeout [ms]
-     *                     [0: continuous, others timeout]
      */
-    void    ( *RxBoosted )( uint32_t timeout );
-    /*!
-     * \brief Sets the Rx duty cycle management parameters
-     *
-     * \remark Available on SX126x radios only.
-     *
-     * \param [in]  rxTime        Structure describing reception timeout value
-     * \param [in]  sleepTime     Structure describing sleep timeout value
-     */
-    void ( *SetRxDutyCycle ) ( uint32_t rxTime, uint32_t sleepTime );
+    void  ( *RxDisable )( void );
 };
 
 /*!

--- a/hw/drivers/lora/sx1276/src/sx1276-board.c
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.c
@@ -55,7 +55,8 @@ const struct Radio_s Radio =
     .ReadBuffer = SX1276ReadBuffer,
     .SetMaxPayloadLength = SX1276SetMaxPayloadLength,
     .SetPublicNetwork = SX1276SetPublicNetwork,
-    .GetWakeupTime = SX1276GetWakeupTime
+    .GetWakeupTime = SX1276GetWakeupTime,
+    .RxDisable = SX1276RxDisable
 };
 
 void
@@ -231,3 +232,20 @@ SX1276GetBoardTcxoWakeupTime(void)
     return 0;
 }
 
+void
+SX1276RxIoIrqDisable(void)
+{
+    hal_gpio_irq_disable(SX1276_DIO0);
+    hal_gpio_irq_disable(SX1276_DIO1);
+    hal_gpio_irq_disable(SX1276_DIO2);
+    hal_gpio_irq_disable(SX1276_DIO3);
+}
+
+void
+SX1276RxIoIrqEnable(void)
+{
+    hal_gpio_irq_enable(SX1276_DIO0);
+    hal_gpio_irq_enable(SX1276_DIO1);
+    hal_gpio_irq_enable(SX1276_DIO2);
+    hal_gpio_irq_enable(SX1276_DIO3);
+}

--- a/hw/drivers/lora/sx1276/src/sx1276-board.h
+++ b/hw/drivers/lora/sx1276/src/sx1276-board.h
@@ -124,6 +124,16 @@ void SX1276SetPublicNetwork(bool enable);
 uint32_t SX1276GetBoardTcxoWakeupTime(void);
 
 /*!
+ * \brief Disables all receive related IO Irqs
+ */
+void SX1276RxIoIrqDisable( void );
+
+/*!
+ * \brief Enables all receive related IO Irqs
+ */
+void SX1276RxIoIrqEnable( void );
+
+/*!
  * Radio hardware and global parameters
  */
 extern SX1276_t SX1276;

--- a/hw/drivers/lora/sx1276/src/sx1276.c
+++ b/hw/drivers/lora/sx1276/src/sx1276.c
@@ -1712,3 +1712,31 @@ SX1276OnDio5Irq(void *unused)
         break;
     }
 }
+
+void
+SX1276RxDisable(void)
+{
+    if (SX1276.Settings.Modem == MODEM_LORA) {
+        /* Disable GPIO interrupts */
+        SX1276RxIoIrqDisable();
+
+        /* Disable RX interrupts */
+        SX1276Write(REG_LR_IRQFLAGSMASK, RFLR_IRQFLAGS_RXTIMEOUT_MASK       |
+                                         RFLR_IRQFLAGS_RXDONE_MASK          |
+                                         RFLR_IRQFLAGS_PAYLOADCRCERROR_MASK |
+                                         RFLR_IRQFLAGS_CADDONE_MASK         |
+                                         RFLR_IRQFLAGS_CADDETECTED_MASK);
+
+        /* Put radio into standby */
+        SX1276SetStby();
+
+        /* Clear any pending interrupts */
+        SX1276Write(REG_LR_IRQFLAGS, RFLR_IRQFLAGS_RXTIMEOUT            |
+                                     RFLR_IRQFLAGS_RXDONE               |
+                                     RFLR_IRQFLAGS_PAYLOADCRCERROR_MASK |
+                                     RFLR_IRQFLAGS_CADDONE_MASK         |
+                                     RFLR_IRQFLAGS_CADDETECTED_MASK);
+        /* Enable GPIO interrupts */
+        SX1276RxIoIrqEnable();
+    }
+}

--- a/hw/drivers/lora/sx1276/src/sx1276.h
+++ b/hw/drivers/lora/sx1276/src/sx1276.h
@@ -394,4 +394,6 @@ void SX1276SetPublicNetwork(bool enable);
  */
 uint32_t SX1276GetWakeupTime(void);
 
+void SX1276RxDisable(void);
+
 #endif // __SX1276_H__


### PR DESCRIPTION
These changes should fix non-atomic access to the spi. When attempting to transmit, the start of a reception could cause SPI access during an ISR. This could occur when the device is sending a transmit buffer to the device. This could cause the device to hang.