### PR TITLE
apps/metrics: Fix violated syscfg restriction

### DIFF
--- a/apps/metrics/syscfg.yml
+++ b/apps/metrics/syscfg.yml
@@ -22,3 +22,4 @@ syscfg.vals:
     LOG_CLI: 1
     LOG_VERSION: 3
     METRICS_CLI: 1
+    SHELL_TASK: 1


### PR DESCRIPTION
Syscfg restriction violations detected:
    Setting LOG_CLI(1) requires: SHELL_TASK

Setting history (newest -> oldest):
    LOG_CLI: [@apache-mynewt-core/apps/metrics:1, @apache-mynewt-core/sys/log/full:0]
    SHELL_TASK: [@apache-mynewt-core/sys/shell:0]