### PR TITLE
fe310: Fix SPI blocking read

### DIFF
--- a/hw/mcu/sifive/fe310/include/mcu/fe310_hal.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310_hal.h
@@ -51,6 +51,8 @@ void hal_uart_sys_clock_changed(void);
 
 void hal_uart_sys_clock_changed(void);
 
+#define FE310_SPI_FIFO_LENGHT 8
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/sifive/fe310/src/hal_spi.c
+++ b/hw/mcu/sifive/fe310/src/hal_spi.c
@@ -359,15 +359,11 @@ hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int len)
         rc = SYS_EINVAL;
         goto err;
     }
-    while (_REG32(spi->spi_base, SPI_REG_TXFIFO) & SPI_TXFIFO_FULL) {
-        if (_REG32(spi->spi_base, SPI_REG_RXFIFO)) {
-        }
-    }
     while (!(_REG32(spi->spi_base, SPI_REG_RXFIFO) & SPI_RXFIFO_EMPTY)) {
     }
 
     while (received < len) {
-        if (sent < len &&
+        if (sent < len && (sent - received) < FE310_SPI_FIFO_LENGHT &&
             !(_REG32(spi->spi_base, SPI_REG_TXFIFO) & SPI_TXFIFO_FULL)) {
             _REG32(spi->spi_base, SPI_REG_TXFIFO) = ((uint8_t *)txbuf)[sent++];
         }


### PR DESCRIPTION
To avoid situation when RX data is lost due to RX FIFO overrun,
number of bytes put in the TX FIFO can not be greater than the number
of bytes read from the RX FIFO plus FIFO size (8).