### PR TITLE
sys/console; rename global variables to make them more identifiable

### DIFF
--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -43,7 +43,7 @@ struct console_input {
 
 typedef void (*console_rx_cb)(void);
 typedef int (*console_append_char_cb)(char *line, uint8_t byte);
-typedef void (*completion_cb)(char *str, console_append_char_cb cb);
+typedef void (*console_completion_cb)(char *str, console_append_char_cb cb);
 
 int console_init(console_rx_cb rx_cb);
 int console_is_init(void);
@@ -58,7 +58,7 @@ void console_echo(int on);
 int console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;
 
-void console_set_completion_cb(completion_cb cb);
+void console_set_completion_cb(console_completion_cb cb);
 int console_handle_char(uint8_t byte);
 
 /* Set queue to send console line events to */

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -30,7 +30,7 @@
 static struct hal_timer rtt_timer;
 #endif
 
-static const char CR = '\r';
+static const char rtt_CR = '\r';
 
 int
 console_out(int character)
@@ -38,7 +38,7 @@ console_out(int character)
     char c = (char)character;
 
     if ('\n' == c) {
-        SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
+        SEGGER_RTT_WriteWithOverwriteNoLock(0, &rtt_CR, 1);
         console_is_midline = 0;
     } else {
         console_is_midline = 1;

--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -34,7 +34,7 @@ struct console_input {
 
 typedef void (*console_rx_cb)(void);
 typedef int (*console_append_char_cb)(char *line, uint8_t byte);
-typedef void (*completion_cb)(char *str, console_append_char_cb cb);
+typedef void (*console_completion_cb)(char *str, console_append_char_cb cb);
 
 static int inline
 console_is_init(void)


### PR DESCRIPTION
as console variables. Current naming was confusing while running code
in debugger.