### PR TITLE
sys/reboot: Add info to log entries and limit writes to one per boot

### DIFF
--- a/kernel/os/pkg.yml
+++ b/kernel/os/pkg.yml
@@ -43,5 +43,8 @@ pkg.deps.BSP_SIMULATED:
 pkg.deps.OS_SYSVIEW:
     - "@apache-mynewt-core/sys/sysview"
 
+pkg.deps.OS_CRASH_LOG:
+    - "@apache-mynewt-core/sys/reboot"
+
 pkg.init:
     os_pkg_init: 0

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -37,6 +37,10 @@ syscfg.defs:
     OS_CRASH_STACKTRACE:
         description: 'Attempt to print stack trace when system crashes.'
         value: 0
+    OS_CRASH_LOG:
+        description: >
+            Write an entry to the reboot log when the system crashes.
+        value: 1
     OS_WATCHDOG_MONITOR:
         description: >
             'Attempt to capture state of stuck system before HW watchdog fires.'
@@ -135,3 +139,9 @@ syscfg.vals.OS_DEBUG_MODE:
     OS_CTX_SW_STACK_CHECK: 1
     OS_MEMPOOL_CHECK: 1
     OS_MEMPOOL_POISON: 1
+
+syscfg.vals.SELFTEST:
+    # OS_CRASH_LOG depends on some APIs that are almost never present in self
+    # tests (bootloader and newtmgr).  Explicitly disable this setting in self
+    # tests.
+    OS_CRASH_LOG: 0

--- a/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
+++ b/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
@@ -319,12 +319,21 @@ nmgr_reset_tmo(struct os_event *ev)
 static int
 nmgr_reset(struct mgmt_cbuf *cb)
 {
+#if MYNEWT_VAL(LOG_SOFT_RESET)
+    struct log_reboot_info info;
+#endif
     int rc;
 
     os_callout_init(&nmgr_reset_callout, mgmt_evq_get(), nmgr_reset_tmo, NULL);
 
 #if MYNEWT_VAL(LOG_SOFT_RESET)
-    log_reboot(HAL_RESET_REQUESTED);
+    info = (struct log_reboot_info) {
+        .reason = HAL_RESET_REQUESTED,
+        .file = NULL,
+        .line = 0,
+        .pc = 0,
+    };
+    log_reboot(&info);
 #endif
     os_callout_reset(&nmgr_reset_callout, OS_TICKS_PER_SEC / 4);
 

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -19,11 +19,12 @@
 #ifndef __LOG_REBOOT_H__
 #define __LOG_REBOOT_H__
 
+#include <hal/hal_system.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <hal/hal_system.h>
 #define REBOOT_REASON_STR(reason)                                       \
     (reason == HAL_RESET_POR ? "HARD" :                                 \
       (reason == HAL_RESET_PIN ? "RESET_PIN" :                          \
@@ -33,7 +34,14 @@ extern "C" {
               (reason == HAL_RESET_REQUESTED ? "REQUESTED" :            \
                 "UNKNOWN"))))))
 
-int log_reboot(enum hal_reset_reason);
+struct log_reboot_info {
+    enum hal_reset_reason reason;
+    const char *file;
+    int line;
+    uint32_t pc;
+};
+
+int log_reboot(const struct log_reboot_info *info);
 void reboot_start(enum hal_reset_reason reason);
 
 extern uint16_t reboot_cnt;

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -35,13 +35,14 @@
 #endif
 
 uint16_t reboot_cnt;
-static uint16_t soft_reboot;
 static char reboot_cnt_str[12];
