### PR TITLE
Fill in missing `hf_erased_val` for some MCUs

### DIFF
--- a/hw/drivers/flash/at45db/src/at45db.c
+++ b/hw/drivers/flash/at45db/src/at45db.c
@@ -83,6 +83,7 @@ static struct at45db_dev at45db_default_dev = {
         .hf_size       = 8192 * 512,  /* FIXME: depends on page size */
         .hf_sector_cnt = 8192,
         .hf_align      = 0,
+        .hf_erased_val = 0xff,
     },
 
     /* SPI settings + updates baudrate on _init */

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -86,6 +86,7 @@ struct spiflash_dev spiflash_dev = {
                          MYNEWT_VAL(SPIFLASH_SECTOR_SIZE),
         .hf_sector_cnt = MYNEWT_VAL(SPIFLASH_SECTOR_COUNT),
         .hf_align      = 1,
+        .hf_erased_val = 0xff,
     },
 
     /* SPI settings */

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_flash.c
@@ -49,7 +49,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 1024 * 1024,	/* XXX read from factory info? */
     .hf_sector_cnt = 256,	/* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #elif defined(NRF52810_XXAA)
 const struct hal_flash nrf52k_flash_dev = {
@@ -57,7 +58,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 192 * 1024,  /* XXX read from factory info? */
     .hf_sector_cnt = 48,   /* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #elif defined(NRF52832_XXAA)
 const struct hal_flash nrf52k_flash_dev = {
@@ -65,7 +67,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 512 * 1024,	/* XXX read from factory info? */
     .hf_sector_cnt = 128,	/* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #else
 #error "Must define hal_flash struct for NRF52 type"

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_qspi.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_qspi.c
@@ -92,7 +92,8 @@ const struct hal_flash nrf52k_qspi_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT) * MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE),
     .hf_sector_cnt = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT),
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 static int

--- a/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_flash.c
@@ -58,7 +58,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 192 * 1024,  /* XXX read from factory info? */
     .hf_sector_cnt = 48,   /* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #elif defined(NRF52832_XXAA)
 const struct hal_flash nrf52k_flash_dev = {
@@ -66,7 +67,8 @@ const struct hal_flash nrf52k_flash_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = 512 * 1024,	/* XXX read from factory info? */
     .hf_sector_cnt = 128,	/* XXX read from factory info? */
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 #else
 #error "Must define hal_flash struct for NRF52 type"

--- a/hw/mcu/nordic/nrf52xxx/src/hal_qspi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_qspi.c
@@ -92,7 +92,8 @@ const struct hal_flash nrf52k_qspi_dev = {
     .hf_base_addr = 0x00000000,
     .hf_size = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT) * MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE),
     .hf_sector_cnt = MYNEWT_VAL(QSPI_FLASH_SECTOR_COUNT),
-    .hf_align = 1
+    .hf_align = 1,
+    .hf_erased_val = 0xff,
 };
 
 static int


### PR DESCRIPTION
This `struct hal_flash` member wasn't specified for some MCUs.  This resulted in an "erased value" of 0.  Consequently, the FCB initialization function did not view an erased sector as actually erased, so it failed the magic number test instead.