### PR TITLE
On Newt Load, use the specified port if one is given in --extrajtagcmd options

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
 # RELEASE NOTES
 
-04 June 2018 - Apache Mynewt v1.4.0
+21 June 2018 - Apache Mynewt v1.4.1
 
 For full release notes, please visit the
 [Apache Mynewt Wiki](https://cwiki.apache.org/confluence/display/MYNEWT/Release+Notes).
 
-This is the seventh source release of Apache Mynewt Core. For more
+This is the first bugfix source release of Apache Mynewt Core 1.4. For more
 information on Apache Mynewt, please visit the
 [Apache Mynewt Website](https://mynewt.apache.org/).
 

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -27,6 +27,7 @@ JLINK_GDB_SERVER=JLinkGDBServer
 jlink_load () {
     GDB_CMD_FILE=.gdb_cmds
     GDB_OUT_FILE=.gdb_out
+    PORT=3333
 
     windows_detect
     if [ $WINDOWS -eq 1 ]; then
@@ -46,6 +47,10 @@ jlink_load () {
         echo "Missing flash offset"
         exit 1
     fi
+    if [[ $EXTRA_JTAG_CMD =~ '-port ' ]]; then
+        # ExtraJTagCommand contains PORT - Use that port instead.
+        PORT=$(awk '{for(i=1;i<=NF;i++) if ($i=="-port") print $(i+1)}' <<< $EXTRA_JTAG_CMD)
+    fi
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
@@ -53,8 +58,8 @@ jlink_load () {
     # downloading somewhere in the flash. So need to figure out how to tell it
     # not to do that, or report failure if gdb fails to write this file
     #
-    echo "shell sh -c \"trap '' 2; $JLINK_GDB_SERVER -device $JLINK_DEV -speed 1000 -if SWD -port 3333 -singlerun $EXTRA_JTAG_CMD  &\" " > $GDB_CMD_FILE
-    echo "target remote localhost:3333" >> $GDB_CMD_FILE
+    echo "shell sh -c \"trap '' 2; $JLINK_GDB_SERVER -device $JLINK_DEV -speed 1000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD  &\" " > $GDB_CMD_FILE
+    echo "target remote localhost:$PORT" >> $GDB_CMD_FILE
     echo "mon reset" >> $GDB_CMD_FILE
     echo "restore $FILE_NAME binary $FLASH_OFFSET" >> $GDB_CMD_FILE
 

--- a/repository.yml
+++ b/repository.yml
@@ -32,6 +32,7 @@ repo.versions:
     "1.2.0": "mynewt_1_2_0_tag"
     "1.3.0": "mynewt_1_3_0_tag"
     "1.4.0": "mynewt_1_4_0_tag"
+    "1.4.1": "mynewt_1_4_1_tag"
 
     "0-latest": "1.4.1"
     "1-latest": "1.4.1"
@@ -43,7 +44,7 @@ repo.versions:
     "1.1-latest": "1.1.0"
     "1.2-latest": "1.2.0"
     "1.3-latest": "1.3.0"
-    "1.4-latest": "1.4.0"
+    "1.4-latest": "1.4.1"
 
 repo.newt_compatibility:
     # Allow all versions for 0.0.0.  This is a workaround to prevent a warning

--- a/repository.yml
+++ b/repository.yml
@@ -32,7 +32,6 @@ repo.versions:
     "1.2.0": "mynewt_1_2_0_tag"
     "1.3.0": "mynewt_1_3_0_tag"
     "1.4.0": "mynewt_1_4_0_tag"
-    "1.4.1": "mynewt_1_4_1_tag"
 
     "0-latest": "1.4.1"
     "1-latest": "1.4.1"
@@ -44,7 +43,7 @@ repo.versions:
     "1.1-latest": "1.1.0"
     "1.2-latest": "1.2.0"
     "1.3-latest": "1.3.0"
-    "1.4-latest": "1.4.1"
+    "1.4-latest": "1.4.0"
 
 repo.newt_compatibility:
     # Allow all versions for 0.0.0.  This is a workaround to prevent a warning
@@ -71,5 +70,4 @@ repo.deps:
         repo: mynewt-nimble
         vers:
             master: 0-dev
-            mynewt_1_4_0_tag: 1.0.0
-            mynewt_1_4_1_tag: 1.0.0
+            1.4.0: 1.0.0

--- a/version.yml
+++ b/version.yml
@@ -19,4 +19,4 @@
 
 # Newt uses this file to determine the version of a checked out repo.
 # This should always be 0.0.0 in the master branch.
-repo.version: 0.0.0
+repo.version: 1.4.0

--- a/version.yml
+++ b/version.yml
@@ -19,4 +19,4 @@
 
 # Newt uses this file to determine the version of a checked out repo.
 # This should always be 0.0.0 in the master branch.
-repo.version: 1.4.0
+repo.version: 1.4.1


### PR DESCRIPTION
If -port is specified, use that port instead.

When using 'newt load', if '--extrajtagcmd "-port 3334"' is used, the load will hang.  The hardcoded 3333 port needs to match JLink's port.
In this case, the command looks like:

Command line: -device nRF52 -speed 1000 -if SWD -port 3333 -singlerun -select USB=123456789 -port 3334

JLink uses the second declared port of 3334, while newt is listening to 3333.

Note: Port needs to be unique for parallel execution.  In the case of multiple boards attached to the computer and code that could potentially try to upload to different boards at the same time, this change is necessary.