### PR TITLE
kernel/os: Fix PIC32 stack size

### DIFF
--- a/kernel/os/include/os/arch/pic32/os/os_arch.h
+++ b/kernel/os/include/os/arch/pic32/os/os_arch.h
@@ -27,8 +27,7 @@
 typedef uint32_t os_sr_t;
 
 /* Stack element */
-/* uint64_t in an attempt to get the stack 8 aligned */
-typedef uint64_t os_stack_t;
+typedef uint32_t os_stack_t;
 
 /* Stack sizes for common OS tasks */
 #define OS_SANITY_STACK_SIZE (64)


### PR DESCRIPTION
There's no need to force alignment by using uint64_t for stack element
since stack aligmnent is forced by variable attribute (assuming stack is
defined by approprite macro which is the proper way to do this).

Also this made stacks 2x larger than they need to be...