### PR TITLE
Nucleo l476 fixes

### DIFF
--- a/hw/bsp/nucleo-l476rg/bsp.yml
+++ b/hw/bsp/nucleo-l476rg/bsp.yml
@@ -40,11 +40,11 @@ bsp.flash_map:
         FLASH_AREA_IMAGE_0:
             device: 0
             offset: 0x08010000
-            size:  464kB
+            size:  240kB
         FLASH_AREA_IMAGE_1:
             device: 0
             offset: 0x08084000
-            size: 464kB
+            size: 240kB
         FLASH_AREA_IMAGE_SCRATCH:
             device: 0
             offset: 0x080f8000

--- a/hw/bsp/nucleo-l476rg/nucleo-l476rg_debug.sh
+++ b/hw/bsp/nucleo-l476rg/nucleo-l476rg_debug.sh
@@ -30,7 +30,7 @@
 . $CORE_PATH/hw/scripts/openocd.sh
 
 FILE_NAME=$BIN_BASENAME.elf
-CFG="-f board/st_nucleo_l4.cfg"
+CFG="-f board/st_nucleo_l476rg.cfg"
 # Exit openocd when gdb detaches.
 EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32l4x.cpu configure -event gdb-detach {if {[stm32l4x.cpu curstate] eq \"halted\"} resume;shutdown}"
 

--- a/hw/bsp/nucleo-l476rg/nucleo-l476rg_download.sh
+++ b/hw/bsp/nucleo-l476rg/nucleo-l476rg_download.sh
@@ -31,7 +31,7 @@
 
 . $CORE_PATH/hw/scripts/openocd.sh
 
-CFG="-f board/st_nucleo_l4.cfg"
+CFG="-f board/st_nucleo_l476rg.cfg"
 
 if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0x08000000


### PR DESCRIPTION
With sector size 2048 bytes and 120 max sector count in bootloader
it is impossible to have more than 240kB per slot.
This fix does not changes slot positions and is considered to be
intermediate fix that allows to use nucleo board.
Proper fix should also change layout or sector size and placement.

File board/st_nucleo_l4.cfg is not present in openocd releases.
Debug and download script now have correct path:
board/st_nucleo_l476rg.cf