### PR TITLE
sys/shell: Fix command parameters completion

### DIFF
--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -470,6 +470,11 @@ get_command_from_module(const char *command, int len, int module)
 
     shell_module = &shell_modules[module];
     for (i = 0; shell_module->commands[i].sc_cmd; i++) {
+
+        if (strlen(shell_module->commands[i].sc_cmd) != len) {
+            continue;
+        }
+
         if (!strncmp(command, shell_module->commands[i].sc_cmd, len)) {
             return i;
         }


### PR DESCRIPTION
When trying to complete parameters for a command for which there are other
commands with the same prefix, get_command_from_module function would return the
first command with matching prefix instead of the first command that matches exactly.

For the following example, when trying to list available params for command
'set' the shell would print out parameters for command 'set-scan-opts'.

```
set-scan-opts
set
set-adv-data
set-scan-rsp
set-priv-mode
```

This patch fixes this issue by ensuring that the found command matches exactly with
the typed one.