### PR TITLE
spiflash: Add support for multiple chips

### DIFF
--- a/hw/drivers/flash/spiflash/chips/pkg.yml
+++ b/hw/drivers/flash/spiflash/chips/pkg.yml
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-pkg.name: hw/drivers/flash/spiflash
-pkg.description: SpiFlash driver
+pkg.name: hw/drivers/flash/spiflash/chips
+pkg.description: SpiFlash chip selection package
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+    - spiflash
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/hw/drivers/flash/spiflash/chips"

--- a/hw/drivers/flash/spiflash/chips/syscfg.yml
+++ b/hw/drivers/flash/spiflash/chips/syscfg.yml
@@ -1,0 +1,490 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPIFLASH_GD25D05C:
+        description: Add support for GD25D05C
+        value: 0
+    SPIFLASH_GD25LD05C:
+        description: Add support for GD25LD05C
+        value: 0
+    SPIFLASH_GD25LE05C:
+        description: Add support for GD25LE05C
+        value: 0
+    SPIFLASH_GD25LH05C:
+        description: Add support for GD25LH05C
+        value: 0
+    SPIFLASH_GD25VD05B:
+        description: Add support for GD25VD05B
+        value: 0
+    SPIFLASH_GD25WD05C:
+        description: Add support for GD25WD05C
+        value: 0
+    SPIFLASH_GD25D10C:
+        description: Add support for GD25D10C
+        value: 0
+    SPIFLASH_GD25LD10C:
+        description: Add support for GD25LD10C
+        value: 0
+    SPIFLASH_GD25LE10C:
+        description: Add support for GD25LE10C
+        value: 0
+    SPIFLASH_GD25LH10C:
+        description: Add support for GD25LH10C
+        value: 0
+    SPIFLASH_GD25VD10B:
+        description: Add support for GD25VD10B
+        value: 0
+    SPIFLASH_GD25WD10C:
+        description: Add support for GD25WD10C
+        value: 0
+    SPIFLASH_GD25LE20C:
+        description: Add support for GD25LE20C
+        value: 0
+    SPIFLASH_GD25LH20C:
+        description: Add support for GD25LH20C
+        value: 0
+    SPIFLASH_GD25D20C:
+        description: Add support for GD25D20C
+        value: 0
+    SPIFLASH_GD25LD20C:
+        description: Add support for GD25LD20C
+        value: 0
+    SPIFLASH_GD25VE20C:
+        description: Add support for GD25VE20C
+        value: 0
+    SPIFLASH_GD25WD20C:
+        description: Add support for GD25WD20C
+        value: 0
+    SPIFLASH_GD25LE40C:
+        description: Add support for GD25LE40C
+        value: 0
+    SPIFLASH_GD25LH40C:
+        description: Add support for GD25LH40C
+        value: 0
+    SPIFLASH_GD25D40C:
+        description: Add support for GD25D40C
+        value: 0
+    SPIFLASH_GD25LD40C:
+        description: Add support for GD25LD40C
+        value: 0
+    SPIFLASH_GD25WD40C:
+        description: Add support for GD25WD40C
+        value: 0
+    SPIFLASH_GD25VE40C:
+        description: Add support for GD25VE40C
+        value: 0
+    SPIFLASH_GD25VE40B:
+        description: Add support for GD25VE40B
+        value: 0
+    SPIFLASH_GD25D80C:
+        description: Add support for GD25D80C
+        value: 0
+    SPIFLASH_GD25LD80C:
+        description: Add support for GD25LD80C
+        value: 0
+    SPIFLASH_GD25LE80C:
+        description: Add support for GD25LE80C
+        value: 0
+    SPIFLASH_GD25LH80B:
+        description: Add support for GD25LH80B
+        value: 0
+    SPIFLASH_GD25LH80C:
+        description: Add support for GD25LH80C
+        value: 0
+    SPIFLASH_GD25WD80C:
+        description: Add support for GD25WD80C
+        value: 0
+    SPIFLASH_GD25Q80C:
+        description: Add support for GD25Q80C
+        value: 0
+    SPIFLASH_GD25B16C:
+        description: Add support for GD25B16C
+        value: 0
+    SPIFLASH_GD25LE16C:
+        description: Add support for GD25LE16C
+        value: 0
+    SPIFLASH_GD25LH16C:
+        description: Add support for GD25LH16C
+        value: 0
+    SPIFLASH_GD25Q16C:
+        description: Add support for GD25Q16C
+        value: 0
+    SPIFLASH_GD25VE16C:
+        description: Add support for GD25VE16C
+        value: 0
+    SPIFLASH_MX25L512E:
+        description: Add support for MX25L512E
+        value: 0
+    SPIFLASH_MX25L5121E:
+        description: Add support for MX25L5121E
+        value: 0
+    SPIFLASH_MX25L1021E:
+        description: Add support for MX25L1021E
+        value: 0
+    SPIFLASH_MX25R512F:
+        description: Add support for MX25R512F
+        value: 0
+    SPIFLASH_MX25U5121E:
+        description: Add support for MX25U5121E
+        value: 0
+    SPIFLASH_MX25U1001E:
+        description: Add support for MX25U1001E
+        value: 0
+    SPIFLASH_MX25V512E:
+        description: Add support for MX25V512E
+        value: 0
+    SPIFLASH_MX25V512F:
+        description: Add support for MX25V512F
+        value: 0
+    SPIFLASH_MX25L1006E:
+        description: Add support for MX25L1006E
+        value: 0
+    SPIFLASH_MX25L1026E:
+        description: Add support for MX25L1026E
+        value: 0
+    SPIFLASH_MX25R1035F:
+        description: Add support for MX25R1035F
+        value: 0
+    SPIFLASH_MX25V1006E:
+        description: Add support for MX25V1006E
+        value: 0
+    SPIFLASH_MX25V1006F:
+        description: Add support for MX25V1006F
+        value: 0
+    SPIFLASH_MX25V1035F:
+        description: Add support for MX25V1035F
+        value: 0
+    SPIFLASH_MX25L2006E:
+        description: Add support for MX25L2006E
+        value: 0
+    SPIFLASH_MX25L2026E:
+        description: Add support for MX25L2026E
+        value: 0
+    SPIFLASH_MX25R2035F:
+        description: Add support for MX25R2035F
+        value: 0
+    SPIFLASH_MX25U2032E:
+        description: Add support for MX25U2032E
+        value: 0
+    SPIFLASH_MX25U2033E:
+        description: Add support for MX25U2033E
+        value: 0
+    SPIFLASH_MX25U2035F:
+        description: Add support for MX25U2035F
+        value: 0
+    SPIFLASH_MX25V2006E:
+        description: Add support for MX25V2006E
+        value: 0
+    SPIFLASH_MX25V2033F:
+        description: Add support for MX25V2033F
+        value: 0
+    SPIFLASH_MX25V2035F:
+        description: Add support for MX25V2035F
+        value: 0
+    SPIFLASH_MX25L4006E:
+        description: Add support for MX25L4006E
+        value: 0
+    SPIFLASH_MX25L4026E:
+        description: Add support for MX25L4026E
+        value: 0
+    SPIFLASH_MX25R4035F:
+        description: Add support for MX25R4035F
+        value: 0
+    SPIFLASH_MX25U4032E:
+        description: Add support for MX25U4032E
+        value: 0
+    SPIFLASH_MX25U4033E:
+        description: Add support for MX25U4033E
+        value: 0
+    SPIFLASH_MX25U4035:
+        description: Add support for MX25U4035
+        value: 0
+    SPIFLASH_MX25U4035F:
+        description: Add support for MX25U4035F
+        value: 0
+    SPIFLASH_MX25V4006E:
+        description: Add support for MX25V4006E
+        value: 0
+    SPIFLASH_MX25V4035F:
+        description: Add support for MX25V4035F
+        value: 0
+    SPIFLASH_MX25U8035:
+        description: Add support for MX25U8035
+        value: 0
+    SPIFLASH_MX25L8006E:
+        description: Add support for MX25L8006E
+        value: 0
+    SPIFLASH_MX25L8008E:
+        description: Add support for MX25L8008E
+        value: 0
+    SPIFLASH_MX25L8035E:
+        description: Add support for MX25L8035E
+        value: 0
+    SPIFLASH_MX25L8036E:
+        description: Add support for MX25L8036E
+        value: 0
+    SPIFLASH_MX25L8073E:
+        description: Add support for MX25L8073E
+        value: 0
+    SPIFLASH_MX25R8035F:
+        description: Add support for MX25R8035F
+        value: 0
+    SPIFLASH_MX25U8032E:
+        description: Add support for MX25U8032E
+        value: 0
+    SPIFLASH_MX25U8033E:
+        description: Add support for MX25U8033E
+        value: 0
+    SPIFLASH_MX25U8035E:
+        description: Add support for MX25U8035E
+        value: 0
+    SPIFLASH_MX25U8035F:
+        description: Add support for MX25U8035F
+        value: 0
+    SPIFLASH_MX25V8006E:
+        description: Add support for MX25V8006E
+        value: 0
+    SPIFLASH_MX25V8033F:
+        description: Add support for MX25V8033F
+        value: 0
+    SPIFLASH_MX25V8035F:
+        description: Add support for MX25V8035F
+        value: 0
+    SPIFLASH_MX25L1606E:
+        description: Add support for MX25L1606E
+        value: 0
+    SPIFLASH_MX25L1608E:
+        description: Add support for MX25L1608E
+        value: 0
+    SPIFLASH_MX25L1633E:
+        description: Add support for MX25L1633E
+        value: 0
+    SPIFLASH_MX25L1635E:
+        description: Add support for MX25L1635E
+        value: 0
+    SPIFLASH_MX25L1636E:
+        description: Add support for MX25L1636E
+        value: 0
+    SPIFLASH_MX25L1673E:
+        description: Add support for MX25L1673E
+        value: 0
+    SPIFLASH_MX25R1635F:
+        description: Add support for MX25R1635F
+        value: 0
+    SPIFLASH_MX25U1633F:
+        description: Add support for MX25U1633F
+        value: 0
+    SPIFLASH_MX25U1635E:
+        description: Add support for MX25U1635E
+        value: 0
+    SPIFLASH_MX25U1635F:
+        description: Add support for MX25U1635F
+        value: 0
+    SPIFLASH_MX25V1635F:
+        description: Add support for MX25V1635F
+        value: 0
+    SPIFLASH_MX25L3206E:
+        description: Add support for MX25L3206E
+        value: 0
+    SPIFLASH_MX25L3208E:
+        description: Add support for MX25L3208E
+        value: 0
+    SPIFLASH_MX25L3233F:
+        description: Add support for MX25L3233F
+        value: 0
+    SPIFLASH_MX25L3235E:
+        description: Add support for MX25L3235E
+        value: 0
+    SPIFLASH_MX25L3236F:
+        description: Add support for MX25L3236F
+        value: 0
+    SPIFLASH_MX25L3239E:
+        description: Add support for MX25L3239E
+        value: 0
+    SPIFLASH_MX25L3273E:
+        description: Add support for MX25L3273E
+        value: 0
+    SPIFLASH_MX25L3273F:
+        description: Add support for MX25L3273F
+        value: 0
+    SPIFLASH_MX25R3235F:
+        description: Add support for MX25R3235F
+        value: 0
+    SPIFLASH_MX25U3235E:
+        description: Add support for MX25U3235E
+        value: 0
+    SPIFLASH_MX25U3235F:
+        description: Add support for MX25U3235F
+        value: 0
+    SPIFLASH_MX25U3273F:
+        description: Add support for MX25U3273F
+        value: 0
+    SPIFLASH_IS25LP080D:
+        description: Add support for IS25LP080D
+        value: 0
+    SPIFLASH_IS25WP080D:
+        description: Add support for IS25WP080D
+        value: 0
+    SPIFLASH_IS25WP040D:
+        description: Add support for IS25WP040D
+        value: 0
+    SPIFLASH_IS25WP020D:
+        description: Add support for IS25WP020D
+        value: 0
+    SPIFLASH_IS25LQ040B:
+        description: Add support for IS25LQ040B
+        value: 0
+    SPIFLASH_IS25LQ020B:
+        description: Add support for IS25LQ020B
+        value: 0
+    SPIFLASH_IS25LQ010B:
+        description: Add support for IS25LQ010B
+        value: 0
+    SPIFLASH_IS25LQ512B:
+        description: Add support for IS25LQ512B
+        value: 0
+    SPIFLASH_IS25WQ040:
+        description: Add support for IS25WQ040
+        value: 0
+    SPIFLASH_IS25WQ020:
+        description: Add support for IS25WQ020
+        value: 0
+    SPIFLASH_IS25LQ025B:
+        description: Add support for IS25LQ025B
+        value: 0
+    SPIFLASH_IS25LP016D:
+        description: Add support for IS25LP016D
+        value: 0
+    SPIFLASH_IS25WP016D:
+        description: Add support for IS25WP016D
+        value: 0
+    SPIFLASH_IS25LP032D:
+        description: Add support for IS25LP032D
+        value: 0
+    SPIFLASH_IS25WP032D:
+        description: Add support for IS25WP032D
+        value: 0
+    SPIFLASH_W25X05CL:
+        description: Add support for W25X05CL
+        value: 0
+    SPIFLASH_W25Q10EW:
+        description: Add support for W25Q10EW
+        value: 0
+    SPIFLASH_W25X10CL:
+        description: Add support for W25X10CL
+        value: 0
+    SPIFLASH_W25Q20CL:
+        description: Add support for W25Q20CL
+        value: 0
+    SPIFLASH_W25Q20EW:
+        description: Add support for W25Q20EW
+        value: 0
+    SPIFLASH_W25X20CL:
+        description: Add support for W25X20CL
+        value: 0
+    SPIFLASH_W25Q40CL:
+        description: Add support for W25Q40CL
+        value: 0
+    SPIFLASH_W25Q40EW:
+        description: Add support for W25Q40EW
+        value: 0
+    SPIFLASH_W25X40CL:
+        description: Add support for W25X40CL
+        value: 0
+    SPIFLASH_W25Q80DV:
+        description: Add support for W25Q80DV
+        value: 0
+    SPIFLASH_W25Q80DL:
+        description: Add support for W25Q80DL
+        value: 0
+    SPIFLASH_W25Q80EW:
+        description: Add support for W25Q80EW
+        value: 0
+    SPIFLASH_W25Q16DV:
+        description: Add support for W25Q16DV
+        value: 0
+    SPIFLASH_W25Q16DW:
+        description: Add support for W25Q16DW
+        value: 0
+    SPIFLASH_W25Q16FW:
+        description: Add support for W25Q16FW
+        value: 0
+    SPIFLASH_W25Q16JL:
+        description: Add support for W25Q16JL
+        value: 0
+    SPIFLASH_W25Q16JV_DTR:
+        description: Add support for W25Q16JV_DTR
+        value: 0
+    SPIFLASH_W25Q16JV_IQ:
+        description: Add support for W25Q16JV_IQ
+        value: 0
+    SPIFLASH_W25Q16JV_IM:
+        description: Add support for W25Q16JV_IM
+        value: 0
+    SPIFLASH_W25Q32BV:
+        description: Add support for W25Q32BV
+        value: 0
+    SPIFLASH_W25Q32FV:
+        description: Add support for W25Q32FV
+        value: 0
+    SPIFLASH_W25Q32FW:
+        description: Add support for W25Q32FW
+        value: 0
+    SPIFLASH_W25Q32JV:
+        description: Add support for W25Q32JV
+        value: 0
+    SPIFLASH_W25Q32JV_IQ:
+        description: Add support for W25Q32JV_IQ
+        value: 0
+    SPIFLASH_W25Q32JW:
+        description: Add support for W25Q32JW
+        value: 0
+    SPIFLASH_W25Q32JW_IQ:
+        description: Add support for W25Q32JW_IQ
+        value: 0
+    SPIFLASH_AT25SF041:
+        description: Add support for AT25SF041
+        value: 0
+    SPIFLASH_AT25SF081:
+        description: Add support for AT25SF081
+        value: 0
+    SPIFLASH_AT25DF081A:
+        description: Add support for AT25DF081A
+        value: 0
+    SPIFLASH_AT25DL081:
+        description: Add support for AT25DL081
+        value: 0
+    SPIFLASH_AT25SF161:
+        description: Add support for AT25SF161
+        value: 0
+    SPIFLASH_AT25DL161:
+        description: Add support for AT25DL161
+        value: 0
+    SPIFLASH_AT25SL321:
+        description: Add support for AT25SL321
+        value: 0
+    SPIFLASH_AT25SF321:
+        description: Add support for AT25SF321
+        value: 0
+    SPIFLASH_AT25DF321A:
+        description: Add support for AT25DF321A
+        value: 0
+    SPIFLASH_AT25QL321:
+        description: Add support for AT25QL321
+        value: 0

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -35,6 +35,10 @@ struct spiflash_dev {
     int ss_pin;
     uint16_t sector_size;
     uint16_t page_size;
+    /* Array of supported flash chips */
+    const struct spiflash_chip *supported_chips;
+    /* Pointer to one of the supported chips */
+    const struct spiflash_chip *flash_chip;
 };
 
 extern struct spiflash_dev spiflash_dev;
