### PR TITLE
Log statistics

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -144,6 +144,13 @@ fcb_offset_last_n(struct fcb *fcb, uint8_t entries,
  */
 int fcb_clear(struct fcb *fcb);
 
+/**
+ * Usage report for a given FCB area. Returns number of elements and the
+ * number of bytes stored in them.
+ */
+int fcb_area_info(struct fcb *fcb, struct flash_area *fa, int *elemsp,
+                  int *bytesp);
+
 #ifdef __cplusplus
 }
 

--- a/fs/fcb/src/fcb_area_info.c
+++ b/fs/fcb/src/fcb_area_info.c
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "fcb/fcb.h"
+#include "fcb_priv.h"
+
+int
+fcb_area_info(struct fcb *fcb, struct flash_area *fa, int *elemsp, int *bytesp)
+{
+    struct fcb_entry loc;
+    int rc;
+    int elems = 0;
+    int bytes = 0;
+
+    loc.fe_area = fa;
+    loc.fe_elem_off = 0;
+
+    while (1) {
+        rc = fcb_getnext(fcb, &loc);
+        if (rc) {
+            break;
+        }
+        if (!fa) {
+            fa = loc.fe_area;
+        } else if (fa != loc.fe_area) {
+            break;
+        }
+        elems++;
+        bytes += loc.fe_data_len;
+    }
+    if (elemsp) {
+        *elemsp = elems;
+    }
+    if (bytesp) {
+        *bytesp = bytes;
+    }
+    return 0;
+}

--- a/fs/fcb/test/src/fcb_test.c
+++ b/fs/fcb/test/src/fcb_test.c
@@ -158,6 +158,7 @@ TEST_CASE_DECL(fcb_test_reset)
 TEST_CASE_DECL(fcb_test_rotate)
 TEST_CASE_DECL(fcb_test_multiple_scratch)
 TEST_CASE_DECL(fcb_test_last_of_n)
+TEST_CASE_DECL(fcb_test_area_info)
 
 TEST_SUITE(fcb_test_all)
 {
@@ -190,6 +191,10 @@ TEST_SUITE(fcb_test_all)
 
     tu_case_set_pre_cb(fcb_tc_pretest, (void*)4);
     fcb_test_last_of_n();
+
+    tu_case_set_pre_cb(fcb_tc_pretest, (void*)2);
+    fcb_test_area_info();
+
 }
 
 #if MYNEWT_VAL(SELFTEST)

--- a/fs/fcb/test/src/testcases/fcb_test_area_info.c
+++ b/fs/fcb/test/src/testcases/fcb_test_area_info.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "fcb_test.h"
+
+TEST_CASE(fcb_test_area_info)
+{
+    struct fcb *fcb;
+    int rc;
+    int i;
+    struct fcb_entry loc;
+    uint8_t test_data[128];
+    int elem_cnts[2] = {0, 0};
+    int area_elems[2];
+    int area_bytes[2];
+
+    fcb = &test_fcb;
+
+    /*
+     * Should be empty, with elem count and byte count zero.
+     */
+    for (i = 0; i < 2; i++) {
+        rc = fcb_area_info(fcb, &fcb->f_sectors[i], &area_elems[i],
+                           &area_bytes[i]);
+        TEST_ASSERT(rc == 0);
+        TEST_ASSERT(area_elems[i] == 0);
+        TEST_ASSERT(area_bytes[i] == 0);
+    }
+
+    /*
+     * Fill up the areas, make sure that reporting is ok.
+     */
+    while (1) {
+        rc = fcb_append(fcb, sizeof(test_data), &loc);
+        if (rc == FCB_ERR_NOSPACE) {
+            break;
+        }
+        if (loc.fe_area == &test_fcb_area[0]) {
+            elem_cnts[0]++;
+        } else if (loc.fe_area == &test_fcb_area[1]) {
+            elem_cnts[1]++;
+        } else {
+            TEST_ASSERT(0);
+        }
+
+        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+          sizeof(test_data));
+        TEST_ASSERT(rc == 0);
+
+        rc = fcb_append_finish(fcb, &loc);
+        TEST_ASSERT(rc == 0);
+
+        for (i = 0; i < 2; i++) {
+            rc = fcb_area_info(fcb, &fcb->f_sectors[i], &area_elems[i],
+                               &area_bytes[i]);
+            TEST_ASSERT(rc == 0);
+            TEST_ASSERT(area_elems[i] == elem_cnts[i]);
+            TEST_ASSERT(area_bytes[i] == elem_cnts[i] * sizeof(test_data));
+        }
+    }
+
+    /*
+     * Wipe out the oldest, should report zeroes for that area now.
+     */
+    rc = fcb_rotate(fcb);
+    TEST_ASSERT(rc == 0);
+
+    rc = fcb_area_info(fcb, &fcb->f_sectors[0], &area_elems[0], &area_bytes[0]);
+    TEST_ASSERT(rc == 0);
+    rc = fcb_area_info(fcb, &fcb->f_sectors[1], &area_elems[1], &area_bytes[1]);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(area_elems[0] == 0);
+    TEST_ASSERT(area_bytes[0] == 0);
+    TEST_ASSERT(area_elems[1] == elem_cnts[1]);
+    TEST_ASSERT(area_bytes[1] == elem_cnts[1] * sizeof(test_data));
+
+    /*
+     * If area pointer is NULL, should check the oldest area (area 1).
+     */
+    rc = fcb_area_info(fcb, NULL, &area_elems[0], &area_bytes[0]);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(area_elems[0] == elem_cnts[1]);
+    TEST_ASSERT(area_bytes[0] == elem_cnts[1] * sizeof(test_data));
+}

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -22,6 +22,9 @@
 #include "os/mynewt.h"
 #include "cbmem/cbmem.h"
 #include "log_common/log_common.h"
