### PR TITLE
Allow flash devices to specify erase value

### DIFF
--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -60,7 +60,8 @@ const struct hal_flash stm32f4_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 512 * 1024,
     .hf_sector_cnt = NAREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -69,7 +69,8 @@ const struct hal_flash stm32f4_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 1536 * 1024,
     .hf_sector_cnt = NAREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -77,7 +77,8 @@ const struct hal_flash stm32f4_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 1024 * 1024,
     .hf_sector_cnt = NAREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -78,7 +78,8 @@ const struct hal_flash stm32f4_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 2048 * 1024,
     .hf_sector_cnt = NAREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -66,7 +66,8 @@ const struct hal_flash stm32f4_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 1024 * 1024,
     .hf_sector_cnt = NAREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/drivers/flash/enc_flash/src/enc_flash.c
+++ b/hw/drivers/flash/enc_flash/src/enc_flash.c
@@ -162,7 +162,7 @@ enc_flash_is_empty(const struct hal_flash *h_dev, uint32_t addr, uint32_t len)
     if (h_dev->hf_itf->hff_is_empty) {
         return h_dev->hf_itf->hff_is_empty(h_dev, addr, len);
     } else {
-        return hal_flash_is_ones(h_dev, addr, len);
+        return hal_flash_is_erased(h_dev, addr, len);
     }
 }
 
@@ -183,6 +183,7 @@ enc_flash_init(const struct hal_flash *h_dev)
     dev->efd_hal.hf_size =  h_dev->hf_size;
     dev->efd_hal.hf_sector_cnt = h_dev->hf_sector_cnt;
     dev->efd_hal.hf_align = h_dev->hf_align;
+    dev->efd_hal.hf_erased_val = h_dev->hf_erased_val;
 
     enc_flash_init_arch(dev);
 

--- a/hw/hal/include/hal/hal_flash.h
+++ b/hw/hal/include/hal/hal_flash.h
@@ -42,6 +42,7 @@ int hal_flash_erase_sector(uint8_t flash_id, uint32_t sector_address);
 int hal_flash_erase(uint8_t flash_id, uint32_t address, uint32_t num_bytes);
 int hal_flash_isempty(uint8_t flash_id, uint32_t address, uint32_t num_bytes);
 uint8_t hal_flash_align(uint8_t flash_id);
+uint8_t hal_flash_erased_val(uint8_t flash_id);
 int hal_flash_init(void);
 
 #ifdef __cplusplus

--- a/hw/hal/include/hal/hal_flash_int.h
+++ b/hw/hal/include/hal/hal_flash_int.h
@@ -51,6 +51,7 @@ struct hal_flash {
     uint32_t hf_size;
     int hf_sector_cnt;
     int hf_align;       /* Alignment requirement. 1 if unrestricted. */
+    uint8_t hf_erased_val;
 };
 
 /*
@@ -58,11 +59,7 @@ struct hal_flash {
  */
 uint32_t hal_flash_sector_size(const struct hal_flash *hf, int sec_idx);
 
