### PR TITLE
 kernel/os: If OS_DEBUG, ensure callouts initialized

### DIFF
--- a/kernel/os/src/os_callout.c
+++ b/kernel/os/src/os_callout.c
@@ -71,6 +71,9 @@ os_callout_reset(struct os_callout *c, os_time_t ticks)
     os_sr_t sr;
     int ret;
 
+    /* Ensure this callout has been initialized. */
+    assert(c->c_evq != NULL);
+
     os_trace_api_u32x2(OS_TRACE_ID_CALLOUT_RESET, (uint32_t)c, (uint32_t)ticks);
 
     if (ticks > INT32_MAX) {


### PR DESCRIPTION
It is an error to reset a callout prior to initializing it, as it has no event queue to post to on expiry.  This commit asserts that a callout has been initialized before it is reset (if `OS_DEBUG` is enabled).