### PR TITLE
battery: Prevent `maybe-uninitialized` warning

### DIFF
--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -77,7 +77,7 @@ battery_poll_event_cb(struct os_event *ev)
 {
     int i;
     int pflag;
-    os_time_t next_poll;
+    os_time_t next_poll = 0;
     os_time_t now = os_time_get();
     struct battery *bat;
     os_stime_t ticks;


### PR DESCRIPTION
repos/apache-mynewt-core/kernel/os/include/os/os_time.h:109:59: error: 'next_poll' may be used uninitialized in this function [-Werror=maybe-uninitialized]

This is a spurious warning `next_poll` is initialized before it is used.
This warning is detected in debug build only, optimized code does not
see it as a problem.
Added initialization to disable warning.