### PR TITLE
Reduce ram usage in fcb

### DIFF
--- a/fs/fcb/src/fcb_area_info.c
+++ b/fs/fcb/src/fcb_area_info.c
@@ -34,8 +34,9 @@ fcb_area_info(struct fcb *fcb, int sector, int *elemsp, int *bytesp)
     loc.fe_sector = info.si_sector_in_range + loc.fe_range->sr_first_sector;
     loc.fe_elem_off = 0;
     /* In case caller passed oldest, get real sector number */
-    if (sector == FCB_SECTOR_OLDEST)
+    if (sector == FCB_SECTOR_OLDEST) {
         sector =  loc.fe_sector;
+    }
 
     while (1) {
         rc = fcb_getnext(fcb, &loc);

--- a/fs/fcb/src/fcb_elem_info.c
+++ b/fs/fcb/src/fcb_elem_info.c
@@ -38,10 +38,11 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *c8p)
     uint32_t end;
     int rc;
 
-    if (loc->fe_elem_off + 2 > loc->fe_area->fa_size) {
+    if (loc->fe_elem_off + 2 > loc->fe_range->sr_sector_size) {
         return FCB_ERR_NOVAR;
     }
-    rc = flash_area_read_is_empty(loc->fe_area, loc->fe_elem_off, tmp_str, 2);
+    rc = flash_area_read_is_empty(&loc->fe_range->sr_flash_area,
+        fcb_sector_flash_offset(loc) + loc->fe_elem_off, tmp_str, 2);
     if (rc < 0) {
         return FCB_ERR_FLASH;
     } else if (rc == 1) {
@@ -63,7 +64,7 @@ fcb_elem_crc8(struct fcb *fcb, struct fcb_entry *loc, uint8_t *c8p)
             blk_sz = sizeof(tmp_str);
         }
 
-        rc = flash_area_read(loc->fe_area, off, tmp_str, blk_sz);
+        rc = fcb_read_from_sector(loc, off, tmp_str, blk_sz);
         if (rc) {
             return FCB_ERR_FLASH;
         }
@@ -88,7 +89,7 @@ fcb_elem_info(struct fcb *fcb, struct fcb_entry *loc)
     }
     off = loc->fe_data_off + fcb_len_in_flash(fcb, loc->fe_data_len);
 
-    rc = flash_area_read(loc->fe_area, off, &fl_crc8, sizeof(fl_crc8));
+    rc = fcb_read_from_sector(loc, off, &fl_crc8, sizeof(fl_crc8));
     if (rc) {
         return FCB_ERR_FLASH;
     }

--- a/fs/fcb/src/fcb_priv.h
+++ b/fs/fcb/src/fcb_priv.h
@@ -49,13 +49,33 @@ fcb_len_in_flash(struct fcb *fcb, uint16_t len)
 
 int fcb_getnext_in_area(struct fcb *fcb, struct fcb_entry *loc);
 struct flash_area *fcb_getnext_area(struct fcb *fcb, struct flash_area *fap);
+
+static inline int
+fcb_getnext_sector(struct fcb *fcb, int sector)
+{
+    if (++sector >= fcb->f_sector_cnt) {
+        sector = 0;
+    }
+    return sector;
+}
+
+static inline int
+fcb_sector_flash_offset(const struct fcb_entry *loc)
+{
+    return (loc->fe_sector - loc->fe_range->sr_first_sector) *
+        loc->fe_range->sr_sector_size;
+}
+
 int fcb_getnext_nolock(struct fcb *fcb, struct fcb_entry *loc);
 
 int fcb_elem_info(struct fcb *, struct fcb_entry *);
 int fcb_elem_crc8(struct fcb *, struct fcb_entry *loc, uint8_t *crc8p);
 
