### PR TITLE
compiler/gdbmacros; mbuf_pool struct was updated. Reflect it here.

### DIFF
--- a/compiler/gdbmacros/mbuf.gdb
+++ b/compiler/gdbmacros/mbuf.gdb
@@ -163,7 +163,7 @@ define mn_mbuf_pool_print
     set $pool = ($arg0)
     set $om = (struct os_mbuf *)$pool->omp_pool.mp_membuf_addr
     set $elem_size = $pool->omp_databuf_len + sizeof (struct os_mbuf)
-    set $end = (uint8_t *)$om + $pool->omp_mbuf_count * $elem_size
+    set $end = (uint8_t *)$om + $pool->omp_pool.mp_num_blocks * $elem_size
 
     while $om < $end
         printf "Mbuf addr: %p\n", $om

--- a/compiler/gdbmacros/os.gdb
+++ b/compiler/gdbmacros/os.gdb
@@ -38,6 +38,7 @@ Displays os tasks
 end
 
 define os_callouts
+	set $c = g_callout_list.tqh_first
 	printf "Callouts:\n"
 	printf " %8s %10s %10s\n", "tick", "callout", "func"
 	while $c != 0
@@ -61,7 +62,6 @@ define os_sleep_list
 end
 
 define os_wakeups
-	set $c = g_callout_list.tqh_first
 	printf " Now is %d\n", g_os_time
 	os_callouts
 	os_sleep_list


### PR DESCRIPTION
It was not possible to call os_callouts directly, had to call os_wakeups
instead.