### PR TITLE
net/nimble: Change packages to transient

### DIFF
--- a/net/nimble/controller/pkg.yml
+++ b/net/nimble/controller/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/controller
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/controller"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/controller"

--- a/net/nimble/controller/test/pkg.yml
+++ b/net/nimble/controller/test/pkg.yml
@@ -17,6 +17,5 @@
 #
 pkg.name: net/nimble/controller/test
 pkg.description: "NimBLE controller unit tests."
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/controller/test"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/controller/test"

--- a/net/nimble/host/mesh/pkg.yml
+++ b/net/nimble/host/mesh/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/mesh
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/mesh"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/mesh"

--- a/net/nimble/host/pkg.yml
+++ b/net/nimble/host/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host"

--- a/net/nimble/host/services/ans/pkg.yml
+++ b/net/nimble/host/services/ans/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/ans
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/ans"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/ans"

--- a/net/nimble/host/services/bleuart/pkg.yml
+++ b/net/nimble/host/services/bleuart/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/bleuart
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/bleuart"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/bleuart"

--- a/net/nimble/host/services/gap/pkg.yml
+++ b/net/nimble/host/services/gap/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/gap
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/gap"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/gap"

--- a/net/nimble/host/services/gatt/pkg.yml
+++ b/net/nimble/host/services/gatt/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/gatt
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/gatt"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/gatt"

--- a/net/nimble/host/services/ias/pkg.yml
+++ b/net/nimble/host/services/ias/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/ias
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/ias"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/ias"

--- a/net/nimble/host/services/lls/pkg.yml
+++ b/net/nimble/host/services/lls/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/lls
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/lls"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/lls"

--- a/net/nimble/host/services/tps/pkg.yml
+++ b/net/nimble/host/services/tps/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/services/tps
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/services/tps"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/services/tps"

--- a/net/nimble/host/store/config/pkg.yml
+++ b/net/nimble/host/store/config/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/store/config
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/store/config"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/store/config"

--- a/net/nimble/host/store/ram/pkg.yml
+++ b/net/nimble/host/store/ram/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/store/ram
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/store/ram"

--- a/net/nimble/host/test/pkg.yml
+++ b/net/nimble/host/test/pkg.yml
@@ -16,7 +16,5 @@
 # under the License.
 #
 pkg.name: net/nimble/host/test
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/test"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/test"

--- a/net/nimble/host/util/pkg.yml
+++ b/net/nimble/host/util/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/host/util
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/host/util"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/host/util"

--- a/net/nimble/pkg.yml
+++ b/net/nimble/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble"

--- a/net/nimble/transport/emspi/pkg.yml
+++ b/net/nimble/transport/emspi/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/transport/emspi
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/transport/emspi"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/transport/emspi"

--- a/net/nimble/transport/pkg.yml
+++ b/net/nimble/transport/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/transport
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/transport"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/transport"

--- a/net/nimble/transport/ram/pkg.yml
+++ b/net/nimble/transport/ram/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/transport/ram
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/transport/ram"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/transport/ram"

--- a/net/nimble/transport/socket/pkg.yml
+++ b/net/nimble/transport/socket/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/transport/socket
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/transport/socket"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/transport/socket"

--- a/net/nimble/transport/uart/pkg.yml
+++ b/net/nimble/transport/uart/pkg.yml
@@ -18,7 +18,5 @@
 #
 
 pkg.name: net/nimble/transport/uart
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.deps:
-    - "@apache-mynewt-nimble/nimble/transport/uart"
+pkg.type: transient
+pkg.link: "@apache-mynewt-nimble/nimble/transport/uart"


### PR DESCRIPTION
These packages shall be removed before next release, but since we now
have transient packages let's use them for now so people see warnings
and can finally switch to proper packages.

Note that this requires latest 'newt' to work properly.