### PR TITLE
sys/sys: Add `DEBUG_PANIC()` macro

### DIFF
--- a/kernel/os/include/os/os_fault.h
+++ b/kernel/os/include/os/os_fault.h
@@ -24,8 +24,14 @@
 extern "C" {
 #endif
 
-void __assert_func(const char *, int, const char *, const char *)
+void __assert_func(const char *file, int line, const char *func, const char *e)
     __attribute((noreturn));
+
+#if MYNEWT_VAL(OS_CRASH_FILE_LINE)
+#define OS_CRASH() __assert_func(__FILE__, __LINE__, NULL, NULL)
+#else
+#define OS_CRASH() __assert_func(NULL, 0, NULL, NULL)
+#endif
 
 #ifdef __cplusplus
 }

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -135,6 +135,11 @@ syscfg.defs:
         description: >
             Enables debug runtime checks for time-related functionality.
         value: 0
+    OS_CRASH_FILE_LINE:
+        description: >
+            Include filename and line number in crash messages.  Aids in
+            debugging, but increases text size.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -5,8 +5,6 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
-#include "syscfg/syscfg.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,18 +21,9 @@ extern "C" {
 
 #else
 #include <stddef.h>
+#include "os/mynewt.h"
 
-extern void __assert_func(const char *, int, const char *, const char *)
-    __attribute((noreturn));
-
-#if MYNEWT_VAL(BASELIBC_ASSERT_FILE_LINE)
-#define assert(x) ((x) ? (void)0 : \
-    __assert_func(__FILE__, __LINE__, NULL, NULL))
-#else
-#define assert(x) ((x) ? (void)0 : \
-    __assert_func(NULL, 0, NULL, NULL))
-#endif
-
+#define assert(x) ((x) ? (void)0 : OS_CRASH())
 
 #endif
 

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -23,7 +23,6 @@ syscfg.defs:
         value: 1
 
     BASELIBC_ASSERT_FILE_LINE:
-        description: >
-            Include filename and line number in assert messages.  Aids in
-            debugging, but increases text size.
+        defunct: 1
+        description: 'Use OS_CRASH_FILE_LINE instead'
         value: 0

--- a/sys/sys/include/sys/debug_panic.h
+++ b/sys/sys/include/sys/debug_panic.h
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-#ifndef H_OS_MYNEWT_
-#define H_OS_MYNEWT_
+#ifndef H_DEBUG_PANIC_
+#define H_DEBUG_PANIC_
 
-#include "syscfg/syscfg.h"
-#include "sysinit/sysinit.h"
-#include "sysflash/sysflash.h"
-#include "os/os.h"
-#include "defs/error.h"
-#include "sys/debug_panic.h"
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(DEBUG_PANIC_ENABLED)
+#define DEBUG_PANIC() OS_CRASH()
+#else
+#define DEBUG_PANIC()
+#endif
 
 #endif

--- a/sys/sys/syscfg.yml
+++ b/sys/sys/syscfg.yml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+syscfg.defs:
+    DEBUG_PANIC_ENABLED:
+        description: >
+            If enabled, the `DEBUG_PANIC()` macro to trigger a crash.  When
+            disabled, `DEBUG_PANIC()` has no effect.
+        value: 1


### PR DESCRIPTION
The `DEBUG_PANIC()` macro triggers a crash if the `DEBUG_PANIC_ENABLED` syscfg setting is enabled.  If this setting is disabled, the macro expands to nothing.

This feature is discussed briefly here: https://lists.apache.org/thread.html/0ce981b90eb74226fd660f25ba88f4ce6804eea2943edac70bf8731e@%3Cdev.mynewt.apache.org%3E