### PR TITLE
mgmt/imgmgr: Add option to enable verbose error messages

### DIFF
--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -32,3 +32,7 @@ syscfg.defs:
             The maximum amount of image or core data that can fit in a
             single NMP message
         value: 512
+    IMGMGR_VERBOSE_ERR:
+        description: >
+            Send verbose error message in responses.
+        value: 0


### PR DESCRIPTION
If enabled, most of interesting errors will have "rsn" field in response
with verbose error message. This is helpful for debugging since the same
error code is returned in many different cases.