### PR TITLE
kernel/os: Add missing const to parameters in os_dev

### DIFF
--- a/kernel/os/include/os/os_dev.h
+++ b/kernel/os/include/os/os_dev.h
@@ -138,7 +138,7 @@ struct os_dev {
     /** Device flags.  */
     uint8_t od_flags;
     /** Device name */
-    char *od_name;
+    const char *od_name;
     STAILQ_ENTRY(os_dev) od_next;
 };
 
@@ -182,7 +182,7 @@ int os_dev_resume(struct os_dev *dev);
  *
  * @return 0 on success, non-zero on failure.
  */
-int os_dev_create(struct os_dev *dev, char *name, uint8_t stage,
+int os_dev_create(struct os_dev *dev, const char *name, uint8_t stage,
         uint8_t priority, os_dev_init_func_t od_init, void *arg);
 
 /**
@@ -195,7 +195,7 @@ int os_dev_create(struct os_dev *dev, char *name, uint8_t stage,
  *
  * @return A pointer to the device corresponding to name, or NULL if not found.
  */
-struct os_dev *os_dev_lookup(char *name);
+struct os_dev *os_dev_lookup(const char *name);
 
 /**
  * Initialize all devices for a given state.
@@ -234,7 +234,7 @@ int os_dev_resume_all(void);
  *
  * @return 0 on success, non-zero on failure.
  */
-struct os_dev *os_dev_open(char *devname, uint32_t timo, void *arg);
+struct os_dev *os_dev_open(const char *devname, uint32_t timo, void *arg);
 
 /**
  * Close a device.

--- a/kernel/os/src/os_dev.c
+++ b/kernel/os/src/os_dev.c
@@ -23,7 +23,7 @@
 static STAILQ_HEAD(, os_dev) g_os_dev_list;
 
 static int
-os_dev_init(struct os_dev *dev, char *name, uint8_t stage,
+os_dev_init(struct os_dev *dev, const char *name, uint8_t stage,
         uint8_t priority, os_dev_init_func_t od_init, void *arg)
 {
     dev->od_name = name;
@@ -108,7 +108,7 @@ err:
 }
 
 int
-os_dev_create(struct os_dev *dev, char *name, uint8_t stage,
+os_dev_create(struct os_dev *dev, const char *name, uint8_t stage,
         uint8_t priority, os_dev_init_func_t od_init, void *arg)
 {
     int rc;
@@ -185,7 +185,7 @@ err:
 }
 
 struct os_dev *
-os_dev_lookup(char *name)
+os_dev_lookup(const char *name)
 {
     struct os_dev *dev;
 
@@ -199,7 +199,7 @@ os_dev_lookup(char *name)
 }
 
 struct os_dev *
-os_dev_open(char *devname, uint32_t timo, void *arg)
+os_dev_open(const char *devname, uint32_t timo, void *arg)
 {
     struct os_dev *dev;
     os_sr_t sr;


### PR DESCRIPTION
Device name is not modified anywhere so can be const.