### PR TITLE
bootutil; fix crash when image slot1 contains data which bootutil

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -377,7 +377,6 @@ boot_swap_type(void)
         }
     }
 
-    assert(0);
     return BOOT_SWAP_TYPE_NONE;
 }
 


### PR DESCRIPTION
does not understand.