### PR TITLE
test/runtest: Null-terminate segments of log entry

### DIFF
--- a/compiler/arc/compiler.yml
+++ b/compiler/arc/compiler.yml
@@ -25,9 +25,9 @@ compiler.path.objdump: arc-elf32-objdump
 compiler.path.objsize: arc-elf32-size
 compiler.path.objcopy: arc-elf32-objcopy
 
-compiler.flags.default: -mno-sdata -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections
-compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
-compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
+compiler.flags.default: [-mno-sdata, -Wall, -Werror, -fno-exceptions, -fomit-frame-pointer, -ffunction-sections, -fdata-sections]
+compiler.flags.optimized: [compiler.flags.default, -Os, -ggdb]
+compiler.flags.debug: [compiler.flags.default, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 

--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -25,10 +25,10 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.default: -march=armv6s-m -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -DCMSIS_VECTAB_VIRTUAL -DCMSIS_VECTAB_VIRTUAL_HEADER_FILE="mynewt_cm0_vectab.h"
-compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
-compiler.flags.speed: [compiler.flags.default, -O3 -ggdb]
-compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
+compiler.flags.default: [-march=armv6s-m, -mcpu=cortex-m0, -mthumb-interwork, -mthumb, -Wall, -Werror, -fno-exceptions, -fomit-frame-pointer, -ffunction-sections, -fdata-sections, -DCMSIS_VECTAB_VIRTUAL, -DCMSIS_VECTAB_VIRTUAL_HEADER_FILE="mynewt_cm0_vectab.h"]
+compiler.flags.optimized: [compiler.flags.default, -Os, -ggdb]
+compiler.flags.speed: [compiler.flags.default, -O3, -ggdb]
+compiler.flags.debug: [compiler.flags.default, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 

--- a/compiler/arm-none-eabi-m3/compiler.yml
+++ b/compiler/arm-none-eabi-m3/compiler.yml
@@ -25,11 +25,11 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m3 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
-compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
-compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
-compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
-compiler.flags.debug: [compiler.flags.base, -Og -ggdb]
+compiler.flags.base: [-mcpu=cortex-m3, -mthumb-interwork, -mthumb, -Wall, -Werror, -fno-exceptions, -ffunction-sections, -fdata-sections]
+compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
+compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3, -ggdb]
+compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 

--- a/compiler/arm-none-eabi-m4/compiler.yml
+++ b/compiler/arm-none-eabi-m4/compiler.yml
@@ -25,11 +25,11 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m4 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
-compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
-compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
-compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
-compiler.flags.debug: [compiler.flags.base, -Og -ggdb]
+compiler.flags.base: [-mcpu=cortex-m4, -mthumb-interwork, -mthumb, -Wall, -Werror, -fno-exceptions, -ffunction-sections, -fdata-sections]
+compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
+compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3, -ggdb]
+compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 

--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -25,11 +25,11 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m7 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
-compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
-compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
-compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
-compiler.flags.debug: [compiler.flags.base, -O0 -ggdb]
+compiler.flags.base: [-mcpu=cortex-m7, -mthumb-interwork, -mthumb, -Wall, -Werror, -fno-exceptions, -ffunction-sections, -fdata-sections]
+compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
+compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3, -ggdb]
+compiler.flags.debug: [compiler.flags.base, -O0, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 

--- a/compiler/mips/compiler.yml
+++ b/compiler/mips/compiler.yml
@@ -24,7 +24,7 @@ compiler.path.objdump: "mips-mti-elf-objdump"
 compiler.path.objsize: "mips-mti-elf-size"
 compiler.path.objcopy: "mips-mti-elf-objcopy"
 
-compiler.flags.base: -std=gnu11 -EL -mips32r2 -Wall -Werror
+compiler.flags.base: [-std=gnu11, -EL, -mips32r2, -Wall, -Werror]
 compiler.flags.default: [compiler.flags.base, -O2, -g]
 compiler.flags.optimized: [compiler.flags.base, -Os, -g]
 compiler.flags.debug: [compiler.flags.base, -g3]

--- a/compiler/riscv64/compiler.yml
+++ b/compiler/riscv64/compiler.yml
@@ -24,10 +24,10 @@ compiler.path.objdump: "riscv64-unknown-elf-objdump"
 compiler.path.objsize: "riscv64-unknown-elf-size"
 compiler.path.objcopy: "riscv64-unknown-elf-objcopy"
 
-compiler.flags.base: -std=gnu11 -Wall -Werror -Wno-format-truncation -ffunction-sections -fdata-sections -fno-builtin-printf
-compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
-compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
-compiler.flags.debug: [compiler.flags.base, -Og -ggdb]
+compiler.flags.base: [-std=gnu11, -Wall, -Werror, -Wno-format-truncation, -ffunction-sections, -fdata-sections, -fno-builtin-printf]
+compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
+compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
+compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x assembler-with-cpp]
 

--- a/compiler/sim-mips/compiler.yml
+++ b/compiler/sim-mips/compiler.yml
@@ -24,8 +24,7 @@ compiler.path.archive: "mips-mti-linux-gnu-ar"
 compiler.path.objdump: "mips-mti-linux-gnu-objdump"
 compiler.path.objsize: "mips-mti-linux-gnu-size"
 compiler.path.objcopy: "mips-mti-linux-gnu-objcopy"
