### PR TITLE
kernel/os: Don't compare t_taskid

### DIFF
--- a/kernel/os/src/os_task.c
+++ b/kernel/os/src/os_task.c
@@ -129,15 +129,13 @@ err:
 int
 os_task_remove(struct os_task *t)
 {
-    struct os_task *current;
     int rc;
     os_sr_t sr;
 
-    current = os_sched_get_current_task();
     /*
      * Can't suspend yourself
      */
-    if (t->t_taskid == current->t_taskid) {
+    if (t == os_sched_get_current_task()) {
         return OS_INVALID_PARM;
     }
 


### PR DESCRIPTION
`os_task_remove()` ensures that a task does not remove itself.  It does this by comparing the specified task's `t_taskid` member with that of the current task's.

This is not a reliable way to detect duplicate tasks.  Task IDs are not guaranteed to be unique.  If tasks are repeatedly added and removed, the `g_task_id` variable will wrap, leading to duplicate IDs.

Duplicate task IDs is a bigger problem that this PR does not address.  This PR just fixes `os_task_remove()` - it detects self-removal by comparing task addresses rather than task IDs.