### PR TITLE
Reduce I2C timeout values to reduce system latency when failures take place

### DIFF
--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -141,7 +141,8 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
@@ -150,7 +151,7 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
 
     i2c.len = 1;
     i2c.buffer = (uint8_t *)val;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
@@ -177,7 +178,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
@@ -186,7 +187,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
 
     i2c.len = 2;
     i2c.buffer = (uint8_t *)val;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
@@ -220,7 +221,7 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
@@ -251,7 +252,7 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
@@ -299,7 +300,7 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -339,7 +340,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -352,7 +353,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     i2c.len = 1;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -363,7 +364,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
 
     i2c.len = 36;
     i2c.buffer = tmpbuf;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
@@ -445,7 +446,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -458,7 +459,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.len = 1;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 0,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -469,7 +470,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
 
     i2c.len = buflen + 2;
     i2c.buffer = tmpbuf;
-    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
@@ -529,7 +530,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return rc;
     }
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
@@ -547,7 +548,7 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     i2c.len = 3;
     i2c.buffer = tmpbuf;
 
-    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, OS_TICKS_PER_SEC, 1,
+    rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -26,7 +26,7 @@ syscfg.defs:
         value: 0
     BQ27Z561_LOG:
         description: 'Enable BQ27Z561 logging'
-        value: 0
+        value: 1
     BQ27Z561_LOG_MODULE:
         description: 'Numeric module ID to use for BQ27Z561 log messages'
         value: 111
@@ -41,3 +41,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the BQ27Z561 sends an unexpected NACK.
         value: 2
+    BQ27Z561_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.            
+        value: 6

--- a/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
+++ b/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
@@ -206,7 +206,7 @@ adp5061_get_reg(struct adp5061_dev *dev, uint8_t addr, uint8_t *value)
     /* Register write */
     payload = addr;
     rc = i2cn_master_write(dev->a_chg_ctrl.cc_itf.cci_num, &data_struct,
-            OS_TICKS_PER_SEC / 10, 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
+            MYNEWT_VAL(ADP5061_I2C_TIMEOUT_TICKS), 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
     if (rc) {
         goto err;
     }
@@ -214,7 +214,7 @@ adp5061_get_reg(struct adp5061_dev *dev, uint8_t addr, uint8_t *value)
     /* Read one byte back */
     payload = addr;
     rc = i2cn_master_read(dev->a_chg_ctrl.cc_itf.cci_num, &data_struct,
-            OS_TICKS_PER_SEC / 10, 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
+            MYNEWT_VAL(ADP5061_I2C_TIMEOUT_TICKS), 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
     *value = payload;
 
 err:
@@ -240,7 +240,7 @@ adp5061_set_reg(struct adp5061_dev *dev, uint8_t addr, uint8_t value)
     }
 
     rc = i2cn_master_write(dev->a_chg_ctrl.cc_itf.cci_num, &data_struct,
-            OS_TICKS_PER_SEC / 10, 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
+            MYNEWT_VAL(ADP5061_I2C_TIMEOUT_TICKS), 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
 
     adp5061_itf_unlock(&dev->a_chg_ctrl.cc_itf);
 
@@ -271,7 +271,7 @@ adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
     }
 
     rc = i2cn_master_write(dev->a_chg_ctrl.cc_itf.cci_num, &data_struct,
-            OS_TICKS_PER_SEC / 10, 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
+            MYNEWT_VAL(ADP5061_I2C_TIMEOUT_TICKS), 1, MYNEWT_VAL(ADP5061_I2C_RETRIES));
 
     adp5061_itf_unlock(&dev->a_chg_ctrl.cc_itf);
 

--- a/hw/drivers/chg_ctrl/adp5061/syscfg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/syscfg.yml
@@ -32,3 +32,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the ADP5061 sends an unexpected NACK.
         value: 2
+    ADP5061_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -67,7 +67,7 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
         return rc;
     }
 
-    rc = i2cn_master_write(itf->li_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
@@ -101,7 +101,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
     }
 
     /* Register write */
