### PR TITLE
kernel/os: Add os_arch_in_isr() API

### DIFF
--- a/kernel/os/include/os/arch/common.h
+++ b/kernel/os/include/os/arch/common.h
@@ -63,6 +63,7 @@ void os_arch_ctx_sw(struct os_task *);
 os_sr_t os_arch_save_sr(void);
 void os_arch_restore_sr(os_sr_t);
 int os_arch_in_critical(void);
+int os_arch_in_isr(void);
 void os_arch_init(void);
 uint32_t os_arch_start(void);
 os_error_t os_arch_os_init(void);

--- a/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "mcu/cmsis_nvic.h"
 #include "mcu/cortex_m0.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,12 @@ typedef uint32_t os_stack_t;
 #else
 #define OS_IDLE_STACK_SIZE (64)
 #endif
+
+static inline int
+os_arch_in_isr(void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "mcu/cmsis_nvic.h"
 #include "mcu/cortex_m3.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,12 @@ typedef uint32_t os_stack_t;
 #else
 #define OS_IDLE_STACK_SIZE (64)
 #endif
+
+static inline int
+os_arch_in_isr(void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "mcu/cmsis_nvic.h"
 #include "mcu/cortex_m4.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,12 @@ typedef uint32_t os_stack_t;
 #else
 #define OS_IDLE_STACK_SIZE (64)
 #endif
+
+static inline int
+os_arch_in_isr(void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "mcu/cmsis_nvic.h"
 #include "mcu/cortex_m7.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,12 @@ typedef uint32_t os_stack_t;
 #else
 #define OS_IDLE_STACK_SIZE (64)
 #endif
+
+static inline int
+os_arch_in_isr(void)
+{
+    return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/arch/mips/os/os_arch.h
+++ b/kernel/os/include/os/arch/mips/os/os_arch.h
@@ -46,6 +46,13 @@ typedef uint32_t os_stack_t;
 #define OS_IS_CRITICAL()                    ((mips_getsr() & 1) == 0)
 #define OS_ASSERT_CRITICAL()                assert(OS_IS_CRITICAL())
 
+static inline int
+os_arch_in_isr(void)
+{
+    /* check the EXL bit */
+    return (mips_getsr() & (1 << 1)) ? 1 : 0;
+}
+
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"
 

--- a/kernel/os/include/os/arch/pic32/os/os_arch.h
+++ b/kernel/os/include/os/arch/pic32/os/os_arch.h
@@ -43,6 +43,13 @@ typedef uint64_t os_stack_t;
 #define OS_IS_CRITICAL()               ((_CP0_GET_STATUS() & 1) == 0)
 #define OS_ASSERT_CRITICAL()            assert(OS_IS_CRITICAL())
 
+static inline int
+os_arch_in_isr(void)
+{
+    /* check the EXL bit */
+    return (_CP0_GET_STATUS() & _CP0_STATUS_EXL_MASK) ? 1 : 0;
+}
+
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"
 

--- a/kernel/os/src/arch/mips/os_arch_mips.c
+++ b/kernel/os/src/arch/mips/os_arch_mips.c
@@ -48,13 +48,6 @@ _mips_isr_hw5(void)
     timer_handler();
 }
 
-static int
-os_in_isr(void)
-{
-    /* check the EXL bit */
-    return (mips_getsr() & (1 << 1)) ? 1 : 0;
-}
-
 void
 timer_handler(void)
 {
@@ -133,7 +126,7 @@ os_arch_os_init(void)
     os_error_t err;
 
     err = OS_ERR_IN_ISR;
-    if (os_in_isr() == 0) {
+    if (os_arch_in_isr() == 0) {
         err = OS_OK;
 
         /* should be in kernel mode here */
@@ -171,7 +164,7 @@ os_arch_os_start(void)
     os_error_t err;
 
     err = OS_ERR_IN_ISR;
-    if (os_in_isr() == 0) {
+    if (os_arch_in_isr() == 0) {
         err = OS_OK;
         /* should be in kernel mode here */
         os_arch_start();

--- a/kernel/os/src/arch/pic32/os_arch_pic32.c
+++ b/kernel/os/src/arch/pic32/os_arch_pic32.c
@@ -74,13 +74,6 @@ void
 __attribute__((interrupt(IPL1AUTO), vector(_CORE_SOFTWARE_0_VECTOR)))
 isr_sw0(void);
 
-static int
-os_in_isr(void)
-{
-    /* check the EXL bit */
-    return (_CP0_GET_STATUS() & _CP0_STATUS_EXL_MASK) ? 1 : 0;
-}
-
 void
 timer_handler(void)
 {
@@ -176,7 +169,7 @@ os_arch_os_init(void)
     os_error_t err;
 
     err = OS_ERR_IN_ISR;
-    if (os_in_isr() == 0) {
+    if (os_arch_in_isr() == 0) {
         err = OS_OK;
         os_sr_t sr;
         OS_ENTER_CRITICAL(sr);
@@ -242,7 +235,7 @@ os_arch_os_start(void)
     os_error_t err;
 
     err = OS_ERR_IN_ISR;
-    if (os_in_isr() == 0) {
+    if (os_arch_in_isr() == 0) {
         err = OS_OK;
         /* should be in kernel mode here */
         os_arch_start();


### PR DESCRIPTION
Added implementation for Cortex-M.
MIPS and PIC32 already had local implementation so just moved this to public header.
RISC-V is missing.