### PR TITLE
hw/sensor: Disable OIC sensor server by default

### DIFF
--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -25,7 +25,7 @@ syscfg.defs:
 
     SENSOR_OIC:
         description: 'Enable/Disable the OIC sensor server'
-        value: 1
+        value: 0
         restrictions:
             - OC_SERVER
 


### PR DESCRIPTION
It requires OIC support to be enabled so usually it needs to be anyway
manually disabled in app/target.