@@ -46,12 +50,43 @@ extern struct spiflash_dev spiflash_dev;
 #define SPIFLASH_WRITE_ENABLE               0x06
 #define SPIFLASH_FAST_READ                  0x0B
 #define SPIFLASH_SECTOR_ERASE               0x20
+#define SPIFLASH_DEEP_POWER_DOWN            0xB9
 #define SPIFLASH_RELEASE_POWER_DOWN         0xAB
 #define SPIFLASH_READ_MANUFACTURER_ID       0x90
 #define SPIFLASH_READ_JEDEC_ID              0x9F
 
 #define SPIFLASH_STATUS_BUSY                0x01
 #define SPIFLASH_STATUS_WRITE_ENABLE        0x02
+
+/*
+ * Flash identification bytes from 0x9F command
+ */
+struct jedec_id {
+    uint8_t ji_manufacturer;
+    uint8_t ji_type;
+    uint8_t ji_capacity;
+};
+struct spiflash_chip {
+    struct jedec_id fc_jedec_id;
+    void (*fc_release_power_down)(struct spiflash_dev *dev);
+};
+
+#define JEDEC_MFC_ISSI              0x9D
+#define JEDEC_MFC_WINBOND           0xEF
+#define JEDEC_MFC_GIGADEVICE        0xC8
+#define JEDEC_MFC_MACRONIX          0xC2
+#define JEDEC_MFC_MICRON            0x20
+#define JEDEC_MFC_MICROCHIP         0xBF
+#define JEDEC_MFC_ADESTO            0x1F
+
+#define FLASH_CAPACITY_256KBIT      0x09
+#define FLASH_CAPACITY_512KBIT      0x10
+#define FLASH_CAPACITY_1MBIT        0x11
+#define FLASH_CAPACITY_2MBIT        0x12
+#define FLASH_CAPACITY_4MBIT        0x13
+#define FLASH_CAPACITY_8MBIT        0x14
+#define FLASH_CAPACITY_16MBIT       0x15
+#define FLASH_CAPACITY_32MBIT       0x16
 
 int spiflash_init(const struct hal_flash *dev);
 

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -28,18 +28,6 @@
 
 #if MYNEWT_VAL(SPIFLASH)
 
