### PR TITLE
Remove misleading comments from .yml files

### DIFF
--- a/apps/blesplit/syscfg.yml
+++ b/apps/blesplit/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blesplit
-
 syscfg.vals:
     # Use INFO log level to reduce code size.  DEBUG is too large for nRF51.
     LOG_LEVEL: 1

--- a/apps/bleuart/syscfg.yml
+++ b/apps/bleuart/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/bleuart
-
 syscfg.vals:
     # Disable unused roles; bleuart is a peripheral-only app.
     BLE_ROLE_OBSERVER: 0

--- a/apps/boot/syscfg.yml
+++ b/apps/boot/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/boot
-
 syscfg.defs:
     BOOT_LOADER:
         description: 'Set to indicate that this app is a bootloader.'

--- a/apps/iptest/syscfg.yml
+++ b/apps/iptest/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/iptest
-
 syscfg.defs:
     BUILD_WITH_OIC:
        description: 'needed?'

--- a/apps/sensors_test/syscfg.yml
+++ b/apps/sensors_test/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/sensors_test
-
 syscfg.vals:
     # Enable the shell task.
     SHELL_TASK: 1

--- a/apps/slinky/syscfg.yml
+++ b/apps/slinky/syscfg.yml
@@ -16,7 +16,6 @@
 # under the License.
 #
 
-# Package: apps/slinky
 syscfg.defs:
     SLINKY_LOG_MODULE_GPIO:
         description: The log module to use for slinky GPIO messages.

--- a/apps/slinky_oic/syscfg.yml
+++ b/apps/slinky_oic/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/slinky
-
 syscfg.vals:
     # Enable the shell task.
     SHELL_TASK: 1

--- a/apps/spitest/syscfg.yml
+++ b/apps/spitest/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/spitest
-
 syscfg.defs:
     SPITEST_SS_PIN:
         description: 'SPI slave select pin number'

--- a/apps/splitty/syscfg.yml
+++ b/apps/splitty/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/splitty
-
 syscfg.vals:
     # Enable the shell task.
     SHELL_TASK: 1

--- a/apps/testbench/syscfg.yml
+++ b/apps/testbench/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/testbench
-
 syscfg.defs:
     TESTBENCH_BLE:
         description: Enables BLE support in the testbench app.

--- a/apps/timtest/syscfg.yml
+++ b/apps/timtest/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/timtest
-
 syscfg.vals:
     SHELL_TASK: 0
     TIMER_1: 1

--- a/boot/boot_serial/test/syscfg.yml
+++ b/boot/boot_serial/test/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: boot/boot_serial/test
-
 syscfg.vals:
     # This is here to work around the $notnull syscfg restriction.
     BOOT_SERIAL_DETECT_PIN: 0

--- a/boot/bootutil/syscfg.yml
+++ b/boot/bootutil/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: boot/bootutil
-
 syscfg.defs:
     BOOTUTIL_SIGN_RSA:
         description: 'Images are signed using RSA2048.'

--- a/compiler/arm-none-eabi-m3/syscfg.yml
+++ b/compiler/arm-none-eabi-m3/syscfg.yml
@@ -17,4 +17,3 @@
 # under the License.
 #
 
-# Package: compiler/arm-none-eabi-m3

--- a/compiler/arm-none-eabi-m4/syscfg.yml
+++ b/compiler/arm-none-eabi-m4/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: compiler/arm-none-eabi-m4
-
 syscfg.defs:
    HARDFLOAT:
        description: 'Use hardware FPU'

--- a/compiler/arm-none-eabi-m7/syscfg.yml
+++ b/compiler/arm-none-eabi-m7/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: compiler/arm-none-eabi-m7
-
 syscfg.defs:
    HARDFLOAT:
        description: 'Use hardware FPU'

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: crypto/mbedtls
-
 syscfg.defs:
   # Enabled curves
   MBEDTLS_ECP_DP_SECP192R1:

--- a/crypto/tinycrypt/syscfg.yml
+++ b/crypto/tinycrypt/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: crypto/tinycrypt
-
 syscfg.defs:
     TINYCRYPT_UECC_RNG_USE_TRNG:
         description: >

--- a/encoding/cborattr/syscfg.yml
+++ b/encoding/cborattr/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: mgmt/imgmgr
-
 syscfg.defs:
     CBORATTR_MAX_SIZE:
         description: 'The maximum size of a CBOR attribute during decoding'

--- a/fs/fs/syscfg.yml
+++ b/fs/fs/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: fs/fs
-
 syscfg.defs:
     FS_CLI:
         description: 'CLI commands to interact with files.'

