### PR TITLE
fe310 fix build

### DIFF
--- a/hw/mcu/sifive/fe310/src/arch/rv32imac/start.s
+++ b/hw/mcu/sifive/fe310/src/arch/rv32imac/start.s
@@ -67,7 +67,7 @@ _reset_handler:
     call atexit
     call __libc_init_array
 
-    call _init
+    call SystemInit
     call _start
     call _fini
     tail exit

--- a/hw/mcu/sifive/fe310/src/init.c
+++ b/hw/mcu/sifive/fe310/src/init.c
@@ -29,7 +29,7 @@ volatile int test;
 
 /* Function called just before main() */
 void
-_init()
+SystemInit(void)
 {
     select_clock(&MYNEWT_VAL(SYS_CLOCK));
 }


### PR DESCRIPTION
fe310 bsp had function called _init that was used during startup.
Recent rename of __libc_init_array to _init resulted in
multiple definition.
bsp function was just renamed to SystemInit that is commonly used
in other platforms.