### PR TITLE
tinyprintf: Add support for parametrized field width

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -282,7 +282,10 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
             }
 
             /* Width */
-            if (ch >= '0' && ch <= '9') {
+            if (ch == '*') {
+                p.width = intarg(0, 1, &va);
+                ch = *(fmt++);
+            } else if (ch >= '0' && ch <= '9') {
                 ch = a2i(ch, &fmt, 10, &(p.width));
             }
             if (ch == 'l') {


### PR DESCRIPTION
This adds support for field width passed as a parameter, e.g.: `printf("%0*d", width, value);`