### PR TITLE
 kernel/os: Make os_time ms<->ticks conversions static inline 

### DIFF
--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/cortex_m4.h
@@ -20,8 +20,6 @@
 #ifndef __MCU_CORTEX_M4_H__
 #define __MCU_CORTEX_M4_H__
 
-#include "os/mynewt.h"
-
 #include "nrf.h"
 
 #ifdef __cplusplus

--- a/hw/mcu/nordic/nrf52xxx-compat/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/hal_system.c
@@ -18,6 +18,7 @@
  */
 
 #include <mcu/cortex_m4.h>
+#include "syscfg/syscfg.h"
 #include "hal/hal_system.h"
 #include "nrf.h"
 

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -20,8 +20,6 @@
 #ifndef __MCU_CORTEX_M4_H__
 #define __MCU_CORTEX_M4_H__
 
-#include "os/mynewt.h"
-
 #include "nrf.h"
 
 #ifdef __cplusplus

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <mcu/cortex_m4.h>
+#include "syscfg/syscfg.h"
 #include "hal/hal_system.h"
 #include "nrf.h"
 

--- a/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m0/os/os_arch.h
@@ -21,7 +21,8 @@
 #define _OS_ARCH_ARM_H
 
 #include <stdint.h>
-#include <mcu/cortex_m0.h>
+#include "syscfg/syscfg.h"
+#include "mcu/cortex_m0.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m3/os/os_arch.h
@@ -21,6 +21,7 @@
 #define _OS_ARCH_ARM_H
 
 #include <stdint.h>
+#include "syscfg/syscfg.h"
 #include "mcu/cortex_m3.h"
 
 #ifdef __cplusplus

--- a/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -21,6 +21,7 @@
 #define _OS_ARCH_ARM_H
 
 #include <stdint.h>
+#include "syscfg/syscfg.h"
 #include "mcu/cortex_m4.h"
 
 #ifdef __cplusplus

--- a/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
+++ b/kernel/os/include/os/arch/cortex_m7/os/os_arch.h
@@ -21,6 +21,7 @@
 #define _OS_ARCH_ARM_H
 
 #include <stdint.h>
+#include "syscfg/syscfg.h"
 #include "mcu/cortex_m7.h"
 
 #ifdef __cplusplus

--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -62,6 +62,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "os/os_arch.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -242,7 +243,15 @@ int os_time_ticks_to_ms(os_time_t ticks, uint32_t *out_ms);
  *
  * @return                      result on success
  */
-os_time_t os_time_ms_to_ticks32(uint32_t ms);
+static inline os_time_t
+os_time_ms_to_ticks32(uint32_t ms)
+{
+#if OS_TICKS_PER_SEC == 1000
+    return ms;
+#else
+    return ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
+#endif
+}
 
 /**
  * Converts OS ticks to milliseconds.
@@ -254,7 +263,15 @@ os_time_t os_time_ms_to_ticks32(uint32_t ms);
  *
  * @return                      result on success
  */
-uint32_t os_time_ticks_to_ms32(os_time_t ticks);
+static inline uint32_t
+os_time_ticks_to_ms32(os_time_t ticks)
+{
+#if OS_TICKS_PER_SEC == 1000
+    return ticks;
+#else
+    return ((uint64_t)ticks * 1000) / OS_TICKS_PER_SEC;
+#endif
+}
 
 #ifdef __cplusplus
 }

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -229,23 +229,3 @@ os_time_ticks_to_ms(os_time_t ticks, uint32_t *out_ms)
 
     return 0;
 }
-
-os_time_t
-os_time_ms_to_ticks32(uint32_t ms)
-{
-#if OS_TICKS_PER_SEC == 1000
-    return ms;
-#else
-    return ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
-#endif
-}
-
-uint32_t
-os_time_ticks_to_ms32(os_time_t ticks)
-{
-#if OS_TICKS_PER_SEC == 1000
-    return ticks;
-#else
-    return ((uint64_t)ticks * 1000) / OS_TICKS_PER_SEC;
-#endif
-}


### PR DESCRIPTION
This allows conversions to be evaluated by compiler in case argument is a constant expression which results in faster code.

Note that it may increase code size a bit since all conversions where argument is not a constant expression will be inlined and not evaliated by compiler, but the difference should be negligible. For example, for `bleprph` app it's 64 bytes more.