### PR TITLE
Fix double read on enc_flash driver

### DIFF
--- a/hw/drivers/flash/enc_flash/src/enc_flash.c
+++ b/hw/drivers/flash/enc_flash/src/enc_flash.c
@@ -159,7 +159,6 @@ enc_flash_is_empty(const struct hal_flash *h_dev, uint32_t addr, void *buf,
     struct enc_flash_dev *dev = HAL_TO_ENC(h_dev);
     const struct hal_flash *hwdev;
     int rc;
-    int rc2;
 
     hwdev = dev->efd_hwdev;
 
@@ -167,18 +166,18 @@ enc_flash_is_empty(const struct hal_flash *h_dev, uint32_t addr, void *buf,
         return hwdev->hf_itf->hff_is_empty(hwdev, addr, buf, len);
     } else {
         rc = hal_flash_is_erased(hwdev, addr, buf, len);
-        if (rc < 0) {
+
+        /*
+         * If error or low-level flash is erased, avoid reading it.
+         */
+        if (rc < 0 || rc == 1) {
             return rc;
         }
 
         /*
          * Also read the underlying data.
          */
-        rc2 = enc_flash_read(h_dev, addr, buf, len);
-        if (rc2 < 0) {
-            return rc2;
-        }
-        return rc;
+        return enc_flash_read(h_dev, addr, buf, len);
     }
 }
 

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -189,25 +189,17 @@ flash_area_erased_val(const struct flash_area *fa)
 int
 flash_area_is_empty(const struct flash_area *fa, bool *empty)
 {
-    uint32_t data[64 >> 2];
-    uint32_t data_off = 0;
-    int8_t bytes_to_read;
     int rc;
 
-     while (data_off < fa->fa_size) {
-         bytes_to_read = min(64, fa->fa_size - data_off);
-         rc = hal_flash_isempty(fa->fa_device_id, fa->fa_off + data_off, data,
-                                bytes_to_read);
-         if (rc < 0) {
-             return rc;
-         } else if (rc == 0) {
-             *empty = false;
-             return 0;
-         }
-         data_off += bytes_to_read;
-     }
-     *empty = true;
-     return 0;
+    *empty = false;
+    rc = hal_flash_isempty_no_buf(fa->fa_device_id, fa->fa_off, fa->fa_size);
+    if (rc < 0) {
+        return rc;
+    } else if (rc == 1) {
+        *empty = true;
+    }
+
+    return 0;
 }
 
 int


### PR DESCRIPTION
- Update flash_area_is_empty to use the new hal_flash_isempty_no_buf call
- When enc_flash is testing for an empty flash, now it checks that the lower-level driver returned an empty flash already and avoids reading data that when it is known to be empty.