-static char soft_reboot_str[12];
+static char log_reboot_written_str[12];
+static int8_t log_reboot_written;
+
 static char *reboot_conf_get(int argc, char **argv, char *buf, int max_len);
 static int reboot_conf_set(int argc, char **argv, char *val);
 static int reboot_conf_export(void (*export_func)(char *name, char *val),
-                             enum conf_export_tgt tgt);
+                              enum conf_export_tgt tgt);
 
 struct conf_handler reboot_conf_handler = {
     .ch_name = "reboot",
@@ -138,8 +139,8 @@ reboot_cnt_inc(void)
  * @param reason for reboot
  * @return 0 on success; non-zero on failure
  */
-int
-log_reboot(const struct log_reboot_info *info)
+static int
+log_reboot_write(const struct log_reboot_info *info)
 {
     struct image_version ver;
     uint8_t hash[IMGMGR_HASH_LEN];
@@ -157,17 +158,9 @@ log_reboot(const struct log_reboot_info *info)
     }
 #endif
 
-    if (reason == HAL_RESET_REQUESTED) {
-        conf_save_one("reboot/soft_reboot", "1");
-    } else {
-        conf_save_one("reboot/soft_reboot", "0");
-    }
-
-    if (!soft_reboot || reason != HAL_RESET_SOFT) {
-        rc = imgr_read_info(boot_current_slot, &ver, hash, NULL);
-        if (rc != 0) {
-            return rc;
-        }
+    rc = imgr_read_info(boot_current_slot, &ver, hash, NULL);
+    if (rc != 0) {
+        return rc;
     }
 
     off = 0;
@@ -204,6 +197,30 @@ log_reboot(const struct log_reboot_info *info)
     return 0;
 }
 
+int
+log_reboot(const struct log_reboot_info *info)
+{
+    int rc;
+
+    /* Don't log a second reboot entry. */
+    if (log_reboot_written) {
+        return 0;
+    }
+
+    rc = log_reboot_write(info);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* Record that we have written a reboot entry for the current boot.  Upon
+     * rebooting, we won't write a second entry.
+     */
+    log_reboot_written = 1;
+    conf_save_one("reboot/written", "1");
+
+    return 0;
+}
+
 /**
  * Increments the reboot counter and writes an entry to the reboot log, if
  * necessary.  This function should be called from main() after config
@@ -218,13 +235,20 @@ reboot_start(enum hal_reset_reason reason)
 
     reboot_cnt_inc();
 
-    info = (struct log_reboot_info) {
-        .reason = reason,
-        .file = NULL,
-        .line = 0,
-        .pc = 0,
-    };
-    log_reboot_write(&info);
+    /* If an entry wasn't written before the previous reboot, write one now. */
+    if (!log_reboot_written) {
+        info = (struct log_reboot_info) {
+            .reason = reason,
+            .file = NULL,
+            .line = 0,
+            .pc = 0,
+        };
+        log_reboot_write(&info);
+    }
+
+    /* Record that we haven't written a reboot entry for the current boot. */
+    log_reboot_written = 0;
+    conf_save_one("reboot/written", "0");
 }
 
 static char *
@@ -234,10 +258,10 @@ reboot_conf_get(int argc, char **argv, char *buf, int max_len)
         if (!strcmp(argv[0], "reboot_cnt")) {
             return conf_str_from_value(CONF_INT16, &reboot_cnt,
                                        reboot_cnt_str, sizeof reboot_cnt_str);
-        } else if (!strcmp(argv[0], "soft_reboot")) {
-            return conf_str_from_value(CONF_INT16, &soft_reboot,
-                                       soft_reboot_str,
-                                       sizeof soft_reboot_str);
+        } else if (!strcmp(argv[0], "written")) {
+            return conf_str_from_value(CONF_BOOL, &log_reboot_written,
+                                       log_reboot_written_str,
+                                       sizeof log_reboot_written_str);
         }
     }
     return NULL;
@@ -249,8 +273,8 @@ reboot_conf_set(int argc, char **argv, char *val)
     if (argc == 1) {
         if (!strcmp(argv[0], "reboot_cnt")) {
             return CONF_VALUE_SET(val, CONF_INT16, reboot_cnt);
-        } else if (!strcmp(argv[0], "soft_reboot")) {
-            return CONF_VALUE_SET(val, CONF_INT16, soft_reboot);
+        } else if (!strcmp(argv[0], "written")) {
+            return CONF_VALUE_SET(val, CONF_INT16, log_reboot_written);
         }
     }
 
@@ -263,7 +287,7 @@ reboot_conf_export(void (*func)(char *name, char *val),
 {
     if (tgt == CONF_EXPORT_SHOW) {
         func("reboot/reboot_cnt", reboot_cnt_str);
-        func("reboot/soft_reboot", soft_reboot_str);
+        func("reboot/written", log_reboot_written_str);
     }
     return 0;
 }

--- a/sys/reboot/syscfg.yml
+++ b/sys/reboot/syscfg.yml
@@ -40,3 +40,9 @@ syscfg.defs:
     REBOOT_LOG_ENTRY_COUNT:
         description: 'Minimum number of reboot log entries retained'
         value: 10
+
+    REBOOT_LOG_BUF_SIZE:
+        description: >
+            The maximum size, in bytes, of a reboot log entry.  A buffer of
+            this size is allocated on the stack each time an entry is written.
+        value: 256


### PR DESCRIPTION
This PR introduces two changes to the reboot log.

#### 1. Add info to reboot log entries

Prior to this commit, a reboot entry contained the following information:

* reason (`rsn`)
* count (`cnt`)
* image version (`img`)

This commit adds the following:

* image hash (`hash`)
* file:line, if available
* value of PC register, if available

#### 2. Limit log writes to one per boot

Prior to this PR, some crashes would result in two entries being written to the reboot log.  For example, on a failed assert, an entry gets logged with the die file and die line.  `__assert_func()` then triggers a nonmaskable interrupt in order to generate a core, which results in a second entry being written to the reboot log.

Finally, after resetting, an additional entry would often (always?) get written to the log.

This PR changes the reboot log semantics as follows:
* When the system resets or crashes, a single entry gets written.  Subsequent faults do not generate an additional log entry.
* Upon booting, the system only records a new log entry if it detects that it did not write one for the previous reset.
