### PR TITLE
tinyprintf: Limit allowed values for variable field length

### DIFF
--- a/libc/baselibc/src/tinyprintf.c
+++ b/libc/baselibc/src/tinyprintf.c
@@ -64,6 +64,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include "os/mynewt.h"
 
@@ -244,6 +245,7 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
     double d;
     int n;
 #endif
+    int i;
 
     p.bf = bf;
 
@@ -283,7 +285,12 @@ size_t tfp_format(FILE *putp, const char *fmt, va_list va)
 
             /* Width */
             if (ch == '*') {
-                p.width = intarg(0, 1, &va);
+                i = intarg(0, 1, &va);
+                if (i > UCHAR_MAX) {
+                    p.width = UCHAR_MAX;
+                } else if (i > 0) {
+                    p.width = i;
+                }
                 ch = *(fmt++);
             } else if (ch >= '0' && ch <= '9') {
                 ch = a2i(ch, &fmt, 10, &(p.width));


### PR DESCRIPTION
Need to make sure speficied field width is within uchar range, otherwise
this may have unpredictable results.