### PR TITLE
RTT console fixes

### DIFF
--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -35,20 +35,25 @@ static const char CR = '\r';
 int
 console_out(int character)
 {
+    os_sr_t sr;
     char c = (char)character;
 
     if (g_silence_console) {
         return c;
     }
 
+    OS_ENTER_CRITICAL(sr);
+
     if ('\n' == c) {
-        SEGGER_RTT_WriteWithOverwriteNoLock(0, &CR, 1);
+        SEGGER_RTT_WriteNoLock(0, &CR, 1);
         console_is_midline = 0;
     } else {
         console_is_midline = 1;
     }
 
-    SEGGER_RTT_WriteWithOverwriteNoLock(0, &c, 1);
+    SEGGER_RTT_WriteNoLock(0, &c, 1);
+
+    OS_EXIT_CRITICAL(sr);
 
     return character;
 }

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -30,30 +30,94 @@
 static struct hal_timer rtt_timer;
 #endif
 
-static const char CR = '\r';
+#if MYNEWT_VAL(CONSOLE_RTT_RETRY_COUNT) > 0
+
+static void
+rtt_console_wait_for_retry(void)
+{
+    uint32_t ticks;
+
+    if (os_arch_in_isr()) {
+#if MYNEWT_VAL(CONSOLE_RTT_RETRY_IN_ISR)
+        os_cputime_delay_usecs(MYNEWT_VAL(CONSOLE_RTT_RETRY_DELAY_MS) * 1000);
+#endif
+    } else {
+        ticks = max(1, os_time_ms_to_ticks32(MYNEWT_VAL(CONSOLE_RTT_RETRY_DELAY_MS)));
+        os_time_delay(ticks);
+    }
+}
+
+static void
+rtt_console_write_ch(char c)
+{
+    static int rtt_console_retries_left = MYNEWT_VAL(CONSOLE_RTT_RETRY_COUNT);
+    os_sr_t sr;
+    int ret;
+
+    while (1) {
+        OS_ENTER_CRITICAL(sr);
+        ret = SEGGER_RTT_WriteNoLock(0, &c, 1);
+        OS_EXIT_CRITICAL(sr);
+
+        /*
+         * In case write failed we can wait a bit and retry to allow host pull
+         * some data from buffer. However, in case there is no host connected
+         * we should not spend time retrying over and over again so need to be
+         * smarter here:
+         * - each successful write resets retry counter to predefined value
+         * - each failed write will retry until success or retry counter drops
+         *   to zero
+         * This means that if we failed to write some character after number of
+         * retries (which means that most likely there is no host connected to
+         * read data), we stop retrying until successful write (which means that
+         * host is reading data).
+         */
+
+        if (ret) {
+            rtt_console_retries_left = MYNEWT_VAL(CONSOLE_RTT_RETRY_COUNT);
+            break;
+        }
+
+        if (!rtt_console_retries_left) {
+            break;
+        }
+
+        rtt_console_wait_for_retry();
+        rtt_console_retries_left--;
+    }
+}
+
+#else
+
+static void
+rtt_console_write_ch(char c)
+{
+    os_sr_t sr;
+
+    OS_ENTER_CRITICAL(sr);
+    SEGGER_RTT_WriteNoLock(0, &c, 1);
+    OS_EXIT_CRITICAL(sr);
+}
+
+#endif
 
 int
 console_out(int character)
 {
-    os_sr_t sr;
     char c = (char)character;
 
     if (g_silence_console) {
         return c;
     }
 
-    OS_ENTER_CRITICAL(sr);
-
     if ('\n' == c) {
-        SEGGER_RTT_WriteNoLock(0, &CR, 1);
+        rtt_console_write_ch('\r');
         console_is_midline = 0;
     } else {
         console_is_midline = 1;
     }
 
-    SEGGER_RTT_WriteNoLock(0, &c, 1);
-
-    OS_EXIT_CRITICAL(sr);
+    rtt_console_write_ch(c);
 
     return character;
 }

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -72,6 +72,20 @@ syscfg.defs:
         description: 'Console UART device.'
         value: '"uart0"'
 
+    CONSOLE_RTT_RETRY_COUNT:
+        description: >
+            Number of retries to write data in case buffer is full. This allows
+            to wait for host to read data from buffer in case there's a lot of
+            data to write which do not fit in buffer.
+        value: 2
+    CONSOLE_RTT_RETRY_DELAY_MS:
+        description: >
+            Delay (in miliseconds) between each write retry.
+        value: 2
+    CONSOLE_RTT_RETRY_IN_ISR:
+        description: >
+            Set to non-zero to enable write retries also in ISR.
+        value: 0
     CONSOLE_RTT_INPUT_POLL_INTERVAL_MAX:
         description: >
             Maximum interval (milliseconds) to poll for RTT input.


### PR DESCRIPTION
This fixes 2 problems with RTT console:
1. output data may be corrupted
2. output data may be skipped when writing lots of data at once to RTT

1st problem is because we write data using function which can overwrite existing data in buffer - this should not be used when host is reading data since both sides may modify write pointer without sync (thus data corruption). To resolve this we use proper function which skips data instead of overwriting - this is safe.
2nd problem is because we can write data to RTT quickly, but host reads data by polling periodically thus it may not start reading data when we fill buffer. To solve this we will now wait a bit when buffer is full and retry which gives host some time to start reading data. Retry number and delay is configurable. Also we will not retry if detected that host is not reading data at all.