### PR TITLE
sys/config: Add API to use FCB as generic key-value storage

### DIFF
--- a/sys/config/include/config/config_generic_kv.h
+++ b/sys/config/include/config/config_generic_kv.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef __SYS_CONFIG_GENERIC_KV_H_
+#define __SYS_CONFIG_GENERIC_KV_H_
+
+#include <stddef.h>
+#include "config/config.h"
+#include "fcb/fcb.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Load value for given key from FCB key-value storage area
+ *
+ * This loads latest value set for given key from FCB key-value storage area.
+ * The FCB kv store can be any FCB provided by application, however it's up to
+ * application to make sure such FCB was not used for other purposes. Trying to
+ * load value from FCB which was used for other purposes may yield undefined
+ * results.
+ *
+ * The returned value is always null-terminated.
+ *
+ * @param fcb    FCB with kv store
+ * @param name   Key name to load
+ * @param value  Buffer to store value
+ * @param len    Length of buffer
+ *
+ * @return OS_OK on success, error code otherwise
+ */
+int conf_fcb_kv_load(struct fcb *fcb, const char *name, char *value, size_t len);
+
+/**
+ * Store value for given key to FCB key-value storage area
+ *
+ * This stores new value for given key to FCB key-value storage area.
+ * The FCB kv store can be any FCB provided by application.
+ *
+ * @param fcb    FCB with kv store
+ * @param name   Key name to store
+ * @param value  Value to store
+ *
+ * @return OS_OK on success, error code otherwise
+ */
+int conf_fcb_kv_save(struct fcb *fcb, const char *name, const char *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYS_CONFIG_GENERIC_KV_H_ */

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -26,6 +26,7 @@
 
 #include "config/config.h"
 #include "config/config_fcb.h"
+#include "config/config_generic_kv.h"
 #include "config_priv.h"
 
 #define CONF_FCB_VERS		1
@@ -33,6 +34,12 @@
 struct conf_fcb_load_cb_arg {
     load_cb cb;
     void *cb_arg;
+};
+
+struct conf_kv_load_cb_arg {
+    const char *name;
+    char *value;
+    size_t len;
 };
 
 static int conf_fcb_load(struct conf_store *, load_cb cb, void *cb_arg);
@@ -150,11 +157,11 @@ conf_fcb_var_read(struct fcb_entry *loc, char *buf, char **name, char **val)
     return rc;
 }
 
