### PR TITLE
kernel/os: Registration of time-change listeners

### DIFF
--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -26,6 +26,9 @@ CTASSERT(sizeof(os_time_t) == 4);
 
 os_time_t g_os_time;
 
+static STAILQ_HEAD(, os_time_change_listener) os_time_change_listeners =
+    STAILQ_HEAD_INITIALIZER(os_time_change_listeners);
+
 /*
  * Time-of-day collateral.
  */
@@ -116,13 +119,125 @@ os_time_delay(os_time_t osticks)
     }
 }
 
+/**
+ * Searches the list of registered time change listeners for the specified
+ * entry.
+ *
+ * @param listener              The listener to find.
+ * @param out_prev              On success, the specified listener's
+ *                                  predecessor gets written here.  Pass NULL
+ *                                  if you do not require this information.
+ *
+ * @return                      0 if the specified listener was found;
+ *                              SYS_ENOENT if the listener is not present.
+ */
+static int
+os_time_change_listener_find(const struct os_time_change_listener *listener,
+                             struct os_time_change_listener **out_prev)
+{
+    struct os_time_change_listener *prev;
+    struct os_time_change_listener *cur;
+
+    prev = NULL;
+    STAILQ_FOREACH(cur, &os_time_change_listeners, tcl_next) {
+        if (cur == listener) {
+            break;
+        }
+
+        prev = cur;
+    }
+
+    if (cur == NULL) {
+        return SYS_ENOENT;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+
+    return 0;
+}
+
+void
+os_time_change_listen(struct os_time_change_listener *listener)
+{
+#if MYNEWT_VAL(OS_TIME_DEBUG)
+    assert(listener->tcl_fn != NULL);
+    assert(os_time_change_listener_find(listener, NULL) == SYS_ENOENT);
+#endif
+
+    STAILQ_INSERT_TAIL(&os_time_change_listeners, listener, tcl_next);
+}
+
+int
+os_time_change_remove(const struct os_time_change_listener *listener)
+{
+    struct os_time_change_listener *prev;
+    int rc;
+
+    rc = os_time_change_listener_find(listener, &prev);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (prev == NULL) {
+        STAILQ_REMOVE_HEAD(&os_time_change_listeners, tcl_next);
+    } else {
+        STAILQ_NEXT(prev, tcl_next) = STAILQ_NEXT(listener, tcl_next);
+    }
+
+    return 0;
+}
+
+static void
+os_time_change_notify(const struct os_time_change_info *info)
+{
+    struct os_time_change_listener *listener;
+
+    STAILQ_FOREACH(listener, &os_time_change_listeners, tcl_next) {
+        listener->tcl_fn(info, listener->tcl_arg);
+    }
+}
+
+static int
+os_time_populate_info(struct os_time_change_info *info,
+                      const struct os_timeval *new_tv,
+                      const struct os_timezone *new_tz)
+{
+    if (new_tv == NULL && new_tz == NULL) {
+        return SYS_EINVAL;
+    }
+
+    if (new_tv == NULL) {
+        new_tv = &basetod.utctime;
+    }
+    if (new_tz == NULL) {
+        new_tz = &basetod.timezone;
+    }
+
+    info->tci_prev_tv = &basetod.utctime;
+    info->tci_cur_tv = new_tv;
+    info->tci_prev_tz = &basetod.timezone;
+    info->tci_cur_tz = new_tz;
+    info->tci_newly_synced = !os_time_is_set();
+
+    return 0;
+}
+
 int
 os_settimeofday(struct os_timeval *utctime, struct os_timezone *tz)
 {
     os_sr_t sr;
     os_time_t delta;
+    struct os_time_change_info info;
+    bool notify;
+    int rc;
 
     OS_ENTER_CRITICAL(sr);
+
+    rc = os_time_populate_info(&info, utctime, tz);
+    notify = rc == 0;
+
     if (utctime != NULL) {
         /*
          * Update all time-of-day base values.
@@ -136,7 +251,13 @@ os_settimeofday(struct os_timeval *utctime, struct os_timezone *tz)
     if (tz != NULL) {
         basetod.timezone = *tz;
     }
+
     OS_EXIT_CRITICAL(sr);
+
+    /* Notify all listeners of time change. */
+    if (notify) {
+        os_time_change_notify(&info);
+    }
 
     return (0);
 }
@@ -159,6 +280,12 @@ os_gettimeofday(struct os_timeval *tv, struct os_timezone *tz)
     OS_EXIT_CRITICAL(sr);
 
     return (0);
+}
+
+bool
+os_time_is_set(void)
+{
+    return basetod.utctime.tv_sec > 0;
 }
 
 void

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -129,9 +129,14 @@ syscfg.defs:
         description: >
             Maximum duration of tickless idle period in miliseconds.
         value: 600000
+    OS_TIME_DEBUG:
+        description: >
+            Enables debug runtime checks for time-related functionality.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1
     OS_CTX_SW_STACK_CHECK: 1
     OS_MEMPOOL_CHECK: 1
     OS_MEMPOOL_POISON: 1
+    OS_TIME_DEBUG: 1

--- a/kernel/os/test/src/os_test.c
+++ b/kernel/os/test/src/os_test.c
@@ -70,6 +70,7 @@ os_test_all(void)
     os_mbuf_test_suite();
     os_eventq_test_suite();
     os_callout_test_suite();
+    os_time_test_suite();
 
     return tu_case_failed;
 }

