### PR TITLE
[DO NOT MERGE] I2C retries - HAL

### DIFF
--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -133,6 +133,7 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
     struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
     i2c.len = 1;
     i2c.buffer = &reg;
 
@@ -167,6 +168,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
     struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
     i2c.len = 1;
     i2c.buffer = &reg;
 
@@ -208,6 +210,7 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
     buf[1] = val;
 
     i2c.address = dev->bq27_itf.itf_num;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
     i2c.len     = 2;
     i2c.buffer  = buf;
 
@@ -238,6 +241,7 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
     buf[2] = (uint8_t)(val >> 8);
 
     i2c.address = dev->bq27_itf.itf_num;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
     i2c.len     = 3;
     i2c.buffer  = buf;
 
@@ -284,8 +288,9 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
         memcpy(&tmpbuf[3], buf, len);
     }
 
-    i2c.len = len + 3;
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
+    i2c.len = len + 3;
     i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
@@ -323,8 +328,9 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     tmpbuf[1] = (uint8_t)cmd;
     tmpbuf[2] = (uint8_t)(cmd >> 8);
 
-    i2c.len = 3;
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
+    i2c.len = 3;
     i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
@@ -426,8 +432,9 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     tmpbuf[1] = (uint8_t)addr;
     tmpbuf[2] = (uint8_t)(addr >> 8);
 
-    i2c.len = 3;
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
+    i2c.len = 3;
     i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
@@ -507,8 +514,9 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     tmpbuf[2] = (uint8_t)(addr >> 8);
     memcpy(&tmpbuf[3], buf, buflen);
 
-    i2c.len = buflen + 3;
     i2c.address = dev->bq27_itf.itf_addr;
+    i2c.retries = MYNEWT_VAL(BQ27Z561_I2C_RETRIES);
+    i2c.len = buflen + 3;
     i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -36,3 +36,8 @@ syscfg.defs:
     BQ27Z561_ITF_LOCK_TMO:
         description: 'BQ27Z561 interface lock timeout in milliseconds'
         value: 1000
+    BQ27Z561_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the BQ27Z561 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
+++ b/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
@@ -57,10 +57,9 @@ static const struct adp5061_config default_config = {
     .iend = 0x01,
 };
 
-
 #if MYNEWT_VAL(ADP5061_INT_PIN) >= 0
 /**
-* ADP5061 interrupt hanlder CB
+* ADP5061 interrupt handler CB
 * gets interrupt status and prints to console
 */
 
@@ -81,7 +80,7 @@ adp5061_event(struct os_event *ev)
 /**
 * ADP5061 interrupt handler structure
 */
