### PR TITLE
sys/log/stub: Define one instance of log handlers

### DIFF
--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -56,11 +56,11 @@ log_init(void)
 /*
  * Dummy handler exports.
  */
-const struct log_handler log_console_handler;
-const struct log_handler log_cbmem_handler;
-const struct log_handler log_fcb_handler;
+extern const struct log_handler log_console_handler;
+extern const struct log_handler log_cbmem_handler;
+extern const struct log_handler log_fcb_handler;
 #if MYNEWT_VAL(LOG_FCB_SLOT1)
-const struct log_handler log_fcb_slot1_handler;
+extern const struct log_handler log_fcb_slot1_handler;
 #endif
 
 #if MYNEWT_VAL(LOG_CONSOLE)

--- a/sys/log/stub/src/log.c
+++ b/sys/log/stub/src/log.c
@@ -21,3 +21,9 @@
 #include "log/log.h"
 
 struct log_info g_log_info;
+const struct log_handler log_console_handler;
+const struct log_handler log_cbmem_handler;
+const struct log_handler log_fcb_handler;
+#if MYNEWT_VAL(LOG_FCB_SLOT1)
+const struct log_handler log_fcb_slot1_handler;
+#endif


### PR DESCRIPTION
Prior to this PR, it was the stub log header that defined each log handler.  This caused each source file that included the stub header to have its own instance of each handler, causing newt to raise an error similar to the following:

    Global Symbol Conflict: log_fcb_handler from packages mgmt/newtmgr/transport/ble and nimble/host/store/config

This PR moves the handler definitions to a C file, and makes the declarations in the header file `extern`.