### PR TITLE
Add flash-id parameter to flash cli command

### DIFF
--- a/test/flash_test/src/flash_test/flash_test.c
+++ b/test/flash_test/src/flash_test/flash_test.c
@@ -41,69 +41,99 @@ flash_cli_cmd(int argc, char **argv)
     uint32_t sz = 1;
     int sec_cnt;
     int i;
+    int devid;
     int soff;
     char *eptr;
     char tmp_buf[8];
     char pr_str[80];
 
-    hf = hal_bsp_flash_dev(0);
-    if (!hf) {
-        console_printf("No flash device present\n");
+    if (argc > 1 && (!strcmp(argv[1], "?") || !strcmp(argv[1], "help"))) {
+        console_printf("Commands Available\n");
+        console_printf("flash [flash-id] -- dumps sector map \n");
+        console_printf("flash <flash-id> read <offset> <size> -- reads bytes from flash \n");
+        console_printf("flash <flash-id> write <offset>  <size>  -- writes incrementing data pattern 0-8 to flash \n");
+        console_printf("flash <flash-id> erase <offset> <size> -- erases flash \n");
         return 0;
     }
-    if (argc == 1) {
-        /*
-         * print status
-         */
-        console_printf("Flash at 0x%lx size 0x%lx with %d sectors,"
-          " alignment req %d bytes\n",
-                (long unsigned int) hf->hf_base_addr,
-                (long unsigned int) hf->hf_size,
-                hf->hf_sector_cnt,
-                hf->hf_align);
-        sec_cnt = hf->hf_sector_cnt;
-        if (sec_cnt > 32) {
-            sec_cnt = 32;
+
+    devid = 0;
+    if (argc < 3) {
+        if (argc == 2) {
+            devid = strtoul(argv[1], &eptr, 0);
+            if (*eptr != 0) {
+                console_printf("Invalid flash id %s\n", argv[1]);
+                return 0;
+            }
         }
-        for (i = 0; i < sec_cnt; i++) {
-            console_printf("  %d: %lx\n", i,
-                    (long unsigned int) hal_flash_sector_size(hf, i));
-        }
-        if (sec_cnt != hf->hf_sector_cnt) {
-            console_printf("...  %d: %lx\n", hf->hf_sector_cnt - 1,
-              (long unsigned int) hal_flash_sector_size(hf, hf->hf_sector_cnt - 1));
-        }
+        do {
+            hf = hal_bsp_flash_dev(devid);
+            if (!hf) {
+                if (argc == 2) {
+                    console_printf("Flash device not present\n");
+                }
+                return 0;
+            }
+            console_printf("Flash %d at 0x%lx size 0x%lx with %d sectors,"
+              " alignment req %d bytes\n",
+                    devid,
+                    (long unsigned int) hf->hf_base_addr,
+                    (long unsigned int) hf->hf_size,
+                    hf->hf_sector_cnt,
+                    hf->hf_align);
+            sec_cnt = hf->hf_sector_cnt;
+            if (sec_cnt > 32) {
+                sec_cnt = 32;
+            }
+            for (i = 0; i < sec_cnt; i++) {
+                console_printf("  %d: %lx\n", i,
+                        (long unsigned int) hal_flash_sector_size(hf, i));
+            }
+            if (sec_cnt != hf->hf_sector_cnt) {
+                console_printf("...  %d: %lx\n", hf->hf_sector_cnt - 1,
+                  (long unsigned int) hal_flash_sector_size(hf, hf->hf_sector_cnt - 1));
+            }
+            ++devid;
+        } while(argc == 1);
+
         return 0;
     }
-    if (argc > 2) {
-        off = strtoul(argv[2], &eptr, 0);
+
+    if (argc > 1) {
+        devid = strtoul(argv[1], &eptr, 0);
+        if (*eptr != 0) {
+            console_printf("Invalid flash id %s\n", argv[1]);
+            goto err;
+        }
+    }
+    if (argc > 3) {
+        off = strtoul(argv[3], &eptr, 0);
         if (*eptr != '\0') {
             console_printf("Invalid offset %s\n", argv[2]);
             goto err;
         }
     }
-    if (argc > 3) {
-        sz = strtoul(argv[3], &eptr, 0);
+    if (argc > 4) {
+        sz = strtoul(argv[4], &eptr, 0);
         if (*eptr != '\0') {
             console_printf("Invalid size %s\n", argv[3]);
             goto err;
         }
     }
-    if (!strcmp(argv[1], "erase")) {
+    if (!strcmp(argv[2], "erase")) {
         console_printf("Erase 0x%lx + %lx\n",
                 (long unsigned int) off, (long unsigned int) sz);
 
-        if (hal_flash_erase(0, off, sz)) {
+        if (hal_flash_erase(devid, off, sz)) {
             console_printf("Flash erase failed\n");
         }
         console_printf("Done!\n");
-    } else if (!strcmp(argv[1], "read")) {
+    } else if (!strcmp(argv[2], "read")) {
         console_printf("Read 0x%lx + %lx\n",
                 (long unsigned int) off, (long unsigned int) sz);
         sz += off;
         while (off < sz) {
             sec_cnt = min(sizeof(tmp_buf), sz - off);
-            if (hal_flash_read(0, off, tmp_buf, sec_cnt)) {
+            if (hal_flash_read(devid, off, tmp_buf, sec_cnt)) {
                 console_printf("flash read failure at %lx\n",
                         (long unsigned int) off);
                 break;
@@ -116,7 +146,7 @@ flash_cli_cmd(int argc, char **argv)
                     (long unsigned int) off, pr_str);
             off += sec_cnt;
         }
-    } else if (!strcmp(argv[1], "write")) {
+    } else if (!strcmp(argv[2], "write")) {
         console_printf("Write 0x%lx + %lx\n",
                 (long unsigned int) off, (long unsigned int) sz);
 
@@ -127,20 +157,13 @@ flash_cli_cmd(int argc, char **argv)
 
         while (off < sz) {
             sec_cnt = min(sizeof(tmp_buf), sz - off);
-            if (hal_flash_write(0, off, tmp_buf, sec_cnt)) {
+            if (hal_flash_write(devid, off, tmp_buf, sec_cnt)) {
                 console_printf("flash write failure at %lx\n",
                         (long unsigned int) off);
             }
             off += sec_cnt;
         }
         console_printf("Done!\n");
-    } else if ( !strcmp(argv[1], "?") || !strcmp(argv[1], "help"))
-    {
-        console_printf("Commands Available\n");
-        console_printf("flash -- dumps sector map \n");
-        console_printf("flash read <offset> <size> -- reads bytes from flash \n");
-        console_printf("flash write <offset>  <size>  -- writes incrementing data pattern 0-8 to flash \n");
-        console_printf("flash erase <offset> <size> -- erases flash \n");
     }
     return 0;
 err:


### PR DESCRIPTION
Adds `<flash-id>` option to allow flash command to work on a device that is not 0 (optional on dump command).

> `flash <flash-id>` -- dumps sector map
> `flash <flash-id> read <offset> <size>` -- reads bytes from flash
> `flash <flash-id> write <offset>  <size>` -- writes incrementing data pattern 0-8 to flash
> `flash <flash-id> erase <offset> <size>` -- erases flash

This probably conflicts with https://github.com/apache/mynewt-core/pull/1324 so might wait for that one to be merged.