### PR TITLE
adc/adc_nrf52: Handle ADC calibration done event.

### DIFF
--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -65,7 +65,9 @@ nrf52_saadc_event_handler(const nrfx_saadc_evt_t *event)
                                        done_ev->size * sizeof(nrf_saadc_value_t));
             break;
         case NRFX_SAADC_EVT_CALIBRATEDONE:
-            /*TODO Expose to the user? */
+            rc = global_adc_dev->ad_event_handler_func(global_adc_dev,
+                                       global_adc_dev->ad_event_handler_arg,
+                                       ADC_EVENT_CALIBRATED, NULL, 0);
             break;
         default:
             assert(0);

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -48,7 +48,7 @@ nrf52_saadc_event_handler(const nrfx_saadc_evt_t *event)
     nrfx_saadc_done_evt_t *done_ev;
     int rc;
 
-    if (global_adc_dev == NULL) {
+    if (global_adc_dev == NULL || !global_adc_dev->ad_event_handler_func) {
         ++nrf52_saadc_stats.saadc_events_failed;
         return;
     }

--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -55,17 +55,23 @@ nrf52_saadc_event_handler(const nrfx_saadc_evt_t *event)
 
     ++nrf52_saadc_stats.saadc_events;
 
-    /* Right now only data reads supported, assert for unknown event
-     * type.
-     */
-    assert(event->type == NRFX_SAADC_EVT_DONE);
+    switch (event->type) {
+        case NRFX_SAADC_EVT_DONE:
+            done_ev = (nrfx_saadc_done_evt_t * const) &event->data.done;
 
-    done_ev = (nrfx_saadc_done_evt_t * const) &event->data.done;
+            rc = global_adc_dev->ad_event_handler_func(global_adc_dev,
+                                       global_adc_dev->ad_event_handler_arg,
+                                       ADC_EVENT_RESULT, done_ev->p_buffer,
+                                       done_ev->size * sizeof(nrf_saadc_value_t));
+            break;
+        case NRFX_SAADC_EVT_CALIBRATEDONE:
+            /*TODO Expose to the user? */
+            break;
+        default:
+            assert(0);
+            break;
+    }
 
-    rc = global_adc_dev->ad_event_handler_func(global_adc_dev,
-            global_adc_dev->ad_event_handler_arg,
-            ADC_EVENT_RESULT, done_ev->p_buffer,
-            done_ev->size * sizeof(nrf_saadc_value_t));
     if (rc != 0) {
         ++nrf52_saadc_stats.saadc_events_failed;
     }

--- a/hw/drivers/adc/include/adc/adc.h
+++ b/hw/drivers/adc/include/adc/adc.h
@@ -33,7 +33,8 @@ struct adc_dev;
  */
 typedef enum {
     /* This event represents the result of an ADC run. */
-    ADC_EVENT_RESULT = 0
+    ADC_EVENT_RESULT = 0,
+    ADC_EVENT_CALIBRATED
 } adc_event_type_t;
 
 /**


### PR DESCRIPTION
This PR  fixes assert() when ADC offset calibration is done with nrfx_saadc_calibrate_offset()

This PR does not provide HAL API to trigger ADC calibration (maybe it should be simple adc_offset_calibrate() ?),
however last patch adds support to send ADC_EVENT_CALIBRATED to the user when calibration is completed. 
https://github.com/apache/mynewt-core/commit/ec294361aa11bb3ea425f13f45b9404b7a7cf784

For now I just need first two patches, however open to hear comments on API for this.