-compiler.flags.base: >
-    -std=gnu11 -EL -mips32r2 -Wall -Werror -ggdb
+compiler.flags.base: [-std=gnu11, -EL, -mips32r2, -Wall, -Werror, -ggdb]
 compiler.ld.resolve_circular_deps: true
 
 compiler.flags.default: [compiler.flags.base, -O1]

--- a/compiler/xc32/compiler.yml
+++ b/compiler/xc32/compiler.yml
@@ -24,9 +24,9 @@ compiler.path.objdump: "xc32-objdump"
 compiler.path.objsize: "xc32-size"
 compiler.path.objcopy: "xc32-objcopy"
 
-compiler.flags.base: -std=gnu11 -msmart-io=0
+compiler.flags.base: [-std=gnu11, -msmart-io=0]
 compiler.flags.default: [compiler.flags.base, -O2, -g3]
-compiler.flags.optimized: [compiler.flags.base, -Os -g3]
+compiler.flags.optimized: [compiler.flags.base, -Os, -g3]
 compiler.flags.debug: [compiler.flags.base, -g3]
 
 compiler.as.flags: [-x, assembler-with-cpp]

--- a/test/runtest/src/runtest.c
+++ b/test/runtest/src/runtest.c
@@ -155,8 +155,8 @@ static void
 runtest_log_result(const char *msg, bool passed)
 {
 #if MYNEWT_VAL(RUNTEST_LOG)
-    /* Must log valid json with a strlen less than LOG_PRINTF_MAX_ENTRY_LEN */
-    char buf[LOG_PRINTF_MAX_ENTRY_LEN];
+    /* Must log valid json with a strlen less than MODLOG_MAX_PRINTF_LEN */
+    char buf[MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)];
     char *n;
     int n_len;
     char *s;
@@ -172,8 +172,8 @@ runtest_log_result(const char *msg, bool passed)
 
     /* How much of the test name can we log? */
     n_len = strlen(tu_case_name);
-    if (len + n_len >= LOG_PRINTF_MAX_ENTRY_LEN) {
-        n_len = LOG_PRINTF_MAX_ENTRY_LEN - len - 1;
+    if (len + n_len >= MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)) {
+        n_len = MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - len - 1;
     }
     len += n_len;
     n = buf;
@@ -182,8 +182,8 @@ runtest_log_result(const char *msg, bool passed)
 
     /* How much of the suite name can we log? */
     s_len = strlen(runtest_current_ts->ts_name);
-    if (len + s_len >= LOG_PRINTF_MAX_ENTRY_LEN) {
-        s_len = LOG_PRINTF_MAX_ENTRY_LEN - len - 1;
+    if (len + s_len >= MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)) {
+        s_len = MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - len - 1;
     }
     len += s_len;
     s = n + n_len + 2;
@@ -192,8 +192,8 @@ runtest_log_result(const char *msg, bool passed)
 
     /* How much of the message can we log? */
     m_len = strlen(msg);
-    if (len + m_len >= LOG_PRINTF_MAX_ENTRY_LEN) {
-        m_len = LOG_PRINTF_MAX_ENTRY_LEN - len - 1;
+    if (len + m_len >= MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN)) {
+        m_len = MYNEWT_VAL(MODLOG_MAX_PRINTF_LEN) - len - 1;
     }
     m = s + s_len + 2;
     strncpy(m, msg, m_len);

--- a/test/runtest/src/runtest.c
+++ b/test/runtest/src/runtest.c
@@ -165,8 +165,10 @@ runtest_log_result(const char *msg, bool passed)
     int m_len;
     int len;
 
-    /* str length of {"k":"","n":"","s":"","m":"","r":1}<token> */
-    len = 35 + strlen(runtest_token);
+    /* str length of {"k":"","n":"","s":"","m":"","r":1}<token> plus three
+     * null-terminators.
+     */
+    len = 38 + strlen(runtest_token);
 
     /* How much of the test name can we log? */
     n_len = strlen(tu_case_name);
@@ -175,7 +177,8 @@ runtest_log_result(const char *msg, bool passed)
     }
     len += n_len;
     n = buf;
-    strncpy(n, tu_case_name, n_len + 1);
+    strncpy(n, tu_case_name, n_len);
+    n[n_len] = '\0';
 
     /* How much of the suite name can we log? */
     s_len = strlen(runtest_current_ts->ts_name);
@@ -184,7 +187,8 @@ runtest_log_result(const char *msg, bool passed)
     }
     len += s_len;
     s = n + n_len + 2;
-    strncpy(s, runtest_current_ts->ts_name, s_len + 1);
+    strncpy(s, runtest_current_ts->ts_name, s_len);
+    s[s_len] = '\0';
 
     /* How much of the message can we log? */
     m_len = strlen(msg);
@@ -192,7 +196,8 @@ runtest_log_result(const char *msg, bool passed)
         m_len = LOG_PRINTF_MAX_ENTRY_LEN - len - 1;
     }
     m = s + s_len + 2;
-    strncpy(m, msg, m_len + 1);
+    strncpy(m, msg, m_len);
+    m[m_len] = '\0';
 
     /* XXX Hack to allow the idle task to run and update the timestamp. */
     os_time_delay(1);


### PR DESCRIPTION
Overly long segments (test case name, suite name, and message) were not being null-terminated.  This caused malformed JSON to be included in the log.