-int fcb_sector_hdr_init(struct fcb *, struct flash_area *fap, uint16_t id);
-int fcb_sector_hdr_read(struct fcb *, struct flash_area *fap,
+int fcb_sector_hdr_init(struct fcb *fcb, int sector, uint16_t id);
+
+struct sector_range *fcb_get_sector_range(const struct fcb *fcb, int sector);
+
+int fcb_sector_hdr_read(struct fcb *, struct sector_range *srp, uint16_t sec,
   struct fcb_disk_area *fdap);
 
 #ifdef __cplusplus

--- a/fs/fcb/src/fcb_rotate.c
+++ b/fs/fcb/src/fcb_rotate.c
@@ -23,7 +23,7 @@
 int
 fcb_rotate(struct fcb *fcb)
 {
-    struct flash_area *fap;
+    int sector;
     int rc = 0;
 
     rc = os_mutex_pend(&fcb->f_mtx, OS_WAIT_FOREVER);
@@ -31,25 +31,27 @@ fcb_rotate(struct fcb *fcb)
         return FCB_ERR_ARGS;
     }
 
-    rc = flash_area_erase(fcb->f_oldest, 0, fcb->f_oldest->fa_size);
+    rc = fcb_sector_erase(fcb, fcb->f_oldest_sec);
     if (rc) {
         rc = FCB_ERR_FLASH;
         goto out;
     }
-    if (fcb->f_oldest == fcb->f_active.fe_area) {
+    if (fcb->f_oldest_sec == fcb->f_active.fe_sector) {
         /*
-         * Need to create a new active area, as we're wiping the current.
+         * Need to create a new active sector, as we're wiping the current.
          */
-        fap = fcb_getnext_area(fcb, fcb->f_oldest);
-        rc = fcb_sector_hdr_init(fcb, fap, fcb->f_active_id + 1);
+        sector = fcb_getnext_sector(fcb, fcb->f_oldest_sec);
+
+        rc = fcb_sector_hdr_init(fcb, sector, fcb->f_active_id + 1);
         if (rc) {
             goto out;
         }
-        fcb->f_active.fe_area = fap;
+        fcb->f_active.fe_sector = sector;
+        fcb->f_active.fe_range = fcb_get_sector_range(fcb, sector);
         fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
         fcb->f_active_id++;
     }
-    fcb->f_oldest = fcb_getnext_area(fcb, fcb->f_oldest);
+    fcb->f_oldest_sec = fcb_getnext_sector(fcb, fcb->f_oldest_sec);
 out:
     os_mutex_release(&fcb->f_mtx);
     return rc;

--- a/fs/fcb/src/fcb_walk.c
+++ b/fs/fcb/src/fcb_walk.c
@@ -25,12 +25,12 @@
  * only elements with that flash_area are reported.
  */
 int
-fcb_walk(struct fcb *fcb, struct flash_area *fap, fcb_walk_cb cb, void *cb_arg)
+fcb_walk(struct fcb *fcb, int sector, fcb_walk_cb cb, void *cb_arg)
 {
     struct fcb_entry loc;
     int rc;
 
-    loc.fe_area = fap;
+    fcb_get_sector_loc(fcb, sector, &loc);
     loc.fe_elem_off = 0;
 
     rc = os_mutex_pend(&fcb->f_mtx, OS_WAIT_FOREVER);
@@ -39,7 +39,7 @@ fcb_walk(struct fcb *fcb, struct flash_area *fap, fcb_walk_cb cb, void *cb_arg)
     }
     while ((rc = fcb_getnext_nolock(fcb, &loc)) != FCB_ERR_NOVAR) {
         os_mutex_release(&fcb->f_mtx);
-        if (fap && loc.fe_area != fap) {
+        if (sector != FCB_SECTOR_OLDEST && loc.fe_sector != sector) {
             return 0;
         }
         rc = cb(&loc, cb_arg);

--- a/fs/fcb/test/src/fcb_test.h
+++ b/fs/fcb/test/src/fcb_test.h
@@ -34,7 +34,8 @@
 
 extern struct fcb test_fcb;
 
-extern struct flash_area test_fcb_area[];
+//extern struct flash_area test_fcb_area[];
+extern struct sector_range test_fcb_ranges[];
 
 struct append_arg {
     int *elem_cnts;

--- a/fs/fcb/test/src/testcases/fcb_test_append.c
+++ b/fs/fcb/test/src/testcases/fcb_test_append.c
@@ -47,7 +47,7 @@ TEST_CASE(fcb_test_append)
         }
         rc = fcb_append(fcb, i, &loc);
         TEST_ASSERT_FATAL(rc == 0);
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data, i);
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data, i);
         TEST_ASSERT(rc == 0);
         rc = fcb_append_finish(fcb, &loc);
         TEST_ASSERT(rc == 0);

--- a/fs/fcb/test/src/testcases/fcb_test_append_fill.c
+++ b/fs/fcb/test/src/testcases/fcb_test_append_fill.c
@@ -57,15 +57,15 @@ TEST_CASE(fcb_test_append_fill)
         if (rc == FCB_ERR_NOSPACE) {
             break;
         }
-        if (loc.fe_area == &test_fcb_area[0]) {
+        if (loc.fe_sector == 0) {
             elem_cnts[0]++;
-        } else if (loc.fe_area == &test_fcb_area[1]) {
+        } else if (loc.fe_sector == 1) {
             elem_cnts[1]++;
         } else {
             TEST_ASSERT(0);
         }
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -76,16 +76,16 @@ TEST_CASE(fcb_test_append_fill)
     TEST_ASSERT(elem_cnts[0] == elem_cnts[1]);
 
     memset(&aa_together_cnts, 0, sizeof(aa_together_cnts));
-    rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_together);
+    rc = fcb_walk(fcb, FCB_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_together);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(aa_together.elem_cnts[0] == elem_cnts[0]);
     TEST_ASSERT(aa_together.elem_cnts[1] == elem_cnts[1]);
 
     memset(&aa_separate_cnts, 0, sizeof(aa_separate_cnts));
-    rc = fcb_walk(fcb, &test_fcb_area[0], fcb_test_cnt_elems_cb,
+    rc = fcb_walk(fcb, 0, fcb_test_cnt_elems_cb,
       &aa_separate);
     TEST_ASSERT(rc == 0);
-    rc = fcb_walk(fcb, &test_fcb_area[1], fcb_test_cnt_elems_cb,
+    rc = fcb_walk(fcb, 1, fcb_test_cnt_elems_cb,
       &aa_separate);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(aa_separate.elem_cnts[0] == elem_cnts[0]);

--- a/fs/fcb/test/src/testcases/fcb_test_append_too_big.c
+++ b/fs/fcb/test/src/testcases/fcb_test_append_too_big.c
@@ -42,7 +42,7 @@ TEST_CASE(fcb_test_append_too_big)
      * Max element which fits inside sector is
      * sector size - (disk header + crc + 1-2 bytes of length).
      */
-    len = fcb->f_active.fe_area->fa_size;
+    len = fcb->f_active.fe_range->sr_sector_size;
 
     rc = fcb_append(fcb, len, &elem_loc);
     TEST_ASSERT(rc != 0);
@@ -55,7 +55,7 @@ TEST_CASE(fcb_test_append_too_big)
     rc = fcb_append(fcb, len, &elem_loc);
     TEST_ASSERT(rc != 0);
 
-    len = fcb->f_active.fe_area->fa_size -
+    len = fcb->f_active.fe_range->sr_sector_size -
       (sizeof(struct fcb_disk_area) + 1 + 2);
     rc = fcb_append(fcb, len, &elem_loc);
     TEST_ASSERT(rc == 0);

--- a/fs/fcb/test/src/testcases/fcb_test_area_info.c
+++ b/fs/fcb/test/src/testcases/fcb_test_area_info.c
@@ -35,7 +35,7 @@ TEST_CASE(fcb_test_area_info)
      * Should be empty, with elem count and byte count zero.
      */
     for (i = 0; i < 2; i++) {
-        rc = fcb_area_info(fcb, &fcb->f_sectors[i], &area_elems[i],
+        rc = fcb_area_info(fcb, 0, &area_elems[i],
                            &area_bytes[i]);
         TEST_ASSERT(rc == 0);
         TEST_ASSERT(area_elems[i] == 0);
@@ -50,15 +50,15 @@ TEST_CASE(fcb_test_area_info)
         if (rc == FCB_ERR_NOSPACE) {
             break;
         }
-        if (loc.fe_area == &test_fcb_area[0]) {
+        if (loc.fe_sector == 0) {
             elem_cnts[0]++;
-        } else if (loc.fe_area == &test_fcb_area[1]) {
+        } else if (loc.fe_sector == 1) {
             elem_cnts[1]++;
         } else {
             TEST_ASSERT(0);
         }
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -66,7 +66,7 @@ TEST_CASE(fcb_test_area_info)
         TEST_ASSERT(rc == 0);
 
         for (i = 0; i < 2; i++) {
-            rc = fcb_area_info(fcb, &fcb->f_sectors[i], &area_elems[i],
+            rc = fcb_area_info(fcb, i, &area_elems[i],
                                &area_bytes[i]);
             TEST_ASSERT(rc == 0);
             TEST_ASSERT(area_elems[i] == elem_cnts[i]);
@@ -80,9 +80,9 @@ TEST_CASE(fcb_test_area_info)
     rc = fcb_rotate(fcb);
     TEST_ASSERT(rc == 0);
 
-    rc = fcb_area_info(fcb, &fcb->f_sectors[0], &area_elems[0], &area_bytes[0]);
+    rc = fcb_area_info(fcb, 0, &area_elems[0], &area_bytes[0]);
     TEST_ASSERT(rc == 0);
-    rc = fcb_area_info(fcb, &fcb->f_sectors[1], &area_elems[1], &area_bytes[1]);
+    rc = fcb_area_info(fcb, 1, &area_elems[1], &area_bytes[1]);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(area_elems[0] == 0);
     TEST_ASSERT(area_bytes[0] == 0);
@@ -90,9 +90,9 @@ TEST_CASE(fcb_test_area_info)
     TEST_ASSERT(area_bytes[1] == elem_cnts[1] * sizeof(test_data));
 
     /*
-     * If area pointer is NULL, should check the oldest area (area 1).
+     * Test oldest sector should be sector area 1.
      */
-    rc = fcb_area_info(fcb, NULL, &area_elems[0], &area_bytes[0]);
+    rc = fcb_area_info(fcb, FCB_SECTOR_OLDEST, &area_elems[0], &area_bytes[0]);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(area_elems[0] == elem_cnts[1]);
     TEST_ASSERT(area_bytes[0] == elem_cnts[1] * sizeof(test_data));

--- a/fs/fcb/test/src/testcases/fcb_test_init.c
+++ b/fs/fcb/test/src/testcases/fcb_test_init.c
@@ -29,13 +29,15 @@ TEST_CASE(fcb_test_init)
     rc = fcb_init(fcb);
     TEST_ASSERT(rc == FCB_ERR_ARGS);
 
-    fcb->f_sectors = test_fcb_area;
+    fcb->f_ranges = test_fcb_ranges;
 
     rc = fcb_init(fcb);
     TEST_ASSERT(rc == FCB_ERR_ARGS);
 
     fcb->f_sector_cnt = 2;
     fcb->f_magic = 0x12345678;
+    fcb->f_range_cnt = 1;
+    fcb->f_ranges[0].sr_flash_area.fa_size = 2 * fcb->f_ranges[0].sr_sector_size;
     rc = fcb_init(fcb);
     TEST_ASSERT(rc == FCB_ERR_MAGIC);
 

--- a/fs/fcb/test/src/testcases/fcb_test_last_of_n.c
+++ b/fs/fcb/test/src/testcases/fcb_test_last_of_n.c
@@ -44,7 +44,7 @@ TEST_CASE(fcb_test_last_of_n)
             break;
         }
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -57,28 +57,28 @@ TEST_CASE(fcb_test_last_of_n)
     /* last entry */
     rc = fcb_offset_last_n(fcb, 1, &loc);
     assert (rc == 0);
-    assert (areas[4].fe_area == loc.fe_area);
+    assert (areas[4].fe_sector == loc.fe_sector);
     assert (areas[4].fe_data_off == loc.fe_data_off);
     assert (areas[4].fe_data_len == loc.fe_data_len);
 
     /* somewhere in the middle */
     rc = fcb_offset_last_n(fcb, 3, &loc);
     assert (rc == 0);
-    assert (areas[2].fe_area == loc.fe_area);
+    assert (areas[2].fe_sector == loc.fe_sector);
     assert (areas[2].fe_data_off == loc.fe_data_off);
     assert (areas[2].fe_data_len == loc.fe_data_len);
 
     /* first entry */
     rc = fcb_offset_last_n(fcb, 5, &loc);
     assert (rc == 0);
-    assert (areas[0].fe_area == loc.fe_area);
+    assert (areas[0].fe_sector == loc.fe_sector);
     assert (areas[0].fe_data_off == loc.fe_data_off);
     assert (areas[0].fe_data_len == loc.fe_data_len);
 
     /* after last valid entry, returns the first one like for 5 */
     rc = fcb_offset_last_n(fcb, 6, &loc);
     assert (rc == 0);
-    assert (areas[0].fe_area == loc.fe_area);
+    assert (areas[0].fe_sector == loc.fe_sector);
     assert (areas[0].fe_data_off == loc.fe_data_off);
     assert (areas[0].fe_data_len == loc.fe_data_len);
 }

--- a/fs/fcb/test/src/testcases/fcb_test_multiple_scratch.c
+++ b/fs/fcb/test/src/testcases/fcb_test_multiple_scratch.c
@@ -56,10 +56,10 @@ TEST_CASE(fcb_test_multiple_scratch)
         if (rc == FCB_ERR_NOSPACE) {
             break;
         }
-        idx = loc.fe_area - &test_fcb_area[0];
+        idx = loc.fe_sector;
         elem_cnts[idx]++;
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -82,10 +82,10 @@ TEST_CASE(fcb_test_multiple_scratch)
         if (rc == FCB_ERR_NOSPACE) {
             break;
         }
-        idx = loc.fe_area - &test_fcb_area[0];
+        idx = loc.fe_sector;
         elem_cnts[idx]++;
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -101,7 +101,7 @@ TEST_CASE(fcb_test_multiple_scratch)
     TEST_ASSERT(rc == 0);
 
     memset(&cnts, 0, sizeof(cnts));
-    rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
+    rc = fcb_walk(fcb, FCB_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_arg);
     TEST_ASSERT(rc == 0);
 
     TEST_ASSERT(cnts[0] == 0);

--- a/fs/fcb/test/src/testcases/fcb_test_rotate.c
+++ b/fs/fcb/test/src/testcases/fcb_test_rotate.c
@@ -57,15 +57,15 @@ TEST_CASE(fcb_test_rotate)
         if (rc == FCB_ERR_NOSPACE) {
             break;
         }
-        if (loc.fe_area == &test_fcb_area[0]) {
+        if (loc.fe_sector == 0) {
             elem_cnts[0]++;
-        } else if (loc.fe_area == &test_fcb_area[1]) {
+        } else if (loc.fe_sector == 1) {
             elem_cnts[1]++;
         } else {
             TEST_ASSERT(0);
         }
 
-        rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+        rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
           sizeof(test_data));
         TEST_ASSERT(rc == 0);
 
@@ -80,7 +80,7 @@ TEST_CASE(fcb_test_rotate)
     TEST_ASSERT(fcb->f_active_id == old_id); /* no new area created */
 
     memset(cnts, 0, sizeof(cnts));
-    rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
+    rc = fcb_walk(fcb, FCB_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_arg);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(aa_arg.elem_cnts[0] == elem_cnts[0] ||
       aa_arg.elem_cnts[1] == elem_cnts[1]);
@@ -92,7 +92,7 @@ TEST_CASE(fcb_test_rotate)
     rc = fcb_append(fcb, sizeof(test_data), &loc);
     TEST_ASSERT(rc == 0);
 
-    rc = flash_area_write(loc.fe_area, loc.fe_data_off, test_data,
+    rc = fcb_write_to_sector(&loc, loc.fe_data_off, test_data,
       sizeof(test_data));
     TEST_ASSERT(rc == 0);
 
@@ -105,7 +105,7 @@ TEST_CASE(fcb_test_rotate)
     TEST_ASSERT(fcb->f_active_id == old_id);
 
     memset(cnts, 0, sizeof(cnts));
-    rc = fcb_walk(fcb, NULL, fcb_test_cnt_elems_cb, &aa_arg);
+    rc = fcb_walk(fcb, FCB_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_arg);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(aa_arg.elem_cnts[0] == 1 || aa_arg.elem_cnts[1] == 1);
     TEST_ASSERT(aa_arg.elem_cnts[0] == 0 || aa_arg.elem_cnts[1] == 0);

--- a/hw/drivers/flash/enc_flash/test/src/enc_flash_test.c
+++ b/hw/drivers/flash/enc_flash/test/src/enc_flash_test.c
@@ -54,6 +54,20 @@ struct flash_area enc_test_flash_areas[4] = {
     }
 };
 
+struct sector_range enc_test_sector_ranges[1] = {
+    [0] = {
+        .sr_flash_area = {
+            .fa_device_id = 0,
+            .fa_off = 0,
+            .fa_size = 0x10000, /* 64K */
+     },
+     .sr_range_start = 0,
+     .sr_first_sector = 0,
+     .sr_sector_size = 0x4000, /* 16 K */
+     .sr_sector_count = 4,
+    },
+};
+
 TEST_SUITE(enc_flash_test_all)
 {
     enc_flash_test_hal();

--- a/hw/drivers/flash/enc_flash/test/src/enc_flash_test.h
+++ b/hw/drivers/flash/enc_flash/test/src/enc_flash_test.h
@@ -30,5 +30,6 @@ TEST_CASE_DECL(enc_flash_test_flash_map)
 TEST_CASE_DECL(enc_flash_test_fcb)
 
 extern struct flash_area enc_test_flash_areas[4];
+extern struct sector_range enc_test_sector_ranges[1];
 
 #endif

--- a/sys/config/test-fcb/src/conf_test_fcb.c
+++ b/sys/config/test-fcb/src/conf_test_fcb.c
@@ -272,33 +272,28 @@ void config_wipe_srcs(void)
     conf_save_dst = NULL;
 }
 
-void config_wipe_fcb(struct flash_area *fa, int cnt)
+void config_wipe_fcb(struct sector_range *fr, int cnt)
 {
     int rc;
     int i;
 
     for (i = 0; i < cnt; i++) {
-        rc = flash_area_erase(&fa[i], 0, fa[i].fa_size);
+        rc = flash_area_erase(&fr->sr_flash_area, i * fr->sr_sector_size,
+            fr->sr_sector_size);
         TEST_ASSERT(rc == 0);
     }
 }
 
-struct flash_area fcb_areas[] = {
+struct sector_range fcb_range[] = {
     [0] = {
-        .fa_off = 0x00000000,
-        .fa_size = 16 * 1024
-    },
-    [1] = {
-        .fa_off = 0x00004000,
-        .fa_size = 16 * 1024
-    },
-    [2] = {
-        .fa_off = 0x00008000,
-        .fa_size = 16 * 1024
-    },
-    [3] = {
-        .fa_off = 0x0000c000,
-        .fa_size = 16 * 1024
+        .sr_flash_area = {
+            .fa_off = 0x00000000,
+            .fa_size = 4 * 16 * 1024,
+        },
+        .sr_range_start = 0,
+        .sr_first_sector = 0,
+        .sr_sector_size = 16 * 1024,
+        .sr_sector_count = 4
     }
 };
 

--- a/sys/config/test-fcb/src/conf_test_fcb.h
+++ b/sys/config/test-fcb/src/conf_test_fcb.h
@@ -42,7 +42,7 @@ extern char val_string[CONF_TEST_FCB_VAL_STR_CNT][CONF_MAX_VAL_LEN];
 
 #define CONF_TEST_FCB_FLASH_CNT   4
 
-extern struct flash_area fcb_areas[CONF_TEST_FCB_FLASH_CNT];
+extern struct sector_range fcb_range[];
 
 extern uint32_t val32;
 extern uint64_t val64;
@@ -59,7 +59,7 @@ extern void config_test_fill_area(
         char test_value[CONF_TEST_FCB_VAL_STR_CNT][CONF_MAX_VAL_LEN],
         int iteration);
 
-void config_wipe_fcb(struct flash_area *fa, int cnt);
+void config_wipe_fcb(struct sector_range *fr, int cnt);
 
 char *ctest_handle_get(int argc, char **argv, char *val, int val_len_max);
 int ctest_handle_set(int argc, char **argv, char *val);

--- a/sys/config/test-fcb/src/testcases/config_test_compress_reset.c
+++ b/sys/config/test-fcb/src/testcases/config_test_compress_reset.c
@@ -22,17 +22,18 @@ TEST_CASE(config_test_compress_reset)
 {
     int rc;
     struct conf_fcb cf;
-    struct flash_area *fa;
+    int sector;
     char test_value[CONF_TEST_FCB_VAL_STR_CNT][CONF_MAX_VAL_LEN];
     int elems[4];
     int i;
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);
@@ -50,7 +51,7 @@ TEST_CASE(config_test_compress_reset)
         rc = conf_save();
         TEST_ASSERT(rc == 0);
 
-        if (cf.cf_fcb.f_active.fe_area == &fcb_areas[2]) {
+        if (cf.cf_fcb.f_active.fe_sector == 2) {
             /*
              * Started using space just before scratch.
              */
@@ -63,19 +64,20 @@ TEST_CASE(config_test_compress_reset)
         TEST_ASSERT(!memcmp(val_string, test_value, CONF_MAX_VAL_LEN));
     }
 
-    fa = cf.cf_fcb.f_active.fe_area;
+    sector = cf.cf_fcb.f_active.fe_sector;
     rc = fcb_append_to_scratch(&cf.cf_fcb);
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(fcb_free_sector_cnt(&cf.cf_fcb) == 0);
-    TEST_ASSERT(fa != cf.cf_fcb.f_active.fe_area);
+    TEST_ASSERT(sector != cf.cf_fcb.f_active.fe_sector);
 
     config_wipe_srcs();
 
     memset(&cf, 0, sizeof(cf));
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);
@@ -84,7 +86,7 @@ TEST_CASE(config_test_compress_reset)
     TEST_ASSERT(rc == 0);
 
     TEST_ASSERT(fcb_free_sector_cnt(&cf.cf_fcb) == 1);
-    TEST_ASSERT(fa == cf.cf_fcb.f_active.fe_area);
+    TEST_ASSERT(sector == cf.cf_fcb.f_active.fe_sector);
 
     c2_var_count = 0;
 }

--- a/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
+++ b/sys/config/test-fcb/src/testcases/config_test_custom_compress.c
@@ -45,11 +45,12 @@ TEST_CASE(config_test_custom_compress)
     int i;
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);
@@ -70,7 +71,7 @@ TEST_CASE(config_test_custom_compress)
         rc = conf_save();
         TEST_ASSERT(rc == 0);
 
-        if (cf.cf_fcb.f_active.fe_area == &fcb_areas[2]) {
+        if (cf.cf_fcb.f_active.fe_sector == 2) {
             /*
              * Started using space just before scratch.
              */

--- a/sys/config/test-fcb/src/testcases/config_test_empty_fcb.c
+++ b/sys/config/test-fcb/src/testcases/config_test_empty_fcb.c
@@ -24,11 +24,12 @@ TEST_CASE(config_test_empty_fcb)
     struct conf_fcb cf;
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/config/test-fcb/src/testcases/config_test_get_stored.c
+++ b/sys/config/test-fcb/src/testcases/config_test_get_stored.c
@@ -25,11 +25,12 @@ TEST_CASE(config_test_get_stored_fcb)
     char stored_val[32];
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/config/test-fcb/src/testcases/config_test_save_1_fcb.c
+++ b/sys/config/test-fcb/src/testcases/config_test_save_1_fcb.c
@@ -26,8 +26,9 @@ TEST_CASE(config_test_save_1_fcb)
     config_wipe_srcs();
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/config/test-fcb/src/testcases/config_test_save_2_fcb.c
+++ b/sys/config/test-fcb/src/testcases/config_test_save_2_fcb.c
@@ -28,8 +28,9 @@ TEST_CASE(config_test_save_2_fcb)
     config_wipe_srcs();
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/config/test-fcb/src/testcases/config_test_save_3_fcb.c
+++ b/sys/config/test-fcb/src/testcases/config_test_save_3_fcb.c
@@ -25,10 +25,11 @@ TEST_CASE(config_test_save_3_fcb)
     int i;
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
     cf.cf_fcb.f_sector_cnt = 4;
 
     rc = conf_fcb_src(&cf);

--- a/sys/config/test-fcb/src/testcases/config_test_save_one_fcb.c
+++ b/sys/config/test-fcb/src/testcases/config_test_save_one_fcb.c
@@ -24,11 +24,12 @@ TEST_CASE(config_test_save_one_fcb)
     struct conf_fcb cf;
 
     config_wipe_srcs();
-    config_wipe_fcb(fcb_areas, sizeof(fcb_areas) / sizeof(fcb_areas[0]));
+    config_wipe_fcb(fcb_range, fcb_range[0].sr_sector_count);
 
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
-    cf.cf_fcb.f_sectors = fcb_areas;
-    cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_ranges = fcb_range;
+    cf.cf_fcb.f_range_cnt = 1;
+    cf.cf_fcb.f_sector_cnt = fcb_range[0].sr_sector_count;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -52,6 +52,14 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+struct sector_range {
+    struct flash_area sr_flash_area;
+    uint32_t sr_range_start;
+    uint16_t sr_first_sector;
+    uint16_t sr_sector_size;
+    uint16_t sr_sector_count;
+};
+
 extern const struct flash_area *flash_map;
 extern int flash_map_entries;
 
@@ -105,6 +113,11 @@ uint32_t flash_area_erased_val(const struct flash_area *fa);
  * Given flash map index, return info about sectors within the area.
  */
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
+
+/*
+ * Given flash map area id, return info about sectors within the area.
+ */
+int flash_area_to_sector_ranges(int id, int *cnt, struct sector_range *ret);
 
 /*
  * Get-next interface for obtaining info about sectors.

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -56,8 +56,8 @@ struct sector_range {
     struct flash_area sr_flash_area;
     uint32_t sr_range_start;
     uint16_t sr_first_sector;
-    uint16_t sr_sector_size;
     uint16_t sr_sector_count;
+    uint32_t sr_sector_size;
 };
 
 extern const struct flash_area *flash_map;

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -44,6 +44,9 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
 #if MYNEWT_VAL(LOG_STATS)
     int cnt;
 #endif
+#if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
+    struct fcb_sector_info si;
+#endif
 
     fcb_log = (struct fcb_log *)log->l_arg;
     fcb = &fcb_log->fl_fcb;
@@ -87,7 +90,6 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
          * beginning of current oldest area.
          */
         if (fcb_offset_in_sector(fcb, fcb_log->fl_watermark_off, old_sec)) {
-            struct fcb_sector_info si;
             fcb_get_sector_info(fcb, old_sec, &si);
             fcb_log->fl_watermark_off = si.si_sector_offset;
         }

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -55,7 +55,7 @@ struct conf_handler reboot_conf_handler = {
 #if MYNEWT_VAL(REBOOT_LOG_FCB)
 static struct fcb_log reboot_log_fcb;
 static struct log reboot_log;
-static struct flash_area sector;
+static struct sector_range sector;
 #endif
 
 
@@ -88,9 +88,10 @@ log_reboot_init_fcb(void)
         return SYS_EUNKNOWN;
     }
     fcbp = &reboot_log_fcb.fl_fcb;
-    sector = *ptr;
-    fcbp->f_sectors = &sector;
+    sector.sr_flash_area = *ptr;
+    fcbp->f_ranges = &sector;
     fcbp->f_sector_cnt = 1;
+    fcbp->f_range_cnt = 1;
     fcbp->f_magic = 0x7EADBADF;
     fcbp->f_version = g_log_info.li_version;
 


### PR DESCRIPTION
FCB when used with big flash can use a lot of RAM needed for sector information storage.
Information about sectors can be compacted so FCB will use reasonable amount of RAM.

Function introduced in flash_map can also be used in bootloader to get flash slot information.