### PR TITLE
net/test: Fix nm_socket and oic tests

### DIFF
--- a/net/ip/mn_socket/test/src/mn_sock_util.c
+++ b/net/ip/mn_socket/test/src/mn_sock_util.c
@@ -562,6 +562,11 @@ sock_find_multicast_if(void)
         if ((itf.mif_flags & MN_ITF_F_UP) == 0) {
             continue;
         }
+
+        if ((itf.mif_flags & MN_ITF_F_LINK) == 0) {
+            continue;
+        }
+
         if (itf.mif_flags & MN_ITF_F_MULTICAST) {
             return itf.mif_idx;
         }


### PR DESCRIPTION
Those requires interface to be both UP and RUNNING to be able to send
messages. Make sure to check both to avoid failing tests depending
on network interfaces order ie if not connected interface is listed
before connected ones.