### PR TITLE
allow user to override TCP port gdb and jtag emulator use to communicate

### DIFF
--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -42,3 +42,29 @@ windows_detect() {
         COMSPEC=cmd.exe
     fi
 }
+
+#
+# Check if known parameters are set in EXTRA_JTAG_CMD. Filter these
+# parameters out of the arguments passed to jtag emulator software.
+# Only special parameter is -port <portnumber>
+#
+parse_extra_jtag_cmd() {
+    PORT=3333
+
+    NEW_EXTRA_JTAG_CMD=""
+    while [ "$1" != "" ]; do
+	case $1 in
+	    -port)
+		shift
+		PORT=$1
+		shift
+		;;
+	    *)
+		NEW_EXTRA_JTAG_CMD+=" $1"
+		shift
+		;;
+	esac
+    done
+    echo $NEW_EXTRA_JTAG_CMD
+    EXTRA_JTAG_CMD=$NEW_EXTRA_JTAG_CMD
+}

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -30,6 +30,8 @@ jlink_load () {
     PORT=3333
 
     windows_detect
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
+
     if [ $WINDOWS -eq 1 ]; then
 	JLINK_GDB_SERVER=JLinkGDBServerCL
     fi
@@ -114,6 +116,7 @@ jlink_debug() {
     if [ $WINDOWS -eq 1 ]; then
 	JLINK_GDB_SERVER=JLinkGDBServerCL
     fi
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 
     if [ -z "$NO_GDB" ]; then
         GDB_CMD_FILE=.gdb_cmds
@@ -134,17 +137,17 @@ jlink_debug() {
             # Launch jlink server in a separate command interpreter, to make
             # sure it doesn't get killed by Ctrl-C signal from bash.
             #
-            $COMSPEC /C "start $COMSPEC /C $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun $EXTRA_JTAG_CMD"
+            $COMSPEC /C "start $COMSPEC /C $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD"
         else
             #
             # Block Ctrl-C from getting passed to jlink server.
             #
             set -m
-            $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun $EXTRA_JTAG_CMD  > /dev/null &
+            $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD  > /dev/null &
             set +m
         fi
 
-        echo "target remote localhost:3333" > $GDB_CMD_FILE
+        echo "target remote localhost:$PORT" > $GDB_CMD_FILE
         # Whether target should be reset or not
         if [ ! -z "$RESET" ]; then
             echo "mon reset" >> $GDB_CMD_FILE
@@ -160,7 +163,7 @@ jlink_debug() {
             rm $GDB_CMD_FILE
 	fi
     else
-        $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port 3333 -singlerun $EXTRA_JTAG_CMD
+        $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD
     fi
     return 0
 }

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -27,6 +27,7 @@ JLINK_GDB_SERVER=JLinkGDBServer
 jlink_load () {
     GDB_CMD_FILE=.gdb_cmds
     GDB_OUT_FILE=.gdb_out
+    PORT=3333
 
     windows_detect
     if [ $WINDOWS -eq 1 ]; then
@@ -46,6 +47,10 @@ jlink_load () {
         echo "Missing flash offset"
         exit 1
     fi
+    if [[ $EXTRA_JTAG_CMD =~ '-port ' ]]; then
+        # ExtraJTagCommand contains PORT - Use that port instead.
+        PORT=$(awk '{for(i=1;i<=NF;i++) if ($i=="-port") print $(i+1)}' <<< $EXTRA_JTAG_CMD)
+    fi
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
@@ -53,8 +58,8 @@ jlink_load () {
     # downloading somewhere in the flash. So need to figure out how to tell it
     # not to do that, or report failure if gdb fails to write this file
     #
-    echo "shell sh -c \"trap '' 2; $JLINK_GDB_SERVER -device $JLINK_DEV -speed 1000 -if SWD -port 3333 -singlerun $EXTRA_JTAG_CMD  &\" " > $GDB_CMD_FILE
-    echo "target remote localhost:3333" >> $GDB_CMD_FILE
+    echo "shell sh -c \"trap '' 2; $JLINK_GDB_SERVER -device $JLINK_DEV -speed 1000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD  &\" " > $GDB_CMD_FILE
+    echo "target remote localhost:$PORT" >> $GDB_CMD_FILE
     echo "mon reset" >> $GDB_CMD_FILE
     echo "restore $FILE_NAME binary $FLASH_OFFSET" >> $GDB_CMD_FILE
 

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -49,10 +49,6 @@ jlink_load () {
         echo "Missing flash offset"
         exit 1
     fi
-    if [[ $EXTRA_JTAG_CMD =~ '-port ' ]]; then
-        # ExtraJTagCommand contains PORT - Use that port instead.
-        PORT=$(awk '{for(i=1;i<=NF;i++) if ($i=="-port") print $(i+1)}' <<< $EXTRA_JTAG_CMD)
-    fi
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -27,6 +27,8 @@ GDB=arm-none-eabi-gdb
 openocd_load () {
     OCD_CMD_FILE=.openocd_cmds
 
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
+
     echo "$EXTRA_JTAG_CMD" > $OCD_CMD_FILE
     echo "init" >> $OCD_CMD_FILE
     echo "$CFG_RESET" >> $OCD_CMD_FILE
@@ -66,9 +68,10 @@ openocd_debug () {
     OCD_CMD_FILE=.openocd_cmds
 
     windows_detect
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 
-    echo "gdb_port 3333" > $OCD_CMD_FILE
-    echo "telnet_port 4444" >> $OCD_CMD_FILE
+    echo "gdb_port $PORT" > $OCD_CMD_FILE
+    echo "telnet_port $(($PORT+1))" >> $OCD_CMD_FILE
     echo "$EXTRA_JTAG_CMD" >> $OCD_CMD_FILE
 
     if [ -z "$NO_GDB" ]; then
@@ -101,7 +104,7 @@ openocd_debug () {
 
         GDB_CMD_FILE=.gdb_cmds
 
-        echo "target remote localhost:3333" > $GDB_CMD_FILE
+        echo "target remote localhost:$PORT" > $GDB_CMD_FILE
         if [ ! -z "$RESET" ]; then
             echo "mon reset halt" >> $GDB_CMD_FILE
         fi


### PR DESCRIPTION
This contains cherry-picked change from https://github.com/apache/mynewt-core/pull/1401. Here it is extended to be used also for 'newt debug' with Jlink, as well as use with openocd.