-#if MYNEWT_VAL(SPIFLASH_MANUFACTURER) == 0
-#error SPIFLASH_MANUFACTURER must be set to the correct value in bsp syscfg.yml
-#endif
-
-#if MYNEWT_VAL(SPIFLASH_MEMORY_TYPE) == 0
-#error SPIFLASH_MEMORY_TYPE must be set to the correct value in bsp syscfg.yml
-#endif
-
-#if MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY) == 0
-#error SPIFLASH_MEMORY_CAPACITY must be set to the correct value in bsp syscfg.yml
-#endif
-
 #if MYNEWT_VAL(SPIFLASH_SPI_CS_PIN) < 0
 #error SPIFLASH_SPI_CS_PIN must be set to the correct value in bsp syscfg.yml
 #endif
@@ -59,6 +47,517 @@
 #if MYNEWT_VAL(SPIFLASH_BAUDRATE) == 0
 #error SPIFLASH_BAUDRATE must be set to the correct value in bsp syscfg.yml
 #endif
+
+void spiflash_release_power_down_macronix(struct spiflash_dev *dev);
+void spiflash_release_power_down(struct spiflash_dev *dev);
+
+#define STD_FLASH_CHIP(name, mfid, typ, cap, release_power_down) \
+    { \
+        .fc_jedec_id = { \
+            .ji_manufacturer = mfid, \
+            .ji_type = typ, \
+            .ji_capacity = cap, \
+        }, \
+        .fc_release_power_down = release_power_down, \
+    }
+
+
+#define ISSI_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_ISSI, typ, cap, spiflash_release_power_down)
+#define WINBOND_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_WINBOND, typ, cap, spiflash_release_power_down)
+#define MACRONIX_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_MACRONIX, typ, cap, spiflash_release_power_down)
+/* Macro for chips with no RPD command */
+#define MACRONIX_CHIP1(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_MACRONIX, typ, cap, spiflash_release_power_down_macronix)
+#define GIGADEVICE_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_GIGADEVICE, typ, cap, spiflash_release_power_down)
+#define MICRON_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_MICRON, typ, cap, spiflash_release_power_down)
+#define ADESTO_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_ADESTO, typ, cap, spiflash_release_power_down)
+
+static struct spiflash_chip supported_chips[] = {
+#if MYNEWT_VAL(SPIFLASH_MANUFACTURER) && MYNEWT_VAL(SPIFLASH_MEMORY_TYPE) && MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY)
+    STD_FLASH_CHIP("", MYNEWT_VAL(SPIFLASH_MANUFACTURER),
+        MYNEWT_VAL(SPIFLASH_MEMORY_TYPE), MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY),
+        spiflash_release_power_down),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25D05C)
+    GIGADEVICE_CHIP(GD25D05C, 0x40, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LD05C)
+    GIGADEVICE_CHIP(GD25LD05C, 0x60, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE05C)
+    GIGADEVICE_CHIP(GD25LE05C, 0x60, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH05C)
+    GIGADEVICE_CHIP(GD25LH05C, 0x60, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VD05B)
+    GIGADEVICE_CHIP(GD25VD05B, 0x40, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25WD05C)
+    GIGADEVICE_CHIP(GD25WD05C, 0x64, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25D10C)
+    GIGADEVICE_CHIP(GD25D10C, 0x40, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LD10C)
+    GIGADEVICE_CHIP(GD25LD10C, 0x60, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE10C)
+    GIGADEVICE_CHIP(GD25LE10C, 0x60, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH10C)
+    GIGADEVICE_CHIP(GD25LH10C, 0x60, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VD10B)
+    GIGADEVICE_CHIP(GD25VD10B, 0x40, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25WD10C)
+    GIGADEVICE_CHIP(GD25WD10C, 0x64, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE20C)
+    GIGADEVICE_CHIP(GD25LE20C, 0x60, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH20C)
+    GIGADEVICE_CHIP(GD25LH20C, 0x60, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25D20C)
+    GIGADEVICE_CHIP(GD25D20C, 0x40, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LD20C)
+    GIGADEVICE_CHIP(GD25LD20C, 0x60, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VE20C)
+    GIGADEVICE_CHIP(GD25VE20C, 0x42, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25WD20C)
+    GIGADEVICE_CHIP(GD25WD20C, 0x64, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE40C)
+    GIGADEVICE_CHIP(GD25LE40C, 0x60, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH40C)
+    GIGADEVICE_CHIP(GD25LH40C, 0x60, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25D40C)
+    GIGADEVICE_CHIP(GD25D40C, 0x40, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LD40C)
+    GIGADEVICE_CHIP(GD25LD40C, 0x60, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25WD40C)
+    GIGADEVICE_CHIP(GD25WD40C, 0x64, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VE40C)
+    GIGADEVICE_CHIP(GD25VE40C, 0x42, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VE40B)
+    GIGADEVICE_CHIP(GD25VE40B, 0x60, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25D80C)
+    GIGADEVICE_CHIP(GD25D80C, 0x40, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LD80C)
+    GIGADEVICE_CHIP(GD25LD80C, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE80C)
+    GIGADEVICE_CHIP(GD25LE80C, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH80B)
+    GIGADEVICE_CHIP(GD25LH80B, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH80C)
+    GIGADEVICE_CHIP(GD25LH80C, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25WD80C)
+    GIGADEVICE_CHIP(GD25WD80C, 0x64, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25Q80C)
+    GIGADEVICE_CHIP(GD25Q80C, 0x40, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25B16C)
+    GIGADEVICE_CHIP(GD25B16C, 0x40, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LE16C)
+    GIGADEVICE_CHIP(GD25LE16C, 0x60, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25LH16C)
+    GIGADEVICE_CHIP(GD25LH16C, 0x60, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25Q16C)
+    GIGADEVICE_CHIP(GD25Q16C, 0x40, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_GD25VE16C)
+    GIGADEVICE_CHIP(GD25VE16C, 0x42, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L512E)
+    MACRONIX_CHIP(MX25L512E, 0x20, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L5121E)
+    MACRONIX_CHIP(MX25L5121E, 0x22, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1021E)
+    MACRONIX_CHIP(MX25L1021E, 0x22, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R512F)
+    MACRONIX_CHIP1(MX25R512F, 0x28, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U5121E)
+    MACRONIX_CHIP(MX25U5121E, 0x25, 0x20 | FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U1001E)
+    MACRONIX_CHIP(MX25U1001E, 0x25, 0x20 | FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V512E)
+    MACRONIX_CHIP(MX25V512E, 0x20, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V512F)
+    MACRONIX_CHIP1(MX25V512F, 0x23, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1006E)
+    MACRONIX_CHIP(MX25L1006E, 0x20, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1026E)
+    MACRONIX_CHIP(MX25L1026E, 0x20, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R1035F)
+    MACRONIX_CHIP1(MX25R1035F, 0x28, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V1006E)
+    MACRONIX_CHIP(MX25V1006E, 0x20, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V1006F)
+    MACRONIX_CHIP(MX25V1006F, 0x20, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V1035F)
+    MACRONIX_CHIP1(MX25V1035F, 0x23, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L2006E)
+    MACRONIX_CHIP(MX25L2006E, 0x20, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L2026E)
+    MACRONIX_CHIP(MX25L2026E, 0x20, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R2035F)
+    MACRONIX_CHIP1(MX25R2035F, 0x28, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U2032E)
+    MACRONIX_CHIP(MX25U2032E, 0x25, 0x20 | FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U2033E)
+    MACRONIX_CHIP(MX25U2033E, 0x25, 0x20 | FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U2035F)
+    MACRONIX_CHIP1(MX25U2035F, 0x25, 0x20 | FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V2006E)
+    MACRONIX_CHIP(MX25V2006E, 0x20, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V2033F)
+    MACRONIX_CHIP(MX25V2033F, 0x20, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V2035F)
+    MACRONIX_CHIP1(MX25V2035F, 0x23, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L4006E)
+    MACRONIX_CHIP(MX25L4006E, 0x20, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L4026E)
+    MACRONIX_CHIP(MX25L4026E, 0x20, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R4035F)
+    MACRONIX_CHIP1(MX25R4035F, 0x28, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U4032E)
+    MACRONIX_CHIP(MX25U4032E, 0x25, 0x20 | FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U4033E)
+    MACRONIX_CHIP(MX25U4033E, 0x25, 0x20 | FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U4035)
+    MACRONIX_CHIP(MX25U4035, 0x25, 0x20 | FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U4035F)
+    MACRONIX_CHIP1(MX25U4035F, 0x25, 0x20 | FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V4006E)
+    MACRONIX_CHIP(MX25V4006E, 0x20, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V4035F)
+    MACRONIX_CHIP1(MX25V4035F, 0x23, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U8035)
+    MACRONIX_CHIP(MX25U8035, 0x25, 0x20 | FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L8006E)
+    MACRONIX_CHIP(MX25L8006E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L8008E)
+    MACRONIX_CHIP(MX25L8008E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L8035E)
+    MACRONIX_CHIP(MX25L8035E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L8036E)
+    MACRONIX_CHIP(MX25L8036E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L8073E)
+    MACRONIX_CHIP(MX25L8073E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R8035F)
+    MACRONIX_CHIP1(MX25R8035F, 0x28, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U8032E)
+    MACRONIX_CHIP(MX25U8032E, 0x25, 0x20 | FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U8033E)
+    MACRONIX_CHIP(MX25U8033E, 0x25, 0x20 | FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U8035E)
+    MACRONIX_CHIP(MX25U8035E, 0x25, 0x20 | FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U8035F)
+    MACRONIX_CHIP1(MX25U8035F, 0x25, 0x20 | FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V8006E)
+    MACRONIX_CHIP(MX25V8006E, 0x20, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V8033F)
+    MACRONIX_CHIP1(MX25V8033F, 0x23, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V8035F)
+    MACRONIX_CHIP1(MX25V8035F, 0x23, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1606E)
+    MACRONIX_CHIP(MX25L1606E, 0x20, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1608E)
+    MACRONIX_CHIP(MX25L1608E, 0x20, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1633E)
+    MACRONIX_CHIP(MX25L1633E, 0x24, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1635E)
+    MACRONIX_CHIP(MX25L1635E, 0x25, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1636E)
+    MACRONIX_CHIP(MX25L1636E, 0x25, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L1673E)
+    MACRONIX_CHIP(MX25L1673E, 0x24, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R1635F)
+    MACRONIX_CHIP1(MX25R1635F, 0x28, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U1633F)
+    MACRONIX_CHIP1(MX25U1633F, 0x25, 0x20 | FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U1635E)
+    MACRONIX_CHIP(MX25U1635E, 0x25, 0x20 | FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U1635F)
+    MACRONIX_CHIP(MX25U1635F, 0x25, 0x20 | FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25V1635F)
+    MACRONIX_CHIP1(MX25V1635F, 0x23, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3206E)
+    MACRONIX_CHIP(MX25L3206E, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3208E)
+    MACRONIX_CHIP(MX25L3208E, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3233F)
+    MACRONIX_CHIP(MX25L3233F, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3235E)
+    MACRONIX_CHIP(MX25L3235E, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3236F)
+    MACRONIX_CHIP(MX25L3236F, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3239E)
+    MACRONIX_CHIP(MX25L3239E, 0x25, 0x20 | FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3273E)
+    MACRONIX_CHIP(MX25L3273E, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25L3273F)
+    MACRONIX_CHIP(MX25L3273F, 0x20, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25R3235F)
+    MACRONIX_CHIP1(MX25R3235F, 0x28, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U3235E)
+    MACRONIX_CHIP(MX25U3235E, 0x25, 0x20 | FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U3235F)
+    MACRONIX_CHIP(MX25U3235F, 0x25, 0x20 | FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_MX25U3273F)
+    MACRONIX_CHIP1(MX25U3273F, 0x25, 0x20 | FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LP080D)
+    ISSI_CHIP(IS25LP080D, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WP080D)
+    ISSI_CHIP(IS25WP080D, 0x70, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WP040D)
+    ISSI_CHIP(IS25WP040D, 0x70, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WP020D)
+    ISSI_CHIP(IS25WP020D, 0x70, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LQ040B)
+    ISSI_CHIP(IS25LQ040B, 0x40, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LQ020B)
+    ISSI_CHIP(IS25LQ020B, 0x40, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LQ010B)
+    ISSI_CHIP(IS25LQ010B, 0x40, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LQ512B)
+    ISSI_CHIP(IS25LQ512B, 0x40, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WQ040)
+    ISSI_CHIP(IS25WQ040, 0x12, 0x4 | FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WQ020)
+    ISSI_CHIP(IS25WQ020, 0x11, 0x4 | FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LQ025B)
+    ISSI_CHIP(IS25LQ025B, 0x40, FLASH_CAPACITY_256KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LP016D)
+    ISSI_CHIP(IS25LP016D, 0x60, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WP016D)
+    ISSI_CHIP(IS25WP016D, 0x70, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25LP032D)
+    ISSI_CHIP(IS25LP032D, 0x60, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_IS25WP032D)
+    ISSI_CHIP(IS25WP032D, 0x70, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25X05CL)
+    WINBOND_CHIP(W25X05CL, 0x30, FLASH_CAPACITY_512KBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q10EW)
+    WINBOND_CHIP(W25Q10EW, 0x60, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25X10CL)
+    WINBOND_CHIP(W25X10CL, 0x30, FLASH_CAPACITY_1MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q20CL)
+    WINBOND_CHIP(W25Q20CL, 0x40, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q20EW)
+    WINBOND_CHIP(W25Q20EW, 0x60, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25X20CL)
+    WINBOND_CHIP(W25X20CL, 0x30, FLASH_CAPACITY_2MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q40CL)
+    WINBOND_CHIP(W25Q40CL, 0x40, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q40EW)
+    WINBOND_CHIP(W25Q40EW, 0x60, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25X40CL)
+    WINBOND_CHIP(W25X40CL, 0x30, FLASH_CAPACITY_4MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q80DV)
+    WINBOND_CHIP(W25Q80DV, 0x40, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q80DL)
+    WINBOND_CHIP(W25Q80DL, 0x40, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q80EW)
+    WINBOND_CHIP(W25Q80EW, 0x60, FLASH_CAPACITY_8MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16DV)
+    WINBOND_CHIP(W25Q16DV, 0x40, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16DW)
+    WINBOND_CHIP(W25Q16DW, 0x60, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16FW)
+    WINBOND_CHIP(W25Q16FW, 0x60, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16JL)
+    WINBOND_CHIP(W25Q16JL, 0x40, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16JV_DTR)
+    WINBOND_CHIP(W25Q16JV_DTR, 0x70, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16JV_IQ)
+    WINBOND_CHIP(W25Q16JV_IQ, 0x40, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q16JV_IM)
+    WINBOND_CHIP(W25Q16JV_IM, 0x70, FLASH_CAPACITY_16MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32BV)
+    WINBOND_CHIP(W25Q32BV, 0x40, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32FV)
+    WINBOND_CHIP(W25Q32FV, 0x40, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32FW)
+    WINBOND_CHIP(W25Q32FW, 0x60, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32JV)
+    WINBOND_CHIP(W25Q32JV, 0x70, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32JV_IQ)
+    WINBOND_CHIP(W25Q32JV_IQ, 0x40, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32JW)
+    WINBOND_CHIP(W25Q32JW, 0x80, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_W25Q32JW_IQ)
+    WINBOND_CHIP(W25Q32JW_IQ, 0x60, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25SF041)
+    ADESTO_CHIP(AT25SF041, 0x84, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25SF081)
+    ADESTO_CHIP(AT25SF081, 0x85, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25DF081A)
+    ADESTO_CHIP(AT25DF081A, 0x45, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25DL081)
+    ADESTO_CHIP(AT25DL081, 0x45, 2),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25SF161)
+    ADESTO_CHIP(AT25SF161, 0x86, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25DL161)
+    ADESTO_CHIP(AT25DL161, 0x46, 3),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25SL321)
+    ADESTO_CHIP(AT25SL321, 0x42, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25SF321)
+    ADESTO_CHIP(AT25SF321, 0x87, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25DF321A)
+    ADESTO_CHIP(AT25DF321A, 0x47, 1),
+#endif
+#if MYNEWT_VAL(SPIFLASH_AT25QL321)
+    ADESTO_CHIP(AT25QL321, 0x42, FLASH_CAPACITY_32MBIT),
+#endif
+
+    { {0} },
+};
 
 static int spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr,
         void *buf, uint32_t len);
