### PR TITLE
kernel/os: Add syscfg for tickless min/max period

### DIFF
--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -68,3 +68,6 @@ syscfg.defs:
         description: 'Priority of native UART poller task.'
         type: task_priority
         value: 0
+
+syscfg.vals:
+    OS_IDLE_TICKLESS_MS_MIN: 1

--- a/kernel/os/src/os.c
+++ b/kernel/os/src/os.c
@@ -51,13 +51,8 @@ OS_TASK_STACK_DEFINE(os_main_stack, OS_MAIN_STACK_SIZE);
  */
 int g_os_started;
 
-#ifdef ARCH_sim
-#define MIN_IDLE_TICKS  1
-#else
-#define MIN_IDLE_TICKS  (100 * OS_TICKS_PER_SEC / 1000) /* 100 msec */
-#endif
-#define MAX_IDLE_TICKS  (600 * OS_TICKS_PER_SEC)        /* 10 minutes */
-
+#define MIN_IDLE_TICKS  (MYNEWT_VAL(OS_IDLE_TICKLESS_MS_MIN) * OS_TICKS_PER_SEC / 1000)
+#define MAX_IDLE_TICKS  (MYNEWT_VAL(OS_IDLE_TICKLESS_MS_MAX) * OS_TICKS_PER_SEC / 1000)
 
 /**
  * Idle operating system task, runs when no other tasks are running.

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -114,6 +114,15 @@ syscfg.defs:
             on error detection.  Enabling this setting increases stack usage.
         value: 0
 
+    OS_IDLE_TICKLESS_MS_MIN:
+        description: >
+            Minimum duration of tickless idle period in miliseconds.
+        value: 100
+    OS_IDLE_TICKLESS_MS_MAX:
+        description: >
+            Maximum duration of tickless idle period in miliseconds.
+        value: 600000
+
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1
     OS_CTX_SW_STACK_CHECK: 1


### PR DESCRIPTION
Not really sure why this was hardcoded, but these values were never changed.
This should be configurable, just not sure where. I think syscfg gives us flexibility here since it can be adjusted anywhere easily, also for testing. But also it could make sense to have dedicated defines in either `mcu/mcu.h` or `bsp/bsp.h` with values which will be used in `os.c` with fallback to default values if these are not provided. In such case I think BSP makes more sense since it's easier to override if someone creates own product with own BSP.