### PR TITLE
Remove gcc-multilib dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ _addons: &addon_conf
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-multilib
       - gcc-7-multilib
+      - linux-libc-dev:i386
 
 go:
   - "1.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,28 +31,26 @@ go:
 matrix:
   include:
     - os: linux
-      addons: *addon_conf
-      env: 
+      env:
         - TEST=BUILD_TARGETS
     - os: linux
-      addons: *addon_conf
-      env: 
+      env:
         - TEST=BUILD_BLINKY
     - os: linux
       addons: *addon_conf
-      env: 
+      env:
         - TEST=TEST_ALL
     - os: osx
       osx_image: xcode9.2
-      env: 
+      env:
         - TEST=BUILD_TARGETS
     - os: osx
       osx_image: xcode9.2
-      env: 
+      env:
         - TEST=BUILD_BLINKY
     - os: osx
       osx_image: xcode9.2
-      env: 
+      env:
         - TEST=TEST_ALL
 
 install:
@@ -74,7 +72,8 @@ script:
 - newt install
 
 - export IGNORED_BSPS="ci40 embarc_emsk hifive1 native-armv7 native-mips
-                       pic32mx470_6lp_clicker pic32mz2048_wi-fire sensorhub"
+                       pic32mx470_6lp_clicker pic32mz2048_wi-fire sensorhub
+                       native"
 - $HOME/ci/run_test.sh
 
 cache:


### PR DESCRIPTION
The gcc-multilib was bringing in full gcc-4.8 (including g++-4.8), so remove it and add kernel headers dep manually.

Also removed `gcc-7-multlib` from ARM target tests.