### PR TITLE
hifive: Peripheral cleanup in riscv board

### DIFF
--- a/hw/bsp/hifive1/syscfg.yml
+++ b/hw/bsp/hifive1/syscfg.yml
@@ -19,27 +19,10 @@
 
 # Package: hw/bsp/hifive
 
-syscfg.defs:
-    XTAL_32768:
-        description: 'External 32k oscillator available.'
-        value: 1
-
-    SYS_CLOCK:
-        description: 'System clock'
-        value:  HFXOSC_PLL_256_MHZ
-
-    UART_0:
-        description: 'Whether to enable UART0'
-        value:  1
-
-    TIMER_0:
-        description: 'Whether to use PWM2 16 bit timer as system timer'
-        value:  1
-
-    TIMER_1:
-        description: 'Whether to use PWM1 16 bit timer as system timer'
-        value:  1
-
-    TIMER_2:
-        description: 'Whether to use PWM0 8 bit timer as system timer'
-        value:  1
+syscfg.vals:
+    XTAL_32768: 1
+    SYS_CLOCK: HFXOSC_PLL_256_MHZ
+    UART_0: 1
+    TIMER_0: 1
+    TIMER_1: 1
+    TIMER_2: 1

--- a/hw/mcu/sifive/fe310/syscfg.yml
+++ b/hw/mcu/sifive/fe310/syscfg.yml
@@ -48,9 +48,27 @@ syscfg.defs:
         description: >
             Default divider used when high frequency oscillator is starting.
         value: 4
+    XTAL_32768:
+        description: 'External 32k oscillator available.'
+        value: 0
+    SYS_CLOCK:
+        description: 'System clock'
+        value:  HFROSC_DIV_4
     SPI_1:
         description: 'SPI 1 master'
         value: 0
     SPI_2:
         description: 'SPI 2 master'
         value: 0
+    UART_0:
+        description: 'Whether to enable UART0'
+        value:  0
+    TIMER_0:
+        description: 'Whether to use PWM2 16 bit timer as system timer'
+        value:  0
+    TIMER_1:
+        description: 'Whether to use PWM1 16 bit timer as system timer'
+        value:  0
+    TIMER_2:
+        description: 'Whether to use PWM0 8 bit timer as system timer'
+        value:  0


### PR DESCRIPTION
MCU specific peripherals definition now moved to mcu
instead of BSP.

BSP now just enables peripherals defined by MCU.