### PR TITLE
Padded log timestamps

### DIFF
--- a/sys/console/full/src/console_fmt.c
+++ b/sys/console/full/src/console_fmt.c
@@ -27,6 +27,15 @@
 
 #if MYNEWT_VAL(BASELIBC_PRESENT)
 
+/* This collection of macros turns an integer into a string */
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+/* This collection of macros strips the parentheses from another macro */
+#define _Args(...) __VA_ARGS__
+#define STRIP_PARENS_HELPER(X) X
+#define STRIP_PARENS(X) STRIP_PARENS_HELPER( _Args X )
+
 /**
  * Prints the specified format string to the console.
  *
@@ -46,7 +55,7 @@ console_printf(const char *fmt, ...)
     if (console_get_ticks()) {
         /* Prefix each line with a timestamp. */
         if (!console_is_midline) {
-            num_chars += printf("%06lu ", (unsigned long)os_time_get());
+            num_chars += printf("%0" STR(STRIP_PARENS(MYNEWT_VAL(CONSOLE_TICKS_PAD))) "lu ", (unsigned long)os_time_get());
         }
     }
 

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -101,3 +101,7 @@ syscfg.defs:
         description: >
             Sysinit stage for console functionality.
         value: 20
+
+    CONSOLE_TICKS_PAD:
+       description: pad the console ticks output with zeros to this length
+       value: 8

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -25,9 +25,11 @@
 #include <console/console.h>
 #include "log/log.h"
 
+/* This collection of macros turns an integer into a string */
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
+/* This collection of macros strips the parentheses from another macro */
 #define _Args(...) __VA_ARGS__
 #define STRIP_PARENS_HELPER(X) X
 #define STRIP_PARENS(X) STRIP_PARENS_HELPER( _Args X )

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -25,6 +25,13 @@
 #include <console/console.h>
 #include "log/log.h"
 
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#define _Args(...) __VA_ARGS__
+#define STRIP_PARENS_HELPER(X) X
+#define STRIP_PARENS(X) STRIP_PARENS_HELPER( _Args X )
+
 static struct log log_console;
 
 struct log *
@@ -36,8 +43,13 @@ log_console_get(void)
 static void
 log_console_print_hdr(const struct log_entry_hdr *hdr)
 {
-    console_printf("[ts=%lluus, mod=%u level=%u] ",
+#if MYNEWT_VAL(LOG_HDR_TS_PAD) > 0
+    console_printf("[ts=%0" STR(STRIP_PARENS(MYNEWT_VAL(LOG_HDR_TS_PAD))) "lluus, mod=%u level=%u] ",
                    hdr->ue_ts, hdr->ue_module, hdr->ue_level);
+#else
+    console_printf("[ts=%lluus, mod=%u level=%u] ",
+                       hdr->ue_ts, hdr->ue_module, hdr->ue_level);
+#endif
 }
 
 static int

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -100,3 +100,7 @@ syscfg.defs:
         description: >
             Sysinit stage for logging to the second image slot.
         value: 101
+
+    LOG_HDR_TS_PAD:
+        description: "pad the timestamp by this many zeros"
+        value: '0'


### PR DESCRIPTION
This is added to facilitate a parsing operation by a resource constrained device which depends on fixed length strings.
It also abuses the preprocessor to keep the inconvenience compiler-side.
I'm sorry.