### PR TITLE
hw/battery: Make property polling more robust

### DIFF
--- a/hw/battery/include/battery/battery.h
+++ b/hw/battery/include/battery/battery.h
@@ -105,6 +105,11 @@ struct battery {
      */
     struct battery_property *b_properties;
 
+    /* Bitmask of properties which needs polling (for poll and change
+     * notifications).
+     */
+    uint32_t b_polled_properties[BATTERY_PROPERTY_MASK_SIZE];
+
     /**
      * Poll rate in ms for this battery.
      * Field managed by battery manager.

--- a/hw/battery/include/battery/battery.h
+++ b/hw/battery/include/battery/battery.h
@@ -96,7 +96,7 @@ struct battery {
     /* All propertied are numbered for battery manager internal use */
     uint8_t b_all_property_count;
 
-    /* Numbre of registered listeners */
+    /* Number of registered listeners */
     uint8_t b_listener_count;
 
     /* Array of properties created by battery manager

--- a/hw/battery/include/battery/battery_prop.h
+++ b/hw/battery/include/battery/battery_prop.h
@@ -40,6 +40,8 @@ extern "C" {
 #define BATTERY_MAX_PROPERTY_COUNT 32
 #endif
 
+#define BATTERY_PROPERTY_MASK_SIZE (((BATTERY_MAX_PROPERTY_COUNT) + 31) / 32)
+
 /* Forward declaration of battery structure. */
 struct battery;
 struct battery_property;


### PR DESCRIPTION
With these changes battery manager will only poll battery properties which at lest one listener is subscribed for. This can reduce polling time significantly (depends on number of subscribed properties).