### PR TITLE
kernel/os: Disable OS_CRASH_LOG by default

### DIFF
--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -40,7 +40,7 @@ syscfg.defs:
     OS_CRASH_LOG:
         description: >
             Write an entry to the reboot log when the system crashes.
-        value: 1
+        value: 0
     OS_WATCHDOG_MONITOR:
         description: >
             'Attempt to capture state of stuck system before HW watchdog fires.'
@@ -139,9 +139,3 @@ syscfg.vals.OS_DEBUG_MODE:
     OS_CTX_SW_STACK_CHECK: 1
     OS_MEMPOOL_CHECK: 1
     OS_MEMPOOL_POISON: 1
-
-syscfg.vals.SELFTEST:
-    # OS_CRASH_LOG depends on some APIs that are almost never present in self
-    # tests (bootloader and newtmgr).  Explicitly disable this setting in self
-    # tests.
-    OS_CRASH_LOG: 0


### PR DESCRIPTION
Enabling this setting by default created API dependencies in every app (`bootloader` and `newtmgr`).  Don't break existing code; disable this setting by default.