### PR TITLE
Add simple PM for UART device driver

### DIFF
--- a/hw/drivers/uart/include/uart/uart.h
+++ b/hw/drivers/uart/include/uart/uart.h
@@ -72,12 +72,6 @@ struct uart_driver_funcs {
     void (*uf_blocking_tx)(struct uart_dev *, uint8_t);
 };
 
-struct uart_dev {
-    struct os_dev ud_dev;
-    struct uart_driver_funcs ud_funcs;
-    void *ud_priv;
-};
-
 /*
  * ***Note that these enum values must match what hw/hal/hal_uart.h***
  */
@@ -92,6 +86,14 @@ enum uart_flow_ctl {
     UART_FLOW_CTL_RTS_CTS = 1   /* RTS/CTS */
 };
 
+struct uart_conf_port {
+    uint32_t uc_speed;          /* baudrate in bps */
+    uint8_t uc_databits;        /* number of data bits */
+    uint8_t uc_stopbits;        /* number of stop bits */
+    enum uart_parity uc_parity;
+    enum uart_flow_ctl uc_flow_ctl;
+};
+
 struct uart_conf {
     uint32_t uc_speed;          /* baudrate in bps */
     uint8_t uc_databits;        /* number of data bits */
@@ -102,6 +104,13 @@ struct uart_conf {
     uart_rx_char uc_rx_char;
     uart_tx_done uc_tx_done;
     void *uc_cb_arg;
+};
+
+struct uart_dev {
+    struct os_dev ud_dev;
+    struct uart_driver_funcs ud_funcs;
+    struct uart_conf_port ud_conf_port;
+    void *ud_priv;
 };
 
 /*

--- a/kernel/os/include/os/os_dev.h
+++ b/kernel/os/include/os/os_dev.h
@@ -157,16 +157,7 @@ struct os_dev {
  *
  * @return 0 on success, non-zero error code on failure.
  */
-static inline int
-os_dev_suspend(struct os_dev *dev, os_time_t suspend_t, uint8_t force)
-{
-    if (dev->od_handlers.od_suspend == NULL) {
-        return (0);
-    } else {
-        return (dev->od_handlers.od_suspend(dev, suspend_t, force));
-    }
-}
-
+int os_dev_suspend(struct os_dev *dev, os_time_t suspend_t, uint8_t force);
 
 /**
  * Resume the device operation.
@@ -175,15 +166,7 @@ os_dev_suspend(struct os_dev *dev, os_time_t suspend_t, uint8_t force)
  *
  * @return 0 on success, non-zero error code on failure.
  */
-static inline int
-os_dev_resume(struct os_dev *dev)
-{
-    if (dev->od_handlers.od_resume == NULL) {
-        return (0);
-    } else {
-        return (dev->od_handlers.od_resume(dev));
-    }
-}
+int os_dev_resume(struct os_dev *dev);
 
 /**
  * Create a new device in the kernel.


### PR DESCRIPTION
This is not complete, just an attempt to be able to disable UART to save some power without hacks like closing and reopening it. The whole `os_dev_suspend`/`os_dev_resume` framework needs more work since it was likely never used before so I just quickly fixed it to make this work.