### PR TITLE
hw/util/i2cn: Remove false positive warning

### DIFF
--- a/hw/util/i2cn/src/i2cn.c
+++ b/hw/util/i2cn/src/i2cn.c
@@ -5,7 +5,7 @@ int
 i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                  uint32_t timeout, uint8_t last_op, int retries)
 {
-    int rc;
+    int rc = 0;
     int i;
 
     /* Ensure at least one try. */
@@ -27,7 +27,7 @@ int
 i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                   uint32_t timeout, uint8_t last_op, int retries)
 {
-    int rc;
+    int rc = 0;
     int i;
 
     /* Ensure at least one try. */


### PR DESCRIPTION
gcc 7.1 when -Og is specified does not see that rc variable
is always initialized.
repos/apache-mynewt-core/hw/util/i2cn/src/i2cn.c:23:12: error: 'rc' may be used uninitialized in this function [-Werror=maybe-uninitialized]

This adds initialization. It does not impact optimized builds
since compiler detects that assigning 0 is not needed.