### PR TITLE
[RFC] Peripherals cleanup in nRF52xxx BSPs

### DIFF
--- a/hw/bsp/ada_feather_nrf52/pkg.yml
+++ b/hw/bsp/ada_feather_nrf52/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/arduino_primo_nrf52/pkg.yml
+++ b/hw/bsp/arduino_primo_nrf52/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/bmd300eval/pkg.yml
+++ b/hw/bsp/bmd300eval/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/dwm1001-dev/pkg.yml
+++ b/hw/bsp/dwm1001-dev/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/nina-b1/pkg.yml
+++ b/hw/bsp/nina-b1/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/nrf52-thingy/pkg.yml
+++ b/hw/bsp/nrf52-thingy/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/nrf52840pdk/pkg.yml
+++ b/hw/bsp/nrf52840pdk/pkg.yml
@@ -33,36 +33,9 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
     - "@apache-mynewt-core/libc/baselibc"
     - "@apache-mynewt-core/sys/flash_map"
-
-pkg.deps.BLE_DEVICE:
-    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
-
-pkg.deps.TRNG:
-    - "@apache-mynewt-core/hw/drivers/trng/trng_nrf52"
-
-pkg.deps.UART_0:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
-
-pkg.deps.UART_1:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
-
-pkg.deps.ADC_0:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
-
-pkg.deps.PWM_0:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_1:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_2:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_3:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nrf52840pdk/pkg.yml
+++ b/hw/bsp/nrf52840pdk/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
     - "@apache-mynewt-core/sys/flash_map"
 

--- a/hw/bsp/nrf52840pdk/syscfg.yml
+++ b/hw/bsp/nrf52840pdk/syscfg.yml
@@ -22,101 +22,28 @@ syscfg.defs:
     BSP_NRF52840:
         description: 'Set to indicate that BSP has NRF52840'
         value: 1
-
-    UART_0:
-        description: 'Whether to enable UART0'
-        value:  1
-    UART_0_PIN_TX:
-        description: 'TX pin for UART0'
-        value:  6
-    UART_0_PIN_RX:
-        description: 'RX pin for UART0'
-        value:  8
-    UART_0_PIN_RTS:
-        description: 'RTS pin for UART0'
-        value:  5
-    UART_0_PIN_CTS:
-        description: 'CTS pin for UART0'
-        value: 7
-
-    UART_1:
-        description: 'Whether to enable UART1'
-        value:  0
-    UART_1_PIN_TX:
-        description: 'TX pin for UART1'
-        value:  -1
-    UART_1_PIN_RX:
-        description: 'RX pin for UART1'
-        value:  -1
-    UART_1_PIN_RTS:
-        description: 'RTS pin for UART1'
-        value:  -1
-    UART_1_PIN_CTS:
-        description: 'CTS pin for UART1'
-        value: -1
-
-    SPI_0_MASTER_PIN_SCK:
-        description: 'SCK pin for SPI_0_MASTER'
-        value:  45
-    SPI_0_MASTER_PIN_MOSI:
-        description: 'MOSI pin for SPI_0_MASTER'
-        value:  46
-    SPI_0_MASTER_PIN_MISO:
-        description: 'MISO pin for SPI_0_MASTER'
-        value:  47
-
-    SPI_0_SLAVE_PIN_SCK:
-        description: 'SCK pin for SPI_0_SLAVE'
-        value:  45
-    SPI_0_SLAVE_PIN_MOSI:
-        description: 'MOSI pin for SPI_0_SLAVE'
-        value:  46
-    SPI_0_SLAVE_PIN_MISO:
-        description: 'MISO pin for SPI_0_SLAVE'
-        value:  47
-    SPI_0_SLAVE_PIN_SS:
-        description: 'SS pin for SPI_0_SLAVE'
-        value:  44
-
-    I2C_0_PIN_SCL:
-        description: 'SCL pin for I2C_0'
-        value:  27
-    I2C_0_PIN_SDA:
-        description: 'SDA pin for I2C_0'
-        value:  26
-    I2C_0_FREQ_KHZ:
-        description: 'Frequency in khz for I2C_0 bus'
-        value:  100
-
-    TIMER_0:
-        description: 'NRF52840 Timer 0'
-        value:  1
-    TIMER_1:
-        description: 'NRF52840 Timer 1'
-        value:  0
-    TIMER_2:
-        description: 'NRF52840 Timer 2'
-        value:  0
-    TIMER_3:
-        description: 'NRF52840 Timer 3'
-        value:  0
-    TIMER_4:
-        description: 'NRF52840 Timer 4'
-        value:  0
-    TIMER_5:
-        description: 'NRF52 RTC 0'
-        value:  0
-    PWM_3:
-        description: 'NRF52 PWM 3'
+    SOFT_PWM:
+        description: 'Enable soft PWM'
         value: 0
-
-syscfg.defs.BLE_LP_CLOCK:
-    TIMER_0:
-        value: 0
-    TIMER_5:
-        value: 1
 
 syscfg.vals:
+    # Enable nRF52840 MCU
+    MCU_NRF52840: 1
+    # Set default pins for peripherals
+    UART_0_PIN_TX: 6
+    UART_0_PIN_RX: 8
+    UART_0_PIN_RTS: 5
+    UART_0_PIN_CTS: 7
+    SPI_0_MASTER_PIN_SCK: 45
+    SPI_0_MASTER_PIN_MOSI: 46
+    SPI_0_MASTER_PIN_MISO: 47
+    SPI_0_SLAVE_PIN_SCK: 45
+    SPI_0_SLAVE_PIN_MOSI: 46
+    SPI_0_SLAVE_PIN_MISO: 47
+    SPI_0_SLAVE_PIN_SS: 44
+    I2C_0_PIN_SCL: 27
+    I2C_0_PIN_SDA: 26
+
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
@@ -133,8 +60,9 @@ syscfg.vals:
     QSPI_PIN_DIO2: 22
     QSPI_PIN_DIO3: 23
 
-
 syscfg.vals.BLE_LP_CLOCK:
+    TIMER_0: 0
+    TIMER_5: 1
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500

--- a/hw/bsp/nrf52dk/pkg.yml
+++ b/hw/bsp/nrf52dk/pkg.yml
@@ -33,32 +33,11 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.ENC_FLASH_DEV:
     - "@apache-mynewt-core/hw/drivers/flash/enc_flash/ef_nrf5x"
-
-pkg.deps.BLE_DEVICE:
-    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
-
-pkg.deps.UART_0:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
-
-pkg.deps.UART_1:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
-
-pkg.deps.ADC_0:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
-
-pkg.deps.PWM_0:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_1:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_2:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nrf52dk/pkg.yml
+++ b/hw/bsp/nrf52dk/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.ENC_FLASH_DEV:

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -24,106 +24,31 @@
 #include "nrfx.h"
 #include "flash_map/flash_map.h"
 #include "hal/hal_bsp.h"
-#include "hal/hal_system.h"
 #include "hal/hal_flash.h"
-#include "hal/hal_spi.h"
-#include "hal/hal_watchdog.h"
-#include "hal/hal_i2c.h"
+#include "hal/hal_system.h"
 #include "mcu/nrf52_hal.h"
-#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
-#include "uart/uart.h"
-#endif
-#if MYNEWT_VAL(UART_0)
-#include "uart_hal/uart_hal.h"
-#endif
-#if MYNEWT_VAL(UART_1)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-#include "bsp.h"
-#if MYNEWT_VAL(ADC_0)
-#include <adc_nrf52/adc_nrf52.h>
-#include <nrfx_saadc.h>
-#endif
-#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
-#include <pwm_nrf52/pwm_nrf52.h>
-#endif
+#include "mcu/nrf52_periph.h"
+#include "bsp/bsp.h"
 #if MYNEWT_VAL(SOFT_PWM)
-#include <soft_pwm/soft_pwm.h>
+#include "pwm/pwm.h"
+#include "soft_pwm/soft_pwm.h"
 #endif
 #if MYNEWT_VAL(ENC_FLASH_DEV)
 #include <ef_nrf5x/ef_nrf5x.h>
 #endif
-
-#if MYNEWT_VAL(UART_0)
-static struct uart_dev os_bsp_uart0;
-static const struct nrf52_uart_cfg os_bsp_uart0_cfg = {
-    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
-    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
-    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
-    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
-};
+#if MYNEWT_VAL(UARTBB_0)
+#include "uart_bitbang/uart_bitbang.h"
 #endif
 
-#if MYNEWT_VAL(UART_1)
-static struct uart_dev os_bsp_bitbang_uart1;
-static const struct uart_bitbang_conf os_bsp_uart1_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UART_1_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UART_1_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
-
-#if MYNEWT_VAL(SPI_0_MASTER)
-/*
- * NOTE: Our HAL expects that the SS pin, if used, is treated as a gpio line
- * and is handled outside the SPI routines.
- */
-static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
-    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
-    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
-    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
-};
-#endif
-
-#if MYNEWT_VAL(SPI_0_SLAVE)
-static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
-    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
-    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
-    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
-    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
-};
-#endif
-
-#if MYNEWT_VAL(ADC_0)
-static struct adc_dev os_bsp_adc0;
-static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
-    .nadc_refmv     = MYNEWT_VAL(ADC_0_REFMV_0),
-};
-#endif
-
-#if MYNEWT_VAL(PWM_0)
-static struct pwm_dev os_bsp_pwm0;
-int pwm0_idx;
-#endif
-#if MYNEWT_VAL(PWM_1)
-static struct pwm_dev os_bsp_pwm1;
-int pwm1_idx;
-#endif
-#if MYNEWT_VAL(PWM_2)
-static struct pwm_dev os_bsp_pwm2;
-int pwm2_idx;
-#endif
 #if MYNEWT_VAL(SOFT_PWM)
 static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-char* spwm_name[MYNEWT_VAL(SOFT_PWM_DEVS)];
-int spwm_idx[MYNEWT_VAL(SOFT_PWM_DEVS)];
 #endif
 
-#if MYNEWT_VAL(I2C_0)
-static const struct nrf52_hal_i2c_cfg hal_i2c_cfg = {
-    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
-    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
-    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
+#if MYNEWT_VAL(UARTBB_0)
+static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
+    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
+    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
+    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
 };
 #endif
 
@@ -207,127 +132,32 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-    int rc;
 #if MYNEWT_VAL(SOFT_PWM)
+    int rc;
     int idx;
+    char *spwm_name;
 #endif
-
-    (void)rc;
 
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
-#if MYNEWT_VAL(TIMER_0)
-    rc = hal_timer_init(0, NULL);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_1)
-    rc = hal_timer_init(1, NULL);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_2)
-    rc = hal_timer_init(2, NULL);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_3)
-    rc = hal_timer_init(3, NULL);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_4)
-    rc = hal_timer_init(4, NULL);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_5)
-    rc = hal_timer_init(5, NULL);
-    assert(rc == 0);
-#endif
+    /* Create all available nRF52840 peripherals */
+    nrf52_periph_create();
 
-#if MYNEWT_VAL(ADC_0)
-    rc = os_dev_create((struct os_dev *) &os_bsp_adc0,
-                       "adc0",
-                       OS_DEV_INIT_KERNEL,
-                       OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_adc_dev_init,
-                       &os_bsp_adc0_config);
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(PWM_0)
-    pwm0_idx = 0;
-    rc = os_dev_create((struct os_dev *) &os_bsp_pwm0,
-                       "pwm0",
-                       OS_DEV_INIT_KERNEL,
-                       OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init,
-                       &pwm0_idx);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(PWM_1)
-    pwm1_idx = 1;
-    rc = os_dev_create((struct os_dev *) &os_bsp_pwm1,
-                       "pwm1",
-                       OS_DEV_INIT_KERNEL,
-                       OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init,
-                       &pwm1_idx);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(PWM_2)
-    pwm2_idx = 2;
-    rc = os_dev_create((struct os_dev *) &os_bsp_pwm2,
-                       "pwm2",
-                       OS_DEV_INIT_KERNEL,
-                       OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init,
-                       &pwm2_idx);
-    assert(rc == 0);
-#endif
 #if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++)
-    {
-        spwm_name[idx] = "spwm0";
-        spwm_name[idx][4] = '0' + idx;
-        spwm_idx[idx] = idx;
-        rc = os_dev_create((struct os_dev *) &os_bsp_spwm[idx],
-                           spwm_name[idx],
-                           OS_DEV_INIT_KERNEL,
-                           OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init,
-                           &spwm_idx[idx]);
+    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
+        asprintf(&spwm_name, "spwm%d", idx);
+        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
+                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                           soft_pwm_dev_init, &idx);
         assert(rc == 0);
     }
 #endif
 
-#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
-    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+#if MYNEWT_VAL(UARTBB_0)
+    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
+                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
+                       (void *)&os_bsp_uartbb0_cfg);
     assert(rc == 0);
 #endif
-
-#if MYNEWT_VAL(I2C_0)
-    rc = hal_i2c_init(0, (void *)&hal_i2c_cfg);
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(SPI_0_MASTER)
-    rc = hal_spi_init(0, (void *)&os_bsp_spi0m_cfg, HAL_SPI_TYPE_MASTER);
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(SPI_0_SLAVE)
-    rc = hal_spi_init(0, (void *)&os_bsp_spi0s_cfg, HAL_SPI_TYPE_SLAVE);
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(UART_0)
-    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
-      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&os_bsp_uart0_cfg);
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(UART_1)
-    rc = os_dev_create((struct os_dev *) &os_bsp_bitbang_uart1, "uart1",
-      OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init, (void *)&os_bsp_uart1_cfg);
-    assert(rc == 0);
-#endif
-
 }

--- a/hw/bsp/nrf52dk/syscfg.yml
+++ b/hw/bsp/nrf52dk/syscfg.yml
@@ -22,95 +22,41 @@ syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
-
-    UART_0:
-        description: 'Whether to enable UART0'
-        value:  1
-    UART_0_PIN_TX:
-        description: 'TX pin for UART0'
-        value:  6
-    UART_0_PIN_RX:
-        description: 'RX pin for UART0'
-        value:  8
-    UART_0_PIN_RTS:
-        description: 'RTS pin for UART0'
-        value:  5
-    UART_0_PIN_CTS:
-        description: 'CTS pin for UART0'
-        value: 7
-
-    UART_1:
-        description: 'Whether to enable bitbanger UART1'
-        value:  0
-    UART_1_PIN_TX:
-        description: 'TX pin for UART1'
-        value:  -1
-    UART_1_PIN_RX:
-        description: 'RX pin for UART1'
-        value:  -1
-
-    SPI_0_MASTER_PIN_SCK:
-        description: 'SCK pin for SPI_0_MASTER'
-        value:  23
-    SPI_0_MASTER_PIN_MOSI:
-        description: 'MOSI pin for SPI_0_MASTER'
-        value:  24
-    SPI_0_MASTER_PIN_MISO:
-        description: 'MISO pin for SPI_0_MASTER'
-        value:  25
-
-    SPI_0_SLAVE_PIN_SCK:
-        description: 'SCK pin for SPI_0_SLAVE'
-        value:  23
-    SPI_0_SLAVE_PIN_MOSI:
-        description: 'MOSI pin for SPI_0_SLAVE'
-        value:  24
-    SPI_0_SLAVE_PIN_MISO:
-        description: 'MISO pin for SPI_0_SLAVE'
-        value:  25
-    SPI_0_SLAVE_PIN_SS:
-        description: 'SS pin for SPI_0_SLAVE'
-        value:  22
-
-    I2C_0_PIN_SCL:
-        description: 'SCL pin for I2C_0'
-        value:  27
-    I2C_0_PIN_SDA:
-        description: 'SDA pin for I2C_0'
-        value:  26
-    I2C_0_FREQ_KHZ:
-        description: 'Frequency in khz for I2C_0 bus'
-        value:  100
-
-    TIMER_0:
-        description: 'NRF52 Timer 0'
-        value:  1
-    TIMER_1:
-        description: 'NRF52 Timer 1'
-        value:  0
-    TIMER_2:
-        description: 'NRF52 Timer 2'
-        value:  0
-    TIMER_3:
-        description: 'NRF52 Timer 3'
-        value:  0
-    TIMER_4:
-        description: 'NRF52 Timer 4'
-        value:  0
-    TIMER_5:
-        description: 'NRF52 RTC 0'
-        value:  0
+    SOFT_PWM:
+        description: 'Enable soft PWM'
+        value: 0
     ENC_FLASH_DEV:
         description: 'Encrypting flash driver over interal flash for testing'
         value: 0
 
-syscfg.defs.BLE_LP_CLOCK:
-    TIMER_0:
+    UARTBB_0:
+        description: 'Enable bit-banger UART 0'
         value: 0
-    TIMER_5:
-        value: 1
+    UARTBB_0_PIN_TX:
+        description: 'TX pin for UARTBB0'
+        value: -1
+    UARTBB_0_PIN_RX:
+        description: 'RX pin for UARTBB0'
+        value: -1
 
 syscfg.vals:
+    # Enable nRF52832 MCU
+    MCU_NRF52832: 1
+    # Set default pins for peripherals
+    UART_0_PIN_TX: 6
+    UART_0_PIN_RX: 8
+    UART_0_PIN_RTS: 5
+    UART_0_PIN_CTS: 7
+    SPI_0_MASTER_PIN_SCK: 23
+    SPI_0_MASTER_PIN_MOSI: 24
+    SPI_0_MASTER_PIN_MISO: 25
+    SPI_0_SLAVE_PIN_SCK: 23
+    SPI_0_SLAVE_PIN_MOSI: 24
+    SPI_0_SLAVE_PIN_MISO: 25
+    SPI_0_SLAVE_PIN_SS: 22
+    I2C_0_PIN_SCL: 27
+    I2C_0_PIN_SDA: 26
+
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
@@ -120,6 +66,11 @@ syscfg.vals:
     BOOT_SERIAL_DETECT_PIN: 13  # Button 1
 
 syscfg.vals.BLE_LP_CLOCK:
+    TIMER_0: 0
+    TIMER_5: 1
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
+
+syscfg.restrictions:
+    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/rb-blend2/pkg.yml
+++ b/hw/bsp/rb-blend2/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/rb-nano2/pkg.yml
+++ b/hw/bsp/rb-nano2/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/ruuvi_tag_revb2/pkg.yml
+++ b/hw/bsp/ruuvi_tag_revb2/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/telee02/pkg.yml
+++ b/hw/bsp/telee02/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/bsp/vbluno52/pkg.yml
+++ b/hw/bsp/vbluno52/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
     - "@apache-mynewt-core/libc/baselibc"
 
 pkg.deps.BLE_DEVICE:

--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cmsis_nvic.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cmsis_nvic.h
@@ -1,0 +1,30 @@
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include <stdint.h>
+#include <bsp/bsp.h>
+
+#define NVIC_NUM_VECTORS      (16 + 38)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
+#include "nrf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_Relocate(void);
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cortex_m4.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_CORTEX_M4_H__
+#define __MCU_CORTEX_M4_H__
+
+#include "os/mynewt.h"
+
+#include "nrf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OS_TICKS_PER_SEC    (128)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_CORTEX_M4_H__ */

--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/mcu.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/mcu.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_MCU_H_
+#define __MCU_MCU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Defines for naming GPIOs. NOTE: the nordic chip docs use numeric labels for
+ * ports. Port A corresponds to Port 0, B to 1, etc. The nrf52832 has only one
+ * port and thus uses pins 0 - 31. The nrf52840 has two ports but Port 1 only
+ * has 16 pins.
+ */
+#define MCU_GPIO_PORTA(pin)	((0 * 16) + (pin))
+#define MCU_GPIO_PORTB(pin)	((1 * 16) + (pin))
+
+#if NRF52
+
+#define MCU_SYSVIEW_INTERRUPTS \
+    "I#1=Reset,I#2=MNI,I#3=HardFault,I#4=MemoryMgmt,I#5=BusFault,I#6=UsageFault," \
+    "I#11=SVCall,I#12=DebugMonitor,I#14=PendSV,I#15=SysTick," \
+    "I#16=POWER_CLOCK,I#17=RADIO,I#18=UARTE0_UART0,I#19=SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0," \
+    "I#20=SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1,I#21=NFCT,I#22=GPIOTE,I#23=SAADC," \
+    "I#24=TIMER0,I#25=TIMER1,I#26=TIMER2,I#27=RTC0,I#28=TEMP,I#29=RNG,I#30=ECB," \
+    "I#31=CCM_AAR,I#32=WDT,I#33=RTC1,I#34=QDEC,I#35=COMP_LPCOMP,I#36=SWI0_EGU0," \
+    "I#37=SWI1_EGU1,I#38=SWI2_EGU2,I#39=SWI3_EGU3,I#40=SWI4_EGU4,I#41=SWI5_EGU5," \
+    "I#42=TIMER3,I#43=TIMER4,I#44=PWM0,I#45=PDM,I#48=MWU,I#49=PWM1,I#50=PWM2," \
+    "I#51=SPIM2_SPIS2_SPI2,I#52=RTC2,I#53=I2S,I#54=FPU"
+
+#elif NRF52840_XXAA
+
+#define MCU_SYSVIEW_INTERRUPTS \
+    "I#1=Reset,I#2=MNI,I#3=HardFault,I#4=MemoryMgmt,I#5=BusFault,I#6=UsageFault," \
+    "I#11=SVCall,I#12=DebugMonitor,I#14=PendSV,I#15=SysTick," \
+    "I#16=POWER_CLOCK,I#17=RADIO,I#18=UARTE0_UART0,I#19=SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0," \
+    "I#20=SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1,I#21=NFCT,I#22=GPIOTE,I#23=SAADC," \
+    "I#24=TIMER0,I#25=TIMER1,I#26=TIMER2,I#27=RTC0,I#28=TEMP,I#29=RNG,I#30=ECB," \
+    "I#31=CCM_AAR,I#32=WDT,I#33=RTC1,I#34=QDEC,I#35=COMP_LPCOMP,I#36=SWI0_EGU0," \
+    "I#37=SWI1_EGU1,I#38=SWI2_EGU2,I#39=SWI3_EGU3,I#40=SWI4_EGU4,I#41=SWI5_EGU5," \
+    "I#42=TIMER3,I#43=TIMER4,I#44=PWM0,I#45=PDM,I#48=MWU,I#49=PWM1,I#50=PWM2," \
+    "I#51=SPIM2_SPIS2_SPI2,I#52=RTC2,I#53=I2S,I#54=FPU,I#55=USBD," \
+    "I#56=UARTE1,I#57=QSPI,I#58=CRYPTOCELL,I#61=PWM3,I#63=SPIM3"
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_MCU_H_ */

--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/nrf52_hal.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/nrf52_hal.h
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF52_HAL_
+#define H_NRF52_HAL_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Helper functions to enable/disable interrupts. */
+#define __HAL_DISABLE_INTERRUPTS(x)                     \
+    do {                                                \
+        x = __get_PRIMASK();                            \
+        __disable_irq();                                \
+    } while(0);
+
+#define __HAL_ENABLE_INTERRUPTS(x)                      \
+    do {                                                \
+        if (!x) {                                       \
+            __enable_irq();                             \
+        }                                               \
+    } while(0);
+
+struct nrf52_uart_cfg {
+    int8_t suc_pin_tx;                          /* pins for IO */
+    int8_t suc_pin_rx;
+    int8_t suc_pin_rts;
+    int8_t suc_pin_cts;
+};
+const struct nrf52_uart_cfg *bsp_uart_config(void);
+
+struct nrf52_hal_i2c_cfg {
+    int scl_pin;
+    int sda_pin;
+    uint32_t i2c_frequency;
+};
+struct hal_flash;
+extern const struct hal_flash nrf52k_flash_dev;
+extern const struct hal_flash nrf52k_qspi_dev;
+
+/* SPI configuration (used for both master and slave) */
+struct nrf52_hal_spi_cfg {
+    uint8_t sck_pin;
+    uint8_t mosi_pin;
+    uint8_t miso_pin;
+    uint8_t ss_pin;
+};
+
+/*
+ * GPIO pin mapping
+ *
+ * The logical GPIO pin numbers (0 to N) are mapped to ports in the following
+ * manner:
+ *  pins 0 - 31: Port 0
+ *  pins 32 - 48: Port 1.
+ *
+ *  The nrf52832 has only one port with 32 pins. The nrf52840 has 48 pins and
+ *  uses two ports.
+ *
+ *  NOTE: in order to save code space, there is no checking done to see if the
+ *  user specifies a pin that is not used by the processor. If an invalid pin
+ *  number is used unexpected and/or erroneous behavior will result.
+ */
+#ifdef NRF52
+#define HAL_GPIO_INDEX(pin)     (pin)
+#define HAL_GPIO_PORT(pin)      (NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << pin)
+#define HAL_GPIOTE_PIN_MASK     GPIOTE_CONFIG_PSEL_Msk
+#endif
+
+#ifdef NRF52840_XXAA
+#define HAL_GPIO_INDEX(pin)     ((pin) & 0x1F)
+#define HAL_GPIO_PORT(pin)      ((pin) > 31 ? NRF_P1 : NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << HAL_GPIO_INDEX(pin))
+#define HAL_GPIOTE_PIN_MASK     (0x3FUL << GPIOTE_CONFIG_PSEL_Pos)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF52_HAL_ */
+

