### PR TITLE
log/full; fix CLI crash when log entry data is larger than 127 bytes.

### DIFF
--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -34,6 +34,7 @@ pkg.deps.LOG_FCB:
     - "@apache-mynewt-core/fs/fcb"
 pkg.deps.LOG_CLI:
     - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/encoding/base64"
 
 pkg.deps.LOG_NEWTMGR:
     - "@apache-mynewt-core/mgmt/mgmt"


### PR DESCRIPTION
Hexdump binary/CBOR entries.