### PR TITLE
bugfix/c++ global constructor

### DIFF
--- a/libc/baselibc/src/start.c
+++ b/libc/baselibc/src/start.c
@@ -39,6 +39,6 @@ void _start(void)
 }
 
 void
-__libc_init_array(void)
+_init(void)
 {
 }


### PR DESCRIPTION
By overwriting `__libc_init_array` the C++ constructors of global variables are not being called, leaving those unitialized.

This patch leaves the compiler generated version of `__libc_init_array` in place which properly calls all constructors of global variables and implements `_init` instead.