### PR TITLE
Make lp5523 reset optional

### DIFF
--- a/hw/drivers/led/lp5523/include/lp5523/lp5523.h
+++ b/hw/drivers/led/lp5523/include/lp5523/lp5523.h
@@ -101,7 +101,8 @@ struct lp5523_cfg {
     uint8_t timer:2;
     /* Force_1x enbale */
     uint8_t force_1x:1;
-
+    /* Optional reset */
+    bool prereset;
     /* All per LED configs go here - 0: D1 8: D9 */
     struct per_led_cfg per_led_cfg[MYNEWT_VAL(LP5523_LEDS_PER_DRIVER)];
 };

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -982,9 +982,11 @@ lp5523_config(struct led_itf *itf, struct lp5523_cfg *cfg)
 
     itf->li_addr = LP5523_I2C_BASE_ADDR + cfg->asel;
 
-    rc = lp5523_reset(itf);
-    if (rc) {
-        return rc;
+    if (cfg->prereset) {
+        rc = lp5523_reset(itf);
+        if (rc) {
+            goto err;
+        }
     }
 
     /* chip enable */


### PR DESCRIPTION
The lp5523 should not always be reset before configuration registers are written. This adds a prereset field to the configuration block to select whether or not the reset is performed.