### PR TITLE
sys/log: Execute callback when log is appended to

### DIFF
--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+struct log;
+
 #define LOG_VERSION_V3  3
 #define LOG_VERSION_V2  2
 #define LOG_VERSION_V1  1
@@ -104,6 +106,15 @@ struct log_info {
 };
 
 extern struct log_info g_log_info;
+
+/** @typedef log_append_cb
+ * @brief Callback that is executed each time the corresponding log is appended
+ * to.
+ *
+ * @param log                   The log that was just appended to.
+ * @param idx                   The index of newly appended log entry.
+ */
+typedef void log_append_cb(struct log *log, uint32_t idx);
 
 #ifdef __cplusplus
 }

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -176,6 +176,7 @@ struct log {
     const struct log_handler *l_log;
     void *l_arg;
     STAILQ_ENTRY(log) l_next;
+    log_append_cb *l_append_cb;
     uint8_t l_level;
 };
 
@@ -215,6 +216,26 @@ const char *log_module_get_name(uint8_t id);
 /* Log functions, manipulate a single log */
 int log_register(char *name, struct log *log, const struct log_handler *,
                  void *arg, uint8_t level);
+
+/**
+ * @brief Configures the given log with the specified append callback.
+ *
+ * A log's append callback is executed each time an entry is appended to the
+ * log.
+ *
+ * @param log                   The log to configure.
+ * @param cb                    The callback to associate with the log.
+ */
+void log_set_append_cb(struct log *log, log_append_cb *cb);
+
+/**
+ * @brief Searches the list of registered logs for one with the specified name.
+ *
+ * @param name                  The name of the log to search for.
+ *
+ * @return                      The sought after log if found, NULL otherwise.
+ */
+struct log *log_find(const char *name);
 
 /**
  * @brief Writes the raw contents of a flat buffer to the specified log.

--- a/sys/log/full/test/util/include/log_test_util/log_test_util.h
+++ b/sys/log/full/test/util/include/log_test_util/log_test_util.h
@@ -60,6 +60,7 @@ TEST_CASE_DECL(log_test_case_fcb_append_mbuf_body);
 
 TEST_SUITE_DECL(log_test_suite_misc);
 TEST_CASE_DECL(log_test_case_level);
+TEST_CASE_DECL(log_test_case_append_cb);
 
 #ifdef __cplusplus
 }

--- a/sys/log/full/test/util/src/log_test.c
+++ b/sys/log/full/test/util/src/log_test.c
@@ -49,4 +49,5 @@ TEST_SUITE(log_test_suite_fcb_mbuf)
 TEST_SUITE(log_test_suite_misc)
 {
     log_test_case_level();
+    log_test_case_append_cb();
 }

--- a/sys/log/full/test/util/src/testcases/log_test_case_append_cb.c
+++ b/sys/log/full/test/util/src/testcases/log_test_case_append_cb.c
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+
+struct ltcwc_entry {
+    struct log *log;
+    uint32_t idx;
+};
+
+#define LTCWC_MAX_ENTRIES   16
+struct ltcwc_entry ltcwc_entries[LTCWC_MAX_ENTRIES];
+int ltcwc_num_entries;
+
+static void
+ltcwc_append_cb(struct log *log, uint32_t idx)
+{
+    struct ltcwc_entry *entry;
+
+    TEST_ASSERT_FATAL(ltcwc_num_entries < LTCWC_MAX_ENTRIES);
+
+    entry = &ltcwc_entries[ltcwc_num_entries++];
+    entry->log = log;
+    entry->idx = idx;
+}
+
+TEST_CASE(log_test_case_append_cb)
+{
+    struct fcb_log fcb_log;
+    struct log log;
+
+    ltu_setup_fcb(&fcb_log, &log);
+
+    /*** No callback; num entries remains 0. */
+
+    log_append_body(&log, 0, 0, LOG_ETYPE_STRING, "0", 1);
+    TEST_ASSERT(ltcwc_num_entries == 0);
+
+    /*** Set callback; num entries increases to 1. */
+
+    log_set_append_cb(&log, ltcwc_append_cb);
+
+    log_append_body(&log, 0, 0, LOG_ETYPE_STRING, "1", 1);
+    TEST_ASSERT(ltcwc_num_entries == 1);
+    TEST_ASSERT(ltcwc_entries[0].log == &log);
+    TEST_ASSERT(ltcwc_entries[0].idx == 1);
+
+    /*** No callback; num entries remains 1. */
+
+    log_set_append_cb(&log, NULL);
+
+    log_append_body(&log, 0, 0, LOG_ETYPE_STRING, "2", 1);
+    TEST_ASSERT(ltcwc_num_entries == 1);
+}

--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -46,6 +46,17 @@ log_register(char *name, struct log *log, const struct log_handler *h,
     return 0;
 }
 
+static inline void
+log_set_append_cb(struct log *log, log_append_cb *cb)
+{
+}
+
+static inline struct log *
+log_find(const char *name)
+{
+    return NULL;
+}
+
 static inline int
 log_append_typed(struct log *log, uint8_t module, uint8_t level, uint8_t etype,
                  void *data, uint16_t len)


### PR DESCRIPTION
This PR augments `struct log` with an "append callback."  If a log's callback is set, it gets called each time the log is appended to.

The callback has the following type:
```
/** @typedef log_append_cb
 * @brief Callback that is executed each time the corresponding log is appended
 * to.
 *
 * @param log                   The log that was just appended to.
 * @param idx                   The index of newly appended log entry.
 */
typedef void log_append_cb(struct log *log, uint32_t idx);
```