-/*
- * Use as hal_flash_funcs.hff_is_empty if flash is erased to zeroes.
- */
-int hal_flash_is_zeroes(const struct hal_flash *, uint32_t, uint32_t);
-int hal_flash_is_ones(const struct hal_flash *, uint32_t, uint32_t);
+int hal_flash_is_erased(const struct hal_flash *, uint32_t, uint32_t);
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/ambiq/apollo2/src/hal_flash.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_flash.c
@@ -53,7 +53,8 @@ const struct hal_flash apollo2_flash_dev = {
         .hf_base_addr = 0x00000000,
         .hf_size = 1024 * 1024,
         .hf_sector_cnt = 128,
-        .hf_align = 1
+        .hf_align = 1,
+        .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_flash.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_flash.c
@@ -56,9 +56,10 @@ const struct hal_flash pic32mx_flash_dev = {
     .hf_base_addr = 0x1D000000,
     .hf_size = 512 * 1024,
     .hf_sector_cnt = 128,
-    .hf_align = 4      /* num bytes must be a multiple of 4 as writes can only
+    .hf_align = 4,     /* num bytes must be a multiple of 4 as writes can only
                         * be done on word boundary.
                         */
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_flash.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_flash.c
@@ -56,10 +56,11 @@ const struct hal_flash pic32mz_flash_dev = {
     .hf_base_addr = 0x1D000000,
     .hf_size = 2048 * 1024,
     .hf_sector_cnt = 128,
-    .hf_align = 4      /* num bytes must be a multiple of 4 as writes can only
+    .hf_align = 4,     /* num bytes must be a multiple of 4 as writes can only
                         * be done on word boundary. This also assumes that
                         * ECC memory is disabled (default on Wi-Fire board).
                         */
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -81,6 +81,7 @@ const struct hal_flash native_flash_dev = {
     .hf_size = 1024 * 1024,
     .hf_sector_cnt = FLASH_NUM_AREAS,
     .hf_align = MYNEWT_VAL(MCU_FLASH_MIN_WRITE_SIZE),
+    .hf_erased_val = 0xff,
 };
 
 static void

--- a/hw/mcu/nordic/nrf51xxx/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_flash.c
@@ -50,7 +50,8 @@ const struct hal_flash nrf51_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 256 * 1024,	/* XXX read from factory info? */
     .hf_sector_cnt = 256,	/* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #define NRF51_FLASH_READY() (NRF_NVMC->READY == NVMC_READY_READY_Ready)

--- a/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
@@ -49,7 +49,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 1024 * 1024,	/* XXX read from factory info? */
     .hf_sector_cnt = 256,	/* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #elif defined(NRF52810_XXAA)
 const struct hal_flash nrf52k_flash_dev = {

--- a/hw/mcu/nxp/MK64F12/src/hal_flash.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_flash.c
@@ -61,7 +61,8 @@ static flash_config_t mk64f12_config;
 struct hal_flash mk64f12_flash_dev = {
     /* Most items are set after FLASH_Init() */
     .hf_itf = &mk64f12_flash_funcs,
-    .hf_align = MK64F12_FLASH_ALIGN
+    .hf_align = MK64F12_FLASH_ALIGN,
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/sifive/fe310/src/hal_flash.c
+++ b/hw/mcu/sifive/fe310/src/hal_flash.c
@@ -50,7 +50,8 @@ const struct hal_flash fe310_flash_dev = {
     .hf_base_addr = 0x20000000,
     .hf_size = 8 * 1024 * 1024,  /* XXX read from factory info? */
     .hf_sector_cnt = 4096,       /* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 #define FLASH_CMD_READ_STATUS_REGISTER 0x05

--- a/hw/mcu/stm/stm32f1xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_flash.c
@@ -50,6 +50,7 @@ const struct hal_flash stm32f1_flash_dev = {
     .hf_size = _FLASH_SIZE,
     .hf_sector_cnt = _FLASH_SIZE / _FLASH_SECTOR_SIZE,
     .hf_align = 2,
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/stm/stm32f3xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f3xx/src/hal_flash.c
@@ -127,6 +127,7 @@ stm32f3_flash_dev()
         stm32f3_flash_dev_.hf_size = HAL_FLASH_SIZE;
         stm32f3_flash_dev_.hf_sector_cnt = HAL_FLASH_SIZE / HAL_FLASH_SECTOR_SIZE;
         stm32f3_flash_dev_.hf_align = 2;
+        stm32f3_flash_dev_.hf_erased_val = 0xff;
     }
     return &stm32f3_flash_dev_;
 }

--- a/hw/mcu/stm/stm32f7xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f7xx/src/hal_flash.c
@@ -66,7 +66,8 @@ const struct hal_flash stm32f7_flash_dev = {
     .hf_base_addr = 0x08000000,
     .hf_size = 2 * 1024 * 1024,
     .hf_sector_cnt = STM32F7_FLASH_NUM_AREAS - 1,
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/stm/stm32l1xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32l1xx/src/hal_flash.c
@@ -52,6 +52,7 @@ const struct hal_flash stm32l1_flash_dev = {
     .hf_size = _FLASH_SIZE,
     .hf_sector_cnt = _FLASH_SIZE / _FLASH_SECTOR_SIZE,
     .hf_align = MYNEWT_VAL(MCU_FLASH_MIN_WRITE_SIZE),
+    .hf_erased_val = 0,
 };
 
 static int

--- a/hw/mcu/stm/stm32l4xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32l4xx/src/hal_flash.c
@@ -51,6 +51,7 @@ const struct hal_flash stm32l4_flash_dev = {
     .hf_size = _FLASH_SIZE,
     .hf_sector_cnt = _FLASH_SIZE / _FLASH_SECTOR_SIZE,
     .hf_align = 8,
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -94,6 +94,11 @@ int flash_area_isempty_at(const struct flash_area *, uint32_t off,
 uint8_t flash_area_align(const struct flash_area *);
 
 /*
+ * Value read from flash when it is erased.
+ */
+uint32_t flash_area_erased_val(const struct flash_area *fa);
+
+/*
  * Given flash map index, return info about sectors within the area.
  */
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -167,9 +167,16 @@ flash_area_align(const struct flash_area *fa)
     return hal_flash_align(fa->fa_device_id);
 }
 
+uint32_t
+flash_area_erased_val(const struct flash_area *fa)
+{
+    return hal_flash_erased_val(fa->fa_device_id);
+}
+
+
 /**
  * Checks if a flash area has been erased. Returns false if there are any
- * non 0xFFFFFFFF bytes.
+ * non non-erased bytes.
  *
  * @param fa                    An opened flash area to iterate.
  *                                  the count of flash area TLVs in the meta


### PR DESCRIPTION
This updates support for devices that are erased to zero instead of 0xff.

@mkiiskila I slightly changed the low-level interfaces you have initially written but should be 100% compatible from the user perspective.