-static struct os_event interrup_handler = {
+static struct os_event interrupt_handler = {
     .ev_cb = adp5061_event,
 };
 
@@ -91,7 +90,7 @@ static struct os_event interrup_handler = {
 */
 static void
 adp5061_isr(void *arg){
-    os_eventq_put(os_eventq_dflt_get(), &interrup_handler);
+    os_eventq_put(os_eventq_dflt_get(), &interrupt_handler);
 }
 #endif
 
@@ -194,6 +193,7 @@ adp5061_get_reg(struct adp5061_dev *dev, uint8_t addr, uint8_t *value)
     uint8_t payload;
     struct hal_i2c_master_data data_struct = {
         .address = dev->a_chg_ctrl.cc_itf.cci_addr,
+        .retries = MYNEWT_VAL(ADP5061_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -230,6 +230,7 @@ adp5061_set_reg(struct adp5061_dev *dev, uint8_t addr, uint8_t value)
     uint8_t payload[2] = { addr, value };
     struct hal_i2c_master_data data_struct = {
         .address = dev->a_chg_ctrl.cc_itf.cci_addr,
+        .retries = MYNEWT_VAL(ADP5061_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -256,6 +257,7 @@ adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
     uint8_t payload[1 + count];
     struct hal_i2c_master_data data_struct = {
         .address = dev->a_chg_ctrl.cc_itf.cci_addr,
+        .retries = MYNEWT_VAL(ADP5061_I2C_RETRIES),
         .len = count + 1,
         .buffer = payload
     };

--- a/hw/drivers/chg_ctrl/adp5061/syscfg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/syscfg.yml
@@ -27,3 +27,8 @@ syscfg.defs:
     ADP5061_INT_PIN:
         description: 'ADP5061 interrupt pin'
         value: -1
+    ADP5061_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the ADP5061 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/drv2605/src/drv2605.c
+++ b/hw/drivers/drv2605/src/drv2605.c
@@ -75,6 +75,7 @@ drv2605_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(DRV2605_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -118,6 +119,7 @@ drv2605_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(DRV2605_I2C_RETRIES),
         .len = len + 1,
         .buffer = payload
     };
@@ -167,6 +169,7 @@ drv2605_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(DRV2605_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -229,6 +232,7 @@ drv2605_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(DRV2605_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/drv2605/syscfg.yml
+++ b/hw/drivers/drv2605/syscfg.yml
@@ -71,3 +71,8 @@ syscfg.defs:
     DRV2605_CALIBRATED_BEMF_GAIN:
         description: 'Previously Computed Auto-Calibration BEMF_GAIN Result for SEMCO1030'
         value: 1
+    DRV2605_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the DRV2605 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -57,6 +57,7 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->li_addr,
+        .retries = MYNEWT_VAL(LP5523_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -71,8 +72,9 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     if (rc) {
         LP5523_LOG(ERROR,
-                   "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
-                   itf->li_addr, addr, value);
+                   "Failed to write to 0x%02X:0x%02X with value 0x%02X "
+                   "(rc=%d)\n",
+                   itf->li_addr, addr, value, rc);
         STATS_INC(g_lp5523stats, read_errors);
     }
 
@@ -89,6 +91,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->li_addr,
+        .retries = MYNEWT_VAL(LP5523_I2C_RETRIES),
         .len = 1,
         .buffer = &addr
     };
@@ -135,6 +138,7 @@ lp5523_set_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->li_addr,
+        .retries = MYNEWT_VAL(LP5523_I2C_RETRIES),
         .len = len + 1,
         .buffer = regs
     };
@@ -172,6 +176,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->li_addr,
+        .retries = MYNEWT_VAL(LP5523_I2C_RETRIES),
         .len = 1,
         .buffer = &addr_b
     };

--- a/hw/drivers/led/lp5523/syscfg.yml
+++ b/hw/drivers/led/lp5523/syscfg.yml
@@ -39,3 +39,8 @@ syscfg.defs:
     LP5523_LOG_MODULE:
         description: 'Numeric module ID to use for LP5523 log messages'
         value: 105
+    LP5523_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LP5523 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -118,6 +118,7 @@ adxl345_i2c_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(ADXL345_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -151,6 +152,7 @@ adxl345_i2c_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(ADXL345_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };
@@ -196,6 +198,7 @@ adxl345_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(ADXL345_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/adxl345/syscfg.yml
+++ b/hw/drivers/sensors/adxl345/syscfg.yml
@@ -53,3 +53,8 @@ syscfg.defs:
     ADXL345_LOG_MODULE:
         description: 'Numeric module ID to use for ADXL345 log messages'
         value: 75
+    ADXL345_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the ADXL345 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -160,6 +160,7 @@ get_register(struct bma253 * bma253,
     }
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA253_I2C_RETRIES);
     oper.len     = 1;
     oper.buffer  = &addr;
 
@@ -171,6 +172,7 @@ get_register(struct bma253 * bma253,
     }
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA253_I2C_RETRIES);
     oper.len     = 1;
     oper.buffer  = data;
 
@@ -200,6 +202,7 @@ get_registers(struct bma253 * bma253,
     itf = SENSOR_GET_ITF(&bma253->sensor);
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA253_I2C_RETRIES);
     oper.len     = 1;
     oper.buffer  = &addr;
 
@@ -217,6 +220,7 @@ get_registers(struct bma253 * bma253,
     }
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA253_I2C_RETRIES);
     oper.len     = size;
     oper.buffer  = data;
 
@@ -254,6 +258,7 @@ set_register(struct bma253 * bma253,
     tuple[1] = data;
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA253_I2C_RETRIES);
     oper.len     = 2;
     oper.buffer  = tuple;
 

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -57,3 +57,8 @@ syscfg.defs:
     BMA253_ITF_LOCK_TMO:
         description: 'BMA253 interface lock timeout in milliseconds'
         value: 1000
+    BMA253_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the BMA253 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -264,6 +264,7 @@ i2c_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
     int rc;
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA2XX_I2C_RETRIES);
     oper.len     = 1;
     oper.buffer  = &addr;
 
@@ -275,6 +276,7 @@ i2c_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
     }
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA2XX_I2C_RETRIES);
     oper.len     = len;
     oper.buffer  = payload;
 
@@ -300,6 +302,7 @@ i2c_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t data)
     tuple[1] = data;
 
     oper.address = itf->si_addr;
