### PR TITLE
[DO NOT MERGE] - Fix BQ27Z561 and LP5523 I2C repeated-stop operations

### DIFF
--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -41,6 +41,9 @@
 #define BQ27Z561_LOG(lvl_, ...)
 #endif
 
+#define BQ27Z561_I2C_TIMEOUT_TICKS \
+    ((1000 / OS_TICKS_PER_SEC) / MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_MS))
+
 static uint8_t
 bq27z561_calc_chksum(uint8_t *tmpbuf, uint8_t len)
 {
@@ -142,16 +145,18 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
-        goto err;
+        // Allow repeated-start condition to complete
+        // goto err;
     }
 
     i2c.len = 1;
     i2c.buffer = (uint8_t *)val;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
@@ -178,16 +183,17 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
-        goto err;
+        // Allow repeated-start condition to complete
+        //goto err;
     }
 
     i2c.len = 2;
     i2c.buffer = (uint8_t *)val;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
@@ -221,7 +227,7 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
@@ -252,7 +258,7 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
@@ -300,7 +306,7 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -340,7 +346,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -353,18 +359,19 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     i2c.len = 1;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
-        bq27z561_itf_unlock(&dev->bq27_itf);
-        goto err;
+        // Allow repeated-start condition to complete
+        //rc = BQ27Z561_ERR_I2C_ERR;
+        //bq27z561_itf_unlock(&dev->bq27_itf);
+        //goto err;
     }
 
     i2c.len = 36;
     i2c.buffer = tmpbuf;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
@@ -446,7 +453,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -459,18 +466,19 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.len = 1;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
-        bq27z561_itf_unlock(&dev->bq27_itf);
-        goto err;
+        // Allow repeated-start condition to complete
+        //rc = BQ27Z561_ERR_I2C_ERR;
+        //bq27z561_itf_unlock(&dev->bq27_itf);
+        //goto err;
     }
 
     i2c.len = buflen + 2;
     i2c.buffer = tmpbuf;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
@@ -530,7 +538,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -548,7 +556,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.len = 3;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, BQ27Z561_I2C_TIMEOUT_TICKS, 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -42,7 +42,7 @@
 #endif
 
 #define BQ27Z561_I2C_TIMEOUT_TICKS \
-    ((1000 / OS_TICKS_PER_SEC) / MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_MS))
+    (MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_MS) * OS_TICKS_PER_SEC / 1000)
 
 static uint8_t
 bq27z561_calc_chksum(uint8_t *tmpbuf, uint8_t len)

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -41,3 +41,8 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the BQ27Z561 sends an unexpected NACK.
         value: 2
+    BQ27Z561_I2C_TIMEOUT_MS:
+        description: >
+            Number of milliseconds to wait for each I2C transaction to 
+            complete.
+        value: 16

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -108,7 +108,8 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
         LP5523_LOG(ERROR, "I2C access failed at address 0x%02X\n",
                    itf->li_addr);
         STATS_INC(g_lp5523stats, write_errors);
-        goto err;
+        // Allow repeated-start operation to complete
+        //goto err;
     }
 
     /* Read one byte back */
@@ -122,7 +123,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
          STATS_INC(g_lp5523stats, read_errors);
     }
 
-err:
+//err:
     led_itf_unlock(itf);
 
     return rc;
@@ -190,7 +191,8 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
         LP5523_LOG(ERROR, "Failed to write to 0x%02X:0x%02X\n", itf->li_addr,
                    addr_b);
         STATS_INC(g_lp5523stats, read_errors);
-        goto err;
+        // Allow repeated-start operation to complete
+        //goto err;
     }
 
     data_struct.len = len;
@@ -204,7 +206,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
          STATS_INC(g_lp5523stats, read_errors);
     }
 
-err:
+//err:
     led_itf_unlock(itf);
 
     return rc;


### PR DESCRIPTION
The main part of this PR is a possible fix for an I2C failure in our nRF52 system which hangs the bus and keeps SDA low indefinitely. The failure appears to be triggered when doing a read of bq27561 or lp5523 registers, if the write operation (first part of a write-read) fails and no STOP condition gets generated. The condition can be very difficult to reproduce, though it happens with some regularity if certain specific conditions are met which are too detailed to go into here. 

The solution applied by this PR is to allow the following I2C read and STOP condition to go through even though the write has failed. 

This fix is preliminary and testing is on going, though I want to submit it now for review and comments. A more thorough solution might be found by modifying hal_i2c_master_write in the nrf52xxx HAL to place a STOP on the bus if the write operation fails when the >last_op< argument is 0.

Also, the bq27z561 i2c timeout has been reduced from 1 second to 16 milliseconds, as the long timeout was holding up processing of default queue events. 