--- a/fs/nffs/syscfg.yml
+++ b/fs/nffs/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: fs/nffs
-
 syscfg.defs:
     NFFS_FLASH_AREA:
         description: 'Flash area to use for NFFS.'

--- a/hw/battery/syscfg.yml
+++ b/hw/battery/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/battery
-
 syscfg.defs:
     BATTERY_SHELL:
         description: 'Whether or not to enable the battery shell support'

--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/ada_feather_nrf52
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/apollo2_evb/syscfg.yml
+++ b/hw/bsp/apollo2_evb/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/apollo2_evb
-
 syscfg.defs:
     BSP_APOLLO2:
         description: 'Set to indicate that BSP has the APOLLO2 processor'

--- a/hw/bsp/arduino_primo_nrf52/syscfg.yml
+++ b/hw/bsp/arduino_primo_nrf52/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/arduino_primo_nrf52
-
 syscfg.defs:
     OPENOCD_DEBUG:
         description: 'Use OpenOCD for JTAG access.'

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/bbc_microbit
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/ble400/syscfg.yml
+++ b/hw/bsp/ble400/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/ble400
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/bmd200
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/bmd300eval/syscfg.yml
+++ b/hw/bsp/bmd300eval/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/bmd300eval
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/bbc_microbit
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/ci40/syscfg.yml
+++ b/hw/bsp/ci40/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/ci40
-
 syscfg.defs:
     CLOCK_FREQ:
         description: 'Clock frequency (hertz).'

--- a/hw/bsp/dwm1001-dev/syscfg.yml
+++ b/hw/bsp/dwm1001-dev/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/dwm1001-dev
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/embarc_emsk/syscfg.yml
+++ b/hw/bsp/embarc_emsk/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/embarc_emsk
-
 syscfg.defs:
     UART_0:
         description: 'Whether to enable UART0'

--- a/hw/bsp/fanstel-ev-bt840/syscfg.yml
+++ b/hw/bsp/fanstel-ev-bt840/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/fanstel-ev-bt840
-
 syscfg.defs:
     BSP_NRF52840:
         description: 'Set to indicate that BSP has nRF52840'

--- a/hw/bsp/frdm-k64f/syscfg.yml
+++ b/hw/bsp/frdm-k64f/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/frdm-k64f
-
 syscfg.defs:
     BSP_MK64F12:
         description: 'Set to indicate that BSP has NXP MK64F12'

--- a/hw/bsp/hifive1/syscfg.yml
+++ b/hw/bsp/hifive1/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/hifive
-
 syscfg.vals:
     XTAL_32768: 1
     SYS_CLOCK: HFXOSC_PLL_256_MHZ

--- a/hw/bsp/nina-b1/syscfg.yml
+++ b/hw/bsp/nina-b1/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nina-b1
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/nordic_pca10028-16k/syscfg.yml
+++ b/hw/bsp/nordic_pca10028-16k/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nordic_pca10028-16k
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/nordic_pca10028/syscfg.yml
+++ b/hw/bsp/nordic_pca10028/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nordic_pca10028
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/nordic_pca10040/syscfg.yml
+++ b/hw/bsp/nordic_pca10040/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nordic_pca10040
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/nordic_pca10056/syscfg.yml
+++ b/hw/bsp/nordic_pca10056/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nordic_pca10056
-
 syscfg.defs:
     BSP_NRF52840:
         description: 'Set to indicate that BSP has NRF52840'

--- a/hw/bsp/nordic_pca20020/syscfg.yml
+++ b/hw/bsp/nordic_pca20020/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52-thingy
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/nrf51-arduino_101/syscfg.yml
+++ b/hw/bsp/nrf51-arduino_101/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf51-arduino_101
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/nrf51-blenano/syscfg.yml
+++ b/hw/bsp/nrf51-blenano/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf51-blenano
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/olimex_stm32-e407_devboard
-
 syscfg.defs:
     ADC_1:
         description: "ADC_1"

--- a/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/pic32mx470_6lp_clicker
-
 syscfg.defs:
     CLOCK_FREQ:
         description: 'System clock frequency, defined in hal_bsp.c'

--- a/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
+++ b/hw/bsp/pic32mz2048_wi-fire/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/pic32mx2048_wi-fire
-
 syscfg.defs:
     HARDFLOAT:
         description: 'Whether to enable UART0 FPU context switch'

--- a/hw/bsp/puckjs/syscfg.yml
+++ b/hw/bsp/puckjs/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/puckjs
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/rb-blend2/syscfg.yml
+++ b/hw/bsp/rb-blend2/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/rb-blend2
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/rb-nano2/syscfg.yml
+++ b/hw/bsp/rb-nano2/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/rb-nano2
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/ruuvitag_rev_b/syscfg.yml
+++ b/hw/bsp/ruuvitag_rev_b/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/telee02
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/bsp/usbmkw41z/syscfg.yml
+++ b/hw/bsp/usbmkw41z/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/usbmkw41z
-
 syscfg.defs:
     BSP_USBMKW41Z:
         description: 'Set to indicate that BSP has MKW41Z'

