### PR TITLE
Travis cache homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,4 @@ script:
 cache:
   directories:
   - $HOME/TOOLCHAIN
+  - $HOME/Library/Caches/Homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
 
 - newt version
 - gcc --version
-- arm-none-eabi-gcc --version
+- if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
 
 script:
 - cp -R $HOME/ci/mynewt-core-project.yml project.yml


### PR DESCRIPTION
Add homebrew package caching and only check for ARM tooling on machines that run ARM builds (must be merged before https://github.com/runtimeco/mynewt-travis-ci/pull/10)