-void
-conf_fcb_compress(struct conf_fcb *cf,
-                  int (*copy_or_not)(const char *name, const char *val,
-                                     void *cn_arg),
-                  void *cn_arg)
+static void
+conf_fcb_compress_internal(struct fcb *fcb,
+                           int (*copy_or_not)(const char *name, const char *val,
+                                              void *cn_arg),
+                           void *cn_arg)
 {
     int rc;
     char buf1[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
@@ -165,15 +172,15 @@ conf_fcb_compress(struct conf_fcb *cf,
     char *name2, *val2;
     int copy;
 
-    rc = fcb_append_to_scratch(&cf->cf_fcb);
+    rc = fcb_append_to_scratch(fcb);
     if (rc) {
         return; /* XXX */
     }
 
     loc1.fe_area = NULL;
     loc1.fe_elem_off = 0;
-    while (fcb_getnext(&cf->cf_fcb, &loc1) == 0) {
-        if (loc1.fe_area != cf->cf_fcb.f_oldest) {
+    while (fcb_getnext(fcb, &loc1) == 0) {
+        if (loc1.fe_area != fcb->f_oldest) {
             break;
         }
         rc = conf_fcb_var_read(&loc1, buf1, &name1, &val1);
@@ -185,7 +192,7 @@ conf_fcb_compress(struct conf_fcb *cf,
         }
         loc2 = loc1;
         copy = 1;
-        while (fcb_getnext(&cf->cf_fcb, &loc2) == 0) {
+        while (fcb_getnext(fcb, &loc2) == 0) {
             rc = conf_fcb_var_read(&loc2, buf2, &name2, &val2);
             if (rc) {
                 continue;
@@ -213,7 +220,7 @@ conf_fcb_compress(struct conf_fcb *cf,
         if (rc) {
             continue;
         }
-        rc = fcb_append(&cf->cf_fcb, loc1.fe_data_len, &loc2);
+        rc = fcb_append(fcb, loc1.fe_data_len, &loc2);
         if (rc) {
             continue;
         }
@@ -222,9 +229,9 @@ conf_fcb_compress(struct conf_fcb *cf,
         if (rc) {
             continue;
         }
-        fcb_append_finish(&cf->cf_fcb, &loc2);
+        fcb_append_finish(fcb, &loc2);
     }
-    rc = fcb_rotate(&cf->cf_fcb);
+    rc = fcb_rotate(fcb);
     if (rc) {
         /* XXXX */
         ;
@@ -232,21 +239,21 @@ conf_fcb_compress(struct conf_fcb *cf,
 }
 
 static int
-conf_fcb_append(struct conf_fcb *cf, char *buf, int len)
+conf_fcb_append(struct fcb *fcb, char *buf, int len)
 {
     int rc;
     int i;
     struct fcb_entry loc;
 
     for (i = 0; i < 10; i++) {
-        rc = fcb_append(&cf->cf_fcb, len, &loc);
+        rc = fcb_append(fcb, len, &loc);
         if (rc != FCB_ERR_NOSPACE) {
             break;
         }
-        if (cf->cf_fcb.f_scratch_cnt == 0) {
+        if (fcb->f_scratch_cnt == 0) {
             return OS_ENOMEM;
         }
-        conf_fcb_compress(cf, NULL, NULL);
+        conf_fcb_compress_internal(fcb, NULL, NULL);
     }
     if (rc) {
         return OS_EINVAL;
@@ -255,7 +262,7 @@ conf_fcb_append(struct conf_fcb *cf, char *buf, int len)
     if (rc) {
         return OS_EINVAL;
     }
-    fcb_append_finish(&cf->cf_fcb, &loc);
+    fcb_append_finish(fcb, &loc);
     return OS_OK;
 }
 
@@ -263,6 +270,76 @@ static int
 conf_fcb_save(struct conf_store *cs, const char *name, const char *value)
 {
     struct conf_fcb *cf = (struct conf_fcb *)cs;
+
+    return conf_fcb_kv_save(&cf->cf_fcb, name, value);
+}
+
+void
+conf_fcb_compress(struct conf_fcb *cf,
+                  int (*copy_or_not)(const char *name, const char *val,
+                                     void *cn_arg),
+                  void *cn_arg)
+{
+    conf_fcb_compress_internal(&cf->cf_fcb, copy_or_not, cn_arg);
+}
+
+static int
+conf_kv_load_cb(struct fcb_entry *loc, void *arg)
+{
+    struct conf_kv_load_cb_arg *cb_arg = arg;
+    char buf[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
+    char *name_str;
+    char *val_str;
+    int rc;
+    int len;
+
+    len = loc->fe_data_len;
+    if (len >= sizeof(buf)) {
+        len = sizeof(buf) - 1;
+    }
+
+    rc = flash_area_read(loc->fe_area, loc->fe_data_off, buf, len);
+    if (rc) {
+        return 0;
+    }
+    buf[len] = '\0';
+
+    rc = conf_line_parse(buf, &name_str, &val_str);
+    if (rc) {
+        return 0;
+    }
+
+    if (strcmp(name_str, cb_arg->name)) {
+        return 0;
+    }
+
+    strncpy(cb_arg->value, val_str, cb_arg->len);
+    cb_arg->value[cb_arg->len - 1] = '\0';
+
+    return 0;
+}
+
+int
+conf_fcb_kv_load(struct fcb *fcb, const char *name, char *value, size_t len)
+{
+    struct conf_kv_load_cb_arg arg;
+    int rc;
+
+    arg.name = name;
+    arg.value = value;
+    arg.len = len;
+
+    rc = fcb_walk(fcb, 0, conf_kv_load_cb, &arg);
+    if (rc) {
+        return OS_EINVAL;
+    }
+
+    return OS_OK;
+}
+
+int
+conf_fcb_kv_save(struct fcb *fcb, const char *name, const char *value)
+{
     char buf[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
     int len;
 
@@ -274,7 +351,7 @@ conf_fcb_save(struct conf_store *cs, const char *name, const char *value)
     if (len < 0 || len + 2 > sizeof(buf)) {
         return OS_INVALID_PARM;
     }
-    return conf_fcb_append(cf, buf, len);
+    return conf_fcb_append(fcb, buf, len);
 }
 
 #endif

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -163,10 +163,6 @@ out:
     return rc;
 }
 
-/*
- * Walk through all registered subsystems, and ask them to export their
- * config variables. Persist these settings.
- */
 static void
 conf_store_one(char *name, char *value)
 {
@@ -198,6 +194,10 @@ out:
 
 }
 
+/*
+ * Walk through all registered subsystems, and ask them to export their
+ * config variables. Persist these settings.
+ */
 int
 conf_save(void)
 {


### PR DESCRIPTION
This adds simple API to use config_fcb engine as generic key-value
storage without need to use config module. The main difference is that
config values need to be somehow handled by registered module thus it is
useful for pre-defined settings.

With config_fcb_kv API it is possible to read and write any key at any
time and they are immediately persisted and loaded directly from FCB so
there is no need to store them in RAM. This can be used as kind of a
scratchpad and is definitely not intended as replacement for sys/config
module.