--- a/kernel/os/test/src/os_test_priv.h
+++ b/kernel/os/test/src/os_test_priv.h
@@ -22,6 +22,7 @@
 
 #include "os/mynewt.h"
 #include "testutil/testutil.h"
+#include "os_test/os_test.h"
 #include "os_test_priv.h"
 
 #include "callout_test.h"

--- a/kernel/os/test/src/testcases/os_time_test_change.c
+++ b/kernel/os/test/src/testcases/os_time_test_change.c
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os_test_priv.h"
+
+#define OTTC_MAX_ENTRIES    16
+
+struct ottc_entry {
+    struct os_timeval prev_tv;
+    struct os_timeval cur_tv;
+    struct os_timezone prev_tz;
+    struct os_timezone cur_tz;
+    bool newly_synced;
+    void *arg;
+};
+
+/** Holds records of listener callback calls. */
+static struct ottc_entry ottc_entries[OTTC_MAX_ENTRIES];
+static int ottc_num_entries;
+
+static void
+ottc_time_change_cb(const struct os_time_change_info *info, void *arg)
+{
+    struct ottc_entry *entry;
+
+    TEST_ASSERT_FATAL(ottc_num_entries < OTTC_MAX_ENTRIES);
+    entry = &ottc_entries[ottc_num_entries++];
+
+    entry->prev_tv = *info->tci_prev_tv;
+    entry->cur_tv = *info->tci_cur_tv;
+    entry->prev_tz = *info->tci_prev_tz;
+    entry->cur_tz = *info->tci_cur_tz;
+    entry->newly_synced = info->tci_newly_synced;
+    entry->arg = arg;
+}
+
+TEST_CASE(os_time_test_change)
+{
+    struct os_timezone tz1;
+    struct os_timezone tz2;
+    struct os_timeval tv1;
+    struct os_timeval tv2;
+    int rc;
+    int i;
+
+    struct os_time_change_listener listeners[3] = {
+        [0] = {
+            .tcl_fn = ottc_time_change_cb,
+            .tcl_arg = (void *)(uintptr_t)0,
+        },
+        [1] = {
+            .tcl_fn = ottc_time_change_cb,
+            .tcl_arg = (void *)(uintptr_t)1,
+        },
+        [2] = {
+            .tcl_fn = ottc_time_change_cb,
+            .tcl_arg = (void *)(uintptr_t)2,
+        },
+    };
+
+    /* Register one listener. */
+    os_time_change_listen(&listeners[0]);
+
+    /* Set time; ensure single listener called. */
+    tv1.tv_sec = 123;
+    tv1.tv_usec = 456;
+    tz1.tz_minuteswest = 555;
+    tz1.tz_dsttime = 666;
+
+    rc = os_settimeofday(&tv1, &tz1);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    TEST_ASSERT_FATAL(ottc_num_entries == 1);
+    TEST_ASSERT(memcmp(&ottc_entries[0].cur_tv, &tv1, sizeof tv1) == 0);
+    TEST_ASSERT(memcmp(&ottc_entries[0].cur_tz, &tz1, sizeof tz1) == 0);
+    TEST_ASSERT(ottc_entries[0].newly_synced);
+    TEST_ASSERT(ottc_entries[0].arg == (void *)(uintptr_t)0);
+
+    /* Register two more listeners. */
+    os_time_change_listen(&listeners[1]);
+    os_time_change_listen(&listeners[2]);
+
+    /* Set time; ensure all three listeners called. */
+    tv2.tv_sec = 234;
+    tv2.tv_usec = 567;
+    tz2.tz_minuteswest = 777;
+    tz2.tz_dsttime = 888;
+
+    rc = os_settimeofday(&tv2, &tz2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    TEST_ASSERT_FATAL(ottc_num_entries == 4);
+    for (i = 1; i < 4; i++) {
+        TEST_ASSERT(memcmp(&ottc_entries[i].cur_tv, &tv2, sizeof tv2) == 0);
+        TEST_ASSERT(memcmp(&ottc_entries[i].cur_tz, &tz2, sizeof tz2) == 0);
+        TEST_ASSERT(memcmp(&ottc_entries[i].prev_tv, &tv2, sizeof tv2) == 0);
+        TEST_ASSERT(memcmp(&ottc_entries[i].prev_tz, &tz2, sizeof tz2) == 0);
+        TEST_ASSERT(!ottc_entries[i].newly_synced);
+        TEST_ASSERT(ottc_entries[i].arg == (void *)(uintptr_t)(i - 1));
+    }
+
+    /* Remove all three listeners. */
+    for (i = 0; i < 3; i++) {
+        rc = os_time_change_remove(&listeners[i]);
+        TEST_ASSERT(rc == 0);
+    }
+
+    /* Set time; ensure no listeners called. */
+    tv2.tv_sec = 345;
+    tv2.tv_usec = 678;
+    tz2.tz_minuteswest = 888;
+    tz2.tz_dsttime = 999;
+
+    rc = os_settimeofday(&tv2, &tz2);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    TEST_ASSERT_FATAL(ottc_num_entries == 4);
+}

--- a/kernel/os/test/src/time_test.c
+++ b/kernel/os/test/src/time_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -17,26 +17,11 @@
  * under the License.
  */
 
-#ifndef H_OS_TEST_
-#define H_OS_TEST_
+#include <string.h>
+#include "os/mynewt.h"
+#include "os_test_priv.h"
 
-#include "testutil/testutil.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-TEST_SUITE_DECL(os_mutex_test_suite);
-TEST_SUITE_DECL(os_sem_test_suite);
-TEST_SUITE_DECL(os_mempool_test_suite);
-
-TEST_SUITE_DECL(os_time_test_suite);
-TEST_CASE_DECL(os_time_test_change);
-
-int os_test_all(void);
-
-#ifdef __cplusplus
+TEST_SUITE(os_time_test_suite)
+{
+    os_time_test_change();
 }
-#endif
-
-#endif

--- a/kernel/os/test/syscfg.yml
+++ b/kernel/os/test/syscfg.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    OS_TIME_DEBUG: 1


### PR DESCRIPTION
This PR enables the registration of time-change listeners.  When the time is set via a call to `os_settimeofday()`, all registered listeners are notified.  The following information gets passed to each listener:

```
struct os_time_change_info {
    /** UTC time prior to change. */
    const struct os_timeval *tci_prev_tv;
    /** Time zone prior to change. */
    const struct os_timezone *tci_prev_tz;
    /** UTC time after change. */
    const struct os_timeval *tci_cur_tv;
    /** Time zone after change. */
    const struct os_timezone *tci_cur_tz;
    /** True if the time was not set prior to change. */
    bool tci_newly_synced;
};
```

plus an optional listener-specific `void *arg`.

As indicated in the doxygen comments, the listener registration and removal functions are not thread safe.  In the typical case, I expect listeners to get added at startup and never removed, so I didn't think adding thread-safety was justified.