### PR TITLE
Invalid g_os_mempool_list.stqh_last assignment

### DIFF
--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -230,7 +230,7 @@ os_mempool_unregister(struct os_mempool *mp)
     } else {
         next = STAILQ_NEXT(cur, mp_list);
         if (next == NULL) {
-            *g_os_mempool_list.stqh_last = next;
+            g_os_mempool_list.stqh_last = &STAILQ_NEXT(prev, mp_list);
         }
 
         STAILQ_NEXT(prev, mp_list) = next;


### PR DESCRIPTION
Hi,
I think that there is an issue with the assignment of the "g_os_mempool_list.stqh_last" member into the "os_mempool_unregister" function.
According to me, the pointed contents is modified instead of the pointer itself (like it is done with the "STAILQ_REMOVE" macro).
What do you think ?