### PR TITLE
Use syscfg settings for sysinit stage numbers

### DIFF
--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -42,5 +42,5 @@ pkg.cflags.SELFTEST:
     - -DBOOT_SERIAL_DETECT_PIN_CFG=0
 
 pkg.init:
-    boot_serial_os_dev_init: 0
-    boot_serial_pkg_init: 200
+    boot_serial_os_dev_init: 'MYNEWT_VAL(BOOT_SERIAL_SYSINIT_STAGE_OS_DEV)'
+    boot_serial_pkg_init: 'MYNEWT_VAL(BOOT_SERIAL_SYSINIT_STAGE_MAIN)'

--- a/boot/boot_serial/syscfg.yml
+++ b/boot/boot_serial/syscfg.yml
@@ -90,3 +90,14 @@ syscfg.defs:
             - '(BOOT_SERIAL_DETECT_PIN != -1) ||
                (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
 	       (BOOT_SERIAL_NVREG_INDEX != -1)'
+
+    BOOT_SERIAL_SYSINIT_STAGE_OS_DEV:
+        description: >
+            Sysinit stage for OS device initialization.  `os_init()` does not
+            get called for the boot loader, so this is needed as an
+            alternative.
+        value: 0
+
+    BOOT_SERIAL_SYSINIT_STAGE_MAIN:
+        description: Main sysinit stage for serial boot loader functionality.
+        value: 200

--- a/boot/split/pkg.yml
+++ b/boot/split/pkg.yml
@@ -31,4 +31,4 @@ pkg.req_apis:
     - bootloader
 
 pkg.init:
-    split_app_init: 500
+    split_app_init: 'MYNEWT_VAL(SPLIT_APP_SYSINIT_STAGE)'

--- a/boot/split/syscfg.yml
+++ b/boot/split/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    SPLIT_APP_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for split image functionality.
+        value: 500

--- a/crypto/tinycrypt/pkg.yml
+++ b/crypto/tinycrypt/pkg.yml
@@ -30,4 +30,4 @@ pkg.deps.TINYCRYPT_UECC_RNG_USE_TRNG:
     - "@apache-mynewt-core/hw/drivers/trng"
 
 pkg.init.TINYCRYPT_UECC_RNG_USE_TRNG:
-    mynewt_tinycrypt_pkg_init: 200
+    mynewt_tinycrypt_pkg_init: 'MYNEWT_VAL(TINYCRYPT_SYSINIT_STAGE)'

--- a/crypto/tinycrypt/syscfg.yml
+++ b/crypto/tinycrypt/syscfg.yml
@@ -27,3 +27,8 @@ syscfg.defs:
         description: >
             Name of OS device to use as TRNG source.
         value: '"trng"'
+
+    TINYCRYPT_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for tinycrypt.
+        value: 200

--- a/fs/fatfs/pkg.yml
+++ b/fs/fatfs/pkg.yml
@@ -37,4 +37,4 @@ pkg.req_apis:
     - stats
 
 pkg.init:
-    fatfs_pkg_init: 200
+    fatfs_pkg_init: 'MYNEWT_VAL(FATFS_SYSINIT_STAGE)'

--- a/fs/fatfs/syscfg.yml
+++ b/fs/fatfs/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    FATFS_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for FATFS functionality.
+        value: 200

--- a/fs/nffs/pkg.yml
+++ b/fs/nffs/pkg.yml
@@ -39,4 +39,4 @@ pkg.req_apis:
     - stats
 
 pkg.init:
-    nffs_pkg_init: 200
+    nffs_pkg_init: 'MYNEWT_VAL(NFFS_SYSINIT_STAGE)'

--- a/fs/nffs/syscfg.yml
+++ b/fs/nffs/syscfg.yml
@@ -33,3 +33,7 @@ syscfg.defs:
             Number of areas to allocate in the NFFS disk.  A smaller number is
             used if the flash hardware cannot support this value.
         value: 8
+    NFFS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for NFFS functionality.
+        value: 200

--- a/hw/battery/pkg.yml
+++ b/hw/battery/pkg.yml
@@ -28,4 +28,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    battery_pkg_init: 501
+    battery_pkg_init: 'MYNEWT_VAL(BATTERY_SYSINIT_STAGE)'

--- a/hw/battery/syscfg.yml
+++ b/hw/battery/syscfg.yml
@@ -31,3 +31,8 @@ syscfg.defs:
             Maximum number of supported battery properties. Number should
             be a minimum multiple of 32 that is grater of supported properties.
         value: 32
+
+    BATTERY_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for battery functionality.
+        value: 501

--- a/hw/bsp/nordic_pca20020/pkg.yml
+++ b/hw/bsp/nordic_pca20020/pkg.yml
@@ -44,4 +44,4 @@ pkg.deps.LIS2DH12_ONB:
     - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 
 pkg.init:
-    config_lis2dh12_sensor: 400
+    config_lis2dh12_sensor: 'MYNEWT_VAL(NORDIC_PCA20020_SYSINIT_STAGE)'

--- a/hw/bsp/nordic_pca20020/syscfg.yml
+++ b/hw/bsp/nordic_pca20020/syscfg.yml
@@ -39,6 +39,11 @@ syscfg.defs:
         description: 'NRF52 Thingy onboard lis2dh12 sensor'
         value:  0
 
+    NORDIC_PCA20020_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the PCA20020 BSP.
+        value: 400
+
 syscfg.vals:
     # Enable nRF52832 MCU
     MCU_NRF52832: 1

--- a/hw/bsp/ruuvitag_rev_b/pkg.yml
+++ b/hw/bsp/ruuvitag_rev_b/pkg.yml
@@ -50,5 +50,5 @@ pkg.deps.LIS2DH12_ONB:
     - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 
 pkg.init:
-    config_bme280_sensor: 400
-    config_lis2dh12_sensor: 400
+    config_bme280_sensor: 'MYNEWT_VAL(RUUVITAG_REV_B_SYSINIT_STAGE_BME280)'
+    config_lis2dh12_sensor: 'MYNEWT_VAL(RUUVITAG_REV_B_SYSINIT_STAGE_LIS2DH12)'

--- a/hw/bsp/ruuvitag_rev_b/syscfg.yml
+++ b/hw/bsp/ruuvitag_rev_b/syscfg.yml
@@ -50,6 +50,17 @@ syscfg.defs:
         description: 'Enable RuuviTag onboard LIS2DH12 sensor (rev. B3 and newer)'
         value:  0
 
+    RUUVITAG_REV_B_SYSINIT_STAGE_BME280:
+        description: >
+            Sysinit stage for the Ruuvitag, Rev. B; initializes the BME280
+            sensor.
+        value: 400
+    RUUVITAG_REV_B_SYSINIT_STAGE_LIS2DH12:
+        description: >
+            Sysinit stage for the Ruuvitag, Rev. B; initializes the LIS2DH12
+            sensor.
+        value: 400
+
 syscfg.vals:
     # Enable nRF52832 MCU
     MCU_NRF52832: 1

--- a/hw/charge-control/pkg.yml
+++ b/hw/charge-control/pkg.yml
@@ -32,5 +32,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    charge_control_pkg_init: 501
-
+    charge_control_pkg_init: 'MYNEWT_VAL(CHARGE_CONTROL_SYSINIT_STAGE)'

--- a/hw/charge-control/syscfg.yml
+++ b/hw/charge-control/syscfg.yml
@@ -25,3 +25,8 @@ syscfg.defs:
         description: >
             Specify the eventq to be used by the charge control manager
         value:
+
+    CHARGE_CONTROL_SYSINIT_STAGE:
+        description:
+            Sysinit stage for charge control functionality.
+        value: 501

--- a/hw/drivers/bq27z561/pkg.yml
+++ b/hw/drivers/bq27z561/pkg.yml
@@ -38,4 +38,4 @@ pkg.deps.BQ27Z561_CLI:
     - "@apache-mynewt-core/util/parse"
 
 pkg.init:
-    bq27z561_pkg_init: 500
+    bq27z561_pkg_init: 'MYNEWT_VAL(BQ27Z561_SYSINIT_STAGE)'

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -45,3 +45,7 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.            
         value: 6
+    BQ27Z561_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the BQ27Z561 driver.
+        value: 500

--- a/hw/drivers/lwip/stm32_eth/pkg.yml
+++ b/hw/drivers/lwip/stm32_eth/pkg.yml
@@ -38,4 +38,4 @@ pkg.deps.MCU_STM32F7:
 pkg.req_apis: 
 
 pkg.init:
-    stm32_eth_open: 240
+    stm32_eth_open: 'MYNEWT_VAL(STM32_ETH_SYSINIT_STAGE)'

--- a/hw/drivers/lwip/stm32_eth/syscfg.yml
+++ b/hw/drivers/lwip/stm32_eth/syscfg.yml
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    STM32_ETH_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for the stm32 eth driver.
+        value: 240

--- a/hw/sensor/creator/pkg.yml
+++ b/hw/sensor/creator/pkg.yml
@@ -59,4 +59,4 @@ pkg.deps.LPS33HW_OFB:
 pkg.deps.LPS33THW_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lps33thw"
 pkg.init:
-    sensor_dev_create: 500
+    sensor_dev_create: 'MYNEWT_VAL(SENSOR_CREATOR_SYSINIT_STAGE)'

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -75,3 +75,7 @@ syscfg.defs:
         description: 'BME680 is present'
         value: 0
 
+    SENSOR_CREATOR_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the sensor creator package.
+        value: 500

--- a/hw/sensor/pkg.yml
+++ b/hw/sensor/pkg.yml
@@ -37,4 +37,4 @@ pkg.req_apis:
     - console
     
 pkg.init:
-    sensor_pkg_init: 501
+    sensor_pkg_init: 'MYNEWT_VAL(SENSOR_SYSINIT_STAGE)'

--- a/hw/sensor/syscfg.yml
+++ b/hw/sensor/syscfg.yml
@@ -58,3 +58,7 @@ syscfg.defs:
                        notification events so that multiple events can be put
                        on the eventq for processing'
          value: 5
+    SENSOR_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the sensors framework.
+        value: 501

--- a/kernel/os/pkg.yml
+++ b/kernel/os/pkg.yml
@@ -48,4 +48,4 @@ pkg.deps.OS_CRASH_LOG:
     - "@apache-mynewt-core/sys/reboot"
 
 pkg.init:
-    os_pkg_init: 0
+    os_pkg_init: 'MYNEWT_VAL(OS_SYSINIT_STAGE)'

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -143,6 +143,10 @@ syscfg.defs:
             Include filename and line number in crash messages.  Aids in
             debugging, but increases text size.
         value: 0
+    OS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the Mynewt kernel.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1

--- a/mgmt/imgmgr/pkg.yml
+++ b/mgmt/imgmgr/pkg.yml
@@ -46,4 +46,4 @@ pkg.deps.IMGMGR_SHELL:
     - "@apache-mynewt-core/sys/shell"
 
 pkg.init:
-    imgmgr_module_init: 500
+    imgmgr_module_init: 'MYNEWT_VAL(IMGMGR_SYSINIT_STAGE)'

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -34,3 +34,7 @@ syscfg.defs:
         description: >
             Send verbose error message in responses.
         value: 0
+    IMGMGR_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for image management functionality.
+        value: 500

--- a/mgmt/newtmgr/pkg.yml
+++ b/mgmt/newtmgr/pkg.yml
@@ -37,4 +37,4 @@ pkg.apis:
     - newtmgr
 
 pkg.init:
-    nmgr_pkg_init: 500
+    nmgr_pkg_init: 'MYNEWT_VAL(NEWTMGR_SYSINIT_STAGE)'

--- a/mgmt/newtmgr/syscfg.yml
+++ b/mgmt/newtmgr/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    NEWTMGR_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for newtmgr functionality.
+        value: 500

--- a/mgmt/newtmgr/transport/ble/pkg.yml
+++ b/mgmt/newtmgr/transport/ble/pkg.yml
@@ -32,4 +32,4 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host"
 
 pkg.init:
-    newtmgr_ble_pkg_init: 501
+    newtmgr_ble_pkg_init: 'MYNEWT_VAL(NEWTMGR_BLE_SYSINIT_STAGE)'

--- a/mgmt/newtmgr/transport/ble/syscfg.yml
+++ b/mgmt/newtmgr/transport/ble/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    NEWTMGR_BLE_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
+            Sysinit stage for the BLE newtmgr transport.
         value: 501

--- a/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
+++ b/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - "@apache-mynewt-core/mgmt/newtmgr"
 
 pkg.init:
-    nmgr_shell_pkg_init: 501
+    nmgr_shell_pkg_init: 'MYNEWT_VAL(NMGR_SHELL_SYSINIT_STAGE)'

--- a/mgmt/newtmgr/transport/nmgr_shell/syscfg.yml
+++ b/mgmt/newtmgr/transport/nmgr_shell/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    NMGR_SHELL_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
+            Sysinit stage for the shell newtmgr transport.
         value: 501

--- a/mgmt/newtmgr/transport/nmgr_uart/pkg.yml
+++ b/mgmt/newtmgr/transport/nmgr_uart/pkg.yml
@@ -32,4 +32,4 @@ pkg.deps:
     - "@apache-mynewt-core/util/crc"
 
 pkg.init:
-    nmgr_uart_pkg_init: 501
+    nmgr_uart_pkg_init: 'MYNEWT_VAL(NMGR_UART_SYSINIT_STAGE)'

--- a/mgmt/oicmgr/pkg.yml
+++ b/mgmt/oicmgr/pkg.yml
@@ -33,4 +33,4 @@ pkg.apis:
     - newtmgr
 
 pkg.init:
-    oicmgr_init: 500
+    oicmgr_init: 'MYNEWT_VAL(OICMGR_SYSINIT_STAGE)'

--- a/mgmt/oicmgr/syscfg.yml
+++ b/mgmt/oicmgr/syscfg.yml
@@ -17,11 +17,16 @@
 # under the License.
 #
 syscfg.defs:
-   OICMGR_TRANS_SECURITY:
-      description: >
-          Configure transport security for oicmgr resource.
-          Can be OC_TRANS_ENC | OC_TRANS_AUTH, OC_TRANS_ENC or OC_TRANS_AUTH.
-          0 means no security checing.
-      value: 0
-      restrictions:
-         - OC_TRANS_SECURITY
+    OICMGR_TRANS_SECURITY:
+        description: >
+            Configure transport security for oicmgr resource.
+            Can be OC_TRANS_ENC | OC_TRANS_AUTH, OC_TRANS_ENC or OC_TRANS_AUTH.
+            0 means no security checing.
+        value: 0
+        restrictions:
+            - OC_TRANS_SECURITY
+
+    OICMGR_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for OIC manager functionality.
+        value: 500

--- a/net/ip/native_sockets/pkg.yml
+++ b/net/ip/native_sockets/pkg.yml
@@ -30,4 +30,4 @@ pkg.deps:
     - "@apache-mynewt-core/net/ip/mn_socket"
 
 pkg.init:
-    native_sock_init: 200
+    native_sock_init: 'MYNEWT_VAL(NATIVE_SOCKETS_SYSINIT_STAGE)'

--- a/net/ip/native_sockets/syscfg.yml
+++ b/net/ip/native_sockets/syscfg.yml
@@ -35,3 +35,7 @@ syscfg.defs:
         description: 'The priority of the native sockets task.'
         type: task_priority
         value: 2
+    NATIVE_SOCKETS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the native sockets implementation.
+        value: 200

--- a/net/ip/pkg.yml
+++ b/net/ip/pkg.yml
@@ -36,4 +36,4 @@ pkg.deps.LWIP_CLI:
     - "@apache-mynewt-core/sys/shell"
 
 pkg.init:
-    ip_init: 200
+    ip_init: 'MYNEWT_VAL(IP_SYSINIT_STAGE)'

--- a/net/ip/syscfg.yml
+++ b/net/ip/syscfg.yml
@@ -22,3 +22,7 @@ syscfg.defs:
         value: 1
         restrictions:
           - SHELL_TASK
+    IP_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the IP stack.
+        value: 200

--- a/net/lora/node/pkg.yml
+++ b/net/lora/node/pkg.yml
@@ -42,4 +42,4 @@ pkg.req_apis:
     - lora_node_driver
 
 pkg.init:
-    lora_node_init: 200
+    lora_node_init: 'MYNEWT_VAL(LORA_NODE_SYSINIT_STAGE)'

--- a/net/lora/node/syscfg.yml
+++ b/net/lora/node/syscfg.yml
@@ -92,3 +92,8 @@ syscfg.defs:
                 Sets public or private lora network. A value of 1 means
                 the network is public; private otherwise
         value: 0
+
+    LORA_NODE_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the LoRa endpoint.
+        value: 200

--- a/net/oic/pkg.yml
+++ b/net/oic/pkg.yml
@@ -54,9 +54,9 @@ pkg.cflags:
     - "-I@apache-mynewt-core/net/oic/include/oic"
 
 pkg.init:
-    oc_init: 300
-    oc_register_ip6: 301
-    oc_register_ip4: 301
-    oc_register_serial: 301
-    oc_register_gatt: 301
-    oc_register_lora: 301
+    oc_init: 'MYNEWT_VAL(OC_SYSINIT_STAGE_MAIN)'
+    oc_register_ip6: 'MYNEWT_VAL(OC_SYSINIT_STAGE_IP6)'
+    oc_register_ip4: 'MYNEWT_VAL(OC_SYSINIT_STAGE_IP4)'
+    oc_register_serial: 'MYNEWT_VAL(OC_SYSINIT_STAGE_SERIAL)'
+    oc_register_gatt: 'MYNEWT_VAL(OC_SYSINIT_STAGE_GATT)'
+    oc_register_lora: 'MYNEWT_VAL(OC_SYSINIT_STAGE_LORA)'

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -102,3 +102,28 @@ syscfg.defs:
     OC_COAP_RESPONSE_TIMEOUT:
         description: 'How many seconds before client request times out'
         value: 4
+
+    OC_SYSINIT_STAGE_MAIN:
+        description: >
+            Main sysinit stage for OIC functionality.
+        value: 300
+    OC_SYSINIT_STAGE_IP6:
+        description: >
+            Sysinit stage for the IPv6 OIC transport.
+        value: 301
+    OC_SYSINIT_STAGE_IP4:
+        description: >
+            Sysinit stage for the IPv4 OIC transport.
+        value: 301
+    OC_SYSINIT_STAGE_SERIAL:
+        description: >
+            Sysinit stage for the serial OIC transport.
+        value: 301
+    OC_SYSINIT_STAGE_GATT:
+        description: >
+            Sysinit stage for the GATT (BLE) OIC transport.
+        value: 301
+    OC_SYSINIT_STAGE_LORA:
+        description: >
+            Sysinit stage for the LoRa OIC transport.
+        value: 301

--- a/sys/config/pkg.yml
+++ b/sys/config/pkg.yml
@@ -36,5 +36,5 @@ pkg.deps.CONFIG_NFFS:
     - "@apache-mynewt-core/fs/nffs"
 
 pkg.init:
-    config_pkg_init: 50
-    config_pkg_init_stage2: 220
+    config_pkg_init: 'MYNEWT_VAL(CONFIG_SYSINIT_STAGE_1)'
+    config_pkg_init_stage2: 'MYNEWT_VAL(CONFIG_SYSINIT_STAGE_2)'

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -49,6 +49,16 @@ syscfg.defs:
         description: 'Automatically configure a single config region at bootup'
         value: 1
 
+    CONFIG_SYSINIT_STAGE_1:
+        description: >
+            Primary sysinit stage for the config package.
+        value: 50
+    CONFIG_SYSINIT_STAGE_2:
+        description: >
+            Secondary sysinit stage for the config package; populates the
+            underlying storage medium for config if it is has not been done.
+        value: 220
+
 syscfg.defs.CONFIG_FCB:
     CONFIG_FCB_FLASH_AREA:
         description: 'BSP flash area for config'

--- a/sys/console/full/pkg.yml
+++ b/sys/console/full/pkg.yml
@@ -33,4 +33,4 @@ pkg.deps.CONSOLE_RTT:
 pkg.apis: console
 
 pkg.init:
-    console_pkg_init: 20
+    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -92,3 +92,8 @@ syscfg.defs:
             value may affect RTT console responsiveness, using small value may
             affect device performance due to more frequent polling.
         value: 250
+
+    CONSOLE_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for console functionality.
+        value: 20

--- a/sys/console/minimal/pkg.yml
+++ b/sys/console/minimal/pkg.yml
@@ -33,4 +33,4 @@ pkg.deps.CONSOLE_RTT:
 pkg.apis: console
 
 pkg.init:
-    console_pkg_init: 20
+    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'

--- a/sys/console/minimal/syscfg.yml
+++ b/sys/console/minimal/syscfg.yml
@@ -49,3 +49,8 @@ syscfg.defs:
     CONSOLE_UART_DEV:
         description: 'Console UART device.'
         value: '"uart0"'
+
+    CONSOLE_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for console functionality.
+        value: 20

--- a/sys/flash_map/pkg.yml
+++ b/sys/flash_map/pkg.yml
@@ -30,4 +30,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/mfg"
 
 pkg.init:
-    flash_map_init: 2
+    flash_map_init: 'MYNEWT_VAL(FLASH_MAP_SYSINIT_STAGE)'

--- a/sys/flash_map/syscfg.yml
+++ b/sys/flash_map/syscfg.yml
@@ -19,3 +19,8 @@ syscfg.defs:
     FLASH_MAP_MAX_AREAS:
         description: 'Maximum number of expected flash areas'
         value: 10
+
+    FLASH_MAP_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for flash map functionality.
+        value: 2

--- a/sys/id/pkg.yml
+++ b/sys/id/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps:
     - "@apache-mynewt-core/encoding/base64"
 
 pkg.init:
-    id_init: 500
+    id_init: 'MYNEWT_VAL(ID_SYSINIT_STAGE)'

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -52,3 +52,8 @@ syscfg.defs:
         restrictions:
             # Older versions of newt don't export the target name.
             - 'TARGET_NAME'
+
+    ID_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for ID functionality.
+        value: 500

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -48,7 +48,7 @@ pkg.apis:
     - log
 
 pkg.init:
-    log_init: 100
+    log_init: 'MYNEWT_VAL(LOG_SYSINIT_STAGE_MAIN)'
 
 pkg.init.LOG_FCB_SLOT1:
-    log_init_slot1: 101
+    log_init_slot1: 'MYNEWT_VAL(LOG_SYSINIT_STAGE_SLOT1)'

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -91,3 +91,12 @@ syscfg.defs:
             bytes used by entries above watermark.
         value: 0
         restrictions: LOG_STORAGE_INFO
+
+    LOG_SYSINIT_STAGE_MAIN:
+        description: >
+            Primary sysinit stage for logging functionality.
+        value: 100
+    LOG_SYSINIT_STAGE_SLOT1:
+        description: >
+            Sysinit stage for logging to the second image slot.
+        value: 101

--- a/sys/log/modlog/pkg.yml
+++ b/sys/log/modlog/pkg.yml
@@ -32,4 +32,4 @@ pkg.req_apis:
     - log
 
 pkg.init:
-    modlog_init: 100
+    modlog_init: 'MYNEWT_VAL(MODLOG_SYSINIT_STAGE)'

--- a/sys/log/modlog/syscfg.yml
+++ b/sys/log/modlog/syscfg.yml
@@ -41,3 +41,7 @@ syscfg.defs:
             modlog.  This setting will be enabled by default in a future
             release.
         value: 0
+    MODLOG_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for modular logging functionality.
+        value: 100

--- a/sys/metrics/pkg.yml
+++ b/sys/metrics/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps.METRICS_CLI:
     - sys/shell
 
 pkg.init:
-      metrics_pkg_init: 500
+      metrics_pkg_init: 'MYNEWT_VAL(METRICS_SYSINIT_STAGE)'

--- a/sys/metrics/syscfg.yml
+++ b/sys/metrics/syscfg.yml
@@ -27,3 +27,7 @@ syscfg.defs:
     METRICS_CLI:
         description: Enable shell interface
         value: 0
+    METRICS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for metrics functionality.
+        value: 500

--- a/sys/mfg/pkg.yml
+++ b/sys/mfg/pkg.yml
@@ -30,4 +30,4 @@ pkg.deps:
 
 # sys/flash_map must get initialized before sys/mfg.
 pkg.init:
-    mfg_init: 100
+    mfg_init: 'MYNEWT_VAL(MFG_SYSINIT_STAGE)'

--- a/sys/mfg/syscfg.yml
+++ b/sys/mfg/syscfg.yml
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    MFG_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for manufacturing support.
+        value: 100

--- a/sys/reboot/pkg.yml
+++ b/sys/reboot/pkg.yml
@@ -36,4 +36,4 @@ pkg.deps.REBOOT_LOG_FCB:
     - "@apache-mynewt-core/fs/fcb"
 
 pkg.init:
-    log_reboot_pkg_init: 200
+    log_reboot_pkg_init: 'MYNEWT_VAL(REBOOT_SYSINIT_STAGE)'

--- a/sys/reboot/syscfg.yml
+++ b/sys/reboot/syscfg.yml
@@ -44,3 +44,8 @@ syscfg.defs:
             The maximum size, in bytes, of a reboot log entry.  A buffer of
             this size is allocated on the stack each time an entry is written.
         value: 256
+
+    REBOOT_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for reboot functionality.
+        value: 200

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -35,4 +35,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    shell_init: 500
+    shell_init: 'MYNEWT_VAL(SHELL_SYSINIT_STAGE)'

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -63,6 +63,11 @@ syscfg.defs:
         description: 'Include shell prompt module'
         value: 0
 
+    SHELL_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for shell functionality.
+        value: 500
+
 ## duplicated from boot/boot_serial
     BOOT_SERIAL_NVREG_MAGIC:
         description: >

--- a/sys/stats/full/pkg.yml
+++ b/sys/stats/full/pkg.yml
@@ -34,7 +34,7 @@ pkg.deps.STATS_NEWTMGR:
     - "@apache-mynewt-core/mgmt/mgmt"
 
 pkg.init:
-    stats_module_init: 10
+    stats_module_init: 'MYNEWT_VAL(STATS_SYSINIT_STAGE)'
 
 pkg.init.STATS_PERSIST:
     stats_conf_init: 'MYNEWT_VAL(STATS_SYSINIT_STAGE_CONF)'

--- a/sys/stats/full/syscfg.yml
+++ b/sys/stats/full/syscfg.yml
@@ -61,3 +61,7 @@ syscfg.defs:
             Sysdown stage for persistent stat config.  During system shutdown,
             pending stat writes get flushed to disk.
         value: 500
+    STATS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for statistics functionality.
+        value: 10

--- a/sys/sysview/pkg.yml
+++ b/sys/sysview/pkg.yml
@@ -26,4 +26,4 @@ pkg.build_profile: speed
 pkg.deps:
     - "@apache-mynewt-core/sys/sysview/vendor"
 pkg.init:
-    sysview_init: 100
+    sysview_init: 'MYNEWT_VAL(SYSVIEW_SYSINIT_STAGE)'

--- a/sys/sysview/syscfg.yml
+++ b/sys/sysview/syscfg.yml
@@ -42,3 +42,7 @@ syscfg.defs:
             It is recommended to use large SysView buffer to get as much data
             for analysis as possible.
         value: 0
+    SYSVIEW_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for sysview functionality.
+        value: 100

--- a/test/crash_test/pkg.yml
+++ b/test/crash_test/pkg.yml
@@ -33,4 +33,4 @@ pkg.deps.CRASH_TEST_NEWTMGR:
     - "@apache-mynewt-core/encoding/json"
 
 pkg.init:
-    crash_test_init: 500
+    crash_test_init: 'MYNEWT_VAL(CRASH_TEST_SYSINIT_STAGE)'

--- a/test/crash_test/syscfg.yml
+++ b/test/crash_test/syscfg.yml
@@ -24,3 +24,7 @@ syscfg.defs:
     CRASH_TEST_NEWTMGR:
         description: 'Newtmgr commands for crashing'
         value: 1
+    CRASH_TEST_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for crash test functionality.
+        value: 500

--- a/test/flash_test/pkg.yml
+++ b/test/flash_test/pkg.yml
@@ -30,5 +30,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    flash_test_init: 500
-
+    flash_test_init: 'MYNEWT_VAL(FLASH_TEST_SYSINIT_STAGE)'

--- a/test/flash_test/syscfg.yml
+++ b/test/flash_test/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    FLASH_TEST_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for flash test functionality.
+        value: 500

--- a/test/i2c_scan/pkg.yml
+++ b/test/i2c_scan/pkg.yml
@@ -32,4 +32,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    i2c_scan_init: 500
+    i2c_scan_init: 'MYNEWT_VAL(I2C_SCAN_SYSINIT_STAGE)'

--- a/test/i2c_scan/syscfg.yml
+++ b/test/i2c_scan/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    I2C_SCAN_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for I2C scan test functionality.
+        value: 500

--- a/test/runtest/pkg.yml
+++ b/test/runtest/pkg.yml
@@ -37,4 +37,4 @@ pkg.req_apis.RUNTEST_CLI:
     - console
 
 pkg.init:
-    runtest_init: 500
+    runtest_init: 'MYNEWT_VAL(RUNTEST_SYSINIT_STAGE)'

--- a/test/runtest/syscfg.yml
+++ b/test/runtest/syscfg.yml
@@ -56,3 +56,7 @@ syscfg.defs:
             test token is specified by the runtest client and is included in
             test result log entries.
         value: 32
+    RUNTEST_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for runtest functionality.
+        value: 500

--- a/test/testutil/pkg.yml
+++ b/test/testutil/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/sysinit"
 
 pkg.init:
-    tu_init: 1
+    tu_init: 'MYNEWT_VAL(TESTUTIL_SYSINIT_STAGE)'

--- a/test/testutil/syscfg.yml
+++ b/test/testutil/syscfg.yml
@@ -20,3 +20,7 @@ syscfg.defs:
     TESTUTIL_SYSTEM_ASSERT:
         description: 'Crash the system on test failure'
         value: '0'
+    TESTUTIL_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for testutil functionality.
+        value: 1

--- a/time/timesched/pkg.yml
+++ b/time/timesched/pkg.yml
@@ -29,4 +29,4 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
 
 pkg.init:
-    timesched_init: 500
+    timesched_init: 'MYNEWT_VAL(TIMESCHED_SYSINIT_STAGE)'

--- a/time/timesched/syscfg.yml
+++ b/time/timesched/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,15 +18,7 @@
 #
 
 syscfg.defs:
-    NMGR_UART:
-        description: 'UART port number to use for newtmgr'
-        value: '"uart0"'
-
-    NMGR_UART_SPEED:
-        description: 'Baudrate for newtmgr UART'
-        value: 115200
-
-    NMGR_UART_SYSINIT_STAGE:
+    TIMESCHED_SYSINIT_STAGE:
         description: >
-            Sysinit stage for the UART newtmgr transport.
-        value: 501
+            Sysinit stage for time scheduler functionality.
+        value: 500


### PR DESCRIPTION
This allows the app or target to rearrange package initialization order via syscfg overrides.

**Note: This requires an updated version of newt
(https://github.com/apache/mynewt-newt/pull/230).  Older versions of newt fail to parse the updated `pkg.yml` files.

I wanted to make this change backwards compatible via an injected newt syscfg setting, e.g.,
```
pkg.init.NEWT_FEATURE_SYSCFG_STAGES:
    log_init: 'MYNEWT_VAL(LOG_SYSINIT_STAGE)'

pkg.init.!NEWT_FEATURE_SYSCFG_STAGES:
    log_init: 100
```

Unfortunately, this is not possible, as the old newt does not allow conditionals to be applied to `pkg.init`.  So, as soon as this PR is merged, everything will break for users using older versions of newt.

I think it is still worth it to get this change in.  Before we merge, we can send a note to the dev list and the slack channel.  When 1.6.0 is released, we can make sure to add the appropriate newt version restriction.