--- a/hw/bsp/vbluno51/syscfg.yml
+++ b/hw/bsp/vbluno51/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/vbluno51
-
 syscfg.defs:
     BSP_NRF51:
         description: 'Set to indicate that BSP has NRF51'

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/vbluno52
-
 syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'

--- a/hw/charge-control/syscfg.yml
+++ b/hw/charge-control/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/charge-control
-
 syscfg.defs:
     CHARGE_CONTROL_CLI:
         description: 'Whether or not to enable the charge control shell support'

--- a/hw/drivers/pwm/soft_pwm/syscfg.yml
+++ b/hw/drivers/pwm/soft_pwm/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/drivers/pwm/soft_pwm
-
 syscfg.defs:
     SOFT_PWM_DEVS:
         description: 'NUMBER OF SOFT PWM DEVICES'

--- a/hw/drivers/rtt/syscfg.yml
+++ b/hw/drivers/rtt/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/drivers/rtt
-
 syscfg.defs:
     RTT:
         description: >

--- a/hw/drivers/trng/trng_nrf52/syscfg.yml
+++ b/hw/drivers/trng/trng_nrf52/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/drivers/trng/trng_nrf52
-
 syscfg.defs:
     NRF52_TRNG_CACHE_LEN:
         description: 'Internal cache length, shall be power of 2'

--- a/hw/drivers/trng/trng_stm32/syscfg.yml
+++ b/hw/drivers/trng/trng_stm32/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/drivers/trng/trng_stm32
-
 syscfg.defs:
     STM32_TRNG_CACHE_LEN:
         description: 'Internal cache length, shall be power of 2'

--- a/hw/mcu/ambiq/apollo2/syscfg.yml
+++ b/hw/mcu/ambiq/apollo2/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/arc/snps/syscfg.yml
+++ b/hw/mcu/arc/snps/syscfg.yml
@@ -16,4 +16,3 @@
 # under the License.
 #
 
-# Package: hw/mcu/arc/snps

--- a/hw/mcu/mips/danube/syscfg.yml
+++ b/hw/mcu/mips/danube/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     I2C_0:
         description: 'I2C interface 0'

--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     I2C_0:
         description: 'I2C (TWI) interface 0'

--- a/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     I2C_0:
         description: 'I2C (TWI) interface 0'

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     MCU_NRF52832:
         description: Shall be set to 1 by BSP if using nRF52832

--- a/hw/mcu/nxp/MK64F12/syscfg.yml
+++ b/hw/mcu/nxp/MK64F12/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/bsp/nrf52dk
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/sifive/fe310/syscfg.yml
+++ b/hw/mcu/sifive/fe310/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/sifive/fe310
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/stm/stm32f1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f1xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32f1xx
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/stm/stm32f3xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f3xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32f3xx
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/stm/stm32f4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f4xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32f4xx
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/stm/stm32f7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f7xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32f7xx
-
 syscfg.defs:
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >

--- a/hw/mcu/stm/stm32l0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l0xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm32l0xx
-
 syscfg.defs:
     I2C_0:
         description: 'I2C (TWI) interface 0'

--- a/hw/mcu/stm/stm32l1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l1xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32l1xx
-
 syscfg.defs:
     I2C_0:
         description: 'I2C (TWI) interface 0'

--- a/hw/mcu/stm/stm32l4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l4xx/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/mcu/stm/stm32l4xx
-
 syscfg.defs:
     I2C_0:
         description: 'I2C (TWI) interface 0'

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/sensor/creator
-
 syscfg.defs:
     TSL2561_OFB:
         description: 'TSL2561 is present'

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/sensor
-
 syscfg.defs:
     SENSOR_CLI:
         description: 'Whether or not to enable the sensor shell support'

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: kernel/os
-
 syscfg.defs:
     OS_MAIN_TASK_PRIO:
         description: 'Priority of initialization and main task'

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: libc/baselibc
-
 syscfg.defs:
     BASELIBC_PRESENT:
         description: "Indicates that baselibc is the libc implementation."

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: mgmt/imgmgr
-
 syscfg.defs:
     IMGMGR_COREDUMP:
         description: 'Newtmgr commands for fetching/erasing coredump'

