### PR TITLE
sys/console: add support for silencing output from the console

### DIFF
--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -66,6 +66,14 @@ void console_line_queue_set(struct os_eventq *evq);
 /* Put (handled) line event to console */
 void console_line_event_put(struct os_event *ev);
 
+extern bool g_silence_console;
+
+static void inline
+console_silence(bool silent)
+{
+    g_silence_console = silent;
+}
+
 extern int console_is_midline;
 extern int console_out(int character);
 extern void console_rx_restart(void);

--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -65,9 +65,17 @@ int console_handle_char(uint8_t byte);
 void console_line_queue_set(struct os_eventq *evq);
 /* Put (handled) line event to console */
 void console_line_event_put(struct os_event *ev);
-
+/**
+ * Global indicating whether console is silent or not
+ */
 extern bool g_silence_console;
 
+/**
+ * Silences console output, input is still active
+ *
+ * @param silent Let console know if it needs to be silent,
+ *        true for silence, false otherwise
+ */
 static void inline
 console_silence(bool silent)
 {

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -27,6 +27,10 @@
 int
 console_out(int c)
 {
+    if (g_silence_console) {
+        return 0;
+    }
+
     console_is_midline = (c != '\n');
 
     return ble_monitor_out(c);

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -28,7 +28,7 @@ int
 console_out(int c)
 {
     if (g_silence_console) {
-        return 0;
+        return c;
     }
 
     console_is_midline = (c != '\n');

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -82,6 +82,7 @@ static uint16_t cur, end;
 static struct os_eventq avail_queue;
 static struct os_eventq *lines_queue;
 static completion_cb completion;
+bool g_silence_console;
 
 /*
  * Default implementation in case all consoles are disabled - we just ignore any

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -37,6 +37,10 @@ console_out(int character)
 {
     char c = (char)character;
 
+    if (g_silence_console) {
+        return 0;
+    }
+
     if ('\n' == c) {
         SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
         console_is_midline = 0;

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -38,7 +38,7 @@ console_out(int character)
     char c = (char)character;
 
     if (g_silence_console) {
-        return 0;
+        return c;
     }
 
     if ('\n' == c) {

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -154,6 +154,10 @@ uart_console_non_blocking_mode(void)
 int
 console_out(int c)
 {
+    if (g_silence_console) {
+        return 0;
+    }
+
     /* Assure that there is a write cb installed; this enables to debug
      * code that is faulting before the console was initialized.
      */

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -155,7 +155,7 @@ int
 console_out(int c)
 {
     if (g_silence_console) {
-        return 0;
+        return c;
     }
 
     /* Assure that there is a write cb installed; this enables to debug

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -63,6 +63,14 @@ console_set_completion_cb(uint8_t (*completion)(char *str, uint8_t len))
 {
 }
 
+extern bool g_silence_console;
+
+static void inline
+console_silence(bool silent)
+{
+    g_silence_console = silent;
+}
+
 int console_handle_char(uint8_t byte);
 
 extern int console_is_midline;

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -63,8 +63,17 @@ console_set_completion_cb(uint8_t (*completion)(char *str, uint8_t len))
 {
 }
 
+/**
+ * Global indicating whether console is silent or not
+ */
 extern bool g_silence_console;
 
+/**
+ * Silences console output, input is still active
+ *
+ * @param silent Let console know if it needs to be silent,
+ *        true for silence, false otherwise
+ */
 static void inline
 console_silence(bool silent)
 {

--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -56,6 +56,7 @@ static int echo = MYNEWT_VAL(CONSOLE_ECHO);
 static uint8_t cur, end;
 static struct os_eventq *avail_queue;
 static struct os_eventq *lines_queue;
+bool g_silence_console;
 
 int __attribute__((weak))
 console_out(int c)

--- a/sys/console/minimal/src/rtt_console.c
+++ b/sys/console/minimal/src/rtt_console.c
@@ -37,6 +37,10 @@ console_out(int character)
 {
     char c = (char)character;
 
+    if (g_silence_console) {
+        return 0;
+    }
+
     if ('\n' == c) {
         SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
         console_is_midline = 0;

--- a/sys/console/minimal/src/rtt_console.c
+++ b/sys/console/minimal/src/rtt_console.c
@@ -38,7 +38,7 @@ console_out(int character)
     char c = (char)character;
 
     if (g_silence_console) {
-        return 0;
+        return c;
     }
 
     if ('\n' == c) {

--- a/sys/console/minimal/src/uart_console.c
+++ b/sys/console/minimal/src/uart_console.c
@@ -133,7 +133,7 @@ int
 console_out(int c)
 {
     if (g_silence_console) {
-        return 0;
+        return c;
     }
 
     if ('\n' == c) {

--- a/sys/console/minimal/src/uart_console.c
+++ b/sys/console/minimal/src/uart_console.c
@@ -132,6 +132,10 @@ uart_console_non_blocking_mode(void)
 int
 console_out(int c)
 {
+    if (g_silence_console) {
+        return 0;
+    }
+
     if ('\n' == c) {
         write_char_cb(uart_dev, '\r');
         console_is_midline = 0;

--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -20,6 +20,7 @@
 #define __CONSOLE_H__
 
 #include <inttypes.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,6 +110,11 @@ static int inline
 console_out(int character)
 {
     return 0;
+}
+
+static void inline
+console_silence(bool silent)
+{
 }
 
 #define console_is_midline  (0)

--- a/util/parse/src/parse.c
+++ b/util/parse/src/parse.c
@@ -62,6 +62,13 @@ parse_ll_bounds(const char *sval, long long min, long long max,
         return llval;
     }
 
+    if (llval < min || llval > max)
+    {
+        *out_status = SYS_ERANGE;
+
+        return 0;
+    }
+
     *out_status = SYS_EINVAL;
     return 0;
 }
@@ -80,6 +87,13 @@ parse_ull_bounds(const char *sval,
 
         *out_status = 0;
         return ullval;
+    }
+
+    if (ullval < min || ullval > max)
+    {
+        *out_status = SYS_ERANGE;
+
+        return 0;
     }
 
     *out_status = SYS_EINVAL;

--- a/util/parse/src/parse.c
+++ b/util/parse/src/parse.c
@@ -54,19 +54,14 @@ parse_ll_bounds(const char *sval, long long min, long long max,
     char *endptr;
     long long llval;
 
+    *out_status = SYS_EOK;
+
     llval = strtoll(sval, &endptr, parse_num_base(sval));
-    if (sval[0] != '\0' && *endptr == '\0' &&
-        llval >= min && llval <= max) {
-
-        *out_status = 0;
+    if (sval[0] != '\0' && *endptr == '\0') {
+        if (llval < min || llval > max) {
+            *out_status = SYS_ERANGE;
+        }
         return llval;
-    }
-
-    if (llval < min || llval > max)
-    {
-        *out_status = SYS_ERANGE;
-
-        return 0;
     }
 
     *out_status = SYS_EINVAL;
@@ -81,19 +76,14 @@ parse_ull_bounds(const char *sval,
     char *endptr;
     unsigned long long ullval;
 
+    *out_status = SYS_EOK;
+
     ullval = strtoull(sval, &endptr, parse_num_base(sval));
-    if (sval[0] != '\0' && *endptr == '\0' &&
-        ullval >= min && ullval <= max) {
-
-        *out_status = 0;
+    if (sval[0] != '\0' && *endptr == '\0') {
+        if (ullval < min || ullval > max) {
+            *out_status = SYS_ERANGE;
+        }
         return ullval;
-    }
-
-    if (ullval < min || ullval > max)
-    {
-        *out_status = SYS_ERANGE;
-
-        return 0;
     }
 
     *out_status = SYS_EINVAL;


### PR DESCRIPTION
- Add support for silencing output from the console
- Change parse_ull_bounds to check for range and return SYS_ERANGE error