--- a/hw/mcu/nordic/nrf52xxx-compat/include/nrfx52840_config.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/nrfx52840_config.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NRFX52840_CONFIG_H__
+#define NRFX52840_CONFIG_H__
+
+#include "syscfg/syscfg.h"
+
+#define NRFX_CLOCK_ENABLED 0
+#define NRFX_COMP_ENABLED 0
+#define NRFX_GPIOTE_ENABLED 0
+#define NRFX_I2S_ENABLED 0
+#define NRFX_LPCOMP_ENABLED 0
+#define NRFX_PDM_ENABLED 0
+#define NRFX_POWER_ENABLED 0
+#define NRFX_PPI_ENABLED 0
+#define NRFX_PRS_ENABLDE 0
+#define NRFX_QDEC_ENABLED 0
+#define NRFX_RNG_ENABLED 0
+#define NRFX_RTC_ENABLED 0
+#define NRFX_SPIM_ENABLED 0
+#define NRFX_SPIS_ENABLED 0
+#define NRFX_SPI_ENABLED 0
+#define NRFX_SWI_ENABLED 0
+#define NRFX_SYSTICK_ENABLED 0
+#define NRFX_TIMER_ENABLED 0
+#define NRFX_TWIM_ENABLED 0
+#define NRFX_TWIS_ENABLED 0
+#define NRFX_TWI_ENABLED 0
+#define NRFX_UARTE_ENABLED 0
+#define NRFX_UART_ENABLED 0
+#define NRFX_WDT_ENABLED 0
+
+#if MYNEWT_VAL(ADC_0)
+#define NRFX_SAADC_ENABLED 1
+#define NRFX_SAADC_CONFIG_RESOLUTION 1
+#define NRFX_SAADC_CONFIG_OVERSAMPLE 0
+#define NRFX_SAADC_CONFIG_LP_MODE 0
+#define NRFX_SAADC_CONFIG_IRQ_PRIORITY 7
+#endif
+
+#if (MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2) || MYNEWT_VAL(PWM_3))
+#define NRFX_PWM_ENABLED 1
+#define NRFX_PWM_DEFAULT_CONFIG_OUT0_PIN 31
+#define NRFX_PWM_DEFAULT_CONFIG_OUT1_PIN 31
+#define NRFX_PWM_DEFAULT_CONFIG_OUT2_PIN 31
+#define NRFX_PWM_DEFAULT_CONFIG_OUT3_PIN 31
+#define NRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK 4
+#define NRFX_PWM_DEFAULT_CONFIG_COUNT_MODE 0
+#define NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE 1000
+#define NRFX_PWM_DEFAULT_CONFIG_LOAD_MODE 0
+#define NRFX_PWM_DEFAULT_CONFIG_STEP_MODE 0
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+#if MYNEWT_VAL(PWM_0)
+#define NRFX_PWM0_ENABLED 1
+#endif
+
+#if MYNEWT_VAL(PWM_1)
+#define NRFX_PWM1_ENABLED 1
+#endif
+
+#if MYNEWT_VAL(PWM_2)
+#define NRFX_PWM2_ENABLED 1
+#endif
+
+#if MYNEWT_VAL(PWM_3)
+#define NRFX_PWM3_ENABLED 1
+#endif
+
+#endif // NRFX52840_CONFIG_H__

--- a/hw/mcu/nordic/nrf52xxx-compat/include/nrfx52_config.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/nrfx52_config.h
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NRFX52_CONFIG_H__
+#define NRFX52_CONFIG_H__
+
+#include "syscfg/syscfg.h"
+
+#ifndef NRFX_CLOCK_ENABLED
+#define NRFX_CLOCK_ENABLED 0
+#endif
+
+#ifndef NRFX_COMP_ENABLED
+#define NRFX_COMP_ENABLED 0
+#endif
+
+#ifndef NRFX_GPIOTE_ENABLED
+#define NRFX_GPIOTE_ENABLED 0
+#endif
+
+#ifndef NRFX_I2S_ENABLED
+#define NRFX_I2S_ENABLED 0
+#endif
+
+#ifndef NRFX_LPCOMP_ENABLED
+#define NRFX_LPCOMP_ENABLED 0
+#endif
+
+#ifndef NRFX_PDM_ENABLED
+#define NRFX_PDM_ENABLED 0
+#endif
+
+#ifndef NRFX_POWER_ENABLED
+#define NRFX_POWER_ENABLED 0
+#endif
+
+#ifndef NRFX_PPI_ENABLED
+#define NRFX_PPI_ENABLED 0
+#endif
+
+#ifndef NRFX_PRS_ENABLED
+#define NRFX_PRS_ENABLED 0
+#endif
+
+#ifndef NRFX_QDEC_ENABLED
+#define NRFX_QDEC_ENABLED 0
+#endif
+
+#ifndef NRFX_RNG_ENABLED
+#define NRFX_RNG_ENABLED 0
+#endif
+
+#ifndef NRFX_RTC_ENABLED
+#define NRFX_RTC_ENABLED 0
+#endif
+
+#ifndef NRFX_SPIM_ENABLED
+#define NRFX_SPIM_ENABLED 0
+#endif
+
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+
+#ifndef NRFX_SPI_ENABLED
+#define NRFX_SPI_ENABLED 0
+#endif
+
+#ifndef NRFX_SWI_ENABLED
+#define NRFX_SWI_ENABLED 0
+#endif
+
+#ifndef NRFX_SYSTICK_ENABLED
+#define NRFX_SYSTICK_ENABLED 0
+#endif
+
+#ifndef NRFX_TIMER_ENABLED
+#define NRFX_TIMER_ENABLED 0
+#endif
+
+#ifndef NRFX_TWIM_ENABLED
+#define NRFX_TWIM_ENABLED 0
+#endif
+
+#ifndef NRFX_TWIS_ENABLED
+#define NRFX_TWIS_ENABLED 0
+#endif
+
+#ifndef NRFX_TWI_ENABLED
+#define NRFX_TWI_ENABLED 0
+#endif
+
+#ifndef NRFX_UARTE_ENABLED
+#define NRFX_UARTE_ENABLED 0
+#endif
+
+#ifndef NRFX_UART_ENABLED
+#define NRFX_UART_ENABLED 0
+#endif
+
+#ifndef NRFX_WDT_ENABLED
+#define NRFX_WDT_ENABLED 0
+#endif
+
+#if MYNEWT_VAL(ADC_0)
+#ifndef NRFX_SAADC_ENABLED
+#define NRFX_SAADC_ENABLED 1
+#endif
+
+#ifndef NRFX_SAADC_CONFIG_RESOLUTION
+#define NRFX_SAADC_CONFIG_RESOLUTION 1
+#endif
+
+#ifndef NRFX_SAADC_CONFIG_OVERSAMPLE
+#define NRFX_SAADC_CONFIG_OVERSAMPLE 0
+#endif
+
+#ifndef NRFX_SAADC_CONFIG_LP_MODE
+#define NRFX_SAADC_CONFIG_LP_MODE 0
+#endif
+
+#ifndef NRFX_SAADC_CONFIG_IRQ_PRIORITY
+#define NRFX_SAADC_CONFIG_IRQ_PRIORITY 7
+#endif
+
+#endif
+
+#if (MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2))
+
+#ifndef NRFX_PWM_ENABLED
+#define NRFX_PWM_ENABLED 1
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_OUT0_PIN
+#define NRFX_PWM_DEFAULT_CONFIG_OUT0_PIN 0xff
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_OUT1_PIN
+#define NRFX_PWM_DEFAULT_CONFIG_OUT1_PIN 0xff
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_OUT2_PIN
+#define NRFX_PWM_DEFAULT_CONFIG_OUT2_PIN 0xff
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_OUT3_PIN
+#define NRFX_PWM_DEFAULT_CONFIG_OUT3_PIN 0xff
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK
+#define NRFX_PWM_DEFAULT_CONFIG_BASE_CLOCK 4
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_COUNT_MODE
+#define NRFX_PWM_DEFAULT_CONFIG_COUNT_MODE 0
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE
+#define NRFX_PWM_DEFAULT_CONFIG_TOP_VALUE 1000
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_LOAD_MODE
+#define NRFX_PWM_DEFAULT_CONFIG_LOAD_MODE 0
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_STEP_MODE
+#define NRFX_PWM_DEFAULT_CONFIG_STEP_MODE 0
+#endif
+
+#ifndef NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+#endif
+
+#if MYNEWT_VAL(PWM_0)
+#define NRFX_PWM0_ENABLED 1
+#endif
+
+#if MYNEWT_VAL(PWM_1)
+#define NRFX_PWM1_ENABLED 1
+#endif
+
+#if MYNEWT_VAL(PWM_2)
+#define NRFX_PWM2_ENABLED 1
+#endif
+
+#endif // NRFX52_CONFIG_H__

--- a/hw/mcu/nordic/nrf52xxx-compat/include/nrfx_config.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/nrfx_config.h
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef NRFX_CONFIG_H__
+#define NRFX_CONFIG_H__
+
+#if NRF52
+#include "../../nrf52xxx-compat/include/nrfx52_config.h"
+#elif NRF52840_XXAA
+#include "../../nrf52xxx-compat/include/nrfx52840_config.h"
+#else
+#error Unsupported chip selected
+#endif
+
+#endif // NRFX_CONFIG_H__

--- a/hw/mcu/nordic/nrf52xxx-compat/nrf52.ld
+++ b/hw/mcu/nordic/nrf52xxx-compat/nrf52.ld
@@ -1,0 +1,207 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __bssnz_start__
+ *   __bssnz_end__
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .imghdr (NOLOAD):
+    {
+        . = . + _imghdr_size;
+    } > FLASH
+
+    __text = .;
+
+    .text :
+    {
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))
+        __isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RAM
+
+    .data :
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        *(.preinit_array)
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        *(SORT(.init_array.*))
+        *(.init_array)
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM AT > FLASH
+
+    /* Non-zeroed BSS.  This section is similar to BSS, with the following two
+     * caveats:
+     *    1. It does not get zeroed at init-time.
+     *    2. You cannot use it as source memory for EasyDMA.
+     *
+     * This section exists because of a hardware defect; see errata 33 and 34
+     * in nrf52 errata sheet.
+     */
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/hw/mcu/nordic/nrf52xxx-compat/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx-compat/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,46 +17,26 @@
 # under the License.
 #
 
-pkg.name: hw/bsp/puckjs
-pkg.type: bsp
-pkg.description: BSP definition for the Espruino puckjs.
+pkg.name: hw/mcu/nordic/nrf52xxx-compat
+pkg.description: MCU definition for Nordic nRF52 ARM Cortex-M4 chips.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - Espruino
-    - puck
     - nrf52
+    - nrfx
 
-pkg.cflags:
-    - '-DNRF52'
+pkg.deps: 
+    - "@apache-mynewt-core/hw/mcu/nordic"
+    - "@apache-mynewt-core/hw/cmsis-core"
+    - "@apache-mynewt-core/hw/hal"
 
-pkg.cflags.HARDFLOAT:
-    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+# NRF52810 doesn't support SPI/I2C (Use SPIM/I2CM instead)
+pkg.ign_files.BSP_NRF52810:
+    - "hal_spi.c"
+    - "hal_i2c.c"
 
-pkg.deps:
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx-compat"
-    - "@apache-mynewt-core/libc/baselibc"
+pkg.cflags.NFC_PINS_AS_GPIO: 
+    - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
 