+    oper.retries = MYNEWT_VAL(BMA2XX_I2C_RETRIES);
     oper.len     = 2;
     oper.buffer  = tuple;
 

--- a/hw/drivers/sensors/bma2xx/syscfg.yml
+++ b/hw/drivers/sensors/bma2xx/syscfg.yml
@@ -51,3 +51,8 @@ syscfg.defs:
     BMA2XX_ITF_LOCK_TMO:
         description: 'BMA2XX interface lock timeout in milliseconds'
         value: 1000
+    BMA2XX_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the BMA2XX sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -696,6 +696,7 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BMP280_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -804,6 +805,7 @@ bmp280_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BMP280_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -45,3 +45,8 @@ syscfg.defs:
     BMP280_LOG_MODULE:
         description: 'Numeric module ID to use for BMP280 log messages'
         value: 209
+    BMP280_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the BMP280 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -80,6 +80,7 @@ bno055_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BNO055_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -115,6 +116,7 @@ bno055_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BNO055_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -171,6 +173,7 @@ bno055_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BNO055_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -228,6 +231,7 @@ bno055_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(BNO055_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -36,3 +36,8 @@ syscfg.defs:
     BNO055_LOG_MODULE:
         description: 'Numeric module ID to use for BNO055 log messages'
         value: 85
+    BNO055_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the BNO055 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -103,6 +103,7 @@ lis2dh12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DH12_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -226,6 +227,7 @@ lis2dh12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DH12_I2C_RETRIES),
         .len = len + 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -24,3 +24,8 @@ syscfg.defs:
     LIS2DH12_LOG_MODULE:
         description: 'Numeric module ID to use for LIS2DH12 log messages'
         value: 110
+    LIS2DH12_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LIS2DH12 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -127,6 +127,7 @@ lis2ds12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DS12_I2C_RETRIES),
         .len = len + 1,
         .buffer = payload
     };
@@ -255,6 +256,7 @@ lis2ds12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DS12_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/lis2ds12/syscfg.yml
+++ b/hw/drivers/sensors/lis2ds12/syscfg.yml
@@ -47,3 +47,8 @@ syscfg.defs:
     LIS2DS12_LOG_MODULE:
         description: 'Numeric module ID to use for LIS2DS12 log messages'
         value: 212
+    LIS2DS12_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LIS2DS12 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -194,6 +194,7 @@ lis2dw12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DW12_I2C_RETRIES),
         .len = len + 1,
         .buffer = payload
     };
@@ -331,6 +332,7 @@ lis2dw12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LIS2DW12_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -50,3 +50,8 @@ syscfg.defs:
     LIS2DW12_LOG_MODULE:
         description: 'Numeric module ID to use for LIS2DW12 log messages'
         value: 213
+    LIS2DW12_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LIS2DW12 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -171,6 +171,7 @@ lps33hw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LPS33HW_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -341,6 +342,7 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LPS33HW_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -38,3 +38,8 @@ syscfg.defs:
     LPS33HW_LOG_MODULE:
         description: 'Numeric module ID to use for LPS33HW log messages'
         value: 133
