### PR TITLE
net/oic: Function to determine if endpoint is GATT

### DIFF
--- a/net/oic/include/oic/port/mynewt/ble.h
+++ b/net/oic/include/oic/port/mynewt/ble.h
@@ -33,6 +33,15 @@ struct oc_endpoint_ble {
     uint16_t conn_handle;
 };
 
+/**
+ * @brief Indicates whether the provided endpoint is the GATT (BLE) endpoint.
+ *
+ * @param oe                    The endpoint to inspect.
+ *
+ * @return                      1 if `oe` is the GATT endpoint; 0 otherwise.
+ */
+int oc_endpoint_is_gatt(const struct oc_endpoint *oe);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -196,6 +196,12 @@ oc_ep_gatt_size(const struct oc_endpoint *oe)
     return sizeof(struct oc_endpoint_ble);
 }
 
+int
+oc_endpoint_is_gatt(const struct oc_endpoint *oe)
+{
+    return oe->ep.oe_type == oc_gatt_transport_id;
+}
+
 static char *
 oc_log_ep_gatt(char *ptr, int maxlen, const struct oc_endpoint *oe)
 {


### PR DESCRIPTION
Add a function to determine if the provided OIC endpoint is the GATT (BLE) endpoint.  This is an analogue of the existing `oc_endpoint_is_ip` function.

This function is useful for oc_sec_recv callbacks; to inspect an endpoint's details, the callback must first determine the type of endpoint being used.