### PR TITLE
fe310: change default plic isr name

### DIFF
--- a/kernel/os/include/os/arch/rv32imac/os/os_arch.h
+++ b/kernel/os/include/os/arch/rv32imac/os/os_arch.h
@@ -37,6 +37,8 @@ typedef uint32_t os_stack_t;
 #define OS_SANITY_STACK_SIZE (96)
 #define OS_IDLE_STACK_SIZE (64)
 
+void plic_default_isr(int num);
+
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"
 

--- a/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
+++ b/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
@@ -197,7 +197,7 @@ os_arch_os_init(void)
 
     /* Set all external interrupts to default handler */
     for (i = 0; i < PLIC_NUM_INTERRUPTS; ++i) {
-        plic_interrupts[i] = os_default_irq_asm;
+        plic_interrupts[i] = plic_default_isr;
         /* Default priority set to 0, never interrupt */
         PLIC_REG(PLIC_PRIORITY_OFFSET + i * 4) = 0;
     }

--- a/kernel/os/src/arch/rv32imac/os_fault.c
+++ b/kernel/os/src/arch/rv32imac/os_fault.c
@@ -38,7 +38,7 @@ handle_trap(uint32_t cause, void *fault_address, void *exception_frame)
     hal_system_reset();
 }
 
-void os_default_irq_asm(int num)
+void plic_default_isr(int num)
 {
 
 }


### PR DESCRIPTION
There was conflict for os_default_irq_asm.
Function with this name had different signature from other
platforms. When common architecture functions were put in
separate header function prototype start to differ from
implementation.
os_default_irq_asm is used in other platforms as interrupt starting
address while in riscv it was used to handle plic interrupts.

Now default handler for plic interrupts is named plic_default_isr.