+    LPS33HW_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LPS33HW sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -171,6 +171,7 @@ lps33thw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LPS33THW_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -341,6 +342,7 @@ lps33thw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(LPS33THW_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/lps33thw/syscfg.yml
+++ b/hw/drivers/sensors/lps33thw/syscfg.yml
@@ -38,3 +38,8 @@ syscfg.defs:
     LPS33THW_LOG_MODULE:
         description: 'Numeric module ID to use for LPS33THW log messages'
         value: 233
+    LPS33THW_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LPS33THW sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -99,6 +99,7 @@ lsm303dlhc_write8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
 
     struct hal_i2c_master_data data_struct = {
         .address = addr,
+        .retries = MYNEWT_VAL(LSM303DLHC_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -141,6 +142,7 @@ lsm303dlhc_read8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
 
     struct hal_i2c_master_data data_struct = {
         .address = addr,
+        .retries = MYNEWT_VAL(LSM303DLHC_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -196,6 +198,7 @@ lsm303dlhc_read48(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
 
     struct hal_i2c_master_data data_struct = {
         .address = addr,
+        .retries = MYNEWT_VAL(LSM303DLHC_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/lsm303dlhc/syscfg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/syscfg.yml
@@ -23,3 +23,8 @@ syscfg.defs:
     LSM303DLHC_LOG_MODULE:
         description: 'Numeric module ID to use for LSM303DLHC log messages'
         value: 195
+    LSM303DLHC_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the LSM303DLHC sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/mpu6050/src/mpu6050.c
+++ b/hw/drivers/sensors/mpu6050/src/mpu6050.c
@@ -78,6 +78,7 @@ mpu6050_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MPU6050_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -118,6 +119,7 @@ mpu6050_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MPU6050_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };
@@ -169,6 +171,7 @@ mpu6050_read48(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MPU6050_I2C_RETRIES),
         .len = 1,
         .buffer = &reg
     };

--- a/hw/drivers/sensors/mpu6050/syscfg.yml
+++ b/hw/drivers/sensors/mpu6050/syscfg.yml
@@ -23,3 +23,8 @@ syscfg.defs:
     MPU6050_LOG_MODULE:
         description: 'Numeric module ID to use for MPU6050 log messages'
         value: 115
+    MPU6050_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the MPU6050 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -325,6 +325,7 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MS5837_I2C_RETRIES),
         .len = 1,
         .buffer = &addr
     };
@@ -366,6 +367,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MS5837_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/ms5837/syscfg.yml
+++ b/hw/drivers/sensors/ms5837/syscfg.yml
@@ -23,3 +23,8 @@ syscfg.defs:
     MS5837_LOG_MODULE:
         description: 'Numeric module ID to use for MS5837 log messages'
         value: 140
+    MS5837_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the MS5837 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -326,6 +326,7 @@ ms5840_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MS5840_I2C_RETRIES),
         .len = 1,
         .buffer = &addr
     };
@@ -368,6 +369,7 @@ ms5840_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(MS5840_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/ms5840/syscfg.yml
+++ b/hw/drivers/sensors/ms5840/syscfg.yml
@@ -23,3 +23,8 @@ syscfg.defs:
     MS5840_LOG_MODULE:
         description: 'Numeric module ID to use for MS5840 log messages'
         value: 170
+    MS5840_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the MS5840 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -89,6 +89,7 @@ tcs34725_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TCS34725_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -129,6 +130,7 @@ tcs34725_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TCS34725_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -181,6 +183,7 @@ tcs34725_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t l
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TCS34725_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -242,6 +245,7 @@ tcs34725_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t 
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TCS34725_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -973,6 +977,7 @@ tcs34725_clear_interrupt(struct sensor_itf *itf)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TCS34725_I2C_RETRIES),
         .len = 0,
         .buffer = &payload
     };

--- a/hw/drivers/sensors/tcs34725/syscfg.yml
+++ b/hw/drivers/sensors/tcs34725/syscfg.yml
@@ -36,3 +36,8 @@ syscfg.defs:
     TCS34725_LOG_MODULE:
         description: 'Numeric module ID to use for TCS34725 log messages'
         value: 254
+    TCS34725_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the TCS34725 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -86,6 +86,7 @@ tsl2561_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2561_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -117,6 +118,7 @@ tsl2561_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2561_I2C_RETRIES),
         .len = 3,
         .buffer = payload
     };
