### PR TITLE
Fix sim-armv7 build error

### DIFF
--- a/kernel/os/include/os/arch/sim-armv7/os/os_arch.h
+++ b/kernel/os/include/os/arch/sim-armv7/os/os_arch.h
@@ -20,7 +20,7 @@
 #ifndef _OS_ARCH_SIM_H
 #define _OS_ARCH_SIM_H
 
-#include "mcu/mcu_sim.h
+#include "mcu/mcu_sim.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This fixes this build error:

```
    Error: In file included from repos/apache-mynewt-core/kernel/os/include/os/os_time.h:65:0,
                     from repos/apache-mynewt-core/kernel/os/include/os/os_eventq.h:32,
                     from repos/apache-mynewt-core/kernel/os/include/os/os_mbuf.h:33,
                     from repos/blehostd/apps/blehostd/src/blehostd.h:7,
                     from repos/blehostd/apps/blehostd/src/bhd_gap.c:3:
    repos/apache-mynewt-core/kernel/os/include/os/arch/sim-armv7/os/os_arch.h:23:10: error: #include expects "FILENAME" or <FILENAME>
     #include "mcu/mcu_sim.h
              ^~~~~~~~~~~~~~
```