### PR TITLE
apps/slinky_oic: Enlarge main stack (512->1024)

### DIFF
--- a/apps/slinky_oic/syscfg.yml
+++ b/apps/slinky_oic/syscfg.yml
@@ -39,6 +39,3 @@ syscfg.vals:
     OC_SERVER: 1
     OC_TRANSPORT_IP: 1
     OC_TRANSPORT_SERIAL: 1
-
-    # Default task settings
-    OS_MAIN_STACK_SIZE: 512


### PR DESCRIPTION
`OS_MAIN_STACK_SIZE` was being overridden with the value 512.  This is too small to support the `image upload` command when encoded with CoAP; a stack overflow would result.