@@ -147,6 +149,7 @@ tsl2561_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2561_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -188,6 +191,7 @@ tsl2561_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2561_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };
@@ -548,6 +552,7 @@ tsl2561_clear_interrupt(struct sensor_itf *itf)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2561_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };

--- a/hw/drivers/sensors/tsl2561/syscfg.yml
+++ b/hw/drivers/sensors/tsl2561/syscfg.yml
@@ -39,3 +39,8 @@ syscfg.defs:
     TSL2561_LOG_MODULE:
         description: 'Numeric module ID to use for TSL2561 log messages'
         value: 107
+    TSL2561_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the TSL2561 sends an unexpected NACK.
+        value: 2

--- a/hw/drivers/sensors/tsl2591/src/tsl2591.c
+++ b/hw/drivers/sensors/tsl2591/src/tsl2591.c
@@ -79,6 +79,7 @@ tsl2591_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2591_I2C_RETRIES),
         .len = 2,
         .buffer = payload
     };
@@ -110,6 +111,7 @@ tsl2591_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2591_I2C_RETRIES),
         .len = 3,
         .buffer = payload
     };
@@ -141,6 +143,7 @@ tsl2591_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2591_I2C_RETRIES),
         .len = 1,
         .buffer = &payload
     };
@@ -184,6 +187,7 @@ tsl2591_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
 
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
+        .retries = MYNEWT_VAL(TSL2591_I2C_RETRIES),
         .len = 1,
         .buffer = payload
     };

--- a/hw/drivers/sensors/tsl2591/syscfg.yml
+++ b/hw/drivers/sensors/tsl2591/syscfg.yml
@@ -42,3 +42,8 @@ syscfg.defs:
     TSL2591_LOG_MODULE:
         description: 'Numeric module ID to use for TSL2591 log messages'
         value: 108
+    TSL2591_I2C_RETRIES:
+        description: >
+            Number of retries to use for failed I2C communication.  A retry is
+            used when the TSL2591 sends an unexpected NACK.
+        value: 2

--- a/hw/hal/include/hal/hal_i2c.h
+++ b/hw/hal/include/hal/hal_i2c.h
@@ -94,8 +94,13 @@ struct hal_i2c_master_data {
      * writing a 0x81 in its protocol, you would pass
      * only the top 7-bits to this function as 0x40
      */
-    uint8_t  address
-    /** Number of buffer bytes to transmit or receive */;
+    uint8_t  address;
+    /**
+     * Total number of times to attempt the I2C operation.  A retry is
+     * attempted when an unexpected NACK is received.
+     */
+    uint8_t  retries;
+    /** Number of buffer bytes to transmit or receive */
     uint16_t len;
     /** Buffer space to hold the transmit or receive */
     uint8_t *buffer;
@@ -146,7 +151,7 @@ int hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
  * @return 0 on success, and non-zero error code on failure
  */
 int hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                         uint32_t timeout, uint8_t last_op);
+                        uint32_t timeout, uint8_t last_op);
 
 /**
  * Probes the i2c bus for a device with this address.  THIS API

--- a/hw/hal/include/hal/hal_i2c.h
+++ b/hw/hal/include/hal/hal_i2c.h
@@ -62,6 +62,23 @@ extern "C" {
  *      :c:func:`hal_i2c_read()`; --- read back data, setting 'last_op' to '1'
  */
 
+/*** I2C status codes (0=success). */
+
+/** Unknown error. */
+#define HAL_I2C_ERR_UNKNOWN             1
+
+/** Invalid argument. */
+#define HAL_I2C_ERR_INVAL               2
+
+/** MCU failed to report result of I2C operation. */
+#define HAL_I2C_ERR_TIMEOUT             3
+
+/** Slave responded to address with NACK. */
+#define HAL_I2C_ERR_ADDR_NACK           4
+
+/** Slave responded to data byte with NACK. */
+#define HAL_I2C_ERR_DATA_NACK           5
+
 /**
  * When sending a packet, use this structure to pass the arguments.
  */