-pkg.deps.BLE_DEVICE:
-    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
-
-pkg.deps.UART_0:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
-
-pkg.deps.UART_1:
-    - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
-
-pkg.deps.ADC_0:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
-
-pkg.deps.PWM_0:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_1:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.PWM_2:
-    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
-
-pkg.deps.SOFT_PWM:
-    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"
+pkg.cflags.GPIO_AS_PIN_RESET: 
+    - '-DCONFIG_GPIO_AS_PINRESET=1'

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_flash.c
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <assert.h>
+#include "nrf.h"
+#include "mcu/nrf52_hal.h"
+#include <hal/hal_flash_int.h>
+
+#define NRF52K_FLASH_SECTOR_SZ	4096
+
+static int nrf52k_flash_read(const struct hal_flash *dev, uint32_t address,
+        void *dst, uint32_t num_bytes);
+static int nrf52k_flash_write(const struct hal_flash *dev, uint32_t address,
+        const void *src, uint32_t num_bytes);
+static int nrf52k_flash_erase_sector(const struct hal_flash *dev,
+        uint32_t sector_address);
+static int nrf52k_flash_sector_info(const struct hal_flash *dev, int idx,
+        uint32_t *address, uint32_t *sz);
+static int nrf52k_flash_init(const struct hal_flash *dev);
+
+static const struct hal_flash_funcs nrf52k_flash_funcs = {
+    .hff_read = nrf52k_flash_read,
+    .hff_write = nrf52k_flash_write,
+    .hff_erase_sector = nrf52k_flash_erase_sector,
+    .hff_sector_info = nrf52k_flash_sector_info,
+    .hff_init = nrf52k_flash_init
+};
+
+#ifdef NRF52840_XXAA
+const struct hal_flash nrf52k_flash_dev = {
+    .hf_itf = &nrf52k_flash_funcs,
+    .hf_base_addr = 0x00000000,
+    .hf_size = 1024 * 1024,	/* XXX read from factory info? */
+    .hf_sector_cnt = 256,	/* XXX read from factory info? */
+    .hf_align = 1
+};
+#elif defined(NRF52810_XXAA)
+const struct hal_flash nrf52k_flash_dev = {
+    .hf_itf = &nrf52k_flash_funcs,
+    .hf_base_addr = 0x00000000,
+    .hf_size = 192 * 1024,  /* XXX read from factory info? */
+    .hf_sector_cnt = 48,   /* XXX read from factory info? */
+    .hf_align = 1
+};
+#elif defined(NRF52832_XXAA)
+const struct hal_flash nrf52k_flash_dev = {
+    .hf_itf = &nrf52k_flash_funcs,
+    .hf_base_addr = 0x00000000,
+    .hf_size = 512 * 1024,	/* XXX read from factory info? */
+    .hf_sector_cnt = 128,	/* XXX read from factory info? */
+    .hf_align = 1
+};
+#else
+#error "Must define hal_flash struct for NRF52 type"
+#endif
+
+#define NRF52K_FLASH_READY() (NRF_NVMC->READY == NVMC_READY_READY_Ready)
+
+static int
+nrf52k_flash_wait_ready(void)
+{
+    int i;
+
+    for (i = 0; i < 100000; i++) {
+        if (NRF_NVMC->READY == NVMC_READY_READY_Ready) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int
+nrf52k_flash_read(const struct hal_flash *dev, uint32_t address, void *dst,
+        uint32_t num_bytes)
+{
+    memcpy(dst, (void *)address, num_bytes);
+    return 0;
+}
+
+/*
+ * Flash write is done by writing 4 bytes at a time at a word boundary.
+ */
+static int
+nrf52k_flash_write(const struct hal_flash *dev, uint32_t address,
+        const void *src, uint32_t num_bytes)
+{
+    int sr;
+    int rc = -1;
+    uint32_t val;
+    int cnt;
+    uint32_t tmp;
+
+    if (nrf52k_flash_wait_ready()) {
+        return -1;
+    }
+    __HAL_DISABLE_INTERRUPTS(sr);
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen; /* Enable erase OP */
+    tmp = address & 0x3;
+    if (tmp) {
+        if (nrf52k_flash_wait_ready()) {
+            goto out;
+        }
+        /*
+         * Starts at a non-word boundary. Read 4 bytes which were there
+         * before, update with new data, and write back.
+         */
+        val = *(uint32_t *)(address & ~0x3);
+        cnt = 4 - tmp;
+        if (cnt > num_bytes) {
+            cnt = num_bytes;
+        }
+        memcpy((uint8_t *)&val + tmp, src, cnt);
+        *(uint32_t *)(address & ~0x3) = val;
+        address += cnt;
+        num_bytes -= cnt;
+        src += cnt;
+    }
+
+    while (num_bytes >= sizeof(uint32_t)) {
+        /*
+         * Write data 4 bytes at a time.
+         */
+        if (nrf52k_flash_wait_ready()) {
+            goto out;
+        }
+        *(uint32_t *)address = *(uint32_t *)src;
+        address += sizeof(uint32_t);
+        src += sizeof(uint32_t);
+        num_bytes -= sizeof(uint32_t);
+    }
+    if (num_bytes) {
+        /*
+         * Deal with the trailing bytes.
+         */
+        val = *(uint32_t *)address;
+        memcpy(&val, src, num_bytes);
+        if (nrf52k_flash_wait_ready()) {
+            goto out;
+        }
+        *(uint32_t *)address = val;
+    }
+    rc = 0;
+    if (nrf52k_flash_wait_ready()) {
+        rc = -1;
+    }
+out:
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+    __HAL_ENABLE_INTERRUPTS(sr);
+    return rc;
+}
+
+static int
+nrf52k_flash_erase_sector(const struct hal_flash *dev, uint32_t sector_address)
+{
+    int sr;
+    int rc = -1;
+
+    if (nrf52k_flash_wait_ready()) {
+        return -1;
+    }
+    __HAL_DISABLE_INTERRUPTS(sr);
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een; /* Enable erase OP */
+    if (nrf52k_flash_wait_ready()) {
+        goto out;
+    }
+
+    NRF_NVMC->ERASEPAGE = sector_address;
+    if (nrf52k_flash_wait_ready()) {
+        goto out;
+    }
+    rc = 0;
+out:
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren; /* Disable erase OP */
+    __HAL_ENABLE_INTERRUPTS(sr);
+    return rc;
+}
+
+static int
+nrf52k_flash_sector_info(const struct hal_flash *dev, int idx,
+        uint32_t *address, uint32_t *sz)
+{
+    assert(idx < nrf52k_flash_dev.hf_sector_cnt);
+    *address = idx * NRF52K_FLASH_SECTOR_SZ;
+    *sz = NRF52K_FLASH_SECTOR_SZ;
+    return 0;
+}
+
+static int
+nrf52k_flash_init(const struct hal_flash *dev)
+{
+    return 0;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_gpio.c
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include "os/mynewt.h"
+#include "hal/hal_gpio.h"
+#include "mcu/cmsis_nvic.h"
+#include "nrf.h"
+#include "mcu/nrf52_hal.h"
+
+/* XXX:
+ * 1) The code probably does not handle "re-purposing" gpio very well.
+ * "Re-purposing" means changing a gpio from input to output, or calling
+ * gpio_init_in and expecting previously enabled interrupts to be stopped.
+ *
+ */
+
+/*
+ * GPIO pin mapping
+ *
+ * The logical GPIO pin numbers (0 to N) are mapped to ports in the following
+ * manner:
+ *  pins 0 - 31: Port 0
+ *  pins 32 - 48: Port 1.
+ *
+ *  The nrf52832 has only one port with 32 pins. The nrf52840 has 48 pins and
+ *  uses two ports.
+ *
+ *  NOTE: in order to save code space, there is no checking done to see if the
+ *  user specifies a pin that is not used by the processor. If an invalid pin
+ *  number is used unexpected and/or erroneous behavior will result.
+ */
+#if defined(NRF52832_XXAA) || defined(NRF52810_XXAA)
+#define HAL_GPIO_INDEX(pin)     (pin)
+#define HAL_GPIO_PORT(pin)      (NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << pin)
+#define HAL_GPIOTE_PIN_MASK     GPIOTE_CONFIG_PSEL_Msk
+#endif
+
+#ifdef NRF52840_XXAA
+#define HAL_GPIO_INDEX(pin)     ((pin) & 0x1F)
+#define HAL_GPIO_PORT(pin)      ((pin) > 31 ? NRF_P1 : NRF_P0)
+#define HAL_GPIO_MASK(pin)      (1 << HAL_GPIO_INDEX(pin))
+#define HAL_GPIOTE_PIN_MASK     (0x3FUL << GPIOTE_CONFIG_PSEL_Pos)
+#endif
+
+/* GPIO interrupts */
+#define HAL_GPIO_MAX_IRQ        8
+
+/* Storage for GPIO callbacks. */
+struct hal_gpio_irq {
+    hal_gpio_irq_handler_t func;
+    void *arg;
+};
+
+static struct hal_gpio_irq hal_gpio_irqs[HAL_GPIO_MAX_IRQ];
+
+/**
+ * gpio init in
+ *
+ * Initializes the specified pin as an input
+ *
+ * @param pin   Pin number to set as input
+ * @param pull  pull type
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int
+hal_gpio_init_in(int pin, hal_gpio_pull_t pull)
+{
+    uint32_t conf;
+    NRF_GPIO_Type *port;
+    int pin_index = HAL_GPIO_INDEX(pin);
+
+    switch (pull) {
+    case HAL_GPIO_PULL_UP:
+        conf = GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos;
+        break;
+    case HAL_GPIO_PULL_DOWN:
+        conf = GPIO_PIN_CNF_PULL_Pulldown << GPIO_PIN_CNF_PULL_Pos;
+        break;
+    case HAL_GPIO_PULL_NONE:
+    default:
+        conf = 0;
+        break;
+    }
+
+    port = HAL_GPIO_PORT(pin);
+    port->PIN_CNF[pin_index] = conf;
+    port->DIRCLR = HAL_GPIO_MASK(pin);
+
+    return 0;
+}
+
+/**
+ * gpio init out
+ *
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
+ * @param pin Pin number to set as output
+ * @param val Value to set pin
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int
+hal_gpio_init_out(int pin, int val)
+{
+    NRF_GPIO_Type *port;
+    int pin_index = HAL_GPIO_INDEX(pin);
+
+    port = HAL_GPIO_PORT(pin);
+    if (val) {
+        port->OUTSET = HAL_GPIO_MASK(pin);
+    } else {
+        port->OUTCLR = HAL_GPIO_MASK(pin);
+    }
+    port->PIN_CNF[pin_index] = GPIO_PIN_CNF_DIR_Output |
+        (GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
+    port->DIRSET = HAL_GPIO_MASK(pin);
+
+    return 0;
+}
+
+/**
+ * gpio write
+ *
+ * Write a value (either high or low) to the specified pin.
+ *
+ * @param pin Pin to set
+ * @param val Value to set pin (0:low 1:high)
+ */
+void
+hal_gpio_write(int pin, int val)
+{
+    NRF_GPIO_Type *port;
+
+    port = HAL_GPIO_PORT(pin);
+    if (val) {
+        port->OUTSET = HAL_GPIO_MASK(pin);
+    } else {
+        port->OUTCLR = HAL_GPIO_MASK(pin);
+    }
+}
+
+/**
+ * gpio read
+ *
+ * Reads the specified pin.
+ *
+ * @param pin Pin number to read
+ *
+ * @return int 0: low, 1: high
+ */
+int
+hal_gpio_read(int pin)
+{
+    NRF_GPIO_Type *port;
+    port = HAL_GPIO_PORT(pin);
+
+    return (port->DIR & HAL_GPIO_MASK(pin)) ?
+        (port->OUT >> HAL_GPIO_INDEX(pin)) & 1UL :
+        (port->IN >> HAL_GPIO_INDEX(pin)) & 1UL;
+}
+
+/**
+ * gpio toggle
+ *
+ * Toggles the specified pin
+ *
+ * @param pin Pin number to toggle
+ *
+ * @return current pin state int 0: low, 1: high
+ */
+int
+hal_gpio_toggle(int pin)
+{
+    int pin_state = (hal_gpio_read(pin) == 0);
+    hal_gpio_write(pin, pin_state);
+    return pin_state;
+}
+
+/*
+ * GPIO irq handler
+ *
+ * Handles the gpio interrupt attached to a gpio pin.
+ *
+ * @param index
+ */
+static void
+hal_gpio_irq_handler(void)
+{
+    int i;
+
+    os_trace_isr_enter();
+
+    for (i = 0; i < HAL_GPIO_MAX_IRQ; i++) {
+        if (NRF_GPIOTE->EVENTS_IN[i] && (NRF_GPIOTE->INTENSET & (1 << i))) {
+            NRF_GPIOTE->EVENTS_IN[i] = 0;
+            if (hal_gpio_irqs[i].func) {
+                hal_gpio_irqs[i].func(hal_gpio_irqs[i].arg);
+            }
+        }
+    }
+
+    os_trace_isr_exit();
+}
+
+/*
+ * Register IRQ handler for GPIOTE, and enable it.
+ * Only executed once, during first registration.
+ */
+static void
+hal_gpio_irq_setup(void)
+{
+    static uint8_t irq_setup = 0;
+
+    if (!irq_setup) {
+        NVIC_SetVector(GPIOTE_IRQn, (uint32_t)hal_gpio_irq_handler);
+        NVIC_EnableIRQ(GPIOTE_IRQn);
+        irq_setup = 1;
+    }
+}
+
+/*
+ * Find out whether we have an GPIOTE pin event to use.
+ */
+static int
+hal_gpio_find_empty_slot(void)
+{
+    int i;
+
+    for (i = 0; i < HAL_GPIO_MAX_IRQ; i++) {
+        if (hal_gpio_irqs[i].func == NULL) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/*
+ * Find the GPIOTE event which handles this pin.
+ */
+static int
+hal_gpio_find_pin(int pin)
+{
+    int i;
+
+    pin = pin << GPIOTE_CONFIG_PSEL_Pos;
+
+    for (i = 0; i < HAL_GPIO_MAX_IRQ; i++) {
+        if (hal_gpio_irqs[i].func &&
+           (NRF_GPIOTE->CONFIG[i] & HAL_GPIOTE_PIN_MASK) == pin) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * gpio irq init
+ *
+ * Initialize an external interrupt on a gpio pin
+ *
+ * @param pin       Pin number to enable gpio.
+ * @param handler   Interrupt handler
+ * @param arg       Argument to pass to interrupt handler
+ * @param trig      Trigger mode of interrupt
+ * @param pull      Push/pull mode of input.
+ *
+ * @return int
+ */
+int
+hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
+                  hal_gpio_irq_trig_t trig, hal_gpio_pull_t pull)
+{
+    uint32_t conf;
+    int i;
+
+    hal_gpio_irq_setup();
+    i = hal_gpio_find_empty_slot();
+    if (i < 0) {
+        return -1;
+    }
+    hal_gpio_init_in(pin, pull);
+
+    switch (trig) {
+    case HAL_GPIO_TRIG_RISING:
+        conf = GPIOTE_CONFIG_POLARITY_LoToHi << GPIOTE_CONFIG_POLARITY_Pos;
+        break;
+    case HAL_GPIO_TRIG_FALLING:
+        conf = GPIOTE_CONFIG_POLARITY_HiToLo << GPIOTE_CONFIG_POLARITY_Pos;
+        break;
+    case HAL_GPIO_TRIG_BOTH:
+        conf = GPIOTE_CONFIG_POLARITY_Toggle << GPIOTE_CONFIG_POLARITY_Pos;
+        break;
+    default:
+        return -1;
+    }
+    conf |= pin << GPIOTE_CONFIG_PSEL_Pos;
+    conf |= GPIOTE_CONFIG_MODE_Event << GPIOTE_CONFIG_MODE_Pos;
+
+    NRF_GPIOTE->CONFIG[i] = conf;
+
+    hal_gpio_irqs[i].func = handler;
+    hal_gpio_irqs[i].arg = arg;
+
+    return 0;
+}
+
+/**
+ * gpio irq release
+ *
+ * No longer interrupt when something occurs on the pin. NOTE: this function
+ * does not change the GPIO push/pull setting.
+ * It also does not disable the NVIC interrupt enable setting for the irq.
+ *
+ * @param pin
+ */
+void
+hal_gpio_irq_release(int pin)
+{
+    int i;
+
+    i = hal_gpio_find_pin(pin);
+    if (i < 0) {
+        return;
+    }
+    hal_gpio_irq_disable(i);
+
+    NRF_GPIOTE->CONFIG[i] = 0;
+    NRF_GPIOTE->EVENTS_IN[i] = 0;
+
+    hal_gpio_irqs[i].arg = NULL;
+    hal_gpio_irqs[i].func = NULL;
+}
+
+/**
+ * gpio irq enable
+ *
+ * Enable the irq on the specified pin
+ *
+ * @param pin
+ */
+void
+hal_gpio_irq_enable(int pin)
+{
+    int i;
+
+    i = hal_gpio_find_pin(pin);
+    if (i < 0) {
+        return;
+    }
+    NRF_GPIOTE->EVENTS_IN[i] = 0;
+    NRF_GPIOTE->INTENSET = 1 << i;
+}
+
+/**
+ * gpio irq disable
+ *
+ *
+ * @param pin
+ */
+void
+hal_gpio_irq_disable(int pin)
+{
+    int i;
+
+    i = hal_gpio_find_pin(pin);
+    if (i < 0) {
+        return;
+    }
+    NRF_GPIOTE->INTENCLR = 1 << i;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_i2c.c
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <assert.h>
+#include "os/mynewt.h"
+#include <hal/hal_i2c.h>
+#include <hal/hal_gpio.h>
+#include <mcu/nrf52_hal.h>
+
+#include <nrf.h>
+
+#define NRF52_HAL_I2C_MAX (2)
+
+#define NRF52_SCL_PIN_CONF                                              \
+    ((GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos) |          \
+      (GPIO_PIN_CNF_DRIVE_S0D1    << GPIO_PIN_CNF_DRIVE_Pos) |          \
+      (GPIO_PIN_CNF_PULL_Pullup   << GPIO_PIN_CNF_PULL_Pos) |           \
+      (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) |          \
+      (GPIO_PIN_CNF_DIR_Input     << GPIO_PIN_CNF_DIR_Pos))
+#define NRF52_SDA_PIN_CONF NRF52_SCL_PIN_CONF
+
+#define NRF52_SCL_PIN_CONF_CLR                                  \
+     ((GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos) | \
+      (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos) | \
+      (GPIO_PIN_CNF_PULL_Pullup    << GPIO_PIN_CNF_PULL_Pos)  | \
+      (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) | \
+      (GPIO_PIN_CNF_DIR_Output     << GPIO_PIN_CNF_DIR_Pos))
+#define NRF52_SDA_PIN_CONF_CLR    NRF52_SCL_PIN_CONF_CLR
+
+#define NRF52_HAL_I2C_RESOLVE(__n, __v)                      \
+    if ((__n) >= NRF52_HAL_I2C_MAX) {                        \
+        rc = EINVAL;                                         \
+        goto err;                                            \
+    }                                                        \
+    (__v) = (struct nrf52_hal_i2c *) nrf52_hal_i2cs[(__n)];  \
+    if ((__v) == NULL) {                                     \
+        rc = EINVAL;                                         \
+        goto err;                                            \
+    }
+
+struct nrf52_hal_i2c {
+    NRF_TWI_Type *nhi_regs;
+};
+
+#if MYNEWT_VAL(I2C_0)
+struct nrf52_hal_i2c hal_twi_i2c0 = {
+    .nhi_regs = NRF_TWI0
+};
+#endif
+#if MYNEWT_VAL(I2C_1)
+struct nrf52_hal_i2c hal_twi_i2c1 = {
+    .nhi_regs = NRF_TWI1
+};
+#endif
+
+static const struct nrf52_hal_i2c *nrf52_hal_i2cs[NRF52_HAL_I2C_MAX] = {
+#if MYNEWT_VAL(I2C_0)
+    &hal_twi_i2c0,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(I2C_1)
+    &hal_twi_i2c1
+#else
+    NULL
+#endif
+};
+
+static void
+hal_i2c_delay_us(uint32_t number_of_us)
+{
+register uint32_t delay __ASM ("r0") = number_of_us;
+__ASM volatile (
+#ifdef NRF51
+        ".syntax unified\n"
+#endif
+    "1:\n"
+    " SUBS %0, %0, #1\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+#ifdef NRF52
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+    " NOP\n"
+#endif
+    " BNE 1b\n"
+#ifdef NRF51
+    ".syntax divided\n"
+#endif
+    : "+r" (delay));
+}
+
+/**
+ * Reads the input buffer of the specified pin regardless
+ * of if it is set as output or input
+ */
+static int
+read_gpio_inbuffer(int pin)
+{
+    NRF_GPIO_Type *port;
+    port = HAL_GPIO_PORT(pin);
+
+    return (port->IN >> HAL_GPIO_INDEX(pin)) & 1UL;
+}
+
+/*
+ * Clear the bus after reset by clocking 9 bits manually.
+ * This should reset state from (most of) the devices on the other end.
+ */
+static void
+hal_i2c_clear_bus(const struct nrf52_hal_i2c_cfg *cfg)
+{
+    int i;
+    NRF_GPIO_Type *scl_port, *sda_port;
+    /* Resolve which GPIO port these pins belong to */
+    scl_port = HAL_GPIO_PORT(cfg->scl_pin);
+    sda_port = HAL_GPIO_PORT(cfg->sda_pin);
+
+    /* Input connected, standard-low disconnected-high, pull-ups */
+    scl_port->PIN_CNF[cfg->scl_pin] = NRF52_SCL_PIN_CONF;
+    sda_port->PIN_CNF[cfg->sda_pin] = NRF52_SDA_PIN_CONF;
+
+    hal_gpio_write(cfg->scl_pin, 1);
+    hal_gpio_write(cfg->sda_pin, 1);
+
+    scl_port->PIN_CNF[cfg->scl_pin] = NRF52_SCL_PIN_CONF_CLR;
+    sda_port->PIN_CNF[cfg->sda_pin] = NRF52_SDA_PIN_CONF_CLR;
+
+    hal_i2c_delay_us(4);
+
+    for (i = 0; i < 9; i++) {
+        if (read_gpio_inbuffer(cfg->sda_pin)) {
+            if (i == 0) {
+                /*
+                 * Nothing to do here.
+                 */
+                goto ret;
+            } else {
+                break;
+            }
+        }
+        hal_gpio_write(cfg->scl_pin, 0);
+        hal_i2c_delay_us(4);
+        hal_gpio_write(cfg->scl_pin, 1);
+        hal_i2c_delay_us(4);
+    }
+
+    /*
+     * Send STOP.
+     */
+    hal_gpio_write(cfg->sda_pin, 0);
+    hal_i2c_delay_us(4);
+    hal_gpio_write(cfg->sda_pin, 1);
+
+ret:
+    /* Restore GPIO config */
+    scl_port->PIN_CNF[cfg->scl_pin] = NRF52_SCL_PIN_CONF;
+    sda_port->PIN_CNF[cfg->sda_pin] = NRF52_SDA_PIN_CONF;
+}
+
+int
+hal_i2c_init(uint8_t i2c_num, void *usercfg)
+{
+    struct nrf52_hal_i2c *i2c;
+    NRF_TWI_Type *regs;
+    struct nrf52_hal_i2c_cfg *cfg;
+    uint32_t freq;
+    int rc;
+    NRF_GPIO_Type *scl_port, *sda_port;
+
+    assert(usercfg != NULL);
+
+    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+
+    cfg = (struct nrf52_hal_i2c_cfg *) usercfg;
+    regs = i2c->nhi_regs;
+
+    switch (cfg->i2c_frequency) {
+    case 100:
+        freq = TWI_FREQUENCY_FREQUENCY_K100;
+        break;
+    case 250:
+        freq = TWI_FREQUENCY_FREQUENCY_K250;
+        break;
+    case 400:
+        freq = TWI_FREQUENCY_FREQUENCY_K400;
+        break;
+    default:
+        rc = EINVAL;
+        goto err;
+    }
+
+    hal_i2c_clear_bus(cfg);
+
+    /* Resolve which GPIO port these pins belong to */
+    scl_port = HAL_GPIO_PORT(cfg->scl_pin);
+    sda_port = HAL_GPIO_PORT(cfg->sda_pin);
+
+    scl_port->PIN_CNF[cfg->scl_pin] = NRF52_SCL_PIN_CONF;
+    sda_port->PIN_CNF[cfg->sda_pin] = NRF52_SDA_PIN_CONF;
+
+    regs->PSELSCL = cfg->scl_pin;
+    regs->PSELSDA = cfg->sda_pin;
+    regs->FREQUENCY = freq;
+    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
+
+    return (0);
+err:
+    return (rc);
+}
+
+int
+hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                     uint32_t timo, uint8_t last_op)
+{
+    struct nrf52_hal_i2c *i2c;
+    NRF_TWI_Type *regs = NULL;
+    int rc = -1;
+    int i;
+    uint32_t start;
+    int retry_once = 1;
+
+    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+    regs = i2c->nhi_regs;
+
+    regs->ADDRESS = pdata->address;
+
+retry:
+    regs->EVENTS_ERROR = 0;
+    regs->EVENTS_STOPPED = 0;
+    regs->EVENTS_SUSPENDED = 0;
+    regs->SHORTS = 0;
+
+    regs->TASKS_STARTTX = 1;
+    regs->TASKS_RESUME = 1;
+
+    start = os_time_get();
+    for (i = 0; i < pdata->len; i++) {
+        regs->EVENTS_TXDSENT = 0;
+        regs->TXD = pdata->buffer[i];
+        while (!regs->EVENTS_TXDSENT && !regs->EVENTS_ERROR) {
+            if (os_time_get() - start > timo) {
+                regs->TASKS_STOP = 1;
+                if (retry_once) {
+                   /* 
+                    * Some I2C slave peripherals cause a glitch on the bus when
+                    * they reset which puts the TWI in an unresponsive state.
+                    * Disabling and re-enabling the TWI returns it to normal operation.
+                    */
+                    retry_once = 0;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
+                    goto retry;
+                } else {
+                    goto err;
+                }
+            }
+        }
+        if (regs->EVENTS_ERROR) {
+            goto err;
+        }
+    }
+    /* If last_op is zero it means we dont put a stop at end. */
+    if (last_op) {
+        regs->EVENTS_STOPPED = 0;
+        regs->TASKS_STOP = 1;
+        while (!regs->EVENTS_STOPPED && !regs->EVENTS_ERROR) {
+            if (os_time_get() - start > timo) {
+                goto err;
+            }
+        }
+        if (regs->EVENTS_ERROR) {
+            goto err;
+        }
+    }
+    return (0);
+err:
+    if (regs && regs->EVENTS_ERROR) {
+        rc = regs->ERRORSRC;
+        regs->TASKS_STOP = 1;
+        regs->ERRORSRC = rc;
+    }
+    return (rc);
+}
+
+int
+hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                    uint32_t timo, uint8_t last_op)
+{
+    struct nrf52_hal_i2c *i2c;
+    NRF_TWI_Type *regs = NULL;
+    int rc = -1;
+    int i;
+    uint32_t start;
+    int retry_once = 1;
+
+    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+    regs = i2c->nhi_regs;
+
+retry:
+    start = os_time_get();
+
+    if (regs->EVENTS_RXDREADY) {
+        /*
+         * If previous read was interrupted, flush RXD.
+         */
+        (void)regs->RXD;
+        (void)regs->RXD;
+    }
+    regs->EVENTS_ERROR = 0;
+    regs->EVENTS_STOPPED = 0;
+    regs->EVENTS_SUSPENDED = 0;
+    regs->EVENTS_RXDREADY = 0;
+
+    regs->ADDRESS = pdata->address;
+
+    if (pdata->len == 1 && last_op) {
+        regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
+    } else {
+        regs->SHORTS = TWI_SHORTS_BB_SUSPEND_Msk;
+    }
+    regs->TASKS_STARTRX = 1;
+
+    for (i = 0; i < pdata->len; i++) {
+        regs->TASKS_RESUME = 1;
+        while (!regs->EVENTS_RXDREADY && !regs->EVENTS_ERROR) {
+            if (os_time_get() - start > timo) {
+                regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
+                regs->TASKS_STOP = 1;
+                if (retry_once) {
+                   /* 
+                    * Some I2C slave peripherals cause a glitch on the bus when
+                    * they reset which puts the TWI in an unresponsive state.
+                    * Disabling and re-enabling the TWI returns it to normal operation.
+                    */
+                    retry_once = 0;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
+                    goto retry;
+                } else {
+                    goto err;
+                }
+            }
+        }
+        if (regs->EVENTS_ERROR) {
+            goto err;
+        }
+        pdata->buffer[i] = regs->RXD;
+        if (i == pdata->len - 2) {
+            if (last_op) {
+                regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
+            }
+        }
+        regs->EVENTS_RXDREADY = 0;
+    }
+    return (0);
+err:
+    if (regs && regs->EVENTS_ERROR) {
+        rc = regs->ERRORSRC;
+        regs->TASKS_STOP = 1;
+        regs->ERRORSRC = rc;
+    }
+    return (rc);
+}
+
+int
+hal_i2c_master_probe(uint8_t i2c_num, uint8_t address, uint32_t timo)
+{
+    struct hal_i2c_master_data rx;
+    uint8_t buf;
+
+    rx.address = address;
+    rx.buffer = &buf;
+    rx.len = 1;
+
+    return hal_i2c_master_read(i2c_num, &rx, timo, 1);
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_nvreg.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_nvreg.c
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <mcu/cortex_m4.h>
+#include "hal/hal_nvreg.h"
+#include "nrf.h"
+
+/* There are two GPREGRET registers on the NRF52 */
+#define HAL_NVREG_MAX (2)
+
+/* GPREGRET registers only save the 8 lsbits */
+#define HAL_NVREG_WIDTH_BYTES (1)
+
+static volatile uint32_t *regs[HAL_NVREG_MAX] = {
+    &NRF_POWER->GPREGRET,
+    &NRF_POWER->GPREGRET2
+};
+
+void
+hal_nvreg_write(unsigned int reg, uint32_t val)
+{
+    if(reg < HAL_NVREG_MAX) {
+        *regs[reg] = val;
+    }
+}
+
+uint32_t
+hal_nvreg_read(unsigned int reg)
+{
+    uint32_t val = 0;
+
+    if(reg < HAL_NVREG_MAX) {
+        val = *regs[reg];
+    }
+
+    return val;
+}
+
+unsigned int hal_nvreg_get_num_regs(void)
+{
+    return HAL_NVREG_MAX;
+}
+
+unsigned int hal_nvreg_get_reg_width(void)
+{
+    return HAL_NVREG_WIDTH_BYTES;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_os_tick.c
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "os/mynewt.h"
+#include "hal/hal_os_tick.h"
+#include "nrf.h"
+#include "mcu/cmsis_nvic.h"
+
+/* The OS scheduler requires a low-frequency timer. */
+#if MYNEWT_VAL(OS_SCHEDULING)       && \
+    !MYNEWT_VAL(XTAL_32768)         && \
+    !MYNEWT_VAL(XTAL_RC)            && \
+    !MYNEWT_VAL(XTAL_32768_SYNTH)
+
+    #error The OS scheduler requires a low-frequency timer; enable one of: XTAL_32768, XTAL_RC, or XTAL_32768_SYNTH
+#endif
+
+#define RTC_FREQ            32768       /* in Hz */
+#define OS_TICK_TIMER       NRF_RTC1
+#define OS_TICK_IRQ         RTC1_IRQn
+#define OS_TICK_CMPREG      3   /* generate timer interrupt */
+#define RTC_COMPARE_INT_MASK(ccreg) (1UL << ((ccreg) + 16))
+
+struct hal_os_tick
+{
+    int ticks_per_ostick;
+    os_time_t max_idle_ticks;
+    uint32_t lastocmp;
+};
+
+struct hal_os_tick g_hal_os_tick;
+
+/*
+ * Implement (x - y) where the range of both 'x' and 'y' is limited to 24-bits.
+ *
+ * For example:
+ *
+ * sub24(0, 0xffffff) = 1
+ * sub24(0xffffff, 0xfffffe) = 1
+ * sub24(0xffffff, 0) = -1
+ * sub24(0x7fffff, 0) = 8388607
+ * sub24(0x800000, 0) = -8388608
+ */
+static inline int
+sub24(uint32_t x, uint32_t y)
+{
+    int result;
+
+    assert(x <= 0xffffff);
+    assert(y <= 0xffffff);
+
+    result = x - y;
+    if (result & 0x800000) {
+        return (result | 0xff800000);
+    } else {
+        return (result & 0x007fffff);
+    }
+}
+
+static inline uint32_t
+nrf52_os_tick_counter(void)
+{
+    return OS_TICK_TIMER->COUNTER;
+}
+
+static inline void
+nrf52_os_tick_set_ocmp(uint32_t ocmp)
+{
+    int delta;
+    uint32_t counter;
+
+    OS_ASSERT_CRITICAL();
+    while (1) {
+        ocmp &= 0xffffff;
+        OS_TICK_TIMER->CC[OS_TICK_CMPREG] = ocmp;
+        counter = nrf52_os_tick_counter();
+        /*
+         * From nRF52 Product specification
+         *
+         * - If Counter is 'N' writing (N) or (N + 1) to CC register
+         *   may not trigger a compare event.
+         *
+         * - If Counter is 'N' writing (N + 2) to CC register is guaranteed
+         *   to trigger a compare event at 'N + 2'.
+         */
+        delta = sub24(ocmp, counter);
+        if (delta > 2) {
+            break;
+        }
+        ocmp += g_hal_os_tick.ticks_per_ostick;
+    }
+}
+
+static void
+nrf52_timer_handler(void)
+{
+    int delta;
+    int ticks;
+    os_sr_t sr;
+    uint32_t counter;
+
+    os_trace_isr_enter();
+    OS_ENTER_CRITICAL(sr);
+
+    /* Calculate elapsed ticks and advance OS time. */
+
+    counter = nrf52_os_tick_counter();
+    delta = sub24(counter, g_hal_os_tick.lastocmp);
+    ticks = delta / g_hal_os_tick.ticks_per_ostick;
+    os_time_advance(ticks);
+
+    /* Clear timer interrupt */
+    OS_TICK_TIMER->EVENTS_COMPARE[OS_TICK_CMPREG] = 0;
+
+    /* Update the time associated with the most recent tick */
+    g_hal_os_tick.lastocmp = (g_hal_os_tick.lastocmp +
+        (ticks * g_hal_os_tick.ticks_per_ostick)) & 0xffffff;
+
+    /* Update the output compare to interrupt at the next tick */
+    nrf52_os_tick_set_ocmp(g_hal_os_tick.lastocmp + g_hal_os_tick.ticks_per_ostick);
+
+    OS_EXIT_CRITICAL(sr);
+    os_trace_isr_exit();
+}
+
+void
+os_tick_idle(os_time_t ticks)
+{
+    uint32_t ocmp;
+
+    OS_ASSERT_CRITICAL();
+
+    if (ticks > 0) {
+        /*
+         * Enter tickless regime during long idle durations.
+         */
+        if (ticks > g_hal_os_tick.max_idle_ticks) {
+            ticks = g_hal_os_tick.max_idle_ticks;
+        }
+        ocmp = g_hal_os_tick.lastocmp + (ticks*g_hal_os_tick.ticks_per_ostick);
+        nrf52_os_tick_set_ocmp(ocmp);
+    }
+
+    __DSB();
+    __WFI();
+
+    if (ticks > 0) {
+        /*
+         * Update OS time before anything else when coming out of
+         * the tickless regime.
+         */
+        nrf52_timer_handler();
+    }
+}
+
+void
+os_tick_init(uint32_t os_ticks_per_sec, int prio)
+{
+    uint32_t sr;
+
+    assert(RTC_FREQ % os_ticks_per_sec == 0);
+
+    g_hal_os_tick.lastocmp = 0;
+    g_hal_os_tick.ticks_per_ostick = RTC_FREQ / os_ticks_per_sec;
+
+    /*
+     * The maximum number of OS ticks allowed to elapse during idle is
+     * limited to 1/4th the number of timer ticks before the 24-bit counter
+     * rolls over.
+     */
+    g_hal_os_tick.max_idle_ticks = (1UL << 22) / g_hal_os_tick.ticks_per_ostick;
+
+    /* disable interrupts */
+    OS_ENTER_CRITICAL(sr);
+
+    /* Set isr in vector table and enable interrupt */
+    NVIC_SetPriority(OS_TICK_IRQ, prio);
+    NVIC_SetVector(OS_TICK_IRQ, (uint32_t)nrf52_timer_handler);
+    NVIC_EnableIRQ(OS_TICK_IRQ);
+
+    /*
+     * Program the OS_TICK_TIMER to operate at 32KHz and trigger an output
+     * compare interrupt at a rate of 'os_ticks_per_sec'.
+     */
+    OS_TICK_TIMER->TASKS_STOP = 1;
+    OS_TICK_TIMER->TASKS_CLEAR = 1;
+
+    OS_TICK_TIMER->EVTENCLR = 0xffffffff;
+    OS_TICK_TIMER->INTENCLR = 0xffffffff;
+    OS_TICK_TIMER->INTENSET = RTC_COMPARE_INT_MASK(OS_TICK_CMPREG);
+
+    OS_TICK_TIMER->EVENTS_COMPARE[OS_TICK_CMPREG] = 0;
+    OS_TICK_TIMER->CC[OS_TICK_CMPREG] = g_hal_os_tick.ticks_per_ostick;
+
+    OS_TICK_TIMER->TASKS_START = 1;
+
+    OS_EXIT_CRITICAL(sr);
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_qspi.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_qspi.c
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+#include "os/mynewt.h"
+#if MYNEWT_VAL(QSPI_ENABLE)
+#include <mcu/cmsis_nvic.h>
+#include <hal/hal_flash_int.h>
+#include "mcu/nrf52_hal.h"
+#include "nrf.h"
+#include <nrfx/hal/nrf_qspi.h>
+
+#if MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE) < 1
+#error QSPI_FLASH_SECTOR_SIZE must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_FLASH_PAGE_SIZE) < 1
+#error QSPI_FLASH_PAGE_SIZE must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT) < 1
+#error QSPI_FLASH_SECTOR_COUNT must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_CS) < 0
+#error QSPI_PIN_CS must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_SCK) < 0
+#error QSPI_PIN_SCK must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_DIO0) < 0
+#error QSPI_PIN_DIO0 must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_DIO1) < 0
+#error QSPI_PIN_DIO1 must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_DIO2) < 0 && (MYNEWT_VAL(QSPI_READOC) > 2 || MYNEWT_VAL(QSPI_WRITEOC) > 1)
+#error QSPI_PIN_DIO2 must be set to the correct value in bsp syscfg.yml
+#endif
+
+#if MYNEWT_VAL(QSPI_PIN_DIO3) < 0 && (MYNEWT_VAL(QSPI_READOC) > 2 || MYNEWT_VAL(QSPI_WRITEOC) > 1)
+#error QSPI_PIN_DIO3 must be set to the correct value in bsp syscfg.yml
+#endif
+
+static int
+nrf52k_qspi_read(const struct hal_flash *dev, uint32_t address,
+        void *dst, uint32_t num_bytes);
+static int
+nrf52k_qspi_write(const struct hal_flash *dev, uint32_t address,
+        const void *src, uint32_t num_bytes);
+static int
+nrf52k_qspi_erase_sector(const struct hal_flash *dev,
+        uint32_t sector_address);
+static int
+nrf52k_qspi_sector_info(const struct hal_flash *dev, int idx,
+        uint32_t *address, uint32_t *sz);
+static int
+nrf52k_qspi_init(const struct hal_flash *dev);
+
+static const struct hal_flash_funcs nrf52k_qspi_funcs = {
+    .hff_read = nrf52k_qspi_read,
+    .hff_write = nrf52k_qspi_write,
+    .hff_erase_sector = nrf52k_qspi_erase_sector,
+    .hff_sector_info = nrf52k_qspi_sector_info,
+    .hff_init = nrf52k_qspi_init
+};
+
+const struct hal_flash nrf52k_qspi_dev = {
+    .hf_itf = &nrf52k_qspi_funcs,
+    .hf_base_addr = 0x00000000,
+    .hf_size = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT) * MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE),
+    .hf_sector_cnt = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT),
+    .hf_align = 1
+};
+
+static int
+nrf52k_qspi_read(const struct hal_flash *dev, uint32_t address,
+        void *dst, uint32_t num_bytes) {
+    uint32_t ram_buffer[4];
+    uint8_t *ram_ptr = NULL;
+    uint32_t read_bytes;
+
+    while ((NRF_QSPI->STATUS & QSPI_STATUS_READY_Msk) == 0)
+        ;
+
+    while (num_bytes != 0) {
+        /*
+         * If address or destination pointer are unaligned or
+         * number of bytes to read is less then 4 read using ram buffer.
+         */
+        if (((address & 3) != 0) ||
+            ((((uint32_t) dst) & 3) != 0) ||
+            num_bytes < 4) {
+            uint32_t to_read = (num_bytes + (address & 3) + 3) & ~3;
+            if (to_read > sizeof(ram_buffer)) {
+                to_read = sizeof(ram_buffer);
+            }
+            ram_ptr = (uint8_t *)((uint32_t) ram_buffer + (address & 3));
+            read_bytes = to_read - (address & 3);
+            if (read_bytes > num_bytes) {
+                read_bytes = num_bytes;
+            }
+            NRF_QSPI->READ.DST = (uint32_t) ram_buffer;
+            NRF_QSPI->READ.SRC = address & ~3;
+            NRF_QSPI->READ.CNT = to_read;
+        } else {
+            read_bytes = num_bytes & ~3;
+            NRF_QSPI->READ.DST = (uint32_t) dst;
+            NRF_QSPI->READ.SRC = address;
+            NRF_QSPI->READ.CNT = read_bytes;
+        }
+        NRF_QSPI->EVENTS_READY = 0;
+        NRF_QSPI->TASKS_READSTART = 1;
+        while (NRF_QSPI->EVENTS_READY == 0)
+            ;
+        if (ram_ptr != NULL) {
+            memcpy(dst, ram_ptr, read_bytes);
+            ram_ptr = NULL;
+        }
+        address += read_bytes;
+        dst = (void *) ((uint32_t) dst + read_bytes);
+        num_bytes -= read_bytes;
+    }
+    return 0;
+}
+
+static int
+nrf52k_qspi_write(const struct hal_flash *dev, uint32_t address,
+        const void *src, uint32_t num_bytes)
+{
+    uint32_t ram_buffer[4];
+    uint8_t *ram_ptr = NULL;
+    uint32_t written_bytes;
+    const char src_not_in_ram = (((uint32_t) src) & 0xE0000000) != 0x20000000;
+    uint32_t page_limit;
+
+    while ((NRF_QSPI->STATUS & QSPI_STATUS_READY_Msk) == 0)
+        ;
+
+    while (num_bytes != 0) {
+        page_limit = (address & ~(MYNEWT_VAL(QSPI_FLASH_PAGE_SIZE) - 1)) +
+                MYNEWT_VAL(QSPI_FLASH_PAGE_SIZE);
+        /*
+         * Use RAM buffer if src or address is not 4 bytes aligned,
+         * or number of bytes to write is less then 4
+         * or src pointer is not from RAM.
+         */
+        if (((address & 3) != 0) ||
+            ((((uint32_t) src) & 3) != 0) ||
+            num_bytes < 4 ||
+            src_not_in_ram) {
+            uint32_t to_write;
+            if (address + num_bytes > page_limit) {
+                to_write = ((page_limit - address) + 3) & ~3;
+            } else {
+                to_write = (num_bytes + (address & 3) + 3) & ~3;
+            }
+            if (to_write > sizeof(ram_buffer)) {
+                to_write = sizeof(ram_buffer);
+            }
+            memset(ram_buffer, 0xFF, sizeof(ram_buffer));
+            ram_ptr = (uint8_t *)((uint32_t) ram_buffer + (address & 3));
+
+            written_bytes = to_write - (address & 3);
+            if (written_bytes > num_bytes) {
+                written_bytes = num_bytes;
+            }
+            memcpy(ram_ptr, src, written_bytes);
+
+            NRF_QSPI->WRITE.SRC = (uint32_t) ram_buffer;
+            NRF_QSPI->WRITE.DST = address & ~3;
+            NRF_QSPI->WRITE.CNT = to_write;
+        } else {
+            NRF_QSPI->WRITE.SRC = (uint32_t) src;
+            NRF_QSPI->WRITE.DST = address;
+            /*
+             * Limit write to single page.
+             */
+            if (address + num_bytes > page_limit) {
+                written_bytes = page_limit - address;
+            } else {
+                written_bytes = num_bytes & ~3;
+            }
+            NRF_QSPI->WRITE.CNT = written_bytes;
+        }
+        NRF_QSPI->EVENTS_READY = 0;
+        NRF_QSPI->TASKS_WRITESTART = 1;
+        while (NRF_QSPI->EVENTS_READY == 0)
+            ;
+
+        address += written_bytes;
+        src = (void *) ((uint32_t) src + written_bytes);
+        num_bytes -= written_bytes;
+    }
+    return 0;
+}
+
+static int
+nrf52k_qspi_erase_sector(const struct hal_flash *dev,
+        uint32_t sector_address)
+{
+    while ((NRF_QSPI->STATUS & QSPI_STATUS_READY_Msk) == 0)
+        ;
+    NRF_QSPI->EVENTS_READY = 0;
+    NRF_QSPI->ERASE.PTR = sector_address;
+    NRF_QSPI->ERASE.LEN = MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE);
+    NRF_QSPI->TASKS_ERASESTART = 1;
+    while (NRF_QSPI->EVENTS_READY == 0)
+        ;
+    return 0;
+}
+
+static int
+nrf52k_qspi_sector_info(const struct hal_flash *dev, int idx,
+        uint32_t *address, uint32_t *sz)
+{
+    *address = idx * MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE);
+    *sz = MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE);
+
+    return 0;
+}
+
+static int
+nrf52k_qspi_init(const struct hal_flash *dev)
+{
+    const nrf_qspi_prot_conf_t config0 = {
+            .readoc = MYNEWT_VAL(QSPI_READOC),
+            .writeoc = MYNEWT_VAL(QSPI_WRITEOC),
+            .addrmode = MYNEWT_VAL(QSPI_ADDRMODE),
+            .dpmconfig = MYNEWT_VAL(QSPI_DPMCONFIG)
+    };
+    const nrf_qspi_phy_conf_t config1 = {
+            .sck_delay = MYNEWT_VAL(QSPI_SCK_DELAY),
+            .dpmen = 0,
+            .spi_mode = MYNEWT_VAL(QSPI_SPI_MODE),
+            .sck_freq = MYNEWT_VAL(QSPI_SCK_FREQ),
+    };
+    /*
+     * Configure pins
+     */
+    NRF_QSPI->PSEL.CSN = MYNEWT_VAL(QSPI_PIN_CS);
+    NRF_QSPI->PSEL.SCK = MYNEWT_VAL(QSPI_PIN_SCK);
+    NRF_QSPI->PSEL.IO0 = MYNEWT_VAL(QSPI_PIN_DIO0);
+    NRF_QSPI->PSEL.IO1 = MYNEWT_VAL(QSPI_PIN_DIO1);
+    /*
+     * Setup only known fields of IFCONFIG0. Other bits may be set by erratas code.
+     */
+    nrf_qspi_ifconfig0_set(NRF_QSPI, &config0);
+    nrf_qspi_ifconfig1_set(NRF_QSPI, &config1);
+
+    NRF_QSPI->ENABLE = 1;
+    NRF_QSPI->TASKS_ACTIVATE = 1;
+    while (NRF_QSPI->EVENTS_READY == 0)
+        ;
+
+#if (MYNEWT_VAL(QSPI_READOC) > 2) || (MYNEWT_VAL(QSPI_WRITEOC) > 1)
+    NRF_QSPI->PSEL.IO2 = MYNEWT_VAL(QSPI_PIN_DIO2);
+    NRF_QSPI->PSEL.IO3 = MYNEWT_VAL(QSPI_PIN_DIO3);
+#endif
+
+    return 0;
+}
+
+#endif

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_reset_cause.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_reset_cause.c
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <nrf.h>
+#include "hal/hal_system.h"
+
+enum hal_reset_reason
+hal_reset_cause(void)
+{
+    static enum hal_reset_reason reason;
+    uint32_t reg;
+
+    if (reason) {
+        return reason;
+    }
+    reg = NRF_POWER->RESETREAS;
+
+    if (reg & (POWER_RESETREAS_DOG_Msk | POWER_RESETREAS_LOCKUP_Msk)) {
+        reason = HAL_RESET_WATCHDOG;
+    } else if (reg & POWER_RESETREAS_SREQ_Msk) {
+        reason = HAL_RESET_SOFT;
+    } else if (reg & POWER_RESETREAS_RESETPIN_Msk) {
+        reason = HAL_RESET_PIN;
+    } else {
+        reason = HAL_RESET_POR; /* could also be brownout */
+    }
+    NRF_POWER->RESETREAS = reg;
+    return reason;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_spi.c
@@ -1,0 +1,1164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include "os/mynewt.h"
+#include <mcu/cmsis_nvic.h>
+#include <hal/hal_spi.h>
+#include "mcu/nrf52_hal.h"
+#include "nrf.h"
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifdef NRF52840_XXAA
+#define SPIM_TXD_MAXCNT_MAX             65535
+#else
+#define SPIM_TXD_MAXCNT_MAX             255
+#endif
+
+/* IRQ handler type */
+typedef void (*nrf52_spi_irq_handler_t)(void);
+
+/* XXX:
+ * 1) what about stats?
+ * 2) Dealing with errors (OVERFLOW, OVERREAD)
+ * 3) Dont think I need dummy_rx as I can set master RX maxcnt to zero.
+ */
+
+/* The maximum number of SPI interfaces we will allow */
+#define NRF52_HAL_SPI_MAX (3)
+
+/* Used to disable all interrupts */
+#define NRF_SPI_IRQ_DISABLE_ALL 0xFFFFFFFF
+
+/*
+ *  Slave states
+ *
+ *  IDLE: Slave not ready to be used. If master attempts to access
+ *        slave it will receive the default character
+ *  ACQ_SEM: Slave is attempting to acquire semaphore.
+ *  READY: Slave is ready for master to send it data
+ *
+ */
+#define HAL_SPI_SLAVE_STATE_IDLE        (0)
+#define HAL_SPI_SLAVE_STATE_ACQ_SEM     (1)
+#define HAL_SPI_SLAVE_STATE_READY       (2)
+
+struct nrf52_hal_spi
+{
+    uint8_t spi_type;
+    uint8_t spi_xfr_flag;   /* Master only */
+    uint8_t dummy_rx;       /* Master only */
+    uint8_t slave_state;    /* Slave only */
+    struct hal_spi_settings spi_cfg; /* Slave and master */
+
+    /* Pointer to HW registers */
+    union {
+        NRF_SPIM_Type *spim;
+        NRF_SPIS_Type *spis;
+    } nhs_spi;
+
+    /* IRQ number */
+    IRQn_Type irq_num;
+
+    uint8_t *nhs_txbuf;         /* Pointer to TX buffer */
+    uint8_t *nhs_rxbuf;         /* Pointer to RX buffer */
+    uint16_t nhs_buflen;        /* Length of buffer */
+    uint16_t nhs_bytes_txq;     /* Number of bytes queued for TX */
+
+    /* Callback and arguments */
+    hal_spi_txrx_cb txrx_cb_func;
+    void            *txrx_cb_arg;
+};
+
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+struct nrf52_hal_spi nrf52_hal_spi0;
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)  || MYNEWT_VAL(SPI_1_SLAVE)
+struct nrf52_hal_spi nrf52_hal_spi1;
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)  || MYNEWT_VAL(SPI_2_SLAVE)
+struct nrf52_hal_spi nrf52_hal_spi2;
+#endif
+
+static const struct nrf52_hal_spi *nrf52_hal_spis[NRF52_HAL_SPI_MAX] = {
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+    &nrf52_hal_spi0,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)  || MYNEWT_VAL(SPI_1_SLAVE)
+    &nrf52_hal_spi1,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)  || MYNEWT_VAL(SPI_2_SLAVE)
+    &nrf52_hal_spi2,
+#else
+    NULL,
+#endif
+};
+
+#define NRF52_HAL_SPI_RESOLVE(__n, __v)                     \
+    if ((__n) >= NRF52_HAL_SPI_MAX) {                       \
+        rc = EINVAL;                                        \
+        goto err;                                           \
+    }                                                       \
+    (__v) = (struct nrf52_hal_spi *) nrf52_hal_spis[(__n)]; \
+    if ((__v) == NULL) {                                    \
+        rc = EINVAL;                                        \
+        goto err;                                           \
+    }
+
+#if (MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER))
+static void
+nrf52_irqm_handler(struct nrf52_hal_spi *spi)
+{
+    NRF_SPIM_Type *spim;
+    uint16_t xfr_bytes;
+    uint16_t next_len;
+
+    spim = spi->nhs_spi.spim;
+
+    /* Should not occur but if no transfer just leave  */
+    if (spi->spi_xfr_flag == 0) {
+        return;
+    }
+
+    if ((spim->EVENTS_STARTED) && (spim->INTENSET & SPIM_INTENSET_STARTED_Msk)) {
+        spim->EVENTS_STARTED = 0;
+
+        xfr_bytes = spim->TXD.MAXCNT;
+        spi->nhs_bytes_txq += xfr_bytes;
+
+        if (spi->nhs_bytes_txq < spi->nhs_buflen) {
+            spi->nhs_txbuf += xfr_bytes;
+
+            next_len = min(SPIM_TXD_MAXCNT_MAX,
+                           spi->nhs_buflen - spi->nhs_bytes_txq);
+
+            spim->TXD.PTR = (uint32_t)spi->nhs_txbuf;
+            spim->TXD.MAXCNT = next_len;
+
+            /* If no RX buffer was provided, we already set it to dummy one */
+            if (spi->nhs_rxbuf) {
+                spi->nhs_rxbuf += xfr_bytes;
+                spim->RXD.PTR = (uint32_t)spi->nhs_rxbuf;
+                spim->RXD.MAXCNT = next_len;
+            }
+
+            spim->SHORTS |= SPIM_SHORTS_END_START_Msk;
+            spim->INTENSET = SPIM_INTENSET_STARTED_Msk;
+            spim->INTENCLR = SPIM_INTENSET_END_Msk;
+        } else {
+            spim->SHORTS &= ~SPIM_SHORTS_END_START_Msk;
+            spim->INTENSET = SPIM_INTENSET_END_Msk;
+            spim->INTENCLR = SPIM_INTENSET_STARTED_Msk;
+        }
+    }
+
+    if (spim->EVENTS_END) {
+        spim->EVENTS_END = 0;
+
+        if (spim->INTENSET & SPIM_INTENSET_END_Msk) {
+            if (spi->txrx_cb_func) {
+                spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
+            }
+
+            spi->spi_xfr_flag = 0;
+
+            spim->SHORTS &= ~SPIM_SHORTS_END_START_Msk;
+            spim->INTENCLR = SPIM_INTENSET_STARTED_Msk | SPIM_INTENSET_END_Msk;
+        }
+    }
+}
+#endif
+
+#if (MYNEWT_VAL(SPI_0_SLAVE)  || MYNEWT_VAL(SPI_1_SLAVE) || MYNEWT_VAL(SPI_2_SLAVE))
+static void
+nrf52_irqs_handler(struct nrf52_hal_spi *spi)
+{
+    uint8_t xfr_len;
+    NRF_SPIS_Type *spis;
+
+    spis = spi->nhs_spi.spis;
+
+    /* Semaphore acquired event */
+    if (spis->EVENTS_ACQUIRED) {
+        spis->EVENTS_ACQUIRED = 0;
+
+        if (spi->slave_state == HAL_SPI_SLAVE_STATE_ACQ_SEM) {
+            if (spi->nhs_txbuf == NULL) {
+                spis->TXD.PTR = 0;
+                spis->TXD.MAXCNT = 0;
+            } else {
+                spis->TXD.PTR = (uint32_t)spi->nhs_txbuf;
+                spis->TXD.MAXCNT = spi->nhs_buflen;
+            }
+
+            if (spi->nhs_rxbuf == NULL) {
+                spis->RXD.PTR = 0;
+                spis->RXD.MAXCNT = 0;
+            } else {
+                spis->RXD.PTR = (uint32_t)spi->nhs_rxbuf;
+                spis->RXD.MAXCNT = spi->nhs_buflen;
+            }
+            spis->TASKS_RELEASE = 1;
+            spi->slave_state = HAL_SPI_SLAVE_STATE_READY;
+        }
+    }
+
+    /* SPI transaction complete */
+    if (spis->EVENTS_END) {
+        spis->EVENTS_END = 0;
+        if (spi->slave_state == HAL_SPI_SLAVE_STATE_READY) {
+            if (spi->txrx_cb_func) {
+                /* Get transfer length */
+                if (spi->nhs_txbuf == NULL) {
+                    xfr_len = spis->RXD.AMOUNT;
+                } else {
+                    xfr_len = spis->TXD.AMOUNT;
+                }
+                spi->txrx_cb_func(spi->txrx_cb_arg, xfr_len);
+            }
+            spi->slave_state = HAL_SPI_SLAVE_STATE_IDLE;
+        }
+    }
+
+}
+#endif
+
+/* Interrupt handlers for SPI ports */
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+void
+nrf52_spi0_irq_handler(void)
+{
+    os_trace_isr_enter();
+    if (nrf52_hal_spi0.spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_0_MASTER)
+        nrf52_irqm_handler(&nrf52_hal_spi0);
+#endif
+    } else {
+#if MYNEWT_VAL(SPI_0_SLAVE)
+        nrf52_irqs_handler(&nrf52_hal_spi0);
+#endif
+    }
+    os_trace_isr_exit();
+}
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER)  || MYNEWT_VAL(SPI_1_SLAVE)
+void
+nrf52_spi1_irq_handler(void)
+{
+    os_trace_isr_enter();
+    if (nrf52_hal_spi1.spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_1_MASTER)
+        nrf52_irqm_handler(&nrf52_hal_spi1);
+#endif
+    } else {
+#if MYNEWT_VAL(SPI_1_SLAVE)
+        nrf52_irqs_handler(&nrf52_hal_spi1);
+#endif
+    }
+    os_trace_isr_exit();
+}
+#endif
+
+#if MYNEWT_VAL(SPI_2_MASTER)  || MYNEWT_VAL(SPI_2_SLAVE)
+void
+nrf52_spi2_irq_handler(void)
+{
+    os_trace_isr_enter();
+    if (nrf52_hal_spi2.spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_2_MASTER)
+        nrf52_irqm_handler(&nrf52_hal_spi2);
+#endif
+    } else {
+#if MYNEWT_VAL(SPI_2_SLAVE)
+        nrf52_irqs_handler(&nrf52_hal_spi2);
+#endif
+    }
+    os_trace_isr_exit();
+}
+#endif
+
+static void
+hal_spi_stop_transfer(NRF_SPIM_Type *spim)
+{
+    spim->TASKS_STOP = 1;
+    while (!spim->EVENTS_STOPPED) {}
+    spim->EVENTS_STOPPED = 0;
+}
+
+static int
+hal_spi_config_master(struct nrf52_hal_spi *spi,
+                      struct hal_spi_settings *settings)
+{
+    int rc;
+    uint32_t nrf_config;
+    uint32_t frequency;
+    NRF_SPIM_Type *spim;
+
+    spim = spi->nhs_spi.spim;
+    memcpy(&spi->spi_cfg, settings, sizeof(*settings));
+
+    /* Only 8-bit word sizes supported. */
+    rc = 0;
+    switch (settings->word_size) {
+        case HAL_SPI_WORD_SIZE_8BIT:
+            break;
+        default:
+            rc = EINVAL;
+            break;
+    }
+
+    switch (settings->data_mode) {
+        case HAL_SPI_MODE0:
+            nrf_config = (SPIM_CONFIG_CPOL_ActiveHigh << SPIM_CONFIG_CPOL_Pos) |
+                         (SPIM_CONFIG_CPHA_Leading << SPIM_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE1:
+            nrf_config = (SPIM_CONFIG_CPOL_ActiveHigh << SPIM_CONFIG_CPOL_Pos) |
+                         (SPIM_CONFIG_CPHA_Trailing << SPIM_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE2:
+            nrf_config = (SPIM_CONFIG_CPOL_ActiveLow << SPIM_CONFIG_CPOL_Pos) |
+                         (SPIM_CONFIG_CPHA_Leading << SPIM_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE3:
+            nrf_config = (SPIM_CONFIG_CPOL_ActiveLow << SPIM_CONFIG_CPOL_Pos) |
+                         (SPIM_CONFIG_CPHA_Trailing << SPIM_CONFIG_CPHA_Pos);
+            break;
+        default:
+            nrf_config = 0;
+            rc = EINVAL;
+            break;
+    }
+
+    /* NOTE: msb first is 0 so no check done */
+    if (settings->data_order == HAL_SPI_LSB_FIRST) {
+        nrf_config |= SPIM_CONFIG_ORDER_LsbFirst;
+    }
+    spim->CONFIG = nrf_config;
+
+    switch (settings->baudrate) {
+        case 125:
+            frequency = SPIM_FREQUENCY_FREQUENCY_K125;
+            break;
+        case 250:
+            frequency = SPIM_FREQUENCY_FREQUENCY_K250;
+            break;
+        case 500:
+            frequency = SPIM_FREQUENCY_FREQUENCY_K500;
+            break;
+        case 1000:
+            frequency = SPIM_FREQUENCY_FREQUENCY_M1;
+            break;
+        case 2000:
+            frequency = SPIM_FREQUENCY_FREQUENCY_M2;
+            break;
+        case 4000:
+            frequency = SPIM_FREQUENCY_FREQUENCY_M4;
+            break;
+        case 8000:
+            frequency = SPIM_FREQUENCY_FREQUENCY_M8;
+            break;
+        default:
+            frequency = 0;
+            rc = EINVAL;
+            break;
+    }
+    spim->FREQUENCY = frequency;
+
+    return rc;
+}
+
+static int
+hal_spi_config_slave(struct nrf52_hal_spi *spi,
+                     struct hal_spi_settings *settings)
+{
+    int rc;
+    uint32_t nrf_config;
+    NRF_SPIS_Type *spis;
+
+    spis = spi->nhs_spi.spis;
+
+    rc = 0;
+    switch (settings->data_mode) {
+        case HAL_SPI_MODE0:
+            nrf_config = (SPIS_CONFIG_CPOL_ActiveHigh << SPIS_CONFIG_CPOL_Pos) |
+                         (SPIS_CONFIG_CPHA_Leading << SPIS_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE1:
+            nrf_config = (SPIS_CONFIG_CPOL_ActiveHigh << SPIS_CONFIG_CPOL_Pos) |
+                         (SPIS_CONFIG_CPHA_Trailing << SPIS_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE2:
+            nrf_config = (SPIS_CONFIG_CPOL_ActiveLow << SPIS_CONFIG_CPOL_Pos) |
+                         (SPIS_CONFIG_CPHA_Leading << SPIS_CONFIG_CPHA_Pos);
+            break;
+        case HAL_SPI_MODE3:
+            nrf_config = (SPIS_CONFIG_CPOL_ActiveLow << SPIS_CONFIG_CPOL_Pos) |
+                         (SPIS_CONFIG_CPHA_Trailing << SPIS_CONFIG_CPHA_Pos);
+            break;
+        default:
+            nrf_config = 0;
+            rc = EINVAL;
+            break;
+    }
+
+    if (settings->data_order == HAL_SPI_LSB_FIRST) {
+        nrf_config |= SPIS_CONFIG_ORDER_LsbFirst;
+    }
+    spis->CONFIG = nrf_config;
+
+    /* Only 8-bit word sizes supported. */
+    switch (settings->word_size) {
+        case HAL_SPI_WORD_SIZE_8BIT:
+            break;
+        default:
+            rc = EINVAL;
+            break;
+    }
+
+    return rc;
+}
+
+static int
+hal_spi_init_master(struct nrf52_hal_spi *spi,
+                    struct nrf52_hal_spi_cfg *cfg,
+                    nrf52_spi_irq_handler_t handler)
+{
+    NRF_SPIM_Type *spim;
+    NRF_GPIO_Type *port;
+    uint32_t pin;
+
+    /* Configure SCK */
+    port = HAL_GPIO_PORT(cfg->sck_pin);
+    pin = HAL_GPIO_INDEX(cfg->sck_pin);
+    if (spi->spi_cfg.data_mode <= HAL_SPI_MODE1) {
+        port->OUTCLR = (1UL << pin);
+    } else {
+        port->OUTSET = (1UL << pin);
+    }
+    port->PIN_CNF[pin] =
+        (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos) |
+        (GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
+
+    /*  Configure MOSI */
+    port = HAL_GPIO_PORT(cfg->mosi_pin);
+    pin = HAL_GPIO_INDEX(cfg->mosi_pin);
+    port->OUTCLR = (1UL << pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos);
+
+    /* Configure MISO */
+    port = HAL_GPIO_PORT(cfg->miso_pin);
+    pin = HAL_GPIO_INDEX(cfg->miso_pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
+
+    spim = (NRF_SPIM_Type *)spi->nhs_spi.spim;
+    spim->PSEL.SCK = cfg->sck_pin;
+    spim->PSEL.MOSI = cfg->mosi_pin;
+    spim->PSEL.MISO = cfg->miso_pin;
+
+    spim->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
+    NVIC_SetVector(spi->irq_num, (uint32_t)handler);
+    NVIC_SetPriority(spi->irq_num, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_ClearPendingIRQ(spi->irq_num);
+    NVIC_EnableIRQ(spi->irq_num);
+
+    return 0;
+}
+
+static int
+hal_spi_init_slave(struct nrf52_hal_spi *spi,
+                   struct nrf52_hal_spi_cfg *cfg,
+                   nrf52_spi_irq_handler_t handler)
+{
+    NRF_SPIS_Type *spis;
+    NRF_GPIO_Type *port;
+    uint32_t pin;
+
+    /* NOTE: making this pin an input is correct! See datasheet */
+    port = HAL_GPIO_PORT(cfg->miso_pin);
+    pin = HAL_GPIO_INDEX(cfg->miso_pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
+
+    port = HAL_GPIO_PORT(cfg->mosi_pin);
+    pin = HAL_GPIO_INDEX(cfg->mosi_pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
+
+    port = HAL_GPIO_PORT(cfg->ss_pin);
+    pin = HAL_GPIO_INDEX(cfg->ss_pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_PULL_Pullup  << GPIO_PIN_CNF_PULL_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
+
+    port = HAL_GPIO_PORT(cfg->sck_pin);
+    pin = HAL_GPIO_INDEX(cfg->sck_pin);
+    port->PIN_CNF[pin] =
+        ((uint32_t)GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
+        ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos);
+
+    spis = (NRF_SPIS_Type *)spi->nhs_spi.spis;
+    spis->PSEL.SCK  = cfg->sck_pin;
+    spis->PSEL.MOSI = cfg->mosi_pin;
+    spis->PSEL.MISO = cfg->miso_pin;
+    spis->PSEL.CSN  = cfg->ss_pin;
+
+    /* Disable interrupt and clear any interrupt events */
+    spis->INTENCLR = SPIS_INTENSET_ACQUIRED_Msk | SPIS_INTENSET_END_Msk;
+    spis->EVENTS_END = 0;
+    spis->EVENTS_ACQUIRED = 0;
+
+    /* Enable END_ACQUIRE shortcut. */
+    spis->SHORTS = SPIS_SHORTS_END_ACQUIRE_Msk;
+
+    /* Set interrupt vector and enable IRQ */
+    NVIC_SetVector(spi->irq_num, (uint32_t)handler);
+    NVIC_SetPriority(spi->irq_num, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_ClearPendingIRQ(spi->irq_num);
+    NVIC_EnableIRQ(spi->irq_num);
+
+    return 0;
+}
+
+/**
+ * Initialize the SPI, given by spi_num.
+ *
+ * @param spi_num The number of the SPI to initialize
+ * @param cfg HW/MCU specific configuration,
+ *            passed to the underlying implementation, providing extra
+ *            configuration.
+ * @param spi_type SPI type (master or slave)
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
+{
+    int rc;
+    struct nrf52_hal_spi *spi;
+    nrf52_spi_irq_handler_t irq_handler;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    /* Check for valid arguments */
+    rc = EINVAL;
+    if (cfg == NULL) {
+        goto err;
+    }
+
+    if ((spi_type != HAL_SPI_TYPE_MASTER) && (spi_type != HAL_SPI_TYPE_SLAVE)) {
+        goto err;
+    }
+
+    irq_handler = NULL;
+    spi->spi_type  = spi_type;
+    if (spi_num == 0) {
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+        spi->irq_num = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn;
+        irq_handler = nrf52_spi0_irq_handler;
+        if (spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_0_MASTER)
+            spi->nhs_spi.spim = NRF_SPIM0;
+#else
+            assert(0);
+#endif
+        } else {
+#if MYNEWT_VAL(SPI_0_SLAVE)
+            spi->nhs_spi.spis = NRF_SPIS0;
+#else
+            assert(0);
+#endif
+        }
+#else
+        goto err;
+#endif
+    } else if (spi_num == 1) {
+#if MYNEWT_VAL(SPI_1_MASTER)  || MYNEWT_VAL(SPI_1_SLAVE)
+        spi->irq_num = SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn;
+        irq_handler = nrf52_spi1_irq_handler;
+        if (spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_1_MASTER)
+            spi->nhs_spi.spim = NRF_SPIM1;
+#else
+            assert(0);
+#endif
+        } else {
+#if MYNEWT_VAL(SPI_1_SLAVE)
+            spi->nhs_spi.spis = NRF_SPIS1;
+#else
+            assert(0);
+#endif
+        }
+#else
+        goto err;
+#endif
+    } else if (spi_num == 2) {
+#if MYNEWT_VAL(SPI_2_MASTER)  || MYNEWT_VAL(SPI_2_SLAVE)
+        spi->irq_num = SPIM2_SPIS2_SPI2_IRQn;
+        irq_handler = nrf52_spi2_irq_handler;
+        if (spi_type == HAL_SPI_TYPE_MASTER) {
+#if MYNEWT_VAL(SPI_2_MASTER)
+            spi->nhs_spi.spim = NRF_SPIM2;
+#else
+            assert(0);
+#endif
+        } else {
+#if MYNEWT_VAL(SPI_2_SLAVE)
+            spi->nhs_spi.spis = NRF_SPIS2;
+#else
+            assert(0);
+#endif
+        }
+#else
+        goto err;
+#endif
+    } else {
+        goto err;
+    }
+
+    if (spi_type == HAL_SPI_TYPE_MASTER) {
+        rc = hal_spi_init_master(spi, (struct nrf52_hal_spi_cfg *)cfg,
+                                 irq_handler);
+    } else {
+        rc = hal_spi_init_slave(spi, (struct nrf52_hal_spi_cfg *)cfg,
+                                irq_handler);
+    }
+
+err:
+    return (rc);
+}
+
+/**
+ * Configure the spi. Must be called after the spi is initialized (after
+ * hal_spi_init is called) and when the spi is disabled (user must call
+ * hal_spi_disable if the spi has been enabled through hal_spi_enable prior
+ * to calling this function). Can also be used to reconfigure an initialized
+ * SPI (assuming it is disabled as described previously).
+ *
+ * @param spi_num The number of the SPI to configure.
+ * @param psettings The settings to configure this SPI with
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_config(int spi_num, struct hal_spi_settings *settings)
+{
+    int rc;
+    struct nrf52_hal_spi *spi;
+    NRF_SPIM_Type *spim;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    /*
+     * This looks odd, but the ENABLE register is in the same location for
+     * SPIM, SPI and SPIS
+     */
+    spim = spi->nhs_spi.spim;
+    if (spim->ENABLE != 0) {
+        return -1;
+    }
+
+    if (spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        rc = hal_spi_config_master(spi, settings);
+    } else {
+        rc = hal_spi_config_slave(spi, settings);
+    }
+
+err:
+    return (rc);
+}
+
+/**
+ * Enables the SPI. This does not start a transmit or receive operation;
+ * it is used for power mgmt. Cannot be called when a SPI transfer is in
+ * progress.
+ *
+ * @param spi_num
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_enable(int spi_num)
+{
+    int rc;
+    NRF_SPIS_Type *spis;
+    NRF_SPI_Type *nrf_spi;
+    struct nrf52_hal_spi *spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    if (spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        /* For now, enable this in normal SPI mode (not spim) */
+        nrf_spi = (NRF_SPI_Type *)spi->nhs_spi.spim;
+        nrf_spi->ENABLE = (SPI_ENABLE_ENABLE_Enabled << SPI_ENABLE_ENABLE_Pos);
+    } else {
+        if (spi->txrx_cb_func == NULL) {
+            rc = EINVAL;
+            goto err;
+        }
+
+        spis = spi->nhs_spi.spis;
+        spis->EVENTS_END = 0;
+        spis->EVENTS_ACQUIRED = 0;
+        spis->INTENSET = SPIS_INTENSET_END_Msk | SPIS_INTENSET_ACQUIRED_Msk;
+        spis->ENABLE = (SPIS_ENABLE_ENABLE_Enabled << SPIS_ENABLE_ENABLE_Pos);
+    }
+    rc = 0;
+
+err:
+    return rc;
+}
+
+/**
+ * Disables the SPI. Used for power mgmt. It will halt any current SPI transfers
+ * in progress.
+ *
+ * @param spi_num
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_disable(int spi_num)
+{
+    int rc;
+    NRF_SPIS_Type *spis;
+    NRF_SPIM_Type *spim;
+    struct nrf52_hal_spi *spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    if (spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        spim = spi->nhs_spi.spim;
+        spim->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
+
+        if (spi->spi_xfr_flag) {
+            hal_spi_stop_transfer(spim);
+            spi->spi_xfr_flag = 0;
+        }
+        spim->ENABLE = 0;
+    } else {
+        spis = spi->nhs_spi.spis;
+        spis->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
+        spis->EVENTS_END = 0;
+        spis->EVENTS_ACQUIRED = 0;
+        spis->ENABLE = 0;
+        spi->slave_state = HAL_SPI_SLAVE_STATE_IDLE;
+    }
+
+    spi->nhs_txbuf = NULL;
+    spi->nhs_rxbuf = NULL;
+    spi->nhs_buflen = 0;
+    spi->nhs_bytes_txq = 0;
+
+    rc = 0;
+
+err:
+    return rc;
+}
+
+/**
+ * Blocking call to send a value on the SPI. Returns the value received from the
+ * SPI slave.
+ *
+ * MASTER: Sends the value and returns the received value from the slave.
+ * SLAVE: Invalid API. Returns 0xFFFF
+ *
+ * @param spi_num   Spi interface to use
+ * @param val       Value to send
+ *
+ * @return uint16_t Value received on SPI interface from slave. Returns 0xFFFF
+ * if called when the SPI is configured to be a slave
+ */
+uint16_t hal_spi_tx_val(int spi_num, uint16_t val)
+{
+    int rc;
+    uint16_t retval;
+    NRF_SPI_Type *spi;
+    struct nrf52_hal_spi *hal_spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, hal_spi);
+
+    if (hal_spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        spi = (NRF_SPI_Type *)hal_spi->nhs_spi.spim;
+        spi->EVENTS_READY = 0;
+        spi->TXD = (uint8_t)val;
+        while (!spi->EVENTS_READY) {}
+        spi->EVENTS_READY = 0;
+        retval = (uint16_t)spi->RXD;
+    } else {
+        retval = 0xFFFF;
+    }
+
+    return retval;
+
+err:
+    return rc;
+}
+
+/**
+ * Sets the txrx callback (executed at interrupt context) when the
+ * buffer is transferred by the master or the slave using the non-blocking API.
+ * Cannot be called when the spi is enabled. This callback will also be called
+ * when chip select is de-asserted on the slave.
+ *
+ * NOTE: This callback is only used for the non-blocking interface and must
+ * be called prior to using the non-blocking API.
+ *
+ * @param spi_num   SPI interface on which to set callback
+ * @param txrx      Callback function
+ * @param arg       Argument to be passed to callback function
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_set_txrx_cb(int spi_num, hal_spi_txrx_cb txrx_cb, void *arg)
+{
+    int rc;
+    NRF_SPIM_Type *spim;
+    struct nrf52_hal_spi *spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    /*
+     * This looks odd, but the ENABLE register is in the same location for
+     * SPIM, SPI and SPIS
+     */
+    spim = spi->nhs_spi.spim;
+    if (spim->ENABLE != 0) {
+        rc = -1;
+    } else {
+        spi->txrx_cb_func = txrx_cb;
+        spi->txrx_cb_arg = arg;
+        rc = 0;
+    }
+
+err:
+    return rc;
+}
+
+/**
+ * Blocking interface to send a buffer and store the received values from the
+ * slave. The transmit and receive buffers are either arrays of 8-bit (uint8_t)
+ * values or 16-bit values depending on whether the spi is configured for 8 bit
+ * data or more than 8 bits per value. The 'cnt' parameter is the number of
+ * 8-bit or 16-bit values. Thus, if 'cnt' is 10, txbuf/rxbuf would point to an
+ * array of size 10 (in bytes) if the SPI is using 8-bit data; otherwise
+ * txbuf/rxbuf would point to an array of size 20 bytes (ten, uint16_t values).
+ *
+ * NOTE: these buffers are in the native endian-ness of the platform.
+ *
+ *     MASTER: master sends all the values in the buffer and stores the
+ *             stores the values in the receive buffer if rxbuf is not NULL.
+ *             The txbuf parameter cannot be NULL.
+ *     SLAVE: cannot be called for a slave; returns -1
+ *
+ * @param spi_num   SPI interface to use
+ * @param txbuf     Pointer to buffer where values to transmit are stored.
+ * @param rxbuf     Pointer to buffer to store values received from peer.
+ * @param cnt       Number of 8-bit or 16-bit values to be transferred.
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int len)
+{
+    int i;
+    int rc;
+    int txcnt;
+    uint32_t enabled;
+    uint8_t *txd, *rxd;
+    uint8_t rxval;
+    NRF_SPI_Type *spi;
+    NRF_SPIM_Type *spim;
+    struct nrf52_hal_spi *hal_spi;
+
+    rc = EINVAL;
+    if (!len) {
+        goto err;
+    }
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, hal_spi);
+
+    if (hal_spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        /* Must have a txbuf for master! */
+        if (txbuf == NULL) {
+            goto err;
+        }
+
+        /*
+         * If SPIM is enabled, we want to stop, disable, then enable
+         * the legacy SPI interface.
+         */
+        spim = hal_spi->nhs_spi.spim;
+        enabled = spim->ENABLE;
+        if (enabled == SPIM_ENABLE_ENABLE_Enabled) {
+            spim->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
+            hal_spi_stop_transfer(spim);
+            spim->ENABLE = 0;
+            enabled = 0;
+        }
+
+        spi = (NRF_SPI_Type *)spim;
+        if (enabled == 0) {
+            spi->ENABLE = (SPI_ENABLE_ENABLE_Enabled << SPI_ENABLE_ENABLE_Pos);
+        }
+
+        while (spi->EVENTS_READY) {
+            rxval = (uint8_t)spi->RXD;
+            spi->EVENTS_READY = 0;
+        }
+        txd = (uint8_t *)txbuf;
+        spi->TXD = *txd;
+
+        txcnt = len - 1;
+        rxd = (uint8_t *)rxbuf;
+        for (i = 0; i < len; ++i) {
+            if (txcnt) {
+                ++txd;
+                spi->TXD = *txd;
+                --txcnt;
+            }
+            while (!spi->EVENTS_READY) {}
+            spi->EVENTS_READY = 0;
+            rxval = (uint8_t)spi->RXD;
+            if (rxbuf) {
+                *rxd = rxval;
+                ++rxd;
+            }
+        }
+        return 0;
+    }
+
+err:
+    return rc;
+}
+
+/**
+ * Non-blocking interface to send a buffer and store received values. Can be
+ * used for both master and slave SPI types. The user must configure the
+ * callback (using hal_spi_set_txrx_cb); the txrx callback is executed at
+ * interrupt context when the buffer is sent.
+ *
+ * The transmit and receive buffers are either arrays of 8-bit (uint8_t)
+ * values or 16-bit values depending on whether the spi is configured for 8 bit
+ * data or more than 8 bits per value. The 'cnt' parameter is the number of
+ * 8-bit or 16-bit values. Thus, if 'cnt' is 10, txbuf/rxbuf would point to an
+ * array of size 10 (in bytes) if the SPI is using 8-bit data; otherwise
+ * txbuf/rxbuf would point to an array of size 20 bytes (ten, uint16_t values).
+ *
+ * NOTE: these buffers are in the native endian-ness of the platform.
+ *
+ *     MASTER: master sends all the values in the buffer and stores the
+ *             stores the values in the receive buffer if rxbuf is not NULL.
+ *             The txbuf parameter cannot be NULL
+ *     SLAVE: Slave "preloads" the data to be sent to the master (values
+ *            stored in txbuf) and places received data from master in rxbuf
+ *            (if not NULL). The txrx callback occurs when len values are
+ *            transferred or master de-asserts chip select. If txbuf is NULL,
+ *            the slave transfers its default byte. Both rxbuf and txbuf cannot
+ *            be NULL.
+ *
+ * @param spi_num   SPI interface to use
+ * @param txbuf     Pointer to buffer where values to transmit are stored.
+ * @param rxbuf     Pointer to buffer to store values received from peer.
+ * @param cnt       Number of 8-bit or 16-bit values to be transferred.
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int len)
+{
+    int rc;
+    NRF_SPIM_Type *spim;
+    struct nrf52_hal_spi *spi;
+
+    rc = EINVAL;
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    if ((spi->txrx_cb_func == NULL) || (len == 0)) {
+        goto err;
+    }
+
+    if (spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        /* Must have a txbuf for master! */
+        if (txbuf == NULL) {
+            goto err;
+        }
+
+        /* Not allowed if transfer in progress */
+        if (spi->spi_xfr_flag) {
+            rc = -1;
+            goto err;
+        }
+        spim = spi->nhs_spi.spim;
+        spim->INTENCLR = SPIM_INTENCLR_END_Msk;
+        spi->spi_xfr_flag = 1;
+
+        /* Must be enabled for SPIM as opposed to SPI */
+        if (spim->ENABLE != SPIM_ENABLE_ENABLE_Enabled) {
+            spim->ENABLE = 0;
+            spim->ENABLE = (SPIM_ENABLE_ENABLE_Enabled << SPIM_ENABLE_ENABLE_Pos);
+        }
+
+        /* Set internal data structure information */
+        spi->nhs_bytes_txq = 0;
+        spi->nhs_buflen = len;
+        spi->nhs_txbuf = txbuf;
+
+        len = min(SPIM_TXD_MAXCNT_MAX, len);
+
+        /* Set chip registers */
+        spim->TXD.PTR = (uint32_t)txbuf;
+        spim->TXD.MAXCNT = len;
+
+        /* If no rxbuf, we need to set rxbuf and maxcnt to 1 */
+        spi->nhs_rxbuf = rxbuf;
+        if (rxbuf == NULL) {
+            spim->RXD.PTR = (uint32_t)&spi->dummy_rx;
+            spim->RXD.MAXCNT = 1;
+        } else {
+            spim->RXD.PTR = (uint32_t)rxbuf;
+            spim->RXD.MAXCNT = len;
+        }
+
+        spim->EVENTS_END = 0;
+        spim->EVENTS_STOPPED = 0;
+        spim->EVENTS_STARTED = 0;
+        if (spi->nhs_buflen < 256) {
+            spim->INTENCLR = SPIM_INTENSET_STARTED_Msk;
+            spim->INTENSET = SPIM_INTENSET_END_Msk;
+        } else {
+            spim->INTENCLR = SPIM_INTENSET_END_Msk;
+            spim->INTENSET = SPIM_INTENSET_STARTED_Msk;
+        }
+        spim->TASKS_START = 1;
+    } else {
+        /* Must have txbuf or rxbuf */
+        if ((txbuf == NULL) && (rxbuf == NULL)) {
+            goto err;
+        }
+
+        /* XXX: what to do here? */
+        if (len > 255) {
+            goto err;
+        }
+
+        /*
+         * Ready the slave for a transfer. Do not allow this to be called
+         * if the slave has already been readied or is requesting the
+         * semaphore
+         */
+        if (spi->slave_state != HAL_SPI_SLAVE_STATE_IDLE) {
+            rc = -1;
+            goto err;
+        }
+
+        spi->nhs_rxbuf = rxbuf;
+        spi->nhs_txbuf = txbuf;
+        spi->nhs_buflen = len;
+        spi->slave_state = HAL_SPI_SLAVE_STATE_ACQ_SEM;
+        spi->nhs_spi.spis->TASKS_ACQUIRE = 1;
+    }
+    return 0;
+
+err:
+    return rc;
+}
+
+/**
+ * Sets the default value transferred by the slave. Not valid for master
+ *
+ * @param spi_num SPI interface to use
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int
+hal_spi_slave_set_def_tx_val(int spi_num, uint16_t val)
+{
+    int rc;
+    NRF_SPIS_Type *spis;
+    struct nrf52_hal_spi *spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+    if (spi->spi_type  == HAL_SPI_TYPE_SLAVE) {
+        spis = spi->nhs_spi.spis;
+        spis->DEF = (uint8_t)val;
+        spis->ORC = (uint8_t)val;
+        rc = 0;
+    } else {
+        rc = EINVAL;
+    }
+
+err:
+    return rc;
+}
+
+/**
+ * This aborts the current transfer but keeps the spi enabled.
+ *
+ * @param spi_num   SPI interface on which transfer should be aborted.
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ *
+ * NOTE: does not return an error if no transfer was in progress.
+ */
+int
+hal_spi_abort(int spi_num)
+{
+    int rc;
+    NRF_SPIM_Type *spim;
+    struct nrf52_hal_spi *spi;
+
+    NRF52_HAL_SPI_RESOLVE(spi_num, spi);
+
+    rc = 0;
+    if (spi->spi_type  == HAL_SPI_TYPE_MASTER) {
+        spim = spi->nhs_spi.spim;
+        if (spi->spi_xfr_flag) {
+            spim->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
+            hal_spi_stop_transfer(spim);
+            spi->spi_xfr_flag = 0;
+            spim->INTENSET = SPIM_INTENSET_END_Msk;
+        }
+    } else {
+        /* Only way I can see doing this is to disable, then re-enable */
+        hal_spi_disable(spi_num);
+        hal_spi_enable(spi_num);
+    }
+
+err:
+    return rc;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_system.c
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <mcu/cortex_m4.h>
+#include "hal/hal_system.h"
+#include "nrf.h"
+
+/**
+ * Function called at startup. Called after BSS and .data initialized but
+ * prior to the _start function.
+ *
+ * NOTE: this function is called by both the bootloader and the application.
+ * If you add code here that you do not want executed in either case you need
+ * to conditionally compile it using the config variable BOOT_LOADER (will
+ * be set to 1 in case of bootloader build)
+ *
+ */
+void
+hal_system_init(void)
+{
+#if MYNEWT_VAL(MCU_DCDC_ENABLED)
+    NRF_POWER->DCDCEN = 1;
+#endif
+}
+
+void
+hal_system_reset(void)
+{
+    while (1) {
+        if (hal_debugger_connected()) {
+            /*
+             * If debugger is attached, breakpoint here.
+             */
+            asm("bkpt");
+        }
+        NVIC_SystemReset();
+    }
+}
+
+int
+hal_debugger_connected(void)
+{
+    return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+}
+
+/**
+ * hal system clock start
+ *
+ * Makes sure the LFCLK and/or HFCLK is started.
+ */
+void
+hal_system_clock_start(void)
+{
+#if MYNEWT_VAL(XTAL_32768) || MYNEWT_VAL(XTAL_RC) || \
+                                                 MYNEWT_VAL(XTAL_32768_SYNTH)
+    uint32_t regmsk;
+    uint32_t regval;
+    uint32_t clksrc;
+
+    regmsk = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSTAT_SRC_Msk;
+    regval = CLOCK_LFCLKSTAT_STATE_Running << CLOCK_LFCLKSTAT_STATE_Pos;
+
+#if MYNEWT_VAL(XTAL_32768)
+    regval |= CLOCK_LFCLKSTAT_SRC_Xtal << CLOCK_LFCLKSTAT_SRC_Pos;
+    clksrc = CLOCK_LFCLKSRC_SRC_Xtal;
+#endif
+
+#if MYNEWT_VAL(XTAL_32768_SYNTH)
+    regval |= CLOCK_LFCLKSTAT_SRC_Synth << CLOCK_LFCLKSTAT_SRC_Pos;
+    clksrc = CLOCK_LFCLKSRC_SRC_Synth;
+#endif
+
+ #if MYNEWT_VAL(XTAL_RC)
+    regval |= CLOCK_LFCLKSTAT_SRC_RC << CLOCK_LFCLKSTAT_SRC_Pos;
+    clksrc = CLOCK_LFCLKSRC_SRC_RC;
+#endif
+
+
+#if MYNEWT_VAL(XTAL_32768_SYNTH)
+    /* Must turn on HFLCK for synthesized 32768 crystal */
+    if ((NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) !=
+                (CLOCK_HFCLKSTAT_STATE_Running << CLOCK_HFCLKSTAT_STATE_Pos)) {
+        NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        while (1) {
+            if ((NRF_CLOCK->EVENTS_HFCLKSTARTED) != 0) {
+                break;
+            }
+        }
+    }
+#endif
+
+    /* Check if this clock source is already running */
+    if ((NRF_CLOCK->LFCLKSTAT & regmsk) != regval) {
+        NRF_CLOCK->TASKS_LFCLKSTOP = 1;
+        NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
+        NRF_CLOCK->LFCLKSRC = clksrc;
+        NRF_CLOCK->TASKS_LFCLKSTART = 1;
+
+        /* Wait here till started! */
+        while (1) {
+            if (NRF_CLOCK->EVENTS_LFCLKSTARTED) {
+                if ((NRF_CLOCK->LFCLKSTAT & regmsk) == regval) {
+                    break;
+                }
+            }
+        }
+    }
+#endif
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_system_start.c
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <mcu/cortex_m4.h>
+#include <mcu/nrf52_hal.h>
+
+/**
+ * Boots the image described by the supplied image header.
+ *
+ * @param hdr                   The header for the image to boot.
+ */
+void
+hal_system_start(void *img_start)
+{
+    typedef void jump_fn(void);
+
+    uint32_t base0entry;
+    uint32_t jump_addr;
+    register jump_fn *fn;
+
+    /* First word contains initial MSP value. */
+    __set_MSP(*(uint32_t *)img_start);
+
+    /* Second word contains address of entry point (Reset_Handler). */
+    base0entry = *(uint32_t *)(img_start + 4);
+    jump_addr = base0entry;
+    fn = (jump_fn *)jump_addr;
+
+    /* Jump to image. */
+    fn();
+}
+
+/**
+ * Boots the image described by the supplied image header.
+ * This routine is used in split-app scenario when loader decides
+ * that it wants to run the app instead.
+ *
+ * @param hdr                   The header for the image to boot.
+ */
+void
+hal_system_restart(void *img_start)
+{
+    int i;
+    int sr;
+
+    /*
+     * Disable interrupts, and leave the disabled.
+     * They get re-enabled when system starts coming back again.
+     */
+    __HAL_DISABLE_INTERRUPTS(sr);
+    for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
+        NVIC->ICER[i] = 0xffffffff;
+    }
+    (void)sr;
+
+    hal_system_start(img_start);
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_timer.c
@@ -1,0 +1,935 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+#include <errno.h>
+#include "os/mynewt.h"
+#include "mcu/cmsis_nvic.h"
+#include "hal/hal_timer.h"
+#include "nrf.h"
+#include "mcu/nrf52_hal.h"
+
+/* IRQ prototype */
+typedef void (*hal_timer_irq_handler_t)(void);
+
+/* User CC 2 for reading counter, CC 3 for timer isr */
+#define NRF_TIMER_CC_READ       (2)
+#define NRF_TIMER_CC_INT        (3)
+
+/* Output compare 2 used for RTC timers */
+#define NRF_RTC_TIMER_CC_INT    (2)
+
+/* Maximum number of hal timers used */
+#define NRF52_HAL_TIMER_MAX     (6)
+
+/* Maximum timer frequency */
+#define NRF52_MAX_TIMER_FREQ    (16000000)
+
+struct nrf52_hal_timer {
+    uint8_t tmr_enabled;
+    uint8_t tmr_irq_num;
+    uint8_t tmr_rtc;
+    uint8_t tmr_pad;
+    uint32_t tmr_cntr;
+    uint32_t timer_isrs;
+    uint32_t tmr_freq;
+    void *tmr_reg;
+    TAILQ_HEAD(hal_timer_qhead, hal_timer) hal_timer_q;
+};
+
+#if MYNEWT_VAL(TIMER_0)
+struct nrf52_hal_timer nrf52_hal_timer0;
+#endif
+#if MYNEWT_VAL(TIMER_1)
+struct nrf52_hal_timer nrf52_hal_timer1;
+#endif
+#if MYNEWT_VAL(TIMER_2)
+struct nrf52_hal_timer nrf52_hal_timer2;
+#endif
+#if MYNEWT_VAL(TIMER_3)
+struct nrf52_hal_timer nrf52_hal_timer3;
+#endif
+#if MYNEWT_VAL(TIMER_4)
+struct nrf52_hal_timer nrf52_hal_timer4;
+#endif
+#if MYNEWT_VAL(TIMER_5)
+struct nrf52_hal_timer nrf52_hal_timer5;
+#endif
+
+static const struct nrf52_hal_timer *nrf52_hal_timers[NRF52_HAL_TIMER_MAX] = {
+#if MYNEWT_VAL(TIMER_0)
+    &nrf52_hal_timer0,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    &nrf52_hal_timer1,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    &nrf52_hal_timer2,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(TIMER_3)
+    &nrf52_hal_timer3,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(TIMER_4)
+    &nrf52_hal_timer4,
+#else
+    NULL,
+#endif
+#if MYNEWT_VAL(TIMER_5)
+    &nrf52_hal_timer5
+#else
+    NULL
+#endif
+};
+
+/* Resolve timer number into timer structure */
+#define NRF52_HAL_TIMER_RESOLVE(__n, __v)       \
+    if ((__n) >= NRF52_HAL_TIMER_MAX) {         \
+        rc = EINVAL;                            \
+        goto err;                               \
+    }                                           \
+    (__v) = (struct nrf52_hal_timer *) nrf52_hal_timers[(__n)];            \
+    if ((__v) == NULL) {                        \
+        rc = EINVAL;                            \
+        goto err;                               \
+    }
+
+/* Interrupt mask for interrupt enable/clear */
+#define NRF_TIMER_INT_MASK(x)    ((1 << (uint32_t)(x)) << 16)
+
+static uint32_t
+nrf_read_timer_cntr(NRF_TIMER_Type *hwtimer)
+{
+    uint32_t tcntr;
+
+    /* Force a capture of the timer into 'cntr' capture channel; read it */
+    hwtimer->TASKS_CAPTURE[NRF_TIMER_CC_READ] = 1;
+    tcntr = hwtimer->CC[NRF_TIMER_CC_READ];
+
+    return tcntr;
+}
+
+/**
+ * nrf timer set ocmp
+ *
+ * Set the OCMP used by the timer to the desired expiration tick
+ *
+ * NOTE: Must be called with interrupts disabled.
+ *
+ * @param timer Pointer to timer.
+ */
+static void
+nrf_timer_set_ocmp(struct nrf52_hal_timer *bsptimer, uint32_t expiry)
+{
+    int32_t delta_t;
+    uint32_t temp;
+    uint32_t cntr;
+    NRF_TIMER_Type *hwtimer;
+    NRF_RTC_Type *rtctimer;
+
+    if (bsptimer->tmr_rtc) {
+        rtctimer = (NRF_RTC_Type *)bsptimer->tmr_reg;
+        rtctimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_RTC_TIMER_CC_INT);
+        temp = bsptimer->tmr_cntr;
+        cntr = rtctimer->COUNTER;
+        if (rtctimer->EVENTS_OVRFLW) {
+            temp += (1UL << 24);
+            cntr = rtctimer->COUNTER;
+        }
+        temp |= cntr;
+        delta_t = (int32_t)(expiry - temp);
+
+        /*
+         * The nrf documentation states that you must set the output
+         * compare to 2 greater than the counter to guarantee an interrupt.
+         * Since the counter can tick once while we check, we make sure
+         * it is greater than 2.
+         */
+        if (delta_t < 3) {
+            NVIC_SetPendingIRQ(bsptimer->tmr_irq_num);
+        } else  {
+            if (delta_t < (1UL << 24)) {
+                rtctimer->CC[NRF_RTC_TIMER_CC_INT] = expiry & 0x00ffffff;
+            } else {
+                /* CC too far ahead. Just make sure we set compare far ahead */
+                rtctimer->CC[NRF_RTC_TIMER_CC_INT] = cntr + (1UL << 23);
+            }
+            rtctimer->INTENSET = NRF_TIMER_INT_MASK(NRF_RTC_TIMER_CC_INT);
+        }
+    } else {
+        hwtimer = bsptimer->tmr_reg;
+
+        /* Disable ocmp interrupt and set new value */
+        hwtimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
+
+        /* Set output compare register to timer expiration */
+        hwtimer->CC[NRF_TIMER_CC_INT] = expiry;
+
+        /* Clear interrupt flag */
+        hwtimer->EVENTS_COMPARE[NRF_TIMER_CC_INT] = 0;
+
+        /* Enable the output compare interrupt */
+        hwtimer->INTENSET = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
+
+        /* Force interrupt to occur as we may have missed it */
+        if ((int32_t)(nrf_read_timer_cntr(hwtimer) - expiry) >= 0) {
+            NVIC_SetPendingIRQ(bsptimer->tmr_irq_num);
+        }
+    }
+}
+
+/* Disable output compare used for timer */
+static void
+nrf_timer_disable_ocmp(NRF_TIMER_Type *hwtimer)
+{
+    hwtimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
+}
+
+static void
+nrf_rtc_disable_ocmp(NRF_RTC_Type *rtctimer)
+{
+    rtctimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_RTC_TIMER_CC_INT);
+}
+
+static uint32_t
+hal_timer_read_bsptimer(struct nrf52_hal_timer *bsptimer)
+{
+    uint32_t low32;
+    uint32_t ctx;
+    uint32_t tcntr;
+    NRF_RTC_Type *rtctimer;
+
+    rtctimer = (NRF_RTC_Type *)bsptimer->tmr_reg;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    tcntr = bsptimer->tmr_cntr;
+    low32 = rtctimer->COUNTER;
+    if (rtctimer->EVENTS_OVRFLW) {
+        tcntr += (1UL << 24);
+        bsptimer->tmr_cntr = tcntr;
+        low32 = rtctimer->COUNTER;
+        rtctimer->EVENTS_OVRFLW = 0;
+        NVIC_SetPendingIRQ(bsptimer->tmr_irq_num);
+    }
+    tcntr |= low32;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return tcntr;
+}
+
+#if (MYNEWT_VAL(TIMER_0) || MYNEWT_VAL(TIMER_1) || MYNEWT_VAL(TIMER_2) || \
+     MYNEWT_VAL(TIMER_3) || MYNEWT_VAL(TIMER_4) || MYNEWT_VAL(TIMER_5))
+/**
+ * hal timer chk queue
+ *
+ *
+ * @param bsptimer
+ */
+static void
+hal_timer_chk_queue(struct nrf52_hal_timer *bsptimer)
+{
+    int32_t delta;
+    uint32_t tcntr;
+    uint32_t ctx;
+    struct hal_timer *timer;
+
+    /* disable interrupts */
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    while ((timer = TAILQ_FIRST(&bsptimer->hal_timer_q)) != NULL) {
+        if (bsptimer->tmr_rtc) {
+            tcntr = hal_timer_read_bsptimer(bsptimer);
+            /*
+             * If we are within 3 ticks of RTC, we wont be able to set compare.
+             * Thus, we have to service this timer early.
+             */
+            delta = -3;
+        } else {
+            tcntr = nrf_read_timer_cntr(bsptimer->tmr_reg);
+            delta = 0;
+        }
+        if ((int32_t)(tcntr - timer->expiry) >= delta) {
+            TAILQ_REMOVE(&bsptimer->hal_timer_q, timer, link);
+            timer->link.tqe_prev = NULL;
+            timer->cb_func(timer->cb_arg);
+        } else {
+            break;
+        }
+    }
+
+    /* Any timers left on queue? If so, we need to set OCMP */
+    timer = TAILQ_FIRST(&bsptimer->hal_timer_q);
+    if (timer) {
+        nrf_timer_set_ocmp(bsptimer, timer->expiry);
+    } else {
+        if (bsptimer->tmr_rtc) {
+            nrf_rtc_disable_ocmp((NRF_RTC_Type *)bsptimer->tmr_reg);
+        } else {
+            nrf_timer_disable_ocmp(bsptimer->tmr_reg);
+        }
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+}
+#endif
+
+/**
+ * hal timer irq handler
+ *
+ * Generic HAL timer irq handler.
+ *
+ * @param tmr
+ */
+/**
+ * hal timer irq handler
+ *
+ * This is the global timer interrupt routine.
+ *
+ */
+#if (MYNEWT_VAL(TIMER_0) || MYNEWT_VAL(TIMER_1) || MYNEWT_VAL(TIMER_2) || \
+     MYNEWT_VAL(TIMER_3) || MYNEWT_VAL(TIMER_4))
+
+static void
+hal_timer_irq_handler(struct nrf52_hal_timer *bsptimer)
+{
+    uint32_t compare;
+    NRF_TIMER_Type *hwtimer;
+
+    os_trace_isr_enter();
+
+    /* Check interrupt source. If set, clear them */
+    hwtimer = bsptimer->tmr_reg;
+    compare = hwtimer->EVENTS_COMPARE[NRF_TIMER_CC_INT];
+    if (compare) {
+        hwtimer->EVENTS_COMPARE[NRF_TIMER_CC_INT] = 0;
+    }
+
+    /* XXX: make these stats? */
+    /* Count # of timer isrs */
+    ++bsptimer->timer_isrs;
+
+    /*
+     * NOTE: we dont check the 'compare' variable here due to how the timer
+     * is implemented on this chip. There is no way to force an output
+     * compare, so if we are late setting the output compare (i.e. the timer
+     * counter is already passed the output compare value), we use the NVIC
+     * to set a pending interrupt. This means that there will be no compare
+     * flag set, so all we do is check to see if the compare interrupt is
+     * enabled.
+     */
+    if (hwtimer->INTENCLR & NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT)) {
+        hal_timer_chk_queue(bsptimer);
+        /* XXX: Recommended by nordic to make sure interrupts are cleared */
+        compare = hwtimer->EVENTS_COMPARE[NRF_TIMER_CC_INT];
+    }
+
+    os_trace_isr_exit();
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_5)
+static void
+hal_rtc_timer_irq_handler(struct nrf52_hal_timer *bsptimer)
+{
+    uint32_t overflow;
+    uint32_t compare;
+    NRF_RTC_Type *rtctimer;
+
+    os_trace_isr_enter();
+
+    /* Check interrupt source. If set, clear them */
+    rtctimer = (NRF_RTC_Type *)bsptimer->tmr_reg;
+    compare = rtctimer->EVENTS_COMPARE[NRF_RTC_TIMER_CC_INT];
+    if (compare) {
+       rtctimer->EVENTS_COMPARE[NRF_RTC_TIMER_CC_INT] = 0;
+    }
+
+    overflow = rtctimer->EVENTS_OVRFLW;
+    if (overflow) {
+        rtctimer->EVENTS_OVRFLW = 0;
+        bsptimer->tmr_cntr += (1UL << 24);
+    }
+
+    /* Count # of timer isrs */
+    ++bsptimer->timer_isrs;
+
+    /*
+     * NOTE: we dont check the 'compare' variable here due to how the timer
+     * is implemented on this chip. There is no way to force an output
+     * compare, so if we are late setting the output compare (i.e. the timer
+     * counter is already passed the output compare value), we use the NVIC
+     * to set a pending interrupt. This means that there will be no compare
+     * flag set, so all we do is check to see if the compare interrupt is
+     * enabled.
+     */
+    hal_timer_chk_queue(bsptimer);
+
+    /* Recommended by nordic to make sure interrupts are cleared */
+    compare = rtctimer->EVENTS_COMPARE[NRF_RTC_TIMER_CC_INT];
+
+    os_trace_isr_exit();
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_0)
+void
+nrf52_timer0_irq_handler(void)
+{
+    hal_timer_irq_handler(&nrf52_hal_timer0);
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_1)
+void
+nrf52_timer1_irq_handler(void)
+{
+    hal_timer_irq_handler(&nrf52_hal_timer1);
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_2)
+void
+nrf52_timer2_irq_handler(void)
+{
+    hal_timer_irq_handler(&nrf52_hal_timer2);
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_3)
+void
+nrf52_timer3_irq_handler(void)
+{
+    hal_timer_irq_handler(&nrf52_hal_timer3);
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_4)
+void
+nrf52_timer4_irq_handler(void)
+{
+    hal_timer_irq_handler(&nrf52_hal_timer4);
+}
+#endif
+
+#if MYNEWT_VAL(TIMER_5)
+void
+nrf52_timer5_irq_handler(void)
+{
+    hal_rtc_timer_irq_handler(&nrf52_hal_timer5);
+}
+#endif
+
+/**
+ * hal timer init
+ *
+ * Initialize platform specific timer items
+ *
+ * @param timer_num     Timer number to initialize
+ * @param cfg           Pointer to platform specific configuration
+ *
+ * @return int          0: success; error code otherwise
+ */
+int
+hal_timer_init(int timer_num, void *cfg)
+{
+    int rc;
+    uint8_t irq_num;
+    struct nrf52_hal_timer *bsptimer;
+    void *hwtimer;
+    hal_timer_irq_handler_t irq_isr;
+
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+
+    /* If timer is enabled do not allow init */
+    if (bsptimer->tmr_enabled) {
+        rc = EINVAL;
+        goto err;
+    }
+
+    switch (timer_num) {
+#if MYNEWT_VAL(TIMER_0)
+    case 0:
+        irq_num = TIMER0_IRQn;
+        hwtimer = NRF_TIMER0;
+        irq_isr = nrf52_timer0_irq_handler;
+        break;
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    case 1:
+        irq_num = TIMER1_IRQn;
+        hwtimer = NRF_TIMER1;
+        irq_isr = nrf52_timer1_irq_handler;
+        break;
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    case 2:
+        irq_num = TIMER2_IRQn;
+        hwtimer = NRF_TIMER2;
+        irq_isr = nrf52_timer2_irq_handler;
+        break;
+#endif
+#if MYNEWT_VAL(TIMER_3)
+    case 3:
+        irq_num = TIMER3_IRQn;
+        hwtimer = NRF_TIMER3;
+        irq_isr = nrf52_timer3_irq_handler;
+        break;
+#endif
+#if MYNEWT_VAL(TIMER_4)
+    case 4:
+        irq_num = TIMER4_IRQn;
+        hwtimer = NRF_TIMER4;
+        irq_isr = nrf52_timer4_irq_handler;
+        break;
+#endif
+#if MYNEWT_VAL(TIMER_5)
+    case 5:
+        irq_num = RTC0_IRQn;
+        hwtimer = NRF_RTC0;
+        irq_isr = nrf52_timer5_irq_handler;
+        bsptimer->tmr_rtc = 1;
+        break;
+#endif
+    default:
+        hwtimer = NULL;
+        break;
+    }
+
+    if (hwtimer == NULL) {
+        rc = EINVAL;
+        goto err;
+    }
+
+    bsptimer->tmr_reg = hwtimer;
+    bsptimer->tmr_irq_num = irq_num;
+
+    /* Disable IRQ, set priority and set vector in table */
+    NVIC_DisableIRQ(irq_num);
+    NVIC_SetPriority(irq_num, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetVector(irq_num, (uint32_t)irq_isr);
+
+    return 0;
+
+err:
+    return rc;
+}
+
+/**
+ * hal timer config
+ *
+ * Configure a timer to run at the desired frequency. This starts the timer.
+ *
+ * @param timer_num
+ * @param freq_hz
+ *
+ * @return int
+ */
+int
+hal_timer_config(int timer_num, uint32_t freq_hz)
+{
+    int rc;
+    uint8_t prescaler;
+    uint32_t ctx;
+    uint32_t div;
+    uint32_t min_delta;
+    uint32_t max_delta;
+    struct nrf52_hal_timer *bsptimer;
+    NRF_TIMER_Type *hwtimer;
+#if MYNEWT_VAL(TIMER_5)
+    NRF_RTC_Type *rtctimer;
+#endif
+
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+
+#if MYNEWT_VAL(TIMER_5)
+    if (timer_num == 5) {
+        /* NOTE: we only allow the RTC frequency to be set at 32768 */
+        if (bsptimer->tmr_enabled || (freq_hz != 32768) ||
+            (bsptimer->tmr_reg == NULL)) {
+            rc = EINVAL;
+            goto err;
+        }
+
+        bsptimer->tmr_freq = freq_hz;
+        bsptimer->tmr_enabled = 1;
+
+        __HAL_DISABLE_INTERRUPTS(ctx);
+
+        rtctimer = (NRF_RTC_Type *)bsptimer->tmr_reg;
+
+        /* Stop the timer first */
+        rtctimer->TASKS_STOP = 1;
+
+        /* Always no prescaler */
+        rtctimer->PRESCALER = 0;
+
+        /* Clear overflow events and set overflow interrupt */
+        rtctimer->EVENTS_OVRFLW = 0;
+        rtctimer->INTENSET = RTC_INTENSET_OVRFLW_Msk;
+
+        /* Start the timer */
+        rtctimer->TASKS_START = 1;
+
+        /* Set isr in vector table and enable interrupt */
+        NVIC_EnableIRQ(bsptimer->tmr_irq_num);
+
+        __HAL_ENABLE_INTERRUPTS(ctx);
+        return 0;
+    }
+#endif
+
+    /* Set timer to desired frequency */
+    div = NRF52_MAX_TIMER_FREQ / freq_hz;
+
+    /*
+     * Largest prescaler is 2^9 and must make sure frequency not too high.
+     * If hwtimer is NULL it means that the timer was not initialized prior
+     * to call.
+     */
+    if (bsptimer->tmr_enabled || (div == 0) || (div > 512) ||
+        (bsptimer->tmr_reg == NULL)) {
+        rc = EINVAL;
+        goto err;
+    }
+
+    if (div == 1) {
+        prescaler = 0;
+    } else {
+        /* Find closest prescaler */
+        for (prescaler = 1; prescaler < 10; ++prescaler) {
+            if (div <= (1 << prescaler)) {
+                min_delta = div - (1 << (prescaler - 1));
+                max_delta = (1 << prescaler) - div;
+                if (min_delta < max_delta) {
+                    prescaler -= 1;
+                }
+                break;
+            }
+        }
+    }
+
+    /* Now set the actual frequency */
+    bsptimer->tmr_freq = NRF52_MAX_TIMER_FREQ / (1 << prescaler);
+    bsptimer->tmr_enabled = 1;
+
+    /* disable interrupts */
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    /* Make sure HFXO is started */
+    if ((NRF_CLOCK->HFCLKSTAT &
+         (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) !=
+        (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) {
+        NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        while (1) {
+            if ((NRF_CLOCK->EVENTS_HFCLKSTARTED) != 0) {
+                break;
+            }
+        }
+    }
+    hwtimer = bsptimer->tmr_reg;
+
+    /* Stop the timer first */
+    hwtimer->TASKS_STOP = 1;
+
+    /* Put the timer in timer mode using 32 bits. */
+    hwtimer->MODE = TIMER_MODE_MODE_Timer;
+    hwtimer->BITMODE = TIMER_BITMODE_BITMODE_32Bit;
+
+    /* Set the pre-scalar */
+    hwtimer->PRESCALER = prescaler;
+
+    /* Start the timer */
+    hwtimer->TASKS_START = 1;
+
+    NVIC_EnableIRQ(bsptimer->tmr_irq_num);
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+
+err:
+    return rc;
+}
+
+/**
+ * hal timer deinit
+ *
+ * De-initialize a HW timer.
+ *
+ * @param timer_num
+ *
+ * @return int
+ */
+int
+hal_timer_deinit(int timer_num)
+{
+    int rc;
+    uint32_t ctx;
+    struct nrf52_hal_timer *bsptimer;
+    NRF_TIMER_Type *hwtimer;
+    NRF_RTC_Type *rtctimer;
+
+    rc = 0;
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    if (bsptimer->tmr_rtc) {
+        rtctimer = (NRF_RTC_Type *)bsptimer->tmr_reg;
+        rtctimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_RTC_TIMER_CC_INT);
+        rtctimer->TASKS_STOP = 1;
+    } else {
+        hwtimer = (NRF_TIMER_Type *)bsptimer->tmr_reg;
+        hwtimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
+        hwtimer->TASKS_STOP = 1;
+    }
+    bsptimer->tmr_enabled = 0;
+    bsptimer->tmr_reg = NULL;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+err:
+    return rc;
+}
+
+/**
+ * hal timer get resolution
+ *
+ * Get the resolution of the timer. This is the timer period, in nanoseconds
+ *
+ * @param timer_num
+ *
+ * @return uint32_t The
+ */
+uint32_t
+hal_timer_get_resolution(int timer_num)
+{
+    int rc;
+    uint32_t resolution;
+    struct nrf52_hal_timer *bsptimer;
+
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+
+    resolution = 1000000000 / bsptimer->tmr_freq;
+    return resolution;
+
+err:
+    rc = 0;
+    return rc;
+}
+
+/**
+ * hal timer read
+ *
+ * Returns the timer counter. NOTE: if the timer is a 16-bit timer, only
+ * the lower 16 bits are valid. If the timer is a 64-bit timer, only the
+ * low 32-bits are returned.
+ *
+ * @return uint32_t The timer counter register.
+ */
+uint32_t
+hal_timer_read(int timer_num)
+{
+    int rc;
+    uint32_t tcntr;
+    struct nrf52_hal_timer *bsptimer;
+
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+    if (bsptimer->tmr_rtc) {
+        tcntr = hal_timer_read_bsptimer(bsptimer);
+    } else {
+        tcntr = nrf_read_timer_cntr(bsptimer->tmr_reg);
+    }
+
+    return tcntr;
+
+    /* Assert here since there is no invalid return code */
+err:
+    assert(0);
+    rc = 0;
+    return rc;
+}
+
+/**
+ * hal timer delay
+ *
+ * Blocking delay for n ticks
+ *
+ * @param timer_num
+ * @param ticks
+ *
+ * @return int 0 on success; error code otherwise.
+ */
+int
+hal_timer_delay(int timer_num, uint32_t ticks)
+{
+    uint32_t until;
+
+    until = hal_timer_read(timer_num) + ticks;
+    while ((int32_t)(hal_timer_read(timer_num) - until) <= 0) {
+        /* Loop here till finished */
+    }
+
+    return 0;
+}
+
+/**
+ *
+ * Initialize the HAL timer structure with the callback and the callback
+ * argument. Also initializes the HW specific timer pointer.
+ *
+ * @param cb_func
+ *
+ * @return int
+ */
+int
+hal_timer_set_cb(int timer_num, struct hal_timer *timer, hal_timer_cb cb_func,
+                 void *arg)
+{
+    int rc;
+    struct nrf52_hal_timer *bsptimer;
+
+    NRF52_HAL_TIMER_RESOLVE(timer_num, bsptimer);
+
+    timer->cb_func = cb_func;
+    timer->cb_arg = arg;
+    timer->link.tqe_prev = NULL;
+    timer->bsp_timer = bsptimer;
+
+    rc = 0;
+
+err:
+    return rc;
+}
+
+int
+hal_timer_start(struct hal_timer *timer, uint32_t ticks)
+{
+    int rc;
+    uint32_t tick;
+    struct nrf52_hal_timer *bsptimer;
+
+    /* Set the tick value at which the timer should expire */
+    bsptimer = (struct nrf52_hal_timer *)timer->bsp_timer;
+    if (bsptimer->tmr_rtc) {
+        tick = hal_timer_read_bsptimer(bsptimer) + ticks;
+    } else {
+        tick = nrf_read_timer_cntr(bsptimer->tmr_reg) + ticks;
+    }
+    rc = hal_timer_start_at(timer, tick);
+    return rc;
+}
+
+int
+hal_timer_start_at(struct hal_timer *timer, uint32_t tick)
+{
+    uint32_t ctx;
+    struct hal_timer *entry;
+    struct nrf52_hal_timer *bsptimer;
+
+    if ((timer == NULL) || (timer->link.tqe_prev != NULL) ||
+        (timer->cb_func == NULL)) {
+        return EINVAL;
+    }
+    bsptimer = (struct nrf52_hal_timer *)timer->bsp_timer;
+    timer->expiry = tick;
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    if (TAILQ_EMPTY(&bsptimer->hal_timer_q)) {
+        TAILQ_INSERT_HEAD(&bsptimer->hal_timer_q, timer, link);
+    } else {
+        TAILQ_FOREACH(entry, &bsptimer->hal_timer_q, link) {
+            if ((int32_t)(timer->expiry - entry->expiry) < 0) {
+                TAILQ_INSERT_BEFORE(entry, timer, link);
+                break;
+            }
+        }
+        if (!entry) {
+            TAILQ_INSERT_TAIL(&bsptimer->hal_timer_q, timer, link);
+        }
+    }
+
+    /* If this is the head, we need to set new OCMP */
+    if (timer == TAILQ_FIRST(&bsptimer->hal_timer_q)) {
+        nrf_timer_set_ocmp(bsptimer, timer->expiry);
+    }
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+}
+
+/**
+ * hal timer stop
+ *
+ * Stop a timer.
+ *
+ * @param timer
+ *
+ * @return int
+ */
+int
+hal_timer_stop(struct hal_timer *timer)
+{
+    uint32_t ctx;
+    int reset_ocmp;
+    struct hal_timer *entry;
+    struct nrf52_hal_timer *bsptimer;
+
+    if (timer == NULL) {
+        return EINVAL;
+    }
+
+   bsptimer = (struct nrf52_hal_timer *)timer->bsp_timer;
+
+    __HAL_DISABLE_INTERRUPTS(ctx);
+
+    if (timer->link.tqe_prev != NULL) {
+        reset_ocmp = 0;
+        if (timer == TAILQ_FIRST(&bsptimer->hal_timer_q)) {
+            /* If first on queue, we will need to reset OCMP */
+            entry = TAILQ_NEXT(timer, link);
+            reset_ocmp = 1;
+        }
+        TAILQ_REMOVE(&bsptimer->hal_timer_q, timer, link);
+        timer->link.tqe_prev = NULL;
+        if (reset_ocmp) {
+            if (entry) {
+                nrf_timer_set_ocmp((struct nrf52_hal_timer *)entry->bsp_timer,
+                                   entry->expiry);
+            } else {
+                if (bsptimer->tmr_rtc) {
+                    nrf_rtc_disable_ocmp((NRF_RTC_Type *)bsptimer->tmr_reg);
+                } else {
+                    nrf_timer_disable_ocmp(bsptimer->tmr_reg);
+                }
+            }
+        }
+    }
+
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return 0;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_uart.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_uart.c
@@ -1,0 +1,478 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+
+#include "os/mynewt.h"
+#include "hal/hal_uart.h"
+#include "mcu/cmsis_nvic.h"
+#include "bsp/bsp.h"
+
+#include "nrf.h"
+#include "mcu/nrf52_hal.h"
+
+
+#define UARTE_INT_ENDTX		UARTE_INTEN_ENDTX_Msk
+#define UARTE_INT_ENDRX		UARTE_INTEN_ENDRX_Msk
+#define UARTE_CONFIG_PARITY	UARTE_CONFIG_PARITY_Msk
+#define UARTE_CONFIG_HWFC	UARTE_CONFIG_HWFC_Msk
+#define UARTE_ENABLE		UARTE_ENABLE_ENABLE_Enabled
+#define UARTE_DISABLE       UARTE_ENABLE_ENABLE_Disabled
+
+/*
+ * Only one UART on NRF 52832.
+ */
+struct hal_uart {
+    uint8_t u_open:1;
+    uint8_t u_rx_stall:1;
+    uint8_t u_tx_started:1;
+    uint8_t u_rx_buf;
+    uint8_t u_tx_buf[8];
+    hal_uart_rx_char u_rx_func;
+    hal_uart_tx_char u_tx_func;
+    hal_uart_tx_done u_tx_done;
+    void *u_func_arg;
+};
+
+#if defined(NRF52840_XXAA)
+static struct hal_uart uart0;
+static struct hal_uart uart1;
+#else
+static struct hal_uart uart0;
+#endif
+
+int
+hal_uart_init_cbs(int port, hal_uart_tx_char tx_func, hal_uart_tx_done tx_done,
+  hal_uart_rx_char rx_func, void *arg)
+{
+    struct hal_uart *u;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        u = &uart0;
+    } else if (port == 1) {
+        u = &uart1;
+    } else {
+        return -1;
+    }
+#else
+    if (port != 0) {
+        return -1;
+    }
+    u = &uart0;
+#endif
+
+    if (u->u_open) {
+        return -1;
+    }
+    u->u_rx_func = rx_func;
+    u->u_tx_func = tx_func;
+    u->u_tx_done = tx_done;
+    u->u_func_arg = arg;
+    return 0;
+}
+
+static int
+hal_uart_tx_fill_buf(struct hal_uart *u)
+{
+    int data;
+    int i;
+
+    for (i = 0; i < sizeof(u->u_tx_buf); i++) {
+        data = u->u_tx_func(u->u_func_arg);
+        if (data < 0) {
+            break;
+        }
+        u->u_tx_buf[i] = data;
+    }
+    return i;
+}
+
+void
+hal_uart_start_tx(int port)
+{
+    NRF_UARTE_Type *nrf_uart;
+    struct hal_uart *u;
+    int sr;
+    int rc;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        u = &uart0;
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        u = &uart1;
+    } else {
+        return;
+    }
+#else
+    if (port != 0) {
+        return;
+    }
+    nrf_uart = NRF_UARTE0;
+    u = &uart0;
+#endif
+
+    __HAL_DISABLE_INTERRUPTS(sr);
+    if (u->u_tx_started == 0) {
+        rc = hal_uart_tx_fill_buf(u);
+        if (rc > 0) {
+            nrf_uart->INTENSET = UARTE_INT_ENDTX;
+            nrf_uart->TXD.PTR = (uint32_t)&u->u_tx_buf;
+            nrf_uart->TXD.MAXCNT = rc;
+            nrf_uart->TASKS_STARTTX = 1;
+            u->u_tx_started = 1;
+        }
+    }
+    __HAL_ENABLE_INTERRUPTS(sr);
+}
+
+void
+hal_uart_start_rx(int port)
+{
+    NRF_UARTE_Type *nrf_uart;
+    struct hal_uart *u;
+    int sr;
+    int rc;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        u = &uart0;
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        u = &uart1;
+    } else {
+        return;
+    }
+#else
+    if (port != 0) {
+        return;
+    }
+    nrf_uart = NRF_UARTE0;
+    u = &uart0;
+#endif
+
+    if (u->u_rx_stall) {
+        __HAL_DISABLE_INTERRUPTS(sr);
+        rc = u->u_rx_func(u->u_func_arg, u->u_rx_buf);
+        if (rc == 0) {
+            u->u_rx_stall = 0;
+            nrf_uart->TASKS_STARTRX = 1;
+        }
+
+        __HAL_ENABLE_INTERRUPTS(sr);
+    }
+}
+
+void
+hal_uart_blocking_tx(int port, uint8_t data)
+{
+    struct hal_uart *u;
+    NRF_UARTE_Type *nrf_uart;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        u = &uart0;
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        u = &uart1;
+    } else {
+        return;
+    }
+#else
+    if (port != 0) {
+        return;
+    }
+    nrf_uart = NRF_UARTE0;
+    u = &uart0;
+#endif
+
+    if (!u->u_open) {
+        return;
+    }
+
+    /* If we have started, wait until the current uart dma buffer is done */
+    if (u->u_tx_started) {
+        while (nrf_uart->EVENTS_ENDTX == 0) {
+            /* Wait here until the dma is finished */
+        }
+    }
+
+    nrf_uart->EVENTS_ENDTX = 0;
+    nrf_uart->TXD.PTR = (uint32_t)&data;
+    nrf_uart->TXD.MAXCNT = 1;
+    nrf_uart->TASKS_STARTTX = 1;
+
+    while (nrf_uart->EVENTS_ENDTX == 0) {
+        /* Wait till done */
+    }
+
+    /* Stop the uart */
+    nrf_uart->TASKS_STOPTX = 1;
+}
+
+static void
+uart_irq_handler(NRF_UARTE_Type *nrf_uart, struct hal_uart *u)
+{
+    int rc;
+
+    os_trace_isr_enter();
+
+    if (nrf_uart->EVENTS_ENDTX) {
+        nrf_uart->EVENTS_ENDTX = 0;
+        rc = hal_uart_tx_fill_buf(u);
+        if (rc > 0) {
+            nrf_uart->TXD.PTR = (uint32_t)&u->u_tx_buf;
+            nrf_uart->TXD.MAXCNT = rc;
+            nrf_uart->TASKS_STARTTX = 1;
+        } else {
+            if (u->u_tx_done) {
+                u->u_tx_done(u->u_func_arg);
+            }
+            nrf_uart->INTENCLR = UARTE_INT_ENDTX;
+            nrf_uart->TASKS_STOPTX = 1;
+            u->u_tx_started = 0;
+        }
+    }
+    if (nrf_uart->EVENTS_ENDRX) {
+        nrf_uart->EVENTS_ENDRX = 0;
+        rc = u->u_rx_func(u->u_func_arg, u->u_rx_buf);
+        if (rc < 0) {
+            u->u_rx_stall = 1;
+        } else {
+            nrf_uart->TASKS_STARTRX = 1;
+        }
+    }
+    os_trace_isr_exit();
+}
+
+static void
+uart0_irq_handler(void)
+{
+    uart_irq_handler(NRF_UARTE0, &uart0);
+}
+
+#if defined(NRF52840_XXAA)
+static void
+uart1_irq_handler(void)
+{
+    uart_irq_handler(NRF_UARTE1, &uart1);
+}
+#endif
+
+static uint32_t
+hal_uart_baudrate(int baudrate)
+{
+    switch (baudrate) {
+    case 1200:
+        return UARTE_BAUDRATE_BAUDRATE_Baud1200;
+    case 2400:
+        return UARTE_BAUDRATE_BAUDRATE_Baud2400;
+    case 4800:
+        return UARTE_BAUDRATE_BAUDRATE_Baud4800;
+    case 9600:
+        return UARTE_BAUDRATE_BAUDRATE_Baud9600;
+    case 19200:
+        return UARTE_BAUDRATE_BAUDRATE_Baud19200;
+    case 38400:
+        return UARTE_BAUDRATE_BAUDRATE_Baud38400;
+    case 57600:
+        return UARTE_BAUDRATE_BAUDRATE_Baud57600;
+    case 76800:
+        return UARTE_BAUDRATE_BAUDRATE_Baud76800;
+    case 115200:
+        return UARTE_BAUDRATE_BAUDRATE_Baud115200;
+    case 230400:
+        return UARTE_BAUDRATE_BAUDRATE_Baud230400;
+    case 460800:
+        return UARTE_BAUDRATE_BAUDRATE_Baud460800;
+    case 921600:
+        return UARTE_BAUDRATE_BAUDRATE_Baud921600;
+    case 1000000:
+        return UARTE_BAUDRATE_BAUDRATE_Baud1M;
+    default:
+        return 0;
+    }
+}
+
+int
+hal_uart_init(int port, void *arg)
+{
+    struct nrf52_uart_cfg *cfg;
+    NRF_UARTE_Type *nrf_uart;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        NVIC_SetVector(UARTE0_UART0_IRQn, (uint32_t)uart0_irq_handler);
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        NVIC_SetVector(UARTE1_IRQn, (uint32_t)uart1_irq_handler);
+    } else {
+        return -1;
+    }
+#else
+    if (port != 0) {
+        return -1;
+    }
+    nrf_uart = NRF_UARTE0;
+    NVIC_SetVector(UARTE0_UART0_IRQn, (uint32_t)uart0_irq_handler);
+#endif
+
+    cfg = (struct nrf52_uart_cfg *)arg;
+
+    nrf_uart->PSEL.TXD = cfg->suc_pin_tx;
+    nrf_uart->PSEL.RXD = cfg->suc_pin_rx;
+    nrf_uart->PSEL.RTS = cfg->suc_pin_rts;
+    nrf_uart->PSEL.CTS = cfg->suc_pin_cts;
+
+    return 0;
+}
+
+int
+hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
+  enum hal_uart_parity parity, enum hal_uart_flow_ctl flow_ctl)
+{
+    struct hal_uart *u;
+    uint32_t cfg_reg = 0;
+    uint32_t baud_reg;
+    NRF_UARTE_Type *nrf_uart;
+    IRQn_Type irqnum;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        irqnum = UARTE0_UART0_IRQn;
+        u = &uart0;
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        irqnum = UARTE1_IRQn;
+        u = &uart1;
+    } else {
+        return -1;
+    }
+#else
+    if (port != 0) {
+        return -1;
+    }
+    nrf_uart = NRF_UARTE0;
+    irqnum = UARTE0_UART0_IRQn;
+    u = &uart0;
+#endif
+
+    if (u->u_open) {
+        return -1;
+    }
+
+    /*
+     * pin config
+     * UART config
+     * nvic config
+     * enable uart
+     */
+    if (databits != 8) {
+        return -1;
+    }
+    if (stopbits != 1) {
+        return -1;
+    }
+
+    switch (parity) {
+    case HAL_UART_PARITY_NONE:
+        break;
+    case HAL_UART_PARITY_ODD:
+        return -1;
+    case HAL_UART_PARITY_EVEN:
+        cfg_reg |= UARTE_CONFIG_PARITY;
+        break;
+    }
+
+    switch (flow_ctl) {
+    case HAL_UART_FLOW_CTL_NONE:
+        break;
+    case HAL_UART_FLOW_CTL_RTS_CTS:
+        cfg_reg |= UARTE_CONFIG_HWFC;
+        if (nrf_uart->PSEL.RTS == 0xffffffff ||
+          nrf_uart->PSEL.CTS == 0xffffffff) {
+            /*
+             * Can't turn on HW flow control if pins to do that are not
+             * defined.
+             */
+            assert(0);
+            return -1;
+        }
+        break;
+    }
+    baud_reg = hal_uart_baudrate(baudrate);
+    if (baud_reg == 0) {
+        return -1;
+    }
+    nrf_uart->ENABLE = 0;
+    nrf_uart->INTENCLR = 0xffffffff;
+    nrf_uart->BAUDRATE = baud_reg;
+    nrf_uart->CONFIG = cfg_reg;
+
+    NVIC_EnableIRQ(irqnum);
+
+    nrf_uart->ENABLE = UARTE_ENABLE;
+
+    nrf_uart->INTENSET = UARTE_INT_ENDRX;
+    nrf_uart->RXD.PTR = (uint32_t)&u->u_rx_buf;
+    nrf_uart->RXD.MAXCNT = sizeof(u->u_rx_buf);
+    nrf_uart->TASKS_STARTRX = 1;
+
+    u->u_rx_stall = 0;
+    u->u_tx_started = 0;
+    u->u_open = 1;
+
+    return 0;
+}
+
+int
+hal_uart_close(int port)
+{
+    struct hal_uart *u;
+    NRF_UARTE_Type *nrf_uart;
+
+#if defined(NRF52840_XXAA)
+    if (port == 0) {
+        nrf_uart = NRF_UARTE0;
+        u = &uart0;
+    } else if (port == 1) {
+        nrf_uart = NRF_UARTE1;
+        u = &uart1;
+    } else {
+        return -1;
+    }
+#else
+    if (port != 0) {
+        return -1;
+    }
+    nrf_uart = NRF_UARTE0;
+    u = &uart0;
+#endif
+
+    u->u_open = 0;
+    nrf_uart->ENABLE = 0;
+    nrf_uart->INTENCLR = 0xffffffff;
+    return 0;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_watchdog.c
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "os/mynewt.h"
+#include "hal/hal_watchdog.h"
+#include "mcu/cmsis_nvic.h"
+#include "nrf.h"
+
+static void
+nrf52_hal_wdt_default_handler(void)
+{
+    assert(0);
+}
+
+/**@brief WDT interrupt handler. */
+static void
+nrf52_wdt_irq_handler(void)
+{
+    os_trace_isr_enter();
+    if (NRF_WDT->INTENSET & WDT_INTENSET_TIMEOUT_Msk) {
+        NRF_WDT->EVENTS_TIMEOUT = 0;
+        nrf52_hal_wdt_default_handler();
+    }
+    os_trace_isr_exit();
+}
+
+int
+hal_watchdog_init(uint32_t expire_msecs)
+{
+    NRF_WDT->CONFIG = WDT_CONFIG_SLEEP_Msk;
+
+    if (expire_msecs >= 44739243) {
+        /* maximum allowed time is near 12.5 hours! */
+        assert(0);
+    } else {
+        NRF_WDT->CRV = (expire_msecs * 32) + ((expire_msecs * 96) / 125);
+    }
+
+    NVIC_SetVector(WDT_IRQn, (uint32_t) nrf52_wdt_irq_handler);
+    NVIC_SetPriority(WDT_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_ClearPendingIRQ(WDT_IRQn);
+    NVIC_EnableIRQ(WDT_IRQn);
+    NRF_WDT->RREN |= 0x1;
+
+    return (0);
+}
+
+void
+hal_watchdog_enable(void)
+{
+    NRF_WDT->INTENSET = WDT_INTENSET_TIMEOUT_Msk;
+    NRF_WDT->TASKS_START = 1;
+}
+
+void
+hal_watchdog_tickle(void)
+{
+    NRF_WDT->RR[0] = WDT_RR_RR_Reload;
+}
+

--- a/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_hw_id.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_hw_id.c
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <hal/hal_bsp.h>
+#include "nrf.h"
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+int
+hal_bsp_hw_id_len(void)
+{
+    return sizeof(NRF_FICR->DEVICEID) + sizeof(NRF_FICR->DEVICEADDR);
+}
+
+/*
+ * These values are generated at random.
+ * DEVICEID[0-1] and DEVICEADDR[0-1].
+ */
+int
+hal_bsp_hw_id(uint8_t *id, int max_len)
+{
+    int len, cnt;
+
+    cnt = min(sizeof(NRF_FICR->DEVICEID), max_len);
+    memcpy(id, (void *)NRF_FICR->DEVICEID, cnt);
+    len = cnt;
+
+    cnt = min(sizeof(NRF_FICR->DEVICEADDR), max_len - len);
+    memcpy(id + len, (void *)NRF_FICR->DEVICEADDR, cnt);
+
+    return len + cnt;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/system_nrf52.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/system_nrf52.c
@@ -1,0 +1,497 @@
+/* Copyright (c) 2012 ARM LIMITED
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *   * Neither the name of ARM nor the names of its contributors may be used to
+ *     endorse or promote products derived from this software without specific
+ *     prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "mcu/cmsis_nvic.h"
+#include "nrf.h"
+
+#ifdef NRF52840_XXAA
+#include "system_nrf52840.h"
+#endif
+
+#ifdef NRF52
+#include "system_nrf52.h"
+#endif
+
+/*lint ++flb "Enter library region" */
+
+#define __SYSTEM_CLOCK_64M      (64000000UL)
+
+#ifdef NRF52840_XXAA
+static bool errata_36(void);
+static bool errata_98(void);
+static bool errata_103(void);
+static bool errata_115(void);
+static bool errata_120(void);
+static bool errata_121(void);
+#endif
+
+#ifdef NRF52
+static bool errata_16(void);
+static bool errata_31(void);
+static bool errata_32(void);
+static bool errata_36(void);
+static bool errata_37(void);
+static bool errata_57(void);
+static bool errata_66(void);
+static bool errata_108(void);
+#endif
+
+#if defined ( __CC_ARM )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK_64M;
+#elif defined ( __ICCARM__ )
+    __root uint32_t SystemCoreClock = __SYSTEM_CLOCK_64M;
+#elif defined ( __GNUC__ )
+    uint32_t SystemCoreClock __attribute__((used)) = __SYSTEM_CLOCK_64M;
+#endif
+
+void SystemCoreClockUpdate(void)
+{
+    SystemCoreClock = __SYSTEM_CLOCK_64M;
+}
+
+void SystemInit(void)
+{
+#ifdef NRF52
+    /* Workaround for Errata 16 "System: RAM may be corrupt on wakeup from CPU IDLE" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/ */
+    if (errata_16()){
+        *(volatile uint32_t *)0x4007C074 = 3131961357ul;
+    }
+
+    /* Workaround for Errata 31 "CLOCK: Calibration values are not correctly loaded from FICR at reset" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/ */
+    if (errata_31()){
+        *(volatile uint32_t *)0x4000053C = ((*(volatile uint32_t *)0x10000244) & 0x0000E000) >> 13;
+    }
+
+    /* Workaround for Errata 32 "DIF: Debug session automatically enables TracePort pins" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/ */
+    if (errata_32()){
+        CoreDebug->DEMCR &= ~CoreDebug_DEMCR_TRCENA_Msk;
+    }
+
+    /* Workaround for Errata 36 "CLOCK: Some registers are not reset when expected" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_36()){
+        NRF_CLOCK->EVENTS_DONE = 0;
+        NRF_CLOCK->EVENTS_CTTO = 0;
+        NRF_CLOCK->CTIV = 0;
+    }
+
+    /* Workaround for Errata 37 "RADIO: Encryption engine is slow by default" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_37()){
+        *(volatile uint32_t *)0x400005A0 = 0x3;
+    }
+
+    /* Workaround for Errata 57 "NFCT: NFC Modulation amplitude" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_57()){
+        *(volatile uint32_t *)0x40005610 = 0x00000005;
+        *(volatile uint32_t *)0x40005688 = 0x00000001;
+        *(volatile uint32_t *)0x40005618 = 0x00000000;
+        *(volatile uint32_t *)0x40005614 = 0x0000003F;
+    }
+
+    /* Workaround for Errata 66 "TEMP: Linearity specification not met with default settings" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_66()){
+        NRF_TEMP->A0 = NRF_FICR->TEMP.A0;
+        NRF_TEMP->A1 = NRF_FICR->TEMP.A1;
+        NRF_TEMP->A2 = NRF_FICR->TEMP.A2;
+        NRF_TEMP->A3 = NRF_FICR->TEMP.A3;
+        NRF_TEMP->A4 = NRF_FICR->TEMP.A4;
+        NRF_TEMP->A5 = NRF_FICR->TEMP.A5;
+        NRF_TEMP->B0 = NRF_FICR->TEMP.B0;
+        NRF_TEMP->B1 = NRF_FICR->TEMP.B1;
+        NRF_TEMP->B2 = NRF_FICR->TEMP.B2;
+        NRF_TEMP->B3 = NRF_FICR->TEMP.B3;
+        NRF_TEMP->B4 = NRF_FICR->TEMP.B4;
+        NRF_TEMP->B5 = NRF_FICR->TEMP.B5;
+        NRF_TEMP->T0 = NRF_FICR->TEMP.T0;
+        NRF_TEMP->T1 = NRF_FICR->TEMP.T1;
+        NRF_TEMP->T2 = NRF_FICR->TEMP.T2;
+        NRF_TEMP->T3 = NRF_FICR->TEMP.T3;
+        NRF_TEMP->T4 = NRF_FICR->TEMP.T4;
+    }
+
+    /* Workaround for Errata 108 "RAM: RAM content cannot be trusted upon waking up from System ON Idle or System OFF mode" found at the Errata document
+       for your device located at https://infocenter.nordicsemi.com/  */
+    if (errata_108()){
+        *(volatile uint32_t *)0x40000EE4 = *(volatile uint32_t *)0x10000258 & 0x0000004F;
+    }
+
+    /* Enable the FPU if the compiler used floating point unit instructions. __FPU_USED is a MACRO defined by the
+     * compiler. Since the FPU consumes energy, remember to disable FPU use in the compiler if floating point unit
+     * operations are not used in your code. */
+    #if (__FPU_USED == 1)
+        SCB->CPACR |= (3UL << 20) | (3UL << 22);
+        __DSB();
+        __ISB();
+    #endif
+
+    /* Configure NFCT pins as GPIOs if NFCT is not to be used in your code. If CONFIG_NFCT_PINS_AS_GPIOS is not defined,
+       two GPIOs (see Product Specification to see which ones) will be reserved for NFC and will not be available as
+       normal GPIOs. */
+    #if defined (CONFIG_NFCT_PINS_AS_GPIOS)
+        if ((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)){
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_UICR->NFCPINS &= ~UICR_NFCPINS_PROTECT_Msk;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NVIC_SystemReset();
+        }
+    #endif
+
+    /* Configure GPIO pads as pPin Reset pin if Pin Reset capabilities desired. If CONFIG_GPIO_AS_PINRESET is not
+      defined, pin reset will not be available. One GPIO (see Product Specification to see which one) will then be
+      reserved for PinReset and not available as normal GPIO. */
+    #if defined (CONFIG_GPIO_AS_PINRESET)
+        if (((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)) ||
+            ((NRF_UICR->PSELRESET[1] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos))){
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_UICR->PSELRESET[0] = 21;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_UICR->PSELRESET[1] = 21;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+            while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+            NVIC_SystemReset();
+        }
+    #endif
+
+    /* Enable SWO trace functionality. If ENABLE_SWO is not defined, SWO pin will be used as GPIO (see Product
+       Specification to see which one). */
+    #if defined (ENABLE_SWO)
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Serial << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+        NRF_P0->PIN_CNF[18] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+    #endif
+
+    /* Enable Trace functionality. If ENABLE_TRACE is not defined, TRACE pins will be used as GPIOs (see Product
+       Specification to see which ones). */
+    #if defined (ENABLE_TRACE)
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Parallel << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+        NRF_P0->PIN_CNF[14] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[15] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[16] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[18] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        NRF_P0->PIN_CNF[20] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+    #endif
+#endif
+
+#ifdef NRF52840_XXAA
+        /* Workaround for Errata 36 "CLOCK: Some registers are not reset when expected" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_36()){
+            NRF_CLOCK->EVENTS_DONE = 0;
+            NRF_CLOCK->EVENTS_CTTO = 0;
+            NRF_CLOCK->CTIV = 0;
+        }
+
+        /* Workaround for Errata 98 "NFCT: Not able to communicate with the peer" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_98()){
+            *(volatile uint32_t *)0x4000568Cul = 0x00038148ul;
+        }
+
+        /* Workaround for Errata 103 "CCM: Wrong reset value of CCM MAXPACKETSIZE" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_103()){
+            NRF_CCM->MAXPACKETSIZE = 0xFBul;
+        }
+
+        /* Workaround for Errata 115 "RAM: RAM content cannot be trusted upon waking up from System ON Idle or System OFF mode" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_115()){
+            *(volatile uint32_t *)0x40000EE4 = (*(volatile uint32_t *)0x40000EE4 & 0xFFFFFFF0) | (*(uint32_t *)0x10000258 & 0x0000000F);
+        }
+
+        /* Workaround for Errata 120 "QSPI: Data read or written is corrupted" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_120()){
+            *(volatile uint32_t *)0x40029640ul = 0x200ul;
+        }
+
+        /* Workaround for Errata 120 "QSPI: Second read and long read commands fail" found at the Errata document
+           for your device located at https://infocenter.nordicsemi.com/  */
+        if (errata_121()){
+            *(volatile uint32_t *)0x40029600ul = 0x00040400ul;
+        }
+
+        /* Enable the FPU if the compiler used floating point unit instructions. __FPU_USED is a MACRO defined by the
+         * compiler. Since the FPU consumes energy, remember to disable FPU use in the compiler if floating point unit
+         * operations are not used in your code. */
+        #if (__FPU_USED == 1)
+            SCB->CPACR |= (3UL << 20) | (3UL << 22);
+            __DSB();
+            __ISB();
+        #endif
+
+        /* Configure NFCT pins as GPIOs if NFCT is not to be used in your code. If CONFIG_NFCT_PINS_AS_GPIOS is not defined,
+           two GPIOs (see Product Specification to see which ones) will be reserved for NFC and will not be available as
+           normal GPIOs. */
+        #if defined (CONFIG_NFCT_PINS_AS_GPIOS)
+            if ((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)){
+                NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NRF_UICR->NFCPINS &= ~UICR_NFCPINS_PROTECT_Msk;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NVIC_SystemReset();
+            }
+        #endif
+
+        /* Configure GPIO pads as pPin Reset pin if Pin Reset capabilities desired. If CONFIG_GPIO_AS_PINRESET is not
+          defined, pin reset will not be available. One GPIO (see Product Specification to see which one) will then be
+          reserved for PinReset and not available as normal GPIO. */
+        #if defined (CONFIG_GPIO_AS_PINRESET)
+            if (((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)) ||
+                ((NRF_UICR->PSELRESET[1] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos))){
+                NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NRF_UICR->PSELRESET[0] = 18;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NRF_UICR->PSELRESET[1] = 18;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+                while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+                NVIC_SystemReset();
+            }
+        #endif
+
+        /* Enable SWO trace functionality. If ENABLE_SWO is not defined, SWO pin will be used as GPIO (see Product
+           Specification to see which one). */
+        #if defined (ENABLE_SWO)
+            CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+            NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Serial << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+            NRF_P1->PIN_CNF[0] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        #endif
+
+        /* Enable Trace functionality. If ENABLE_TRACE is not defined, TRACE pins will be used as GPIOs (see Product
+           Specification to see which ones). */
+        #if defined (ENABLE_TRACE)
+            CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+            NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Parallel << CLOCK_TRACECONFIG_TRACEMUX_Pos;
+            NRF_P0->PIN_CNF[7]  = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+            NRF_P1->PIN_CNF[0]  = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+            NRF_P0->PIN_CNF[12] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+            NRF_P0->PIN_CNF[11] = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+            NRF_P1->PIN_CNF[9]  = (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos) | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+        #endif
+#endif
+    SystemCoreClockUpdate();
+
+    NVIC_Relocate();
+}
+
+#ifdef NRF52
+static bool errata_16(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_31(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_32(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_36(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_37(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_57(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool errata_66(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+static bool errata_108(void)
+{
+    if ((((*(uint32_t *)0xF0000FE0) & 0x000000FF) == 0x6) && (((*(uint32_t *)0xF0000FE4) & 0x0000000F) == 0x0)){
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x30){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x40){
+            return true;
+        }
+        if (((*(uint32_t *)0xF0000FE8) & 0x000000F0) == 0x50){
+            return true;
+        }
+    }
+
+    return false;
+}
+#endif
+
+#ifdef NRF52840_XXAA
+static bool errata_36(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+static bool errata_98(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+static bool errata_103(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+static bool errata_115(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+static bool errata_120(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+
+static bool errata_121(void)
+{
+	if ((*(uint32_t *)0x10000130ul == 0x8ul) &&
+			(*(uint32_t *)0x10000134ul == 0x0ul)) {
+		return true;
+	}
+
+	return false;
+}
+#endif
+
+/*lint --flb "Leave library region" */

--- a/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
@@ -1,0 +1,215 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: hw/bsp/nrf52dk
+
+syscfg.defs:
+    I2C_0:
+        description: 'I2C (TWI) interface 0'
+        value:  0
+        restrictions:
+            - "!SPI_0_MASTER"
+            - "!SPI_0_SLAVE"
+    I2C_1:
+        description: 'I2C (TWI) interface 1'
+        value:  0
+        restrictions:
+            - "!SPI_1_MASTER"
+            - "!SPI_1_SLAVE"
+
+    MCU_FLASH_MIN_WRITE_SIZE:
+        description: >
+            Specifies the required alignment for internal flash writes.
+            Used internally by the newt tool.
+        value: 1
+
+    MCU_DCDC_ENABLED:
+        description: >
+            Specifies whether or not to enable DC/DC regulator. This requires
+            external circuitry so is defined to be zero by default and
+            expected to be overridden by the BSP.
+        value: 0
+
+    SPI_0_MASTER:
+        description: 'SPI 0 master'
+        value:  0
+        restrictions:
+            - "!SPI_0_SLAVE"
+            - "!I2C_0"
+    SPI_0_SLAVE:
+        description: 'SPI 0 slave'
+        value:  0
+        restrictions:
+            - "!SPI_0_MASTER"
+            - "!I2C_0"
+
+    SPI_1_MASTER:
+        description: 'SPI 1 master'
+        value:  0
+        restrictions:
+            - "!SPI_1_SLAVE"
+            - "!I2C_1"
+    SPI_1_SLAVE:
+        description: 'SPI 1 slave'
+        value:  0
+        restrictions:
+            - "!SPI_1_MASTER"
+            - "!I2C_1"
+
+    SPI_2_MASTER:
+        description: 'SPI 2 master'
+        value: 0
+        restrictions:
+            - "!SPI_2_SLAVE"
+    SPI_2_SLAVE:
+        description: 'SPI 2 slave'
+        value: 0
+        restrictions:
+            - "!SPI_2_MASTER"
+
+    ADC_0:
+        description: 'NRF52 ADC 0'
+        value:  0
+
+    ADC_0_REFMV_0:
+        description: 'reference mV in AREF0 if used'
+        value: 0
+
+    PWM_0:
+        description: 'NRF52 PWM 0'
+        value: 0
+
+    PWM_1:
+        description: 'NRF52 PWM 1'
+        value: 0
+
+    PWM_2:
+        description: 'NRF52 PWM 2'
+        value: 0
+
+    SOFT_PWM:
+        description: 'SOFT PWM'
+        value: 0
+
+    TRNG:
+        description: 'True Random Number Generator (RNG)'
+        value: 0
+
+    QSPI_ENABLE:
+        description: 'NRF52 QSPI'
+        value: 0
+
+    QSPI_READOC:
+        description: >
+            QSPI Command to use
+            0 - 0x09 Fast Read
+            1 - 0x3B Fast Read Dual Output
+            2 - 0xBB Fast Read Dual I/O
+            3 - 0x6B Fast Read Quad Output
+            4 - 0xEB Fast Read Quad I/O
+        value: 0
+    QSPI_WRITEOC:
+        description: >
+            QSPI Command to use
+            0 - 0x02 Page program
+            1 - 0xA2 Page program Dual Data
+            2 - 0x32 Page program Quad Data
+            3 - 0x38 Page program Quad I/O
+        value: 0
+    QSPI_ADDRMODE:
+        description: 'Address lentgh 0=24 bits, 1=32 bits'
+        value: 0
+    QSPI_DPMCONFIG:
+        description: 'Deep power mode enable'
+        value: 0
+    QSPI_SCK_DELAY:
+        description: >
+            Minimum amount of time that the CSN pin must stay high
+            before it can go low again. Value is specified in number of 16
+            MHz periods (62.5 ns).
+        value: 0
+    QSPI_SCK_FREQ:
+        description: '32MHz clock divider (0-31). Clock = 32MHz / (1+divider)'
+        value: 0
+    QSPI_SPI_MODE:
+        description: 'SPI 0=Mode0 or 1=Mode3'
+        value: 0
+
+    QSPI_FLASH_SECTOR_SIZE:
+        description: 'QSPI sector size. In most cases it should be 4096.'
+        value: 0
+    QSPI_FLASH_PAGE_SIZE:
+        description: >
+            QSPI page size. Writes can only be perfrmed to one page at a time.
+            In most cases it should be 256.
+        value: 0
+
+    QSPI_FLASH_SECTOR_COUNT:
+        description: 'QSPI sector count'
+        value: -1
+    QSPI_PIN_CS:
+        description: 'CS pin for QSPI'
+        value: -1
+    QSPI_PIN_SCK:
+        description: 'SCK pin for QSPI'
+        value: -1
+    QSPI_PIN_DIO0:
+        description: 'DIO0 pin for QSPI'
+        value: -1
+    QSPI_PIN_DIO1:
+        description: 'DIO1 pin for QSPI'
+        value: -1
+    QSPI_PIN_DIO2:
+        description: 'DIO2 pin for QSPI'
+        value: -1
+    QSPI_PIN_DIO3:
+        description: 'DIO3 pin for QSPI'
+        value: -1
+
+    NFC_PINS_AS_GPIO:
+        description: 'Use NFC pins as GPIOs instead of NFC functionality'
+        value: 1
+
+    GPIO_AS_PIN_RESET:
+        description: 'Enable pin reset'
+        value: 0
+
+
+# The XTAL_xxx definitions are used to set the clock source used for the low
+# frequency clock. It is required that at least one of these sources is
+# enabled (the bsp should set one of these clock sources).
+    XTAL_32768:
+        description: 'External 32k oscillator LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_RC"
+
+    XTAL_RC:
+        description: 'internal RC LF clock source'
+        value: 0
+        restrictions:
+            - "!XTAL_32768_SYNTH"
+            - "!XTAL_32768"
+
+    XTAL_32768_SYNTH:
+        description: 'Synthesized 32k LF clock source.'
+        value: 0
+        restrictions:
+            - "!XTAL_RC"
+            - "!XTAL_32768"

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_periph.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_periph.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF52_PERIPH_
+#define H_NRF52_PERIPH_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+void nrf52_periph_create(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF52_PERIPH_ */

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -40,3 +40,30 @@ pkg.cflags.NFC_PINS_AS_GPIO:
 
 pkg.cflags.GPIO_AS_PIN_RESET: 
     - '-DCONFIG_GPIO_AS_PINRESET=1'
+
+pkg.deps.BLE_DEVICE:
+    - "@apache-mynewt-core/hw/drivers/nimble/nrf52"
+
+pkg.deps.TRNG:
+    - "@apache-mynewt-core/hw/drivers/trng/trng_nrf52"
+
+pkg.deps.UART_0:
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+
+pkg.deps.UART_1:
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+
+pkg.deps.ADC_0:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_nrf52"
+
+pkg.deps.PWM_0:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
+
+pkg.deps.PWM_1:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
+
+pkg.deps.PWM_2:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
+
+pkg.deps.PWM_3:
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include "syscfg/syscfg.h"
+#include "mcu/nrf52_hal.h"
+#include "hal/hal_i2c.h"
+#include "hal/hal_spi.h"
+#include "nrfx.h"
+#if MYNEWT_VAL(ADC_0)
+#include "adc/adc.h"
+#include "adc_nrf52/adc_nrf52.h"
+#endif
+#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2) || MYNEWT_VAL(PWM_3)
+#include "pwm/pwm.h"
+#include "pwm_nrf52/pwm_nrf52.h"
+#endif
+#if MYNEWT_VAL(TRNG)
+#include "trng/trng.h"
+#include "trng_nrf52/trng_nrf52.h"
+#endif
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1)
+#include "uart/uart.h"
+#include "uart_hal/uart_hal.h"
+#endif
+
+#if MYNEWT_VAL(ADC_0)
+static struct adc_dev os_bsp_adc0;
+static struct nrf52_adc_dev_cfg os_bsp_adc0_config = {
+    .nadc_refmv = MYNEWT_VAL(ADC_0_REFMV_0),
+};
+#endif
+
+#if MYNEWT_VAL(PWM_0)
+static struct pwm_dev os_bsp_pwm0;
+#endif
+#if MYNEWT_VAL(PWM_1)
+static struct pwm_dev os_bsp_pwm1;
+#endif
+#if MYNEWT_VAL(PWM_2)
+static struct pwm_dev os_bsp_pwm2;
+#endif
+#if MYNEWT_VAL(PWM_3)
+static struct pwm_dev os_bsp_pwm3;
+#endif
+
+#if MYNEWT_VAL(TRNG)
+static struct trng_dev os_bsp_trng;
+#endif
+
+#if MYNEWT_VAL(UART_0)
+static struct uart_dev os_bsp_uart0;
+static const struct nrf52_uart_cfg os_bsp_uart0_cfg = {
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+};
+#endif
+#if MYNEWT_VAL(UART_1)
+static struct uart_dev os_bsp_uart1;
+static const struct nrf52_uart_cfg os_bsp_uart1_cfg = {
+    .suc_pin_tx = MYNEWT_VAL(UART_1_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_1_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_1_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_1_PIN_CTS),
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static const struct nrf52_hal_i2c_cfg hal_i2c0_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_0_FREQ_KHZ),
+};
+#endif
+#if MYNEWT_VAL(I2C_1)
+static const struct nrf52_hal_i2c_cfg hal_i2c1_cfg = {
+    .scl_pin = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .sda_pin = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .i2c_frequency = MYNEWT_VAL(I2C_1_FREQ_KHZ),
+};
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+static const struct nrf52_hal_spi_cfg os_bsp_spi0m_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_0_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
+    /* For SPI master, SS pin is controlled as regular GPIO */
+};
+#endif
+#if MYNEWT_VAL(SPI_0_SLAVE)
+static const struct nrf52_hal_spi_cfg os_bsp_spi0s_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_0_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_0_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_0_SLAVE_PIN_SS),
+};
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+static const struct nrf52_hal_spi_cfg os_bsp_spi1m_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_1_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_MASTER_PIN_MISO),
+    /* For SPI master, SS pin is controlled as regular GPIO */
+};
+#endif
+#if MYNEWT_VAL(SPI_1_SLAVE)
+static const struct nrf52_hal_spi_cfg os_bsp_spi1s_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_1_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_1_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_1_SLAVE_PIN_SS),
+};
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)
+static const struct nrf52_hal_spi_cfg os_bsp_spi2m_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_2_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
+    /* For SPI master, SS pin is controlled as regular GPIO */
+};
+#endif
+#if MYNEWT_VAL(SPI_2_SLAVE)
+static const struct nrf52_hal_spi_cfg os_bsp_spi2s_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_2_SLAVE_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_2_SLAVE_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_2_SLAVE_PIN_MISO),
+    .ss_pin       = MYNEWT_VAL(SPI_2_SLAVE_PIN_SS),
+};
+#endif
+
+static void
+nrf52_periph_create_timers(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(TIMER_0)
+    rc = hal_timer_init(0, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    rc = hal_timer_init(1, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    rc = hal_timer_init(2, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_3)
+    rc = hal_timer_init(3, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_4)
+    rc = hal_timer_init(4, NULL);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_5)
+    rc = hal_timer_init(5, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_adc(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(ADC_0)
+    rc = os_dev_create((struct os_dev *)&os_bsp_adc0, "adc0",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_adc_dev_init, &os_bsp_adc0_config);
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_pwm(void)
+{
+    int rc;
+    int idx;
+
+    (void)rc;
+    (void)idx;
+
+#if MYNEWT_VAL(PWM_0)
+    idx = 0;
+    rc = os_dev_create((struct os_dev *) &os_bsp_pwm0, "pwm0",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_pwm_dev_init, &idx);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(PWM_1)
+    idx = 1;
+    rc = os_dev_create(&os_bsp_pwm1.pwm_os_dev, "pwm1",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_pwm_dev_init, &idx);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(PWM_2)
+    idx = 2;
+    rc = os_dev_create(&os_bsp_pwm2.pwm_os_dev, "pwm2",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_pwm_dev_init, &idx);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(PWM_3)
+    idx = 3;
+    rc = os_dev_create(&os_bsp_pwm3.pwm_os_dev, "pwm3",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_pwm_dev_init, &idx);
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_trng(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(TRNG)
+    rc = os_dev_create(&os_bsp_trng.dev, "trng",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       nrf52_trng_dev_init, NULL);
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_uart(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(UART_0)
+    rc = os_dev_create(&os_bsp_uart0.ud_dev, "uart0",
+                       OS_DEV_INIT_PRIMARY, 0, uart_hal_init,
+                       (void *)&os_bsp_uart0_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_1)
+    rc = os_dev_create(&os_bsp_uart1.ud_dev, "uart1",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart1_cfg);
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_i2c(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(I2C_0)
+    assert(hal_i2c0_cfg.scl_pin >= 0);
+    assert(hal_i2c0_cfg.sda_pin >= 0);
+    rc = hal_i2c_init(0, (void *)&hal_i2c0_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(I2C_1)
+    assert(hal_i2c1_cfg.scl_pin >= 0);
+    assert(hal_i2c1_cfg.sda_pin >= 0);
+    rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
+    assert(rc == 0);
+#endif
+}
+
+static void
+nrf52_periph_create_spi(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = hal_spi_init(0, (void *)&os_bsp_spi0m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_0_SLAVE)
+    rc = hal_spi_init(0, (void *)&os_bsp_spi0s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+    rc = hal_spi_init(1, (void *)&os_bsp_spi1m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_1_SLAVE)
+    rc = hal_spi_init(1, (void *)&os_bsp_spi1s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)
+    rc = hal_spi_init(2, (void *)&os_bsp_spi2m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_2_SLAVE)
+    rc = hal_spi_init(2, (void *)&os_bsp_spi2s_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+}
+
+void
+nrf52_periph_create(void)
+{
+    nrf52_periph_create_timers();
+    nrf52_periph_create_adc();
+    nrf52_periph_create_pwm();
+    nrf52_periph_create_trng();
+    nrf52_periph_create_uart();
+    nrf52_periph_create_i2c();
+    nrf52_periph_create_spi();
+}

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -26,19 +26,6 @@ syscfg.defs:
         description: Shall be set to 1 by BSP if using nRF52840
         value: 0
 
-    I2C_0:
-        description: 'I2C (TWI) interface 0'
-        value:  0
-        restrictions:
-            - "!SPI_0_MASTER"
-            - "!SPI_0_SLAVE"
-    I2C_1:
-        description: 'I2C (TWI) interface 1'
-        value:  0
-        restrictions:
-            - "!SPI_1_MASTER"
-            - "!SPI_1_SLAVE"
-
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.
@@ -52,45 +39,146 @@ syscfg.defs:
             expected to be overridden by the BSP.
         value: 0
 
+# MCU peripherals definitions
+    I2C_0:
+        description: 'Enable nRF52xxx I2C (TWI) 0'
+        value: 0
+        restrictions:
+            - "!SPI_0_MASTER"
+            - "!SPI_0_SLAVE"
+    I2C_0_PIN_SCL:
+        description: 'SCL pin for I2C_0'
+        value: -1
+    I2C_0_PIN_SDA:
+        description: 'SDA pin for I2C_0'
+        value: -1
+    I2C_0_FREQ_KHZ:
+        description: 'Frequency [kHz] for I2C_0'
+        value: 100
+
+    I2C_1:
+        description: 'Enable nRF52xxx I2C (TWI) 1'
+        value: 0
+        restrictions:
+            - "!SPI_1_MASTER"
+            - "!SPI_1_SLAVE"
+    I2C_1_PIN_SCL:
+        description: 'SCL pin for I2C_1'
+        value: -1
+    I2C_1_PIN_SDA:
+        description: 'SDA pin for I2C_1'
+        value: -1
+    I2C_1_FREQ_KHZ:
+        description: 'Frequency [kHz] for I2C_1'
+        value: 100
+
     SPI_0_MASTER:
-        description: 'SPI 0 master'
-        value:  0
+        description: 'Enable nRF52xxx SPI Master 0'
+        value: 0
         restrictions:
             - "!SPI_0_SLAVE"
             - "!I2C_0"
+    SPI_0_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_0_MASTER'
+        value: -1
+    SPI_0_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_MASTER'
+        value: -1
+    SPI_0_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_0_MASTER'
+        value: -1
+
     SPI_0_SLAVE:
-        description: 'SPI 0 slave'
-        value:  0
+        description: 'Enable nRF52xxx SPI Slave 0'
+        value: 0
         restrictions:
             - "!SPI_0_MASTER"
             - "!I2C_0"
+    SPI_0_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_0_SLAVE'
+        value: -1
+    SPI_0_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_0_SLAVE'
+        value: -1
+    SPI_0_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_0_SLAVE'
+        value: -1
+    SPI_0_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_0_SLAVE'
+        value: -1
 
     SPI_1_MASTER:
-        description: 'SPI 1 master'
-        value:  0
+        description: 'Enable nRF52xxx SPI Master 1'
+        value: 0
         restrictions:
             - "!SPI_1_SLAVE"
             - "!I2C_1"
+    SPI_1_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_1_MASTER'
+        value: -1
+    SPI_1_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_MASTER'
+        value: -1
+    SPI_1_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_1_MASTER'
+        value: -1
+
     SPI_1_SLAVE:
-        description: 'SPI 1 slave'
-        value:  0
+        description: 'Enable nRF52xxx SPI Slave 1'
+        value: 0
         restrictions:
             - "!SPI_1_MASTER"
             - "!I2C_1"
+    SPI_1_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_1_SLAVE'
+        value: -1
+    SPI_1_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_1_SLAVE'
+        value: -1
+    SPI_1_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_1_SLAVE'
+        value: -1
+    SPI_1_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_1_SLAVE'
+        value: -1
 
     SPI_2_MASTER:
-        description: 'SPI 2 master'
+        description: 'Enable nRF52xxx SPI Master 2'
         value: 0
         restrictions:
             - "!SPI_2_SLAVE"
+            - "MCU_NRF52840"
+    SPI_2_MASTER_PIN_SCK:
+        description: 'SCK pin for SPI_2_MASTER'
+        value: -1
+    SPI_2_MASTER_PIN_MOSI:
+        description: 'MOSI pin for SPI_2_MASTER'
+        value: -1
+    SPI_2_MASTER_PIN_MISO:
+        description: 'MISO pin for SPI_2_MASTER'
+        value: -1
+
     SPI_2_SLAVE:
-        description: 'SPI 2 slave'
+        description: 'Enable nRF52xxx SPI Slave 2'
         value: 0
         restrictions:
             - "!SPI_2_MASTER"
+            - "MCU_NRF52840"
+    SPI_2_SLAVE_PIN_SCK:
+        description: 'SCK pin for SPI_2_SLAVE'
+        value: -1
+    SPI_2_SLAVE_PIN_MOSI:
+        description: 'MOSI pin for SPI_2_SLAVE'
+        value: -1
+    SPI_2_SLAVE_PIN_MISO:
+        description: 'MISO pin for SPI_2_SLAVE'
+        value: -1
+    SPI_2_SLAVE_PIN_SS:
+        description: 'SS pin for SPI_2_SLAVE'
+        value: -1
 
     ADC_0:
-        description: 'NRF52 ADC 0'
+        description: 'Enable nRF52xxx ADC 0'
         value:  0
 
     ADC_0_REFMV_0:
@@ -98,24 +186,76 @@ syscfg.defs:
         value: 0
 
     PWM_0:
-        description: 'NRF52 PWM 0'
+        description: 'Enable nRF52xxx PWM 0'
         value: 0
-
     PWM_1:
-        description: 'NRF52 PWM 1'
+        description: 'Enable nRF52xxx PWM 1'
         value: 0
-
     PWM_2:
-        description: 'NRF52 PWM 2'
+        description: 'Enable nRF52xxx PWM 2'
         value: 0
-
-    SOFT_PWM:
-        description: 'SOFT PWM'
+    PWM_3:
+        description: 'Enable nRF52xxx PWM 3'
         value: 0
+        restrictions:
+            - "MCU_NRF52840"
 
     TRNG:
-        description: 'True Random Number Generator (RNG)'
+        description: 'Enable nRF52xxx TRNG'
         value: 0
+
+    UART_0:
+        description: 'Enable nRF52xxx UART0'
+        value: 1
+    UART_0_PIN_TX:
+        description: 'TX pin for UART0'
+        value: -1
+    UART_0_PIN_RX:
+        description: 'RX pin for UART0'
+        value: -1
+    UART_0_PIN_RTS:
+        description: 'RTS pin for UART0'
+        value: -1
+    UART_0_PIN_CTS:
+        description: 'CTS pin for UART0'
+        value: -1
+
+    UART_1:
+        description: 'Enable nRF52xxx UART1'
+        value: 0
+        restrictions:
+            - "MCU_NRF52840"
+    UART_1_PIN_TX:
+        description: 'TX pin for UART1'
+        value: -1
+    UART_1_PIN_RX:
+        description: 'RX pin for UART1'
+        value: -1
+    UART_1_PIN_RTS:
+        description: 'RTS pin for UART1'
+        value: -1
+    UART_1_PIN_CTS:
+        description: 'CTS pin for UART1'
+        value: -1
+
+    TIMER_0:
+        description: 'Enable nRF52xxx Timer 0'
+        value:  1
+    TIMER_1:
+        description: 'Enable nRF52xxx Timer 1'
+        value:  0
+    TIMER_2:
+        description: 'Enable nRF52xxx Timer 2'
+        value:  0
+    TIMER_3:
+        description: 'Enable nRF52xxx Timer 3'
+        value:  0
+    TIMER_4:
+        description: 'Enable nRF52xxx Timer 4'
+        value:  0
+    TIMER_5:
+        description: 'Enable nRF52xxx RTC 0'
+        value:  0
 
     QSPI_ENABLE:
         description: 'NRF52 QSPI'
@@ -223,3 +363,13 @@ syscfg.defs:
 
 syscfg.restrictions:
     - "MCU_NRF52832 ^^ MCU_NRF52840"
+    - "!I2C_0 || (I2C_0_PIN_SCL >= 0 && I2C_0_PIN_SDA >= 0)"
+    - "!I2C_1 || (I2C_1_PIN_SCL >= 0 && I2C_1_PIN_SDA >= 0)"
+    - "!SPI_0_MASTER || (SPI_0_MASTER_PIN_SCK >= 0 && SPI_0_MASTER_PIN_MOSI >=0 && SPI_0_MASTER_PIN_MISO >= 0)"
+    - "!SPI_1_MASTER || (SPI_1_MASTER_PIN_SCK >= 0 && SPI_1_MASTER_PIN_MOSI >=0 && SPI_1_MASTER_PIN_MISO >= 0)"
+    - "!SPI_2_MASTER || (SPI_2_MASTER_PIN_SCK >= 0 && SPI_2_MASTER_PIN_MOSI >=0 && SPI_2_MASTER_PIN_MISO >= 0)"
+    - "!SPI_0_SLAVE || (SPI_0_SLAVE_PIN_SCK >= 0 && SPI_0_SLAVE_PIN_MOSI >=0 && SPI_0_SLAVE_PIN_MISO >= 0 && SPI_0_SLAVE_PIN_SS >= 0)"
+    - "!SPI_1_SLAVE || (SPI_1_SLAVE_PIN_SCK >= 0 && SPI_1_SLAVE_PIN_MOSI >=0 && SPI_1_SLAVE_PIN_MISO >= 0 && SPI_1_SLAVE_PIN_SS >= 0)"
+    - "!SPI_2_SLAVE || (SPI_2_SLAVE_PIN_SCK >= 0 && SPI_2_SLAVE_PIN_MOSI >=0 && SPI_2_SLAVE_PIN_MISO >= 0 && SPI_2_SLAVE_PIN_SS >= 0)"
+    - "!UART_0 || (UART_0_PIN_TX >= 0 && UART_0_PIN_RX >= 0)"
+    - "!UART_1 || (UART_1_PIN_TX >= 0 && UART_1_PIN_RX >= 0)"

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -19,6 +19,13 @@
 # Package: hw/bsp/nrf52dk
 
 syscfg.defs:
+    MCU_NRF52832:
+        description: Shall be set to 1 by BSP if using nRF52832
+        value: 0
+    MCU_NRF52840:
+        description: Shall be set to 1 by BSP if using nRF52840
+        value: 0
+
     I2C_0:
         description: 'I2C (TWI) interface 0'
         value:  0
@@ -213,3 +220,6 @@ syscfg.defs:
         restrictions:
             - "!XTAL_RC"
             - "!XTAL_32768"
+
+syscfg.restrictions:
+    - "MCU_NRF52832 ^^ MCU_NRF52840"


### PR DESCRIPTION
This refactors `hw/mcu/nordic/nrf52xxx` package to cleanup perihperals code in BSPs. Changes include:
* all peripherals syscfg settings are moved to `hw/mcu` package
* common code to create and initialize peripherals located in `hw/mcu` package (to be used by `hw/bsp` packages)
* package-level restrictions to make sure everything is configured properly