@@ -102,6 +601,9 @@ struct spiflash_dev spiflash_dev = {
     .spi_num            = MYNEWT_VAL(SPIFLASH_SPI_NUM),
     .spi_cfg            = NULL,
     .ss_pin             = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
+
+    .supported_chips = supported_chips,
+    .flash_chip = NULL,
 };
 
 static inline void
@@ -116,22 +618,42 @@ spiflash_cs_deactivate(struct spiflash_dev *dev)
     hal_gpio_write(dev->ss_pin, 1);
 }
 
-uint8_t
-spiflash_release_power_down(struct spiflash_dev *dev, uint8_t *id)
+void
+spiflash_power_down(struct spiflash_dev *dev)
 {
-    uint8_t cmd[5] = { SPIFLASH_RELEASE_POWER_DOWN, 0xFF, 0xFF, 0xFF, 0 };
+    uint8_t cmd[1] = { SPIFLASH_DEEP_POWER_DOWN };
 
     spiflash_cs_activate(dev);
 
     hal_spi_txrx(dev->spi_num, cmd, cmd, sizeof cmd);
 
     spiflash_cs_deactivate(dev);
+}
 
-    if (id) {
-        *id = cmd[4];
-    }
+/*
+ * Some Macronix chips don't have standard release power down command 0xAB.
+ * Instead they use CS pin alone to wake up from sleep.
+ */
+void
+spiflash_release_power_down_macronix(struct spiflash_dev *dev)
+{
+    spiflash_cs_activate(dev);
 
-    return 0;
+    os_cputime_delay_usecs(20);
+
+    spiflash_cs_deactivate(dev);
+}
+
+void
+spiflash_release_power_down(struct spiflash_dev *dev)
+{
+    uint8_t cmd[1] = { SPIFLASH_RELEASE_POWER_DOWN };
+
+    spiflash_cs_activate(dev);
+
+    hal_spi_txrx(dev->spi_num, cmd, cmd, sizeof cmd);
+
+    spiflash_cs_deactivate(dev);
 }
 
 uint8_t
