### PR TITLE
fcb: Fix read of the last entry

### DIFF
--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -113,6 +113,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
     append_loc->fe_data_off = active->fe_elem_off + cnt;
 
     active->fe_elem_off = append_loc->fe_data_off + len;
+    active->fe_data_off = append_loc->fe_data_off;
 
     os_mutex_release(&fcb->f_mtx);
 


### PR DESCRIPTION
When log_walk function is called with lo_ts = -1 (read last entry)
return value is only valid before first write. It correctly reports
logs that were stored in FCB before system started.
This happens because f_active->fe_data_off is not updated during
writes and it is used for read.

This change updated fe_data_off during writes along fe_element_off.