### PR TITLE
Stm32 stack fixes

### DIFF
--- a/hw/bsp/nucleo-f767zi/boot-nucleo-f767zi.ld
+++ b/hw/bsp/nucleo-f767zi/boot-nucleo-f767zi.ld
@@ -23,7 +23,7 @@ MEMORY
   FLASH (rx) :  ORIGIN = 0x08000000, LENGTH = 32K
   ITCM (rx)  :  ORIGIN = 0x00000000, LENGTH = 16K
   DTCM (rwx) :  ORIGIN = 0x20000000, LENGTH = 128K
-  RAM (rwx)  :  ORIGIN = 0x20020000, LENGTH = 512K
+  RAM (rwx)  :  ORIGIN = 0x20020000, LENGTH = 384K
 }
 
 /* The bootloader does not contain an image header */

--- a/hw/bsp/nucleo-f767zi/nucleo-f767zi.ld
+++ b/hw/bsp/nucleo-f767zi/nucleo-f767zi.ld
@@ -24,8 +24,12 @@ MEMORY
 {
   FLASH (rx) :  ORIGIN = 0x08040000, LENGTH = 768K /* Image slot 1 */
   ITCM (rx)  :  ORIGIN = 0x00000000, LENGTH = 16K
+  /*
+   * XXX: DTCM + SRAM1 + SRAM2 are mapped in contiguous areas,
+   *      Could this simply be RAM at 0x20000000 with LENGTH=512k?
+   */
   DTCM (rwx) :  ORIGIN = 0x20000000, LENGTH = 128K
-  RAM (rwx)  :  ORIGIN = 0x20020000, LENGTH = 512K
+  RAM (rwx)  :  ORIGIN = 0x20020000, LENGTH = 384K /* SRAM1 + SRAM2 */
 }
 
 /* This linker script is used for images and thus contains an image header */

--- a/hw/mcu/stm/stm32f1xx/stm32f103.ld
+++ b/hw/mcu/stm/stm32f1xx/stm32f103.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20004FFF;
+_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 SECTIONS
 {

--- a/hw/mcu/stm/stm32f4xx/stm32f413.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f413.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20050000;
+_estack = ORIGIN(CCM) + LENGTH(CCM);
 
 SECTIONS
 {

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20040000;
+_estack = ORIGIN(DTCM) + LENGTH(DTCM);
 
 SECTIONS
 {

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20080000;
+_estack = ORIGIN(DTCM) + LENGTH(DTCM);
 
 SECTIONS
 {

--- a/hw/mcu/stm/stm32l1xx/stm32l152.ld
+++ b/hw/mcu/stm/stm32l1xx/stm32l152.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20007FFF;
+_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 SECTIONS
 {

--- a/hw/mcu/stm/stm32l4xx/stm32l476.ld
+++ b/hw/mcu/stm/stm32l4xx/stm32l476.ld
@@ -52,7 +52,7 @@
  */
 ENTRY(Reset_Handler)
 
-_estack = 0x20007FFF;
+_estack = ORIGIN(RAM) + LENGTH(RAM);
 
 SECTIONS
 {


### PR DESCRIPTION
This sets `_estack` symbol to ORIGIN + LENGTH of RAM (of DCM, DTCM, etc), allowing future reuse of linker scripts without having to fix on RAM amount changes. Also fixed the amount of RAM present in the nucleo-f767zi BSP. 