### PR TITLE
flash_map; add flash_area_to_subareas().

### DIFF
--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -107,6 +107,13 @@ uint32_t flash_area_erased_val(const struct flash_area *fa);
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
 /*
+ * Given flash map index, return info about sectors within the area.
+ * If the physical sector count within region exceeds that, collect
+ * multiple physical sectors into same number of regions.
+ */
+int flash_area_to_subareas(int idx, int *cnt, struct flash_area *ret);
+
+/*
  * Get-next interface for obtaining info about sectors.
  * To start the get-next walk, call with *sec_id set to -1.
  */

--- a/sys/flash_map/test/src/flash_map_test.c
+++ b/sys/flash_map/test/src/flash_map_test.c
@@ -33,18 +33,20 @@ struct flash_area *fa_sectors;
 /*
  * Max number sectors per area (for native BSP)
  */
-#define SELFTEST_FA_SECTOR_COUNT    64
+#define SELFTEST_FA_SECTOR_COUNT    256
 #endif
 
 TEST_CASE_DECL(flash_map_test_case_1)
 TEST_CASE_DECL(flash_map_test_case_2)
 TEST_CASE_DECL(flash_map_test_case_3)
+TEST_CASE_DECL(flash_map_test_case_4)
 
 TEST_SUITE(flash_map_test_suite)
 {
     flash_map_test_case_1();
     flash_map_test_case_2();
     flash_map_test_case_3();
+    flash_map_test_case_4();
 }
 
 #if MYNEWT_VAL(SELFTEST)

--- a/sys/flash_map/test/src/testcases/flash_map_test_case_4.c
+++ b/sys/flash_map/test/src/testcases/flash_map_test_case_4.c
@@ -98,7 +98,7 @@ TEST_CASE(flash_map_test_case_4)
             TEST_ASSERT(new_max <= sec_cnt / j);
 
             printf(" %d/%d -> %d %x\n",
-                   sec_cnt, j, new_max, cmp_secs[0].fa_size);
+              sec_cnt, j, new_max, (unsigned)cmp_secs[0].fa_size);
 
             rc = flash_map_test_case_4_chk_areas(cmp_secs, new_max, fap);
             TEST_ASSERT(rc == 0);

--- a/sys/flash_map/test/src/testcases/flash_map_test_case_4.c
+++ b/sys/flash_map/test/src/testcases/flash_map_test_case_4.c
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <console/console.h>
+#include "flash_map_test.h"
+
+#define FLASH_TEST_MAX_SECTORS 64
+
+extern struct flash_area *fa_sectors;
+
+static struct flash_area *cmp_secs;
+
+static int
+flash_map_test_case_4_chk_areas(const struct flash_area *fap, int cnt,
+                                const struct flash_area *src)
+{
+    int i;
+
+    for (i = 1; i < cnt; i++) {
+        /*
+         * Returned array of flash areas should be contiguous.
+         */
+        if (fap[i].fa_off != fap[i - 1].fa_off + fap[i - 1].fa_size) {
+            return -1;
+        }
+    }
+    if (fap[0].fa_off != src->fa_off) {
+        return -2;
+    }
+    if (fap[cnt - 1].fa_off + fap[cnt - 1].fa_size !=
+        src->fa_off + src->fa_size) {
+        return -3;
+    }
+    return 0;
+}
+
+/*
+ * Test flash_area_to_sectors_max
+ */
+TEST_CASE(flash_map_test_case_4)
+{
+    int areas[] = {
+        FLASH_AREA_BOOTLOADER,
+        FLASH_AREA_IMAGE_0,
+        FLASH_AREA_IMAGE_1,
+        FLASH_AREA_IMAGE_SCRATCH,
+        FLASH_AREA_REBOOT_LOG,
+        FLASH_AREA_NFFS
+    };
+    const struct flash_area *fap;
+    int i;
+    int sec_cnt;
+    int new_max;
+    int aid;
+    int j;
+    int rc;
+
+    cmp_secs = (struct flash_area *)malloc(sizeof(struct flash_area) *
+                                           FLASH_TEST_MAX_SECTORS);
+    TEST_ASSERT_FATAL(cmp_secs);
+
+    for (i = 0; i < sizeof(areas) / sizeof(areas[0]); i++) {
+        aid = areas[i];
+
+        rc = flash_area_open(aid, &fap);
+        TEST_ASSERT_FATAL(rc == 0);
+
+        rc = flash_area_to_sectors(aid, &sec_cnt, NULL);
+        TEST_ASSERT_FATAL(rc == 0, "flash_area_to_sectors failed");
+
+        printf("%d - %d\n", aid, sec_cnt);
+        for (j = 1; j < 8; j++) {
+            new_max = sec_cnt / j;
+
+            if (new_max < 1) {
+                printf("Skipping this test\n");
+                continue;
+            }
+            memset(cmp_secs, 0, sizeof(struct flash_area) * sec_cnt);
+
+            rc = flash_area_to_subareas(aid, &new_max, cmp_secs);
+            TEST_ASSERT_FATAL(rc == 0, "flash_area_to_subareas failed");
+            TEST_ASSERT(new_max <= sec_cnt / j);
+
+            printf(" %d/%d -> %d %x\n",
+                   sec_cnt, j, new_max, cmp_secs[0].fa_size);
+
+            rc = flash_map_test_case_4_chk_areas(cmp_secs, new_max, fap);
+            TEST_ASSERT(rc == 0);
+        }
+        flash_area_close(fap);
+    }
+    free(cmp_secs);
+}


### PR DESCRIPTION
Simpler solution when memory use of FCB is of concern. Creates a flash_area array suitable for passing to FCB out of flash_map index, caller controls the number of array entries created.