### PR TITLE
log_console: Change timestamp suffix "ssb" -> "us"

### DIFF
--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -36,7 +36,7 @@ log_console_get(void)
 static void
 log_console_print_hdr(const struct log_entry_hdr *hdr)
 {
-    console_printf("[ts=%llussb, mod=%u level=%u] ",
+    console_printf("[ts=%lluus, mod=%u level=%u] ",
                    hdr->ue_ts, hdr->ue_module, hdr->ue_level);
 }
 


### PR DESCRIPTION
Log messages printed to the console included a misleading timestamp.  The timestamp had an "ssb" (seconds since boot) suffix.  This is wrong for two reasons:
1. units are microseconds, not seconds
2. the time isn't necessarily "since boot", it is since 1970/01/01 if the device has synced time.

This PR changes the suffix to "us".