### PR TITLE
Fix unit test build errors

### DIFF
--- a/hw/hal/pkg.yml
+++ b/hw/hal/pkg.yml
@@ -23,4 +23,5 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: kernel/os
+pkg.deps:
+    - kernel/os

--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "os/mynewt.h"
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_flash_int.h"


### PR DESCRIPTION
hal_flash.c was using `MYNEWT_VAL()` without including `os/mynewt.h`.