### PR TITLE
Update script to get ignored BSPs from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,9 @@ script:
 - newt install
 - cp -R $HOME/ci/targets .
 
+- export IGNORED_BSPS="ci40 embarc_emsk hifive1 native-armv7 native-mips
+                       pic32mx470_6lp_clicker pic32mz2048_wi-fire sensorhub
+                       usbmkw41z"
 - $HOME/ci/run_test.sh
 
 cache:


### PR DESCRIPTION
This allows IGNORED_BSPS to be configured on travis.yml to automatically ignore BSPs known to fail on build. The list of BSPs is automatically loaded from the "hw/bsp" so that new BSPs are already on by default and to ignore them it is not required to change this repo (only need to add to IGNORED_BSPS in .travis.yml from mynewt-core).