+#if MYNEWT_VAL(LOG_STATS)
+#include "stats/stats.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -171,6 +174,21 @@ struct log_entry_hdr {
 #define LOG_CRITICAL(__l, __mod, ...) IGNORE(__VA_ARGS__)
 #endif
 
+#if MYNEWT_VAL(LOG_STATS)
+STATS_SECT_START(logs)
+    STATS_SECT_ENTRY(writes)
+    STATS_SECT_ENTRY(drops)
+    STATS_SECT_ENTRY(errs)
+    STATS_SECT_ENTRY(lost)
+STATS_SECT_END
+
+#define LOG_STATS_INC(log, name)        STATS_INC(log->l_stats, name)
+#define LOG_STATS_INCN(log, name, cnt)  STATS_INCN(log->l_stats, name, cnt)
+#else
+#define LOG_STATS_INC(log, name)
+#define LOG_STATS_INCN(log, name, cnt)
+#endif
+
 struct log {
     char *l_name;
     const struct log_handler *l_log;
@@ -178,6 +196,9 @@ struct log {
     STAILQ_ENTRY(log) l_next;
     log_append_cb *l_append_cb;
     uint8_t l_level;
+#if MYNEWT_VAL(LOG_STATS)
+    STATS_SECT_DECL(logs) l_stats;
+#endif
 };
 
 /* Log system level functions (for all logs.) */

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -41,6 +41,9 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
     struct fcb_log *fcb_log;
     struct flash_area *old_fa;
     int rc = 0;
+#if MYNEWT_VAL(LOG_STATS)
+    int cnt;
+#endif
 
     fcb_log = (struct fcb_log *)log->l_arg;
     fcb = &fcb_log->fl_fcb;
@@ -66,6 +69,12 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
         old_fa = fcb->f_oldest;
         (void)old_fa; /* to avoid #ifdefs everywhere... */
 
+#if MYNEWT_VAL(LOG_STATS)
+        rc = fcb_area_info(fcb, NULL, &cnt, NULL);
+        if (rc == 0) {
+            LOG_STATS_INCN(log, lost, cnt);
+        }
+#endif
         rc = fcb_rotate(fcb);
         if (rc) {
             goto err;

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -72,6 +72,10 @@ syscfg.defs:
             discarded.  Enabling this setting requires 128 bytes of bss.
         value: 1
 
+    LOG_STATS:
+        description: 'Log statistics'
+        value: 0
+
     LOG_STORAGE_INFO:
         description: >
             Enable "storage_info" API which keeps track of log storage usage and

--- a/sys/log/modlog/src/modlog.c
+++ b/sys/log/modlog/src/modlog.c
@@ -227,6 +227,9 @@ modlog_append_one(struct modlog_mapping *mm, uint8_t module, uint8_t level,
         if (rc != 0) {
             return SYS_EIO;
         }
+    } else {
+        LOG_STATS_INC(mm->desc.log, writes);
+        LOG_STATS_INC(mm->desc.log, drops);
     }
 
     return 0;
@@ -282,6 +285,9 @@ modlog_append_mbuf_one(struct modlog_mapping *mm, uint8_t module,
         if (rc != 0) {
             return SYS_EIO;
         }
+    } else {
+        LOG_STATS_INC(mm->desc.log, writes);
+        LOG_STATS_INC(mm->desc.log, drops);
     }
 
     return 0;


### PR DESCRIPTION
Adds optional statistics per-log. Stat block name comes from the name of the log.
Statistics are kept for number of log entries written, logs filtered out because of log level
settings, log entries dropped due to log collection not fetching (clearing) them on time, and errors while writing.

Note that log entries dropped from cbmem are not counted yet.