### PR TITLE
hw/hal; hal_flash_isempty() also returns data from the location.

### DIFF
--- a/fs/fcb/src/fcb.c
+++ b/fs/fcb/src/fcb.c
@@ -196,7 +196,7 @@ fcb_sector_hdr_read(struct fcb *fcb, struct flash_area *fap,
     if (!fdap) {
         fdap = &fda;
     }
-    rc = flash_area_isempty_at(fap, 0, fdap, sizeof(*fdap));
+    rc = flash_area_read_is_empty(fap, 0, fdap, sizeof(*fdap));
     if (rc < 0) {
         return FCB_ERR_FLASH;
     } else if (rc == 1) {

--- a/fs/fcb/src/fcb.c
+++ b/fs/fcb/src/fcb.c
@@ -196,12 +196,11 @@ fcb_sector_hdr_read(struct fcb *fcb, struct flash_area *fap,
     if (!fdap) {
         fdap = &fda;
     }
-    if (flash_area_isempty_at(fap, 0, sizeof(*fdap))) {
-        return 0;
-    }
-    rc = flash_area_read(fap, 0, fdap, sizeof(*fdap));
-    if (rc) {
+    rc = flash_area_isempty_at(fap, 0, fdap, sizeof(*fdap));
+    if (rc < 0) {
         return FCB_ERR_FLASH;
+    } else if (rc == 1) {
+        return 0;
     }
     if (fdap->fd_magic != fcb->f_magic) {
         return FCB_ERR_MAGIC;

--- a/fs/fcb/src/fcb_elem_info.c
+++ b/fs/fcb/src/fcb_elem_info.c
@@ -41,7 +41,7 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *c8p)
     if (loc->fe_elem_off + 2 > loc->fe_area->fa_size) {
         return FCB_ERR_NOVAR;
     }
-    rc = flash_area_isempty_at(loc->fe_area, loc->fe_elem_off, tmp_str, 2);
+    rc = flash_area_read_is_empty(loc->fe_area, loc->fe_elem_off, tmp_str, 2);
     if (rc < 0) {
         return FCB_ERR_FLASH;
     } else if (rc == 1) {

--- a/fs/fcb/src/fcb_elem_info.c
+++ b/fs/fcb/src/fcb_elem_info.c
@@ -41,12 +41,11 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *c8p)
     if (loc->fe_elem_off + 2 > loc->fe_area->fa_size) {
         return FCB_ERR_NOVAR;
     }
-    if (flash_area_isempty_at(loc->fe_area, loc->fe_elem_off, 2)) {
-        return FCB_ERR_NOVAR;
-    }
-    rc = flash_area_read(loc->fe_area, loc->fe_elem_off, tmp_str, 2);
-    if (rc) {
+    rc = flash_area_isempty_at(loc->fe_area, loc->fe_elem_off, tmp_str, 2);
+    if (rc < 0) {
         return FCB_ERR_FLASH;
+    } else if (rc == 1) {
+        return FCB_ERR_NOVAR;
     }
 
     cnt = fcb_get_len(tmp_str, &len);

--- a/hw/drivers/flash/enc_flash/test/src/testcases/enc_flash_flash_map.c
+++ b/hw/drivers/flash/enc_flash/test/src/testcases/enc_flash_flash_map.c
@@ -45,7 +45,7 @@ TEST_CASE(enc_flash_test_flash_map)
             if (blk_sz > sizeof(readdata)) {
                 blk_sz = sizeof(readdata);
             }
-            rc = flash_area_isempty_at(fa, off, readdata, blk_sz);
+            rc = flash_area_read_is_empty(fa, off, readdata, blk_sz);
             TEST_ASSERT(rc == 1);
         }
         fa++;
@@ -68,7 +68,7 @@ TEST_CASE(enc_flash_test_flash_map)
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(b == false);
     memset(readdata, 0, sizeof(readdata));
-    rc = flash_area_isempty_at(fa, 0, readdata, sizeof(readdata));
+    rc = flash_area_read_is_empty(fa, 0, readdata, sizeof(readdata));
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(!memcmp(writedata, readdata, sizeof(writedata)));
 }

--- a/hw/drivers/flash/enc_flash/test/src/testcases/enc_flash_flash_map.c
+++ b/hw/drivers/flash/enc_flash/test/src/testcases/enc_flash_flash_map.c
@@ -26,6 +26,8 @@ TEST_CASE(enc_flash_test_flash_map)
     int rc;
     struct flash_area *fa;
     int i;
+    int off;
+    int blk_sz;
     bool b;
     char writedata[128];
     char readdata[128];
@@ -38,8 +40,14 @@ TEST_CASE(enc_flash_test_flash_map)
         rc = flash_area_is_empty(fa, &b);
         TEST_ASSERT(rc == 0);
         TEST_ASSERT(b == true);
-        rc = flash_area_isempty_at(fa, 0, fa->fa_size);
-        TEST_ASSERT(rc == 1);
+        for (off = 0; off < fa->fa_size; off += blk_sz) {
+            blk_sz = fa->fa_size - off;
+            if (blk_sz > sizeof(readdata)) {
+                blk_sz = sizeof(readdata);
+            }
+            rc = flash_area_isempty_at(fa, off, readdata, blk_sz);
+            TEST_ASSERT(rc == 1);
+        }
         fa++;
     }
 
@@ -59,7 +67,8 @@ TEST_CASE(enc_flash_test_flash_map)
     rc = flash_area_is_empty(fa, &b);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(b == false);
-    rc = flash_area_isempty_at(fa, 0, fa->fa_size);
+    memset(readdata, 0, sizeof(readdata));
+    rc = flash_area_isempty_at(fa, 0, readdata, sizeof(readdata));
     TEST_ASSERT(rc == 0);
-
+    TEST_ASSERT(!memcmp(writedata, readdata, sizeof(writedata)));
 }

--- a/hw/hal/include/hal/hal_flash.h
+++ b/hw/hal/include/hal/hal_flash.h
@@ -40,7 +40,8 @@ int hal_flash_write(uint8_t flash_id, uint32_t address, const void *src,
   uint32_t num_bytes);
 int hal_flash_erase_sector(uint8_t flash_id, uint32_t sector_address);
 int hal_flash_erase(uint8_t flash_id, uint32_t address, uint32_t num_bytes);
-int hal_flash_isempty(uint8_t flash_id, uint32_t address, uint32_t num_bytes);
+int hal_flash_isempty(uint8_t flash_id, uint32_t address, void *dst,
+                      uint32_t num_bytes);
 uint8_t hal_flash_align(uint8_t flash_id);
 uint8_t hal_flash_erased_val(uint8_t flash_id);
 int hal_flash_init(void);

--- a/hw/hal/include/hal/hal_flash_int.h
+++ b/hw/hal/include/hal/hal_flash_int.h
@@ -41,7 +41,7 @@ struct hal_flash_funcs {
     int (*hff_sector_info)(const struct hal_flash *dev, int idx,
             uint32_t *address, uint32_t *size);
     int (*hff_is_empty)(const struct hal_flash *dev, uint32_t address,
-            uint32_t num_bytes);
+            void *dst, uint32_t num_bytes);
     int (*hff_init)(const struct hal_flash *dev);
 };
 
