### PR TITLE
hw: Move tickless idle period override from MCU to BSP

### DIFF
--- a/hw/bsp/native-mips/syscfg.yml
+++ b/hw/bsp/native-mips/syscfg.yml
@@ -23,6 +23,7 @@ syscfg.defs:
         value: 1
 
 syscfg.vals:
+    OS_IDLE_TICKLESS_MS_MIN: 1
     # Sim isn't flash constrained, so include filename, line number, and
     # message in asserts and sysinit panic messages.
     BASELIBC_ASSERT_FILE_LINE: 1

--- a/hw/bsp/native/syscfg.yml
+++ b/hw/bsp/native/syscfg.yml
@@ -23,6 +23,7 @@ syscfg.defs:
         value: 1
 
 syscfg.vals:
+    OS_IDLE_TICKLESS_MS_MIN: 1
     # Sim isn't flash constrained, so include filename, line number, and
     # message in asserts and sysinit panic messages.
     BASELIBC_ASSERT_FILE_LINE: 1

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -68,6 +68,3 @@ syscfg.defs:
         description: 'Priority of native UART poller task.'
         type: task_priority
         value: 0
-
-syscfg.vals:
-    OS_IDLE_TICKLESS_MS_MIN: 1


### PR DESCRIPTION
Settings from kernel/os cannot be overriden in MCU since both packages
have the same priority - but BSP is also good place to override it.

Priority violations detected (Packages can only override settings \
	defined by packages of lower priority):
    Package: @apache-mynewt-core/hw/mcu/native overriding setting: \
	OS_IDLE_TICKLESS_MS_MIN defined by @apache-mynewt-core/kernel/os