### PR TITLE
Allow parallel tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,53 +28,123 @@ _addons: &addon_conf
 go:
   - "1.10"
 
+git:
+  depth: false
+
 matrix:
   include:
+    # newt build <targets>
     - os: linux
       env:
         - TEST=BUILD_TARGETS
+        - VM_AMOUNT=4
+        - TARGET_SET=1
+    - os: linux
+      env:
+        - TEST=BUILD_TARGETS
+        - VM_AMOUNT=4
+        - TARGET_SET=2
+    - os: linux
+      env:
+        - TEST=BUILD_TARGETS
+        - VM_AMOUNT=4
+        - TARGET_SET=3
+    - os: linux
+      env:
+        - TEST=BUILD_TARGETS
+        - VM_AMOUNT=4
+        - TARGET_SET=4
+
+    # newt build <blinky-for-BSP>
     - os: linux
       env:
         - TEST=BUILD_BLINKY
+        - VM_AMOUNT=4
+        - TARGET_SET=1
+    - os: linux
+      env:
+        - TEST=BUILD_BLINKY
+        - VM_AMOUNT=4
+        - TARGET_SET=2
+    - os: linux
+      env:
+        - TEST=BUILD_BLINKY
+        - VM_AMOUNT=4
+        - TARGET_SET=3
+    - os: linux
+      env:
+        - TEST=BUILD_BLINKY
+        - VM_AMOUNT=4
+        - TARGET_SET=4
+
+    # newt test all (Linux)
     - os: linux
       addons: *addon_conf
       env:
         - TEST=TEST_ALL
-    - os: osx
-      osx_image: xcode9.2
+        - VM_AMOUNT=3
+        - TARGET_SET=1
+    - os: linux
+      addons: *addon_conf
       env:
-        - TEST=BUILD_TARGETS
-    - os: osx
-      osx_image: xcode9.2
+        - TEST=TEST_ALL
+        - VM_AMOUNT=3
+        - TARGET_SET=2
+    - os: linux
+      addons: *addon_conf
       env:
-        - TEST=BUILD_BLINKY
+        - TEST=TEST_ALL
+        - VM_AMOUNT=3
+        - TARGET_SET=3
+
+    # newt test all (osx)
     - os: osx
       osx_image: xcode9.2
       env:
         - TEST=TEST_ALL
+        - VM_AMOUNT=3
+        - TARGET_SET=1
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - TEST=TEST_ALL
+        - VM_AMOUNT=3
+        - TARGET_SET=2
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - TEST=TEST_ALL
+        - VM_AMOUNT=3
+        - TARGET_SET=3
+
+before_install:
+  - printenv
+  - export GOPATH=$HOME/gopath
+  - go version
 
 install:
-- printenv
-- export GOPATH=$HOME/gopath
-- go version
+  - git clone https://github.com/runtimeco/mynewt-travis-ci $HOME/ci
+  - chmod +x $HOME/ci/*.sh
+  - $HOME/ci/${TRAVIS_OS_NAME}_travis_install.sh
 
-- git clone https://github.com/runtimeco/mynewt-travis-ci $HOME/ci
-- chmod +x $HOME/ci/*.sh
-- $HOME/ci/${TRAVIS_OS_NAME}_travis_install.sh
-
-- newt version
-- gcc --version
-- if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
+before_script:
+  - newt version
+  - gcc --version
+  - if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
+  - cp -R $HOME/ci/mynewt-core-project.yml project.yml
+  - cp -R $HOME/ci/mynewt-core-targets targets
+  - newt install
+    # pass in the number of target sets
+  - $HOME/ci/prepare_test.sh $VM_AMOUNT
 
 script:
-- cp -R $HOME/ci/mynewt-core-project.yml project.yml
-- cp -R $HOME/ci/mynewt-core-targets targets
-- newt install
-
-- export IGNORED_BSPS="ci40 embarc_emsk hifive1 native-armv7 native-mips
-                       pic32mx470_6lp_clicker pic32mz2048_wi-fire sensorhub
-                       native"
-- $HOME/ci/run_test.sh
+  # the following list of targets are known to fail building blinky, or
+  # might have extra dependencies hard to provide, non-common toolchains, etc
+  # NOTE: "native" is here to avoid having to install gcc-multilib
+  - export IGNORED_BSPS="ci40 embarc_emsk hifive1 native-armv7 native-mips
+                         pic32mx470_6lp_clicker pic32mz2048_wi-fire sensorhub
+                         native"
+  - $HOME/ci/run_test.sh
 
 cache:
   directories:


### PR DESCRIPTION
The build matrix was updated to support running tests on multiple machines. Brings testing time down to somewhere between 5 min and 10 min usually, depending on amount of travis resources available.

* Other small changes to formatting and style where applied, plus clone git repos without history.
* Some tests that are just "duplicate" on OSX and Linux were disabled on OSX, like `newt build <blinkies>` and `newt build <targets>`.

This depends on https://github.com/runtimeco/mynewt-travis-ci/pull/11 (also `mynewt-nimble` needs update). Results can be seen here: https://travis-ci.org/apache/mynewt-core/builds/440269240