@@ -320,13 +842,92 @@ spiflash_sector_info(const struct hal_flash *hal_flash_dev, int idx,
 }
 
 int
+spiflash_identify(struct spiflash_dev *dev)
+{
+    int i;
+    int j;
+    uint8_t manufacturer = 0;
+    uint8_t memory_type = 0;
+    uint8_t capacity = 0;
+    int release_power_down_count = 0;
+    /* Table with unique release power down functions */
+    void (*rpd[3])(struct spiflash_dev *);
+
+    /* List of supported spi flash chips can be found in:
+     * hw/drivers/flash/spiflash/chips/sysconfig.yml
+     */
+    _Static_assert((sizeof(supported_chips) / sizeof(supported_chips[0])) > 1,
+        "At lease one spiflash chip must be specified in sysconfig with SPIFLASH_<chipid>:1");
+
+    /* Only one chip specified, no need for search*/
+    if ((sizeof(supported_chips) / sizeof(supported_chips[0])) == 2) {
+        spiflash_release_power_down(dev);
+        spiflash_read_jedec_id(dev, &manufacturer, &memory_type, &capacity);
+        /* If BSP defined SpiFlash manufacturer or memory type does not
+         * match SpiFlash is most likely not connected, connected to
+         * different pins, or of different type.
+         * It is unlikely that flash depended packaged will work correctly.
+         */
+        assert(manufacturer == supported_chips[0].fc_jedec_id.ji_manufacturer &&
+               memory_type == supported_chips[0].fc_jedec_id.ji_type &&
+               capacity == supported_chips[0].fc_jedec_id.ji_capacity);
+        if (manufacturer != supported_chips[0].fc_jedec_id.ji_manufacturer ||
+            memory_type != supported_chips[0].fc_jedec_id.ji_type ||
+            capacity != supported_chips[0].fc_jedec_id.ji_capacity) {
+            return -1;
+        }
+        dev->flash_chip = &supported_chips[0];
+    } else {
+        for (i = 0; supported_chips[i].fc_jedec_id.ji_manufacturer != 0; ++i) {
+            for (j = 0; j < release_power_down_count; ++j) {
+                if (rpd[j] == supported_chips[i].fc_release_power_down) {
+                    /* release power down function same as already execute one
+                     * no need check more.
+                     */
+                    break;
+                }
+            }
+            /* New function found, add to function table and call */
+            if (j == release_power_down_count) {
+                rpd[j] = supported_chips[i].fc_release_power_down;
+                rpd[j](dev);
+                spiflash_read_jedec_id(dev, &manufacturer, &memory_type, &capacity);
+                if ((manufacturer == 0xFF && memory_type == 0xFF && capacity == 0xFF) ||
+                    (manufacturer == 0 && memory_type == 0 && capacity == 0)) {
+                    /* Most likely release did not work or device is not
+                     * correctly configured (wrong pins).
+                     * Try another release power down method if found.
+                     */
+                    continue;
+                }
+                /* Something was read from flash, do not try another power up
+                 * just check if chip should be supported */
+                break;
+            }
+        }
+        for (i = 0; supported_chips[i].fc_jedec_id.ji_manufacturer != 0; ++i) {
+            if (manufacturer ==  supported_chips[i].fc_jedec_id.ji_manufacturer &&
+                memory_type == supported_chips[i].fc_jedec_id.ji_type &&
+                capacity == supported_chips[i].fc_jedec_id.ji_capacity) {
+                /* Device is supported */
+                dev->flash_chip = &supported_chips[i];
+                break;
+            }
+        }
+        if (dev->flash_chip == NULL) {
+            /* Not supported chip */
+            assert(0);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int
 spiflash_init(const struct hal_flash *hal_flash_dev)
 {
     int rc;
     struct spiflash_dev *dev;
-    uint8_t manufacturer;
-    uint8_t memory_type;
-    uint8_t capacity;
 
     dev = (struct spiflash_dev *)hal_flash_dev;
 
@@ -340,23 +941,9 @@ spiflash_init(const struct hal_flash *hal_flash_dev)
     hal_spi_set_txrx_cb(dev->spi_num, NULL, NULL);
     hal_spi_enable(dev->spi_num);
 
-    spiflash_release_power_down(dev, &manufacturer);
-    spiflash_read_jedec_id(dev, &manufacturer, &memory_type, &capacity);
-    /* If BSP defined SpiFlash manufacturer or memory type does not
-     * match SpiFlash is most likely not connected, connected to
-     * different pins, or of different type.
-     * It is unlikely that flash depended packaged will work correctly.
-     */
-    assert(manufacturer == MYNEWT_VAL(SPIFLASH_MANUFACTURER) ||
-            memory_type == MYNEWT_VAL(SPIFLASH_MEMORY_TYPE) ||
-            capacity == MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY));
-    if (manufacturer != MYNEWT_VAL(SPIFLASH_MANUFACTURER) ||
-        memory_type != MYNEWT_VAL(SPIFLASH_MEMORY_TYPE) ||
-        capacity != MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY)) {
-        return -1;
-    }
+    rc = spiflash_identify(dev);
 
-    return 0;
+    return rc;
 }
 
 #endif

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -46,7 +46,10 @@ syscfg.defs:
 
     SPIFLASH_MANUFACTURER:
         description: >
-            Expected SpiFlash manufacturer as read by Read JEDEC ID command 9FH
+            Expected SpiFlash manufacturer as read by Read JEDEC ID command 9FH.
+            In case of multiple chip support this can be left as zero and
+            values found in hw/drivers/flash/spiflash/chips/syscfg.yml should be
+            set to 1 for desired chips.
         value: 0
     SPIFLASH_MEMORY_TYPE:
         description: >


### PR DESCRIPTION
SpiFlash chips are often compatible to some extent even
when they come from different vendors.
It is quite possible to have same product that will use
different spiflash even in production.
Now it is possible to specify more than one flash chip.