-    rc = i2cn_master_write(itf->li_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
+    rc = i2cn_master_write(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
@@ -113,7 +113,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
 
     /* Read one byte back */
     data_struct.buffer = value;
-    rc = i2cn_master_read(itf->li_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
@@ -150,7 +150,7 @@ lp5523_set_n_regs(struct led_itf *itf, enum lp5523_registers addr,
         return rc;
     }
 
-    rc = i2cn_master_write(itf->li_num, &data_struct, (OS_TICKS_PER_SEC / 5),
+    rc = i2cn_master_write(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS),
                            1, MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
@@ -183,7 +183,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
         return rc;
     }
 
-    rc = i2cn_master_write(itf->li_num, &data_struct, (OS_TICKS_PER_SEC / 10),
+    rc = i2cn_master_write(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS),
                            0, MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
@@ -195,7 +195,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
 
     data_struct.len = len;
     data_struct.buffer = vals;
-    rc = i2cn_master_read(itf->li_num, &data_struct, OS_TICKS_PER_SEC / 5, 1,
+    rc = i2cn_master_read(itf->li_num, &data_struct, MYNEWT_VAL(LP5523_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {

--- a/hw/drivers/led/lp5523/syscfg.yml
+++ b/hw/drivers/led/lp5523/syscfg.yml
@@ -49,3 +49,7 @@ syscfg.defs:
             Startup sequence delay for chip to finish start sequence
             in micro-seconds
         value: 500
+    LP5523_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -469,7 +469,7 @@ static int
 bmp280_sensor_set_config(struct sensor *sensor, void *cfg)
 {
     struct bmp280* bmp280 = (struct bmp280 *)SENSOR_GET_DEVICE(sensor);
-    
+
     return bmp280_config(bmp280, (struct bmp280_cfg*)cfg);
 }
 
@@ -705,7 +705,7 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     memset(buffer, 0, len);
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BMP280_I2C_RETRIES));
     if (rc) {
         BMP280_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -717,7 +717,7 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     /* Read len bytes back */
     memset(payload, 0, sizeof(payload));
     data_struct.len = len;
-    rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BMP280_I2C_RETRIES));
     if (rc) {
         BMP280_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
@@ -820,7 +820,7 @@ bmp280_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
         payload[1] = buffer[i];
 
         rc = i2cn_master_write(itf->si_num, &data_struct,
-                               OS_TICKS_PER_SEC / 10, 1,
+                               MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 1,
                                MYNEWT_VAL(BMP280_I2C_RETRIES));
         if (rc) {
             BMP280_LOG(ERROR, "Failed to write 0x%02X:0x%02X\n",

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -50,3 +50,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the BMP280 sends an unexpected NACK.
         value: 2
+    BMP280_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -112,7 +112,7 @@ lis2dh12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     memset(buffer, 0, len);
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
         LIS2DH12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -124,7 +124,7 @@ lis2dh12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     /* Read len bytes back */
     memset(payload, 0, sizeof(payload));
     data_struct.len = len;
-    rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
         LIS2DH12_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
@@ -241,7 +241,7 @@ lis2dh12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     memcpy(&payload[1], buffer, len);
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
         LIS2DH12_LOG(ERROR, "I2C access failed at address 0x%02X\n",

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -29,3 +29,8 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the LIS2DH12 sends an unexpected NACK.
         value: 2
+    LIS2DH12_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3
+ 

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -232,7 +232,7 @@ lis2dw12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     memcpy(&payload[1], buffer, len);
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DW12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
     if (rc) {
         LIS2DW12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -362,7 +362,7 @@ lis2dw12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     };
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DW12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
     if (rc) {
         LIS2DW12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -374,7 +374,7 @@ lis2dw12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     /* Read data */
     data_struct.len = len;
     data_struct.buffer = buffer;
-    rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DW12_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
 
     if (rc) {

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -55,3 +55,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the LIS2DW12 sends an unexpected NACK.
         value: 2
+    LIS2DW12_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -176,7 +176,7 @@ lps33hw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
         .buffer = payload
     };
 
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LPS33HW_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LPS33HW_I2C_RETRIES));
 
     if (rc) {
@@ -347,7 +347,7 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     };
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LPS33HW_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LPS33HW_I2C_RETRIES));
     if (rc) {
         LPS33HW_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -360,7 +360,7 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     data_struct.len = size;
     data_struct.buffer = buffer;
     rc = i2cn_master_read(itf->si_num, &data_struct,
-                          (OS_TICKS_PER_SEC / 10) * size, 1,
+                          (MYNEWT_VAL(LPS33HW_I2C_TIMEOUT_TICKS)) * size, 1,
                           MYNEWT_VAL(LPS33HW_I2C_RETRIES));
 
     if (rc) {

--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -43,3 +43,8 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the LPS33HW sends an unexpected NACK.
         value: 2
+    LPS33HW_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3
+ 

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -176,7 +176,7 @@ lps33thw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
         .buffer = payload
     };
 
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LPS33THW_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LPS33THW_I2C_RETRIES));
 
     if (rc) {
@@ -347,7 +347,7 @@ lps33thw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     };
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LPS33THW_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LPS33THW_I2C_RETRIES));
     if (rc) {
         LPS33THW_LOG(ERROR, "I2C access failed at address 0x%02X\n",
@@ -360,7 +360,7 @@ lps33thw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     data_struct.len = size;
     data_struct.buffer = buffer;
     rc = i2cn_master_read(itf->si_num, &data_struct,
-                          (OS_TICKS_PER_SEC / 10) * size, 1,
+                          (MYNEWT_VAL(LPS33THW_I2C_TIMEOUT_TICKS)) * size, 1,
                           MYNEWT_VAL(LPS33THW_I2C_RETRIES));
 
     if (rc) {

--- a/hw/drivers/sensors/lps33thw/syscfg.yml
+++ b/hw/drivers/sensors/lps33thw/syscfg.yml
@@ -43,3 +43,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the LPS33THW sends an unexpected NACK.
         value: 2
+    LPS33THW_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -267,7 +267,7 @@ static int
 ms5837_sensor_set_config(struct sensor *sensor, void *cfg)
 {
     struct ms5837* ms5837 = (struct ms5837 *)SENSOR_GET_DEVICE(sensor);
-    
+
     return ms5837_config(ms5837, (struct ms5837_cfg*)cfg);
 }
 
@@ -336,7 +336,7 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     }
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
         MS5837_LOG(ERROR, "I2C write command write failed at address 0x%02X\n",
@@ -381,7 +381,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     }
 
     /* Command write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
         MS5837_LOG(ERROR, "I2C read command write failed at address 0x%02X\n",
@@ -393,7 +393,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     /* Read len bytes back */
     memset(payload, 0, sizeof(payload));
     data_struct.len = len;
-    rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
         MS5837_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",

--- a/hw/drivers/sensors/ms5837/syscfg.yml
+++ b/hw/drivers/sensors/ms5837/syscfg.yml
@@ -28,3 +28,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the MS5837 sends an unexpected NACK.
         value: 2
+    MS5837_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -239,7 +239,7 @@ ms5840_sensor_read(struct sensor *sensor, sensor_type_t type,
             goto err;
         }
     }
-    
+
     return 0;
 err:
     return rc;
@@ -268,7 +268,7 @@ static int
 ms5840_sensor_set_config(struct sensor *sensor, void *cfg)
 {
     struct ms5840* ms5840 = (struct ms5840 *)SENSOR_GET_DEVICE(sensor);
-    
+
     return ms5840_config(ms5840, (struct ms5840_cfg*)cfg);
 }
 
@@ -337,7 +337,7 @@ ms5840_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     }
 
     /* Register write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5840_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5840_I2C_RETRIES));
     if (rc) {
         MS5840_LOG(ERROR, "I2C write command write failed at address 0x%02X\n",
@@ -382,7 +382,7 @@ ms5840_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     }
 
     /* Command write */
-    rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5840_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5840_I2C_RETRIES));
     if (rc) {
         MS5840_LOG(ERROR, "I2C read command write failed at address 0x%02X\n",
@@ -394,7 +394,7 @@ ms5840_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     /* Read len bytes back */
     memset(payload, 0, sizeof(payload));
     data_struct.len = len;
-    rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
+    rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(MS5840_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(MS5840_I2C_RETRIES));
     if (rc) {
         MS5840_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",

--- a/hw/drivers/sensors/ms5840/syscfg.yml
+++ b/hw/drivers/sensors/ms5840/syscfg.yml
@@ -28,3 +28,7 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the MS5840 sends an unexpected NACK.
         value: 2
+    MS5840_I2C_TIMEOUT_TICKS:
+        description: >
+            Number of OS ticks to wait for each I2C transaction to complete.
+        value: 3


### PR DESCRIPTION
Most I2C devices will respond in well under 1ms but currently the timeout in most drivers is specified as OS_TICKS_PER_SEC/10. This causes undue latency in recovering from I2C errors. This change adds syscfg to some drivers to specify a smaller I2C timeout of 3 OS ticks. 

Also changes BQ27Z561_LOG default value to 1, since the original default value of 0 can cause I2C errors on the device to go unnoticed. 

