### PR TITLE
mynewt.h: Include generated `logcfg/logcfg.h` file

### DIFF
--- a/kernel/os/include/os/mynewt.h
+++ b/kernel/os/include/os/mynewt.h
@@ -26,4 +26,9 @@
 #include "os/os.h"
 #include "defs/error.h"
 
+/* Only include the logcfg header if this version of newt can generate it. */
+#if MYNEWT_VAL(NEWT_FEATURE_LOGCFG)
+#include "logcfg/logcfg.h"
+#endif
+
 #endif


### PR DESCRIPTION
This PR is submitted in the context of https://github.com/apache/mynewt-newt/pull/221.  This PR does not require the newt PR, but it is not useful without it.

Modify `mynewt.h` to take advantage of the new logcfg newt feature.  Now, `mynewt.h` includes the generated logcfg header.