### PR TITLE
Boot loader: Add assert for sector count

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -328,6 +328,11 @@ boot_read_sectors(void)
     if (rc != 0) {
         return BOOT_EFLASH;
     }
+    /*
+     * Make sure that BSP specific number of sectors will not result in
+     * random memory clobber
+     */
+    assert(num_sectors_slot0 <= BOOT_MAX_IMG_SECTORS);
     boot_data.imgs[0].num_sectors = num_sectors_slot0;
 
     num_sectors_slot1 = BOOT_MAX_IMG_SECTORS;
@@ -336,6 +341,11 @@ boot_read_sectors(void)
     if (rc != 0) {
         return BOOT_EFLASH;
     }
+    /*
+     * Make sure that BSP specific number of sectors will not result in
+     * random memory clobber
+     */
+    assert(num_sectors_slot1 <= BOOT_MAX_IMG_SECTORS);
     boot_data.imgs[1].num_sectors = num_sectors_slot1;
 
     rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &scratch);


### PR DESCRIPTION
If sector count declared in bsp is greater than boot loader
specified 120 sectors, random memory can be overwritten.
This type of error can be difficult to detect.
It is much easier to add assert to detect error condition earlier.