@@ -59,7 +59,7 @@ struct hal_flash {
  */
 uint32_t hal_flash_sector_size(const struct hal_flash *hf, int sec_idx);
 
-int hal_flash_is_erased(const struct hal_flash *, uint32_t, uint32_t);
+int hal_flash_is_erased(const struct hal_flash *, uint32_t, void *, uint32_t);
 
 #ifdef __cplusplus
 }

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -219,7 +219,7 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
     if (rc2) {
         return -1;
     }
-    rc2 = flash_area_isempty_at(fa, 0, hdr, sizeof(*hdr));
+    rc2 = flash_area_read_is_empty(fa, 0, hdr, sizeof(*hdr));
     if (rc2 < 0) {
         goto end;
     }
@@ -260,7 +260,7 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
     }
     tlv = (struct image_tlv *)data;
     while (data_off + sizeof(*tlv) <= data_end) {
-        rc2 = flash_area_isempty_at(fa, data_off, tlv, sizeof(*tlv));
+        rc2 = flash_area_read_is_empty(fa, data_off, tlv, sizeof(*tlv));
         if (rc2 < 0) {
             goto end;
         }

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -219,8 +219,8 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
     if (rc2) {
         return -1;
     }
-    rc2 = flash_area_read(fa, 0, hdr, sizeof(*hdr));
-    if (rc2) {
+    rc2 = flash_area_isempty_at(fa, 0, hdr, sizeof(*hdr));
+    if (rc2 < 0) {
         goto end;
     }
 
@@ -231,7 +231,8 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
         if (ver) {
             memcpy(ver, &hdr->ih_ver, sizeof(*ver));
         }
-    } else if (hdr->ih_magic == 0xffffffff) {
+    } else if (rc2 == 1) {
+        /* Area is empty */
         rc = 2;
         goto end;
     } else {
@@ -259,11 +260,11 @@ imgr_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
     }
     tlv = (struct image_tlv *)data;
     while (data_off + sizeof(*tlv) <= data_end) {
-        rc2 = flash_area_read(fa, data_off, tlv, sizeof(*tlv));
-        if (rc2) {
+        rc2 = flash_area_isempty_at(fa, data_off, tlv, sizeof(*tlv));
+        if (rc2 < 0) {
             goto end;
         }
-        if (tlv->it_type == 0xff && tlv->it_len == 0xffff) {
+        if (rc2 == 1) {
             break;
         }
         if (tlv->it_type != IMAGE_TLV_SHA256 ||

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -83,10 +83,12 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 int flash_area_is_empty(const struct flash_area *, bool *);
 
 /*
- * Whether a region of flash_area is empty.
+ * Reads data. Return code indicates whether it thinks that
+ * underlying area is in erased state.
+ *
  * Returns 1 if empty, 0 if not. <0 in case of an error.
  */
-int flash_area_isempty_at(const struct flash_area *, uint32_t off, void *dst,
+int flash_area_read_is_empty(const struct flash_area *, uint32_t off, void *dst,
   uint32_t len);
 
 /*

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -83,9 +83,10 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 int flash_area_is_empty(const struct flash_area *, bool *);
 
 /*
- * Whether a region of flash_area is empty
+ * Whether a region of flash_area is empty.
+ * Returns 1 if empty, 0 if not. <0 in case of an error.
  */
-int flash_area_isempty_at(const struct flash_area *, uint32_t off,
+int flash_area_isempty_at(const struct flash_area *, uint32_t off, void *dst,
   uint32_t len);
 
 /*

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -211,8 +211,8 @@ flash_area_is_empty(const struct flash_area *fa, bool *empty)
 }
 
 int
-flash_area_isempty_at(const struct flash_area *fa, uint32_t off, void *dst,
-                      uint32_t len)
+flash_area_read_is_empty(const struct flash_area *fa, uint32_t off, void *dst,
+                         uint32_t len)
 {
     return hal_flash_isempty(fa->fa_device_id, fa->fa_off + off, dst, len);
 }


### PR DESCRIPTION
sys/flash_map; flash_area_isempty_at() also returns data from the location.

Addresses issue @utzig mentioned before. Common case for checking whether flash area is empty is followed by checking what kind of data is there.