### PR TITLE
Add speed-optimized build profile

### DIFF
--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -27,6 +27,7 @@ compiler.path.objcopy: arm-none-eabi-objcopy
 
 compiler.flags.default: -march=armv6s-m -mcpu=cortex-m0 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -fomit-frame-pointer -ffunction-sections -fdata-sections -DCMSIS_VECTAB_VIRTUAL -DCMSIS_VECTAB_VIRTUAL_HEADER_FILE="mynewt_cm0_vectab.h"
 compiler.flags.optimized: [compiler.flags.default, -Os -ggdb]
+compiler.flags.speed: [compiler.flags.default, -O3 -ggdb]
 compiler.flags.debug: [compiler.flags.default, -Og -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]

--- a/compiler/arm-none-eabi-m3/compiler.yml
+++ b/compiler/arm-none-eabi-m3/compiler.yml
@@ -28,6 +28,7 @@ compiler.path.objcopy: arm-none-eabi-objcopy
 compiler.flags.base: -mcpu=cortex-m3 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
 compiler.flags.debug: [compiler.flags.base, -Og -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]

--- a/compiler/arm-none-eabi-m4/compiler.yml
+++ b/compiler/arm-none-eabi-m4/compiler.yml
@@ -28,6 +28,7 @@ compiler.path.objcopy: arm-none-eabi-objcopy
 compiler.flags.base: -mcpu=cortex-m4 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
 compiler.flags.debug: [compiler.flags.base, -Og -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]

--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -28,6 +28,7 @@ compiler.path.objcopy: arm-none-eabi-objcopy
 compiler.flags.base: -mcpu=cortex-m7 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
 compiler.flags.default: [compiler.flags.base, -O1 -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os -ggdb]
+compiler.flags.speed: [compiler.flags.base, -O3 -ggdb]
 compiler.flags.debug: [compiler.flags.base, -O0 -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]

--- a/hw/drivers/rtt/pkg.yml
+++ b/hw/drivers/rtt/pkg.yml
@@ -25,6 +25,7 @@ pkg.keywords:
 pkg.deps:
 pkg.req_apis: 
 
+pkg.build_profile: speed
 pkg.cflags:
     - -DSEGGER_RTT_SECTION=".rtt"
     - -Wno-array-bounds

--- a/sys/sysview/pkg.yml
+++ b/sys/sysview/pkg.yml
@@ -22,6 +22,7 @@ pkg.description: Segger SystemView tool API
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+pkg.build_profile: speed
 pkg.deps:
     - "@apache-mynewt-core/sys/sysview/vendor"
 pkg.init:

--- a/sys/sysview/vendor/pkg.yml
+++ b/sys/sysview/vendor/pkg.yml
@@ -22,6 +22,7 @@ pkg.description: Segger SystemView tool - vendor code
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+pkg.build_profile: speed
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/rtt"
 


### PR DESCRIPTION
This adds new build profile called `speed` [1] (to ARM compilers for now) which basically enables `-O3` and also changes RTT and SystemView packages to always use this profile since we want this code to run as fast as possible (so it has minimal impact on normal system operation).

[1] I don't have any better name for this...