### PR TITLE
Misc. battery fixes

### DIFF
--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -151,23 +151,6 @@ battery_pkg_init(void)
 }
 
 int
-battery_mgr_register(struct battery *battery)
-{
-    int i;
-
-    os_mutex_pend(&battery_manager.bm_lock, OS_WAIT_FOREVER);
-
-    for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
-        if (battery_manager.bm_batteries[i] == NULL) {
-            battery_manager.bm_batteries[i] = battery;
-        }
-    }
-    os_mutex_release(&battery_manager.bm_lock);
-
-    return 0;
-}
-
-int
 battery_mgr_get_battery_count(void)
 {
     int i;

--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -791,11 +791,14 @@ battery_init(struct os_dev *dev, void *arg)
 
     OS_DEV_SETHANDLERS(dev, battery_open, battery_close);
 
+    os_mutex_pend(&battery_manager.bm_lock, OS_WAIT_FOREVER);
     for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
         if (battery_manager.bm_batteries[i] == NULL) {
             break;
         }
     }
+    os_mutex_release(&battery_manager.bm_lock);
+
     assert(i < BATTERY_MAX_COUNT);
     battery_manager.bm_batteries[i] = bat;
 

--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -475,12 +475,12 @@ err:
 
 static const struct shell_cmd bat_cli_commands[] =
 {
-        { "read", cmd_bat_read, HELP(bat_read_help) },
-        { "write", cmd_bat_write, HELP(bat_write_help) },
-        { "list", cmd_bat_list, HELP(bat_list_help) },
-        { "pollrate", cmd_bat_poll_rate, HELP(bat_poll_rate_help) },
-        { "monitor", cmd_bat_monitor, HELP(bat_monitor_help) },
-        { NULL, NULL, NULL }
+    { "read", cmd_bat_read, HELP(bat_read_help) },
+    { "write", cmd_bat_write, HELP(bat_write_help) },
+    { "list", cmd_bat_list, HELP(bat_list_help) },
+    { "pollrate", cmd_bat_poll_rate, HELP(bat_poll_rate_help) },
+    { "monitor", cmd_bat_monitor, HELP(bat_monitor_help) },
+    { NULL, NULL, NULL }
 };
 
 /**


### PR DESCRIPTION
These are just some assorted `hw/battery` fixes.  The main change is:

*hw/battery: Don't open battery device during init*

**Prior to commit:** The battery shell opened the battery device at init time.  If the open failed, a sysinit panic was triggered.

**After commit:** The battery shell opens the battery device as needed, per command.  If the open fails, the command fails with a `SYS_ENODEV` error.

**Rationale:** A hardware fault may render the battery device inoperable.  It is better for the application to decide how to handle this condition rather than the shell triggering a crash.
```