### PR TITLE
apps/loraping: Fix compilation issues

### DIFF
--- a/apps/loraping/syscfg.yml
+++ b/apps/loraping/syscfg.yml
@@ -23,10 +23,6 @@ syscfg.defs:
             Used by package management system to include mfrg firmware.
         value: 1
 
-    LORA_MAC_TIMER_NUM:
-        description: Timer number used for lora mac and radio
-        value: -1
-
 syscfg.vals:
     STATS_CLI: 1
     STATS_NAMES: 1


### PR DESCRIPTION
Error: Settings defined by multiple packages:
    LORA_MAC_TIMER_NUM: @apache-mynewt-core/apps/loraping @apache-mynewt-core/hw/drivers/lora

Error: repos/apache-mynewt-core/hw/drivers/lora/sx1276/src/sx1276.c:29:2: error: #error "Must define a Lora MAC timer number"
 #error "Must define a Lora MAC timer number"
  ^~~~~