### PR TITLE
Minor fixes to fix some unit tests

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -62,6 +62,7 @@ log_init(void)
 
     (void)rc;
 
+    memset(g_log_module_list, 0, sizeof(g_log_module_list));
     log_written = 0;
 
     STAILQ_INIT(&g_log_list);

--- a/sys/log/stub/include/log/log_fcb_slot1.h
+++ b/sys/log/stub/include/log/log_fcb_slot1.h
@@ -26,12 +26,12 @@
 
 #include "log/log.h"
 #include "fcb/fcb.h"
-#include "cbmem/cbmem.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+struct cbmem;
 typedef int (* log_fcb_slot1_reinit_fcb_fn) (struct fcb_log *arg);
 
 struct log_fcb_slot1 {


### PR DESCRIPTION
sys/log/full: clear module list at startup
This allows unit tests to start from a clean state after calling sysinit().

sys/log/stub: Remove unneeded cbmem dep