--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -25,6 +25,7 @@
 #include <hal/hal_i2c.h>
 #include <hal/hal_gpio.h>
 #include <mcu/nrf52_hal.h>
+#include "nrf_twim.h"
 
 #include <nrf.h>
 
@@ -46,17 +47,6 @@
       (GPIO_PIN_CNF_DIR_Output     << GPIO_PIN_CNF_DIR_Pos))
 #define NRF52_SDA_PIN_CONF_CLR    NRF52_SCL_PIN_CONF_CLR
 
-#define NRF52_HAL_I2C_RESOLVE(__n, __v)                      \
-    if ((__n) >= NRF52_HAL_I2C_MAX) {                        \
-        rc = EINVAL;                                         \
-        goto err;                                            \
-    }                                                        \
-    (__v) = (struct nrf52_hal_i2c *) nrf52_hal_i2cs[(__n)];  \
-    if ((__v) == NULL) {                                     \
-        rc = EINVAL;                                         \
-        goto err;                                            \
-    }
-
 struct nrf52_hal_i2c {
     NRF_TWI_Type *nhi_regs;
 };
@@ -72,7 +62,7 @@ struct nrf52_hal_i2c hal_twi_i2c1 = {
 };
 #endif
 
-static const struct nrf52_hal_i2c *nrf52_hal_i2cs[NRF52_HAL_I2C_MAX] = {
+static struct nrf52_hal_i2c *nrf52_hal_i2cs[NRF52_HAL_I2C_MAX] = {
 #if MYNEWT_VAL(I2C_0)
     &hal_twi_i2c0,
 #else
@@ -162,6 +152,39 @@ __ASM volatile (
     : "+r" (delay));
 }
 
+static int
+hal_i2c_resolve(uint8_t i2c_num, struct nrf52_hal_i2c **out_i2c)
+{
+    if (i2c_num >= NRF52_HAL_I2C_MAX) {
+        *out_i2c = NULL;
+        return HAL_I2C_ERR_INVAL;
+    }
+
+    *out_i2c = nrf52_hal_i2cs[i2c_num];
+    if (*out_i2c == NULL) {
+        return HAL_I2C_ERR_INVAL;
+    }
+
+    return 0;
+}
+
+/**
+ * Converts an nRF SDK I2C status to a HAL I2C error code.
+ */
+static int
+hal_i2c_convert_status(int nrf_status)
+{
+    if (nrf_status == 0) {
+        return 0;
+    } else if (nrf_status & NRF_TWIM_ERROR_DATA_NACK) {
+        return HAL_I2C_ERR_DATA_NACK;
+    } else if (nrf_status & NRF_TWIM_ERROR_ADDRESS_NACK) {
+        return HAL_I2C_ERR_ADDR_NACK;
+    } else {
+        return HAL_I2C_ERR_UNKNOWN;
+    }
+}
+
 /**
  * Reads the input buffer of the specified pin regardless
  * of if it is set as output or input
@@ -242,7 +265,10 @@ hal_i2c_init(uint8_t i2c_num, void *usercfg)
 
     assert(usercfg != NULL);
 
-    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+    rc = hal_i2c_resolve(i2c_num, &i2c);
+    if (rc != 0) {
+        goto err;
+    }
 
     cfg = (struct nrf52_hal_i2c_cfg *) usercfg;
     regs = i2c->nhi_regs;
@@ -258,7 +284,7 @@ hal_i2c_init(uint8_t i2c_num, void *usercfg)
         freq = TWI_FREQUENCY_FREQUENCY_K400;
         break;
     default:
-        rc = EINVAL;
+        rc = HAL_I2C_ERR_INVAL;
         goto err;
     }
 
@@ -281,23 +307,39 @@ err:
     return (rc);
 }
 
-int
-hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                     uint32_t timo, uint8_t last_op)
+/**
+ * Writes a single I2C message.
+ *
+ * @param i2c_num               The index of the I2C interface to use.
+ * @param pdata                 Additional parameters describing the write
+ *                                  operation.
+ * @param timo                  The time, in OS ticks, to wait for the MCU to
+ *                                  indicate completion of each clocked byte.
+ * @param last_op               1 if this is the final message in the
+ *                                  transaction.
+ *
+ * @return                      0 on success;
+ *                              HAL_I2C_ERR_[...] code on failure.
+ */
+static int
+hal_i2c_master_write_once(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                          uint32_t timo, uint8_t last_op)
 {
     struct nrf52_hal_i2c *i2c;
-    NRF_TWI_Type *regs = NULL;
-    int rc = -1;
+    NRF_TWI_Type *regs;
+    int nrf_status;
+    int rc;
     int i;
     uint32_t start;
-    int retry_once = 1;
 
-    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+    rc = hal_i2c_resolve(i2c_num, &i2c);
+    if (rc != 0) {
+        return rc;
+    }
     regs = i2c->nhi_regs;
 
     regs->ADDRESS = pdata->address;
 
-retry:
     regs->EVENTS_ERROR = 0;
     regs->EVENTS_STOPPED = 0;
     regs->EVENTS_SUSPENDED = 0;
@@ -312,20 +354,8 @@ retry:
         regs->TXD = pdata->buffer[i];
         while (!regs->EVENTS_TXDSENT && !regs->EVENTS_ERROR) {
             if (os_time_get() - start > timo) {
-                regs->TASKS_STOP = 1;
-                if (retry_once) {
-                   /* 
-                    * Some I2C slave peripherals cause a glitch on the bus when
-                    * they reset which puts the TWI in an unresponsive state.
-                    * Disabling and re-enabling the TWI returns it to normal operation.
-                    */
-                    retry_once = 0;
-                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
-                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
-                    goto retry;
-                } else {
-                    goto err;
-                }
+                rc = HAL_I2C_ERR_TIMEOUT;
+                goto err;
             }
         }
         if (regs->EVENTS_ERROR) {
@@ -338,6 +368,7 @@ retry:
         regs->TASKS_STOP = 1;
         while (!regs->EVENTS_STOPPED && !regs->EVENTS_ERROR) {
             if (os_time_get() - start > timo) {
+                rc = HAL_I2C_ERR_TIMEOUT;
                 goto err;
             }
         }
@@ -345,31 +376,79 @@ retry:
             goto err;
         }
     }
-    return (0);
+
+    rc = 0;
+
 err:
-    if (regs && regs->EVENTS_ERROR) {
-        rc = regs->ERRORSRC;
-        regs->TASKS_STOP = 1;
-        regs->ERRORSRC = rc;
+    regs->TASKS_STOP = 1;
+
+    if (regs->EVENTS_ERROR) {
+        nrf_status = regs->ERRORSRC;
+        regs->ERRORSRC = nrf_status;
+        rc = hal_i2c_convert_status(nrf_status);
+    } else if (rc == HAL_I2C_ERR_TIMEOUT) {
+       /* Some I2C slave peripherals cause a glitch on the bus when they
+        * reset which puts the TWI in an unresponsive state.  Disabling and
+        * re-enabling the TWI returns it to normal operation.
+        */
+        regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+        regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
     }
+
     return (rc);
 }
 
 int
-hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                    uint32_t timo, uint8_t last_op)
+hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                     uint32_t timo, uint8_t last_op)
+{
+    int rc;
+    int i;
+
+    /* Silence spurious `maybe-uninitialized` warning. */
+    rc = 0;
+
+    for (i = 0; i <= pdata->retries; i++) {
+        rc = hal_i2c_master_write_once(i2c_num, pdata, timo, last_op);
+        if (rc == 0) {
+            break;
+        }
+    }
+
+    return rc;
+}
+
+/**
+ * Reads a single I2C message.
+ *
+ * @param i2c_num               The index of the I2C interface to use.
+ * @param pdata                 Additional parameters describing the read
+ *                                  operation.
+ * @param timo                  The time, in OS ticks, to wait for the MCU to
+ *                                  indicate completion of each clocked byte.
+ * @param last_op               1 if this is the final message in the
+ *                                  transaction.
+ *
+ * @return                      0 on success;
+ *                              HAL_I2C_ERR_[...] code on failure.
+ */
+static int
+hal_i2c_master_read_once(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                         uint32_t timo, uint8_t last_op)
 {
     struct nrf52_hal_i2c *i2c;
-    NRF_TWI_Type *regs = NULL;
-    int rc = -1;
+    NRF_TWI_Type *regs;
+    int nrf_status;
+    int rc;
     int i;
     uint32_t start;
-    int retry_once = 1;
 
-    NRF52_HAL_I2C_RESOLVE(i2c_num, i2c);
+    rc = hal_i2c_resolve(i2c_num, &i2c);
+    if (rc != 0) {
+        return rc;
+    }
     regs = i2c->nhi_regs;
 
-retry:
     start = os_time_get();
 
     if (regs->EVENTS_RXDREADY) {
@@ -397,21 +476,8 @@ retry:
         regs->TASKS_RESUME = 1;
         while (!regs->EVENTS_RXDREADY && !regs->EVENTS_ERROR) {
             if (os_time_get() - start > timo) {
-                regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
-                regs->TASKS_STOP = 1;
-                if (retry_once) {
-                   /* 
-                    * Some I2C slave peripherals cause a glitch on the bus when
-                    * they reset which puts the TWI in an unresponsive state.
-                    * Disabling and re-enabling the TWI returns it to normal operation.
-                    */
-                    retry_once = 0;
-                    regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
-                    regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
-                    goto retry;
-                } else {
-                    goto err;
-                }
+                rc = HAL_I2C_ERR_TIMEOUT;
+                goto err;
             }
         }
         if (regs->EVENTS_ERROR) {
@@ -425,14 +491,47 @@ retry:
         }
         regs->EVENTS_RXDREADY = 0;
     }
+
     return (0);
+
 err:
-    if (regs && regs->EVENTS_ERROR) {
-        rc = regs->ERRORSRC;
-        regs->TASKS_STOP = 1;
-        regs->ERRORSRC = rc;
+    regs->TASKS_STOP = 1;
+    regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
+
+    if (regs->EVENTS_ERROR) {
+        nrf_status = regs->ERRORSRC;
+        regs->ERRORSRC = nrf_status;
+        rc = hal_i2c_convert_status(nrf_status);
+    } else if (rc == HAL_I2C_ERR_TIMEOUT) {
+       /* Some I2C slave peripherals cause a glitch on the bus when they
+        * reset which puts the TWI in an unresponsive state.  Disabling and
+        * re-enabling the TWI returns it to normal operation.
+        */
+        regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
+        regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
     }
+
     return (rc);
+}
+
+int
+hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                    uint32_t timo, uint8_t last_op)
+{
+    int rc;
+    int i;
+
+    /* Silence spurious `maybe-uninitialized` warning. */
+    rc = 0;
+
+    for (i = 0; i <= pdata->retries; i++) {
+        rc = hal_i2c_master_read_once(i2c_num, pdata, timo, last_op);
+        if (rc == 0) {
+            break;
+        }
+    }
+
+    return rc;
 }
 
 int


### PR DESCRIPTION
(dev list discussion: https://lists.apache.org/thread.html/bd2b854cbf7d6e0811fff33177c85fa1435dff7f1fb3c8baab6061e0@%3Cdev.mynewt.apache.org%3E)

This PR implements I2C retries at the "HAL level". This is an alternative to the "driver level" implementation here: #1375 

This PR contains the following changes:
1. Define a common set of error code for the I2C HAL.
2. Add a single member to the `hal_i2c_master_data` struct: `retries`.
3. Modify the nRFxxx HAL I2C implementation so that it retries up to `retries` times when an unexpected NACK is received.
4. Update the drivers in `apache-mynewt-core` to use I2C retries.

*Note:* The only HAL implementation modified by this PR is nRFxxx.  This PR does not break the other implementations, but they won't perform any retries until they are updated separately.