--- a/net/ip/syscfg.yml
+++ b/net/ip/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/ip
-
 syscfg.defs:
     LWIP_CLI:
         description: 'CLI for interacting with LwIP'

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-# Package: net/oic
-
 syscfg.defs:
     OC_TRANSPORT_SERIAL:
         description: 'Enables OIC transport over nlip serial'

--- a/net/oic/test/syscfg.yml
+++ b/net/oic/test/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/config/test-fcb
-
 syscfg.vals:
   OC_TRANSPORT_IP: 1
   OC_TRANSPORT_IPV6: 1

--- a/net/wifi/wifi_mgmt/syscfg.yml
+++ b/net/wifi/wifi_mgmt/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/wifi/wifi_mgmt
-
 syscfg.defs:
     WIFI_MGMT_CLI:
         description: 'CLI for interacting with Wi-Fi interfaces'

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/config
-
 syscfg.defs:
     CONFIG_FCB:
         description: 'Config default storage is in FCB'

--- a/sys/config/test-fcb/syscfg.yml
+++ b/sys/config/test-fcb/syscfg.yml
@@ -16,7 +16,5 @@
 # under the License.
 #
 
-# Package: sys/config/test-fcb
-
 syscfg.vals:
     CONFIG_FCB: 1

--- a/sys/config/test-nffs/syscfg.yml
+++ b/sys/config/test-nffs/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/config/test-nffs
-
 syscfg.vals:
     CONFIG_NFFS: 1
     CONFIG_FCB_FLASH_AREA: 

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/console/full
-
 syscfg.defs:
     CONSOLE_UART:
         description: 'Set console output to UART'

--- a/sys/console/minimal/syscfg.yml
+++ b/sys/console/minimal/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/console/minimal
-
 syscfg.defs:
     CONSOLE_UART:
         description: 'Set console output to UART'

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/id
-
 syscfg.defs:
     ID_SERIAL_PRESENT:
         description: 'Device serial number exported as sys/id/serial.'

--- a/sys/log/full/test/align1/syscfg.yml
+++ b/sys/log/full/test/align1/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/log/test
-
 syscfg.vals:
     LOG_FCB: 1
     LOG_VERSION: 3

--- a/sys/log/full/test/align2/syscfg.yml
+++ b/sys/log/full/test/align2/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/log/test
-
 syscfg.vals:
     LOG_FCB: 1
     LOG_VERSION: 3

--- a/sys/log/full/test/align4/syscfg.yml
+++ b/sys/log/full/test/align4/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/log/test
-
 syscfg.vals:
     LOG_FCB: 1
     LOG_VERSION: 3

--- a/sys/log/full/test/align8/syscfg.yml
+++ b/sys/log/full/test/align8/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/log/test
-
 syscfg.vals:
     LOG_FCB: 1
     LOG_VERSION: 3

--- a/sys/metrics/syscfg.yml
+++ b/sys/metrics/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/metrics
-
 syscfg.defs:
     METRICS_POOL_SIZE:
         description: Block size for metrics' mempool

--- a/sys/reboot/syscfg.yml
+++ b/sys/reboot/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/reboot
-
 syscfg.defs:
     REBOOT_LOG_FCB:
         description: 'Set reboot log target to be FCB.'

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/shell 
-
 syscfg.defs:
     SHELL_TASK:
         description: 'Controls whether shell is enabled or not.'

--- a/sys/stats/full/syscfg.yml
+++ b/sys/stats/full/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/stats/full
-
 syscfg.defs:
     STATS_NAMES:
         description: 'Include and report the textual name of each statistic.'

--- a/sys/sysinit/syscfg.yml
+++ b/sys/sysinit/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/sysinit
-
 syscfg.defs:
     SYSINIT_CONSTRAIN_INIT:
         description: Only allow packages to be initialized by sysinit.

--- a/sys/sysview/syscfg.yml
+++ b/sys/sysview/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: sys/sysview/vendor
-
 syscfg.defs:
     SYSVIEW_BUFFER_SIZE:
         description: Size of the RTT buffer that sysview uses

--- a/test/crash_test/syscfg.yml
+++ b/test/crash_test/syscfg.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Package: test/crash_test
-
 syscfg.defs:
     CRASH_TEST_CLI:
         description: 'CLI for trying out crashes'

--- a/test/runtest/syscfg.yml
+++ b/test/runtest/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: test/runtest
-
 syscfg.defs:
     RUNTEST_LOG:
         description: >

--- a/test/testutil/syscfg.yml
+++ b/test/testutil/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: boot/bootutil
-
 syscfg.defs:
     TESTUTIL_SYSTEM_ASSERT:
         description: 'Crash the system on test failure'


### PR DESCRIPTION
These comments were added by some old version of newt and are never
updated after c&p so they are just misleading and unnecessary.