### PR TITLE
helpers for exporting manufacturing time data via sys/confg

### DIFF
--- a/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
+++ b/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __CONF_MMAP_H
+#define __CONF_MMAP_H
+
+#include <config/config.h>
+#include <config/config_store.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct conf_mmap_kv {
+    const char *cmk_key;
+    uint16_t cmk_off;
+    uint16_t cmk_maxlen;
+};
+
+struct conf_mmap {
+    struct conf_store cm_store;
+    uintptr_t cm_base;
+    int cm_kv_cnt;
+    const struct conf_mmap_kv *cm_kv;
+};
+
+int conf_mmap_src(struct conf_mmap *cm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
+++ b/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
@@ -27,19 +27,60 @@
 extern "C" {
 #endif
 
+/**
+ * Read-only config source from a memory mapped data region.
+ *
+ * Data is expected to be stored without keys. Config source registration
+ * provides key names to values when config source is registered.
+ * Like with other config values, data has to be a printable string.
+ *
+ * E.g. memory layout @ 0x10000
+ *  0x10000: device_serial_number, 16 bytes,
+ *  0x10010: device_model, 6 bytes,
+ *  0x10006: device_hw_version, 8 bytes
+ *
+ * Config name to value mapping would be provided like this:
+ * static const struct conf_mmap_kv my_static_kvs[] = {
+ *   [0] = { "id/serial", 0, 16 },
+ *   [1] = { "id/model", 16, 6 },
+ *   [2] = { "hw/ver", 22, 8 }
+ * };
+ *
+ * Then declare the conf_mmap structure:
+ * static struct conf_mmap my_static_conf = {
+ *   .cm_base = (uintptr_t)0x10000,
+ *   .cm_kv_cnt = sizeof(my_static_kvs) / sizeof(my_static_kvs[0]),
+ *   .cm_kv = my_static_kvs,
+ * };
+ *
+ * and then register this, eg. before registering other config sources
+ *
+ * conf_mmap_src(&my_static_conf);
+ */
+
+/**
+ * Config key value mapping declaration.
+ */
 struct conf_mmap_kv {
-    const char *cmk_key;
-    uint16_t cmk_off;
-    uint16_t cmk_maxlen;
+    const char *cmk_key;  /* key (string) */
+    uint16_t cmk_off;     /* offset from conf_mmap.cm_base */
+    uint16_t cmk_maxlen;  /* maximum length of value */
 };
 
 struct conf_mmap {
     struct conf_store cm_store;
     uintptr_t cm_base;
-    int cm_kv_cnt;
-    const struct conf_mmap_kv *cm_kv;
+    int cm_kv_cnt;        /* number of key/value array elements */
+    const struct conf_mmap_kv *cm_kv; /* key/value array */
 };
 
+/**
+ * Add memory mapped read-only data as a config source.
+ *
+ * @param cm Information about config data
+ *
+ * @return 0 on success, non-zero on failure.
+ */
 int conf_mmap_src(struct conf_mmap *cm);
 
 #ifdef __cplusplus

--- a/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
+++ b/sys/config/conf_mmap/include/conf_mmap/conf_mmap.h
@@ -63,13 +63,13 @@ extern "C" {
  */
 struct conf_mmap_kv {
     const char *cmk_key;  /* key (string) */
-    uint16_t cmk_off;     /* offset from conf_mmap.cm_base */
+    uint16_t cmk_off;     /* offset of value from conf_mmap.cm_base */
     uint16_t cmk_maxlen;  /* maximum length of value */
 };
 
 struct conf_mmap {
     struct conf_store cm_store;
-    uintptr_t cm_base;
+    uintptr_t cm_base;    /* base address */
     int cm_kv_cnt;        /* number of key/value array elements */
     const struct conf_mmap_kv *cm_kv; /* key/value array */
 };

--- a/sys/config/conf_mmap/pkg.yml
+++ b/sys/config/conf_mmap/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: sys/config/conf_mmap
+pkg.description: Memory mapped area for config values.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/config"

--- a/sys/config/conf_mmap/src/conf_mmap.c
+++ b/sys/config/conf_mmap/src/conf_mmap.c
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <os/mynewt.h>
+
+#include <config/config.h>
+#include <config/config_store.h>
+
+#include "conf_mmap/conf_mmap.h"
+
+static int conf_mmap_load(struct conf_store *cs, conf_store_load_cb cb,
+                          void *cb_arg);
+
+static struct conf_store_itf conf_mmap_itf = {
+    .csi_load = conf_mmap_load,
+};
+
+static int
+conf_mmap_load(struct conf_store *cs, conf_store_load_cb cb, void *cb_arg)
+{
+    struct conf_mmap *cm = (struct conf_mmap *)cs;
+    const struct conf_mmap_kv *cmk;
+    char name[CONF_MAX_NAME_LEN + 1];
+    char val[CONF_MAX_VAL_LEN + 1];
+    int len;
+    int i;
+
+    for (i = 0; i < cm->cm_kv_cnt; i++) {
+        cmk = &cm->cm_kv[i];
+
+        strncpy(name, cmk->cmk_key, sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
+        len = cmk->cmk_maxlen;
+        if (len > CONF_MAX_VAL_LEN) {
+            len = CONF_MAX_VAL_LEN;
+        }
+        strncpy(val, (void *)(cm->cm_base + cmk->cmk_off), len);
+        cb(name, val, cb_arg);
+    }
+    return OS_OK;
+}
+
+int
+conf_mmap_src(struct conf_mmap *cm)
+{
+    /* XXX probably should check for magic number or something where
+       cm_base is */
+    cm->cm_store.cs_itf = &conf_mmap_itf;
+    conf_src_register(&cm->cm_store);
+
+    return OS_OK;
+}

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -330,15 +330,6 @@ char *conf_str_from_bytes(void *vp, int vp_len, char *buf, int buf_len);
 #define CONF_VALUE_SET(str, type, val)                                  \
     conf_value_from_str((str), (type), &(val), sizeof(val))
 
-/*
- * Config storage
- */
-struct conf_store_itf;
-struct conf_store {
-    SLIST_ENTRY(conf_store) cs_next;
-    const struct conf_store_itf *cs_itf;
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/config/include/config/config_fcb.h
+++ b/sys/config/include/config/config_fcb.h
@@ -20,6 +20,7 @@
 #define __SYS_CONFIG_FCB_H_
 
 #include "config/config.h"
+#include "config/config_store.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/config/include/config/config_file.h
+++ b/sys/config/include/config/config_file.h
@@ -20,6 +20,7 @@
 #define __SYS_CONFIG_FILE_H_
 
 #include "config/config.h"
+#include "config/config_store.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/config/include/config/config_store.h
+++ b/sys/config/include/config/config_store.h
@@ -16,38 +16,50 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#ifndef __SYS_CONFIG_STORE_H_
+#define __SYS_CONFIG_STORE_H_
 
-#ifndef __CONFIG_PRIV_H_
-#define __CONFIG_PRIV_H_
+/**
+ * @addtogroup SysConfig Configuration of Apache Mynewt System
+ * @{
+ */
+
+#include <os/queue.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int conf_cli_register(void);
-int conf_nmgr_register(void);
+struct conf_store;
 
 /*
- * Lock config subsystem.
+ * API for config storage.
  */
-void conf_lock(void);
-void conf_unlock(void);
+typedef void (*conf_store_load_cb)(char *name, char *val, void *cb_arg);
+struct conf_store_itf {
+    int (*csi_load)(struct conf_store *cs, conf_store_load_cb cb, void *cb_arg);
+    int (*csi_save_start)(struct conf_store *cs);
+    int (*csi_save)(struct conf_store *cs, const char *name, const char *value);
+    int (*csi_save_end)(struct conf_store *cs);
+};
 
-struct mgmt_cbuf;
-int conf_line_parse(char *buf, char **namep, char **valp);
-int conf_line_make(char *dst, int dlen, const char *name, const char *val);
-int conf_line_make2(char *dst, int dlen, const char *name, const char *value);
-struct conf_handler *conf_parse_and_lookup(char *name, int *name_argc,
-                                           char *name_argv[]);
+struct conf_store {
+    SLIST_ENTRY(conf_store) cs_next;
+    const struct conf_store_itf *cs_itf;
+};
 
-SLIST_HEAD(conf_store_head, conf_store);
-extern struct conf_store_head conf_load_srcs;
-SLIST_HEAD(conf_handler_head, conf_handler);
-extern struct conf_handler_head conf_handlers;
-extern struct conf_store *conf_save_dst;
+void conf_src_register(struct conf_store *cs);
+void conf_dst_register(struct conf_store *cs);
+
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __CONFIG_PRIV_H_ */
+/**
+ * @} SysConfig
+ */
+
+
+#endif /* __SYS_CONFIG_H_ */

--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -21,6 +21,7 @@
 
 #include "os/mynewt.h"
 #include "config/config.h"
+#include "config/config_store.h"
 #include "config_priv.h"
 
 #if MYNEWT_VAL(CONFIG_CLI)

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "config/config.h"
+#include "config/config_store.h"
 #include "config/config_fcb.h"
 #include "config/config_generic_kv.h"
 #include "config_priv.h"
@@ -32,7 +33,7 @@
 #define CONF_FCB_VERS		1
 
 struct conf_fcb_load_cb_arg {
-    load_cb cb;
+    conf_store_load_cb cb;
     void *cb_arg;
 };
 
@@ -42,9 +43,10 @@ struct conf_kv_load_cb_arg {
     size_t len;
 };
 
-static int conf_fcb_load(struct conf_store *, load_cb cb, void *cb_arg);
+static int conf_fcb_load(struct conf_store *, conf_store_load_cb cb,
+                         void *cb_arg);
 static int conf_fcb_save(struct conf_store *, const char *name,
-  const char *value);
+                         const char *value);
 
 static struct conf_store_itf conf_fcb_itf = {
     .csi_load = conf_fcb_load,
@@ -128,7 +130,7 @@ conf_fcb_load_cb(struct fcb_entry *loc, void *arg)
 }
 
 static int
-conf_fcb_load(struct conf_store *cs, load_cb cb, void *cb_arg)
+conf_fcb_load(struct conf_store *cs, conf_store_load_cb cb, void *cb_arg)
 {
     struct conf_fcb *cf = (struct conf_fcb *)cs;
     struct conf_fcb_load_cb_arg arg;

--- a/sys/config/src/config_file.c
+++ b/sys/config/src/config_file.c
@@ -30,7 +30,8 @@
 #include "config/config_file.h"
 #include "config_priv.h"
 
-static int conf_file_load(struct conf_store *, load_cb cb, void *cb_arg);
+static int conf_file_load(struct conf_store *, conf_store_load_cb cb,
+                          void *cb_arg);
 static int conf_file_save(struct conf_store *, const char *name,
   const char *value);
 
@@ -104,7 +105,7 @@ conf_getnext_line(struct fs_file *file, char *buf, int blen, uint32_t *loc)
  * item found.
  */
 static int
-conf_file_load(struct conf_store *cs, load_cb cb, void *cb_arg)
+conf_file_load(struct conf_store *cs, conf_store_load_cb cb, void *cb_arg)
 {
     struct conf_file *cf = (struct conf_file *)cs;
     struct fs_file *file;

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -22,6 +22,7 @@
 
 #include "os/mynewt.h"
 #include "config/config.h"
+#include "config/config_store.h"
 #include "config_priv.h"
 
 struct conf_dup_check_arg {

--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -24,14 +24,12 @@
 extern "C" {
 #endif
 
-#if MYNEWT_VAL(ID_SERIAL_LOCAL)
+#if MYNEWT_VAL(ID_SERIAL_PRESENT)
 /*
  * Maximum expected serial number string length.
  */
-#define ID_SERIAL_MAX_LEN       64
+#define ID_SERIAL_MAX_LEN       MYNEWT_VAL(ID_SERIAL_MAX_LEN)
 extern char id_serial[];
-#elif MYNEWT_VAL(ID_SERIAL_PRESENT)
-extern const char id_serial[];
 #endif
 
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)

--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -24,11 +24,36 @@
 extern "C" {
 #endif
 
+#if MYNEWT_VAL(ID_SERIAL_LOCAL)
 /*
- * Maximum configurable serial number.
+ * Maximum expected serial number string length.
  */
 #define ID_SERIAL_MAX_LEN       64
 extern char id_serial[];
+#elif MYNEWT_VAL(ID_SERIAL_PRESENT)
+extern const char id_serial[];
+#endif
+
+#if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
+/*
+ * Maximum expected manufacturer string length.
+ */
+#define ID_MANUFACTURER_MAX_LEN 64
+extern char id_manufacturer[];
+#else
+extern const char id_manufacturer[];
+#endif
+
+#if MYNEWT_VAL(ID_MODEL_LOCAL)
+/*
+ * Maximum expected model name string length.
+ */
+#define ID_MODEL_MAX_LEN        64
+extern char id_model[];
+#elif MYNEWT_VAL(ID_MODEL_PRESENT)
+extern const char id_model[];
+#endif
+
 extern char id_mfghash[];
 extern const char *id_bsp_str;
 extern const char *id_app_str;

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -46,7 +46,7 @@ const char *id_bsp_str = "";
 const char *id_app_str = "";
 #endif
 
-#if MYNEWT_VAL(ID_SERIAL_LOCAL)
+#if MYNEWT_VAL(ID_SERIAL_PRESENT)
 char id_serial[ID_SERIAL_MAX_LEN];
 #endif
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
@@ -105,7 +105,7 @@ static int
 id_conf_set(int argc, char **argv, char *val)
 {
     if (argc == 1) {
-#if MYNEWT_VAL(ID_SERIAL_LOCAL)
+#if MYNEWT_VAL(ID_SERIAL_PRESENT)
         if (!strcmp(argv[0], "serial")) {
             return CONF_VALUE_SET(val, CONF_STRING, id_serial);
         }
@@ -143,13 +143,7 @@ id_conf_export(void (*export_func)(char *name, char *val),
         export_func("id/mfghash", (char *)id_mfghash);
     }
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
-#if MYNEWT_VAL(ID_SERIAL_LOCAL)
     export_func("id/serial", id_serial);
-#else
-    if (tgt == CONF_EXPORT_SHOW) {
-        export_func("id/serial", (char *)id_serial);
-    }
-#endif /* ID_SERIAL_LOCAL */
 #endif /* ID_SERIAL_PRESENT */
 #if MYNEWT_VAL(ID_MANUFACTURER_PRESENT)
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -46,7 +46,15 @@ const char *id_bsp_str = "";
 const char *id_app_str = "";
 #endif
 
+#if MYNEWT_VAL(ID_SERIAL_LOCAL)
 char id_serial[ID_SERIAL_MAX_LEN];
+#endif
+#if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
+char id_manufacturer[ID_MANUFACTURER_MAX_LEN];
+#endif
+#if MYNEWT_VAL(ID_MODEL_LOCAL)
+char id_model[ID_MODEL_MAX_LEN];
+#endif
 
 /** Base64-encoded null-terminated manufacturing hash. */
 char id_mfghash[BASE64_ENCODE_SIZE(MFG_HASH_SZ) + 1];
@@ -74,8 +82,18 @@ id_conf_get(int argc, char **argv, char *val, int val_len_max)
             return (char *)id_bsp_str;
         } else if (!strcmp(argv[0], "app")) {
             return (char *)id_app_str;
+#if MYNEWT_VAL(ID_SERIAL_PRESENT)
         } else if (!strcmp(argv[0], "serial")) {
-            return id_serial;
+            return (char *)id_serial;
+#endif
+#if MYNEWT_VAL(ID_MANUFACTURER_PRESENT)
+        } else if (!strcmp(argv[0], "mfger")) {
+            return (char *)id_manufacturer;
+#endif
+#if MYNEWT_VAL(ID_MODEL_PRESENT)
+        } else if (!strcmp(argv[0], "model")) {
+            return (char *)id_model;
+#endif
         } else if (!strcmp(argv[0], "mfghash")) {
             return id_mfghash;
         }
@@ -87,9 +105,21 @@ static int
 id_conf_set(int argc, char **argv, char *val)
 {
     if (argc == 1) {
+#if MYNEWT_VAL(ID_SERIAL_LOCAL)
         if (!strcmp(argv[0], "serial")) {
             return CONF_VALUE_SET(val, CONF_STRING, id_serial);
         }
+#endif
+#if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
+        if (!strcmp(argv[0], "mfger")) {
+            return CONF_VALUE_SET(val, CONF_STRING, id_manufacturer);
+        }
+#endif
+#if MYNEWT_VAL(ID_MODEL_LOCAL)
+        if (!strcmp(argv[0], "model")) {
+            return CONF_VALUE_SET(val, CONF_STRING, id_model);
+        }
+#endif
     }
     return OS_ENOENT;
 }
@@ -112,8 +142,33 @@ id_conf_export(void (*export_func)(char *name, char *val),
         export_func("id/app", (char *)id_app_str);
         export_func("id/mfghash", (char *)id_mfghash);
     }
+#if MYNEWT_VAL(ID_SERIAL_PRESENT)
+#if MYNEWT_VAL(ID_SERIAL_LOCAL)
     export_func("id/serial", id_serial);
-
+#else
+    if (tgt == CONF_EXPORT_SHOW) {
+        export_func("id/serial", (char *)id_serial);
+    }
+#endif /* ID_SERIAL_LOCAL */
+#endif /* ID_SERIAL_PRESENT */
+#if MYNEWT_VAL(ID_MANUFACTURER_PRESENT)
+#if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
+    export_func("id/mfger", id_manufacturer);
+#else
+    if (tgt == CONF_EXPORT_SHOW) {
+        export_func("id/mfger", (char *)id_manufacturer);
+    }
+#endif /* ID_MANUFACTURER_LOCAL */
+#endif /* ID_MANUFACTURER_PRESENT */
+#if MYNEWT_VAL(ID_MODEL_PRESENT)
+#if MYNEWT_VAL(ID_MODEL_LOCAL)
+    export_func("id/model", id_model);
+#else
+    if (tgt == CONF_EXPORT_SHOW) {
+        export_func("id/model", (char *)id_model);
+    }
+#endif /* ID_MODEL_LOCAL */
+#endif /* ID_MODEL_PRESENT */
     return 0;
 }
 

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: sys/id
+
+syscfg.defs:
+    ID_SERIAL_PRESENT:
+        description: 'Device serial number exported as sys/id/serial.'
+        value: 1
+    ID_SERIAL_LOCAL:
+        description: >
+            If set, device serial number stored in sys/config. Otherwise
+            must be exported by some other package.
+        value: 1
+        restrictions:
+            - 'ID_SERIAL_PRESENT'
+
+    ID_MANUFACTURER_PRESENT:
+        description: 'Device manufacturer string exported as sys/id/mfger.'
+        value: 0
+    ID_MANUFACTURER_LOCAL:
+        description: >
+            If set, device manufacturer stored in sys/config. Otherwise
+            must be exported by some other package.
+        value: 0
+        restrictions:
+            - 'ID_MANUFACTURER_PRESENT'
+
+    ID_MODEL_PRESENT:
+        description: 'Device model name string exported as sys/id/model.'
+        value: 0
+    ID_MODEL_LOCAL:
+        description: >
+            If set, device model name stored in sys/config. Otherwise
+            must be exported by some other package.
+        value: 0
+        restrictions:
+            - 'ID_MODEL_PRESENT'

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -22,13 +22,9 @@ syscfg.defs:
     ID_SERIAL_PRESENT:
         description: 'Device serial number exported as sys/id/serial.'
         value: 1
-    ID_SERIAL_LOCAL:
-        description: >
-            If set, device serial number stored in sys/config. Otherwise
-            must be exported by some other package.
-        value: 1
-        restrictions:
-            - 'ID_SERIAL_PRESENT'
+    ID_SERIAL_MAX_LEN:
+        description: Maximum length of id/serial value
+        value: 64
 
     ID_MANUFACTURER_PRESENT:
         description: 'Device manufacturer string exported as sys/id/mfger.'


### PR DESCRIPTION
sys/id; added device model/manufacturer fields under config branch id/
sys/config/conf_mmap; new package making it easy to export memory mapped structured data as config (e.g. from NRF UICR, STM32 OTP region etc.)