### PR TITLE
kernel/os: Add some idle task stack for SystemView

### DIFF
--- a/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
@@ -47,7 +47,11 @@ typedef uint32_t os_stack_t;
  * Stack sizes for common OS tasks
  */
 #define OS_SANITY_STACK_SIZE (64)
+#if MYNEWT_VAL(OS_SYSVIEW)
+#define OS_IDLE_STACK_SIZE (80)
+#else
 #define OS_IDLE_STACK_SIZE (64)
+#endif
 
 #define OS_STACK_ALIGN(__nmemb) \
     (OS_ALIGN((__nmemb), OS_STACK_ALIGNMENT))

--- a/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
@@ -48,7 +48,11 @@ typedef uint32_t os_stack_t;
  * Stack sizes for common OS tasks
  */
 #define OS_SANITY_STACK_SIZE (64)
+#if MYNEWT_VAL(OS_SYSVIEW)
+#define OS_IDLE_STACK_SIZE (80)
+#else
 #define OS_IDLE_STACK_SIZE (64)
+#endif
 
 #define OS_STACK_ALIGN(__nmemb) \
     (OS_ALIGN((__nmemb), OS_STACK_ALIGNMENT))

--- a/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -48,7 +48,11 @@ typedef uint32_t os_stack_t;
  * Stack sizes for common OS tasks
  */
 #define OS_SANITY_STACK_SIZE (64)
+#if MYNEWT_VAL(OS_SYSVIEW)
+#define OS_IDLE_STACK_SIZE (80)
+#else
 #define OS_IDLE_STACK_SIZE (64)
+#endif
 
 #define OS_STACK_ALIGN(__nmemb) \
     (OS_ALIGN((__nmemb), OS_STACK_ALIGNMENT))

--- a/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
@@ -48,7 +48,11 @@ typedef uint32_t os_stack_t;
  * Stack sizes for common OS tasks
  */
 #define OS_SANITY_STACK_SIZE (64)
+#if MYNEWT_VAL(OS_SYSVIEW)
+#define OS_IDLE_STACK_SIZE (80)
+#else
 #define OS_IDLE_STACK_SIZE (64)
+#endif
 
 #define OS_STACK_ALIGN(__nmemb) \
     (OS_ALIGN((__nmemb), OS_STACK_ALIGNMENT))


### PR DESCRIPTION
If SystemView is enabled, we need a bit more stack for idle task since
replying on SystemView requests which can happen in idle task may
overflow current stack.

Max idle stack usage with SystemView was observed as 78, so 80 should be
enough.