### PR TITLE
Fix handling of PWM instances in nRF52 MCU/BSP

### DIFF
--- a/hw/bsp/nrf52840pdk/src/hal_bsp.c
+++ b/hw/bsp/nrf52840pdk/src/hal_bsp.c
@@ -123,7 +123,7 @@ hal_bsp_init(void)
         asprintf(&spwm_name, "spwm%d", idx);
         rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
                            OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, &idx);
+                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
         assert(rc == 0);
     }
 #endif

--- a/hw/bsp/nrf52dk/src/hal_bsp.c
+++ b/hw/bsp/nrf52dk/src/hal_bsp.c
@@ -149,7 +149,7 @@ hal_bsp_init(void)
         asprintf(&spwm_name, "spwm%d", idx);
         rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
                            OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, &idx);
+                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
         assert(rc == 0);
     }
 #endif

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
@@ -206,37 +206,31 @@ static void
 nrf52_periph_create_pwm(void)
 {
     int rc;
-    int idx;
 
     (void)rc;
-    (void)idx;
 
 #if MYNEWT_VAL(PWM_0)
-    idx = 0;
     rc = os_dev_create(&os_bsp_pwm0.pwm_os_dev, "pwm0",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init, &idx);
+                       nrf52_pwm_dev_init, UINT_TO_POINTER(0));
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(PWM_1)
-    idx = 1;
     rc = os_dev_create(&os_bsp_pwm1.pwm_os_dev, "pwm1",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init, &idx);
+                       nrf52_pwm_dev_init, UINT_TO_POINTER(1));
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(PWM_2)
-    idx = 2;
     rc = os_dev_create(&os_bsp_pwm2.pwm_os_dev, "pwm2",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init, &idx);
+                       nrf52_pwm_dev_init, UINT_TO_POINTER(2));
     assert(rc == 0);
 #endif
 #if MYNEWT_VAL(PWM_3)
-    idx = 3;
     rc = os_dev_create(&os_bsp_pwm3.pwm_os_dev, "pwm3",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                       nrf52_pwm_dev_init, &idx);
+                       nrf52_pwm_dev_init, UINT_TO_POINTER(3));
     assert(rc == 0);
 #endif
 }

--- a/kernel/os/include/os/os.h
+++ b/kernel/os/include/os/os.h
@@ -127,6 +127,7 @@ void os_start(void);
 #include "os/os_time.h"
 #include "os/os_trace_api.h"
 #include "os/queue.h"
+#include "os/util.h"
 
 #ifdef __cplusplus
 }

--- a/kernel/os/include/os/util.h
+++ b/kernel/os/include/os/util.h
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_OS_UTIL_
+#define H_OS_UTIL_
+
+/* Helpers to pass integers as pointers and vice-versa */
+#define POINTER_TO_UINT(p) ((unsigned int) ((uintptr_t) (p)))
+#define UINT_TO_POINTER(u) ((void *) ((uintptr_t) (u)))
+#define POINTER_TO_INT(p) ((int) ((intptr_t) (p)))
+#define INT_TO_POINTER(u) ((void *) ((intptr_t) (u)))
+
+#endif


### PR DESCRIPTION
Original code allocated separate `int` for each instance id. After nRF52 refactoring this was changed to single `int` created on stack but since initialization is not done immediately when device is created, this pointer is invalid when actual initialization takes place.

To avoid creating redundant global variables for each PWM instance we allow to pass instance id as simple in casted to pointer. Some helper macros were added to make this easier - such macros are already used in projects as Zephyr or BlueZ and are very convenient way to pass simple integers via user-data pointers.