### PR TITLE
os: Add option to restore registers state on crash

### DIFF
--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -134,6 +134,9 @@ os_default_irq(struct trap_frame *tf)
 #if MYNEWT_VAL(OS_COREDUMP)
     struct coredump_regs regs;
 #endif
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    uint32_t *orig_sp;
+#endif
 
     console_blocking_mode();
     console_printf("Unhandled interrupt (%ld), exception sp 0x%08lx\n",
@@ -153,6 +156,48 @@ os_default_irq(struct trap_frame *tf)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));
 #endif
+
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    if ((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) < 16) {
+        console_printf("Use 'set $pc = 0x%08lx' to restore PC in gdb\n",
+                       tf->ef->pc);
+
+        orig_sp = &tf->ef->r0;
+        orig_sp += 8;
+        if (tf->ef->psr & SCB_CCR_STKALIGN_Msk) {
+            orig_sp++;
+        }
+
+        console_printf("Use 'set $pc = 0x%08lx' to restore PC in gdb\n",
+                       tf->ef->pc);
+
+        __asm volatile (
+            "mov sp,  %[stack_ptr]\n"
+            "mov r0,  %[regs1]\n"
+            "mov r1,  %[regs2]\n"
+            "mov r2,  r1\n"
+            "add r2,  r2, #16\n"
+            "ldm r2!, {r4-r7}\n"
+            "mov r8,  r4\n"
+            "mov r9,  r5\n"
+            "mov r10, r6\n"
+            "mov r11, r7\n"
+            "ldm r1!, {r4-r7}\n"
+            "ldr r1,  [r0, #16]\n"
+            "mov r12, r1\n"
+            "ldr r1,  [r0, #20]\n"
+            "mov lr,  r1\n"
+            "ldm r0!, {r0-r3}\n"
+            "bkpt"
+            :
+            : [regs1] "r" (tf->ef),
+              [regs2] "r" (&tf->r4),
+              [stack_ptr] "r" (orig_sp)
+            : "r0", "r1", "r2"
+        );
+    }
+#endif
+
     hal_system_reset();
 }
 

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -147,6 +147,9 @@ os_default_irq(struct trap_frame *tf)
 #if MYNEWT_VAL(OS_COREDUMP)
     struct coredump_regs regs;
 #endif
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    uint32_t *orig_sp;
+#endif
 
     console_blocking_mode();
     console_printf("Unhandled interrupt (%ld), exception sp 0x%08lx\n",
@@ -168,5 +171,34 @@ os_default_irq(struct trap_frame *tf)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));
 #endif
+
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    if (((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) < 16) &&
+                                            hal_debugger_connected()) {
+        orig_sp = &tf->ef->r0;
+        orig_sp += 8;
+        if (tf->ef->psr & SCB_CCR_STKALIGN_Msk) {
+            orig_sp++;
+        }
+
+        console_printf("Use 'set $pc = 0x%08lx' to restore PC in gdb\n",
+                       tf->ef->pc);
+
+        __asm volatile (
+            "mov sp, %[stack_ptr]\n"
+            "mov r0, %[regs1]\n"
+            "ldm r0, {r4-r11}\n"
+            "mov r0, %[regs2]\n"
+            "ldm r0, {r0-r3,r12,lr}\n"
+            "bkpt"
+            :
+            : [regs1] "r" (&tf->r4),
+              [regs2] "r" (tf->ef),
+              [stack_ptr] "r" (orig_sp)
+            : "r0"
+        );
+    }
+#endif
+
     hal_system_reset();
 }

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -167,6 +167,9 @@ os_default_irq(struct trap_frame *tf)
 #if MYNEWT_VAL(OS_COREDUMP)
     struct coredump_regs regs;
 #endif
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    uint32_t *orig_sp;
+#endif
 
     console_blocking_mode();
     console_printf("Unhandled interrupt (%ld), exception sp 0x%08lx\n",
@@ -199,5 +202,34 @@ os_default_irq(struct trap_frame *tf)
     trap_to_coredump(tf, &regs);
     coredump_dump(&regs, sizeof(regs));
 #endif
+
+#if MYNEWT_VAL(OS_CRASH_RESTORE_REGS)
+    if (((SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) < 16) &&
+                                            hal_debugger_connected()) {
+        orig_sp = &tf->ef->r0;
+        orig_sp += 8;
+        if (tf->ef->psr & SCB_CCR_STKALIGN_Msk) {
+            orig_sp++;
+        }
+
+        console_printf("Use 'set $pc = 0x%08lx' to restore PC in gdb\n",
+                       tf->ef->pc);
+
+        __asm volatile (
+            "mov sp, %[stack_ptr]\n"
+            "mov r0, %[regs1]\n"
+            "ldm r0, {r4-r11}\n"
+            "mov r0, %[regs2]\n"
+            "ldm r0, {r0-r3,r12,lr}\n"
+            "bkpt"
+            :
+            : [regs1] "r" (&tf->r4),
+              [regs2] "r" (tf->ef),
+              [stack_ptr] "r" (orig_sp)
+            : "r0"
+        );
+    }
+#endif
+
     hal_system_reset();
 }

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -35,6 +35,9 @@ syscfg.defs:
     OS_CRASH_STACKTRACE:
         description: 'Attempt to print stack trace when system crashes.'
         value: 0
+    OS_CRASH_RESTORE_REGS:
+        description: 'Restore registers to pre-fault state on crash'
+        value: 0
     OS_CRASH_LOG:
         description: >
             Write an entry to the reboot log when the system crashes.


### PR DESCRIPTION
This adds a handy option to automatically restore registers state on crash to pre-crash state. The only register to set manually is PC, but this is also easier now with dedicated printout that specifies command to c&p to GDB. Here's how it works when enabled:

Crash in GDB:
```
(gdb) c
Continuing.

Program received signal SIGTRAP, Trace/breakpoint trap.
0x0001116e in os_default_irq (tf=0x0) at repos/apache-mynewt-core/kernel/os/src/arch/cortex_m4/os_fault.c:218
218	        __asm volatile (
(gdb) bt
#0  0x0001116e in os_default_irq (tf=0x0) at repos/apache-mynewt-core/kernel/os/src/arch/cortex_m4/os_fault.c:218
#1  0x00000000 in ?? ()
```
Output on console:
```
002798 Unhandled interrupt (3), exception sp 0x20002d70
002798  r0:0x00000000  r1:0x00000000  r2:0x000000ff  r3:0x00000000
002798  r4:0x00000000  r5:0x00000000  r6:0x00000000  r7:0x00000000
002798  r8:0x00000000  r9:0x00000000 r10:0x00000000 r11:0x00000000
002798 r12:0x00000000  lr:0x00010bef  pc:0x0000fa6c psr:0x61000000
002798 ICSR:0x00421803 HFSR:0x40000000 CFSR:0x02000000
002798 BFAR:0xe000ed38 MMFAR:0xe000ed34
002798 Use 'set $pc = 0x0000fa6c' to restore PC in gdb
```
And back to GDB:
```
(gdb) set $pc = 0x0000fa6c
(gdb) frame 0
#0  cmd_advertise_configure (argc=<optimized out>, argv=<optimized out>) at repos/apache-mynewt-nimble/apps/btshell/src/cmd.c:136
136	    instance /= rc;
(gdb) bt
#0  cmd_advertise_configure (argc=<optimized out>, argv=<optimized out>) at repos/apache-mynewt-nimble/apps/btshell/src/cmd.c:136
#1  0x00030d38 in shell_process_command (line=<optimized out>) at repos/apache-mynewt-core/sys/shell/src/shell.c:408
#2  0x00030f4e in shell (ev=0x200070fc <shell_console_ev+16>) at repos/apache-mynewt-core/sys/shell/src/shell.c:458
#3  0x000118ce in os_eventq_run (evq=<optimized out>) at repos/apache-mynewt-core/kernel/os/src/os_eventq.c:162
#4  0x0000d6de in main (argc=<optimized out>, argv=<optimized out>) at repos/apache-mynewt-nimble/apps/btshell/src/main.c:2238
```