### PR TITLE
kernel/os: Add debug mode syscfg setting

### DIFF
--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -104,15 +104,13 @@ static int
 hal_flash_cmp_erased(const struct hal_flash *hf, uint32_t address,
   uint32_t num_bytes)
 {
-    uint8_t empty[MYNEWT_VAL(HAL_FLASH_VERIFY_BUF_SZ)];
     uint8_t buf[MYNEWT_VAL(HAL_FLASH_VERIFY_BUF_SZ)];
 
     uint32_t off;
     uint32_t rem;
     int chunk_sz;
     int rc;
-
-    memset(empty, 0xff, sizeof empty);
+    int i;
 
     for (off = 0; off < num_bytes; off += sizeof buf) {
         rem = num_bytes - off;
@@ -127,8 +125,10 @@ hal_flash_cmp_erased(const struct hal_flash *hf, uint32_t address,
             return rc;
         }
 
-        if (memcmp(buf, empty, chunk_sz) != 0) {
-            return -1;
+        for (i = 0; i < chunk_sz; i++) {
+            if (buf[i] != 0xff) {
+                return -1;
+            }
         }
     }
 

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -29,9 +29,9 @@ syscfg.defs:
         value: 0
     HAL_FLASH_VERIFY_BUF_SZ:
         description: >
-            The buffer size to use when verifying writes and erases.  Two
-            buffers of this size are allocated on the stack during erase
-            verifies; one buffer during write verifies.
+            The buffer size to use when verifying writes and erases.  One
+            buffer of this size is allocated on the stack during verify
+            operations.
         value: 16
 
 syscfg.vals.OS_DEBUG_MODE:

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    HAL_FLASH_VERIFY_WRITES:
+        description: >
+            If enabled, flash contents are read back and verified after each
+            write.
+        value: 0
+    HAL_FLASH_VERIFY_ERASES:
+        description: >
+            If enabled, flash contents are read back and verified after each
+            erase.
+        value: 0
+    HAL_FLASH_VERIFY_BUF_SZ:
+        description: >
+            The buffer size to use when verifying writes and erases.  Two
+            buffers of this size are allocated on the stack during erase
+            verifies; one buffer during write verifies.
+        value: 16

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -33,3 +33,7 @@ syscfg.defs:
             buffers of this size are allocated on the stack during erase
             verifies; one buffer during write verifies.
         value: 16
+
+syscfg.vals.OS_DEBUG_MODE:
+    HAL_FLASH_VERIFY_WRITES: 1
+    HAL_FLASH_VERIFY_ERASES: 1

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -107,3 +107,15 @@ syscfg.defs:
         description: >
             Enable tracing os_sem APIs by SystemView
         value: 1
+
+    OS_DEBUG_MODE:
+        description: >
+            Enables various runtime error checks.  A failed assert is triggered
+            on error detection.  Enabling this setting increases stack usage.
+        value: 0
+
+syscfg.vals.OS_DEBUG_MODE:
+    OS_CRASH_STACKTRACE: 1
+    OS_CTX_SW_STACK_CHECK: 1
+    OS_MEMPOOL_CHECK: 1
+    OS_MEMPOOL_POISON: 1


### PR DESCRIPTION
This commit adds a new syscfg setting:

    OS_DEBUG_MODE

This setting doesn't do anything by itself, but enabling it causes several other settings to be enabled.  Currently, this setting enables the following:

    OS_CRASH_STACKTRACE
    OS_CTX_SW_STACK_CHECK
    OS_MEMPOOL_CHECK
    OS_MEMPOOL_POISON
    HAL_FLASH_VERIFY_WRITES
    HAL_FLASH_VERIFY_ERASES