### PR TITLE
hw/mcu/nordic: Add hfxo request/release API

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_clock.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/nrf51_clock.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF51_CLOCK_
+#define H_NRF51_CLOCK_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int nrf51_clock_hfxo_request(void);
+
+/**
+ * Release the HFXO; caller no longer needs the HFXO to be turned on. Each call
+ * to release should have been preceeded by a corresponding call to request the
+ * HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int nrf51_clock_hfxo_release(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF51_CLOCK_ */
+

--- a/hw/mcu/nordic/nrf51xxx/src/nrf51_clock.c
+++ b/hw/mcu/nordic/nrf51xxx/src/nrf51_clock.c
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include "mcu/nrf51_hal.h"
+
+static uint8_t nrf51_clock_hfxo_refcnt;
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int
+nrf51_clock_hfxo_request(void)
+{
+    int started;
+    uint32_t ctx;
+
+    started = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf51_clock_hfxo_refcnt < 0xff);
+    if (nrf51_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        started = 1;
+    }
+    ++nrf51_clock_hfxo_refcnt;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return started;
+}
+
+/**
+ * Release the HFXO. This means that the caller no longer needs the HFXO to be
+ * turned on. Each call to release should have been preceeded by a corresponding
+ * call to request the HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int
+nrf51_clock_hfxo_release(void)
+{
+    int stopped;
+    uint32_t ctx;
+
+    stopped = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf51_clock_hfxo_refcnt != 0);
+    --nrf51_clock_hfxo_refcnt;
+    if (nrf51_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+        stopped = 1;
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return stopped;
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/include/mcu/nrf52_clock.h
+++ b/hw/mcu/nordic/nrf52xxx-compat/include/mcu/nrf52_clock.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF52_CLOCK_
+#define H_NRF52_CLOCK_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int nrf52_clock_hfxo_request(void);
+
+/**
+ * Release the HFXO; caller no longer needs the HFXO to be turned on. Each call
+ * to release should have been preceeded by a corresponding call to request the
+ * HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int nrf52_clock_hfxo_release(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF52_CLOCK_ */

--- a/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_clock.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_clock.c
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "mcu/nrf52_hal.h"
+
+static uint8_t nrf52_clock_hfxo_refcnt;
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int
+nrf52_clock_hfxo_request(void)
+{
+    int started;
+    uint32_t ctx;
+
+    started = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf52_clock_hfxo_refcnt < 0xff);
+    if (nrf52_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        started = 1;
+    }
+    ++nrf52_clock_hfxo_refcnt;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return started;
+}
+
+/**
+ * Release the HFXO. This means that the caller no longer needs the HFXO to be
+ * turned on. Each call to release should have been preceeded by a corresponding
+ * call to request the HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int
+nrf52_clock_hfxo_release(void)
+{
+    int stopped;
+    uint32_t ctx;
+
+    stopped = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf52_clock_hfxo_refcnt != 0);
+    --nrf52_clock_hfxo_refcnt;
+    if (nrf52_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+        stopped = 1;
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+}

--- a/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_clock.c
+++ b/hw/mcu/nordic/nrf52xxx-compat/src/nrf52_clock.c
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <assert.h>
 #include "mcu/nrf52_hal.h"
 
 static uint8_t nrf52_clock_hfxo_refcnt;
@@ -69,4 +70,6 @@ nrf52_clock_hfxo_release(void)
         stopped = 1;
     }
     __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return stopped;
 }

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_clock.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_clock.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF52_CLOCK_
+#define H_NRF52_CLOCK_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int nrf52_clock_hfxo_request(void);
+
+/**
+ * Release the HFXO; caller no longer needs the HFXO to be turned on. Each call
+ * to release should have been preceeded by a corresponding call to request the
+ * HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int nrf52_clock_hfxo_release(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF52_CLOCK_ */

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include "mcu/nrf52_hal.h"
+
+static uint8_t nrf52_clock_hfxo_refcnt;
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int
+nrf52_clock_hfxo_request(void)
+{
+    int started;
+    uint32_t ctx;
+
+    started = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf52_clock_hfxo_refcnt < 0xff);
+    if (nrf52_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        started = 1;
+    }
+    ++nrf52_clock_hfxo_refcnt;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return started;
+}
+
+/**
+ * Release the HFXO. This means that the caller no longer needs the HFXO to be
+ * turned on. Each call to release should have been preceeded by a corresponding
+ * call to request the HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int
+nrf52_clock_hfxo_release(void)
+{
+    int stopped;
+    uint32_t ctx;
+
+    stopped = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf52_clock_hfxo_refcnt != 0);
+    --nrf52_clock_hfxo_refcnt;
+    if (nrf52_clock_hfxo_refcnt == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+        stopped = 1;
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return stopped;
+}


### PR DESCRIPTION
This commit adds API so that an application can request the
hfxo and release it. Requesting the hfxo will turn on the hfxo
if it is not already on. Releasing the hfxo will turn it off if
it is not already off. The implementation includes a one byte
reference counter. Each request must have a corresponding release
or the hfxo will always be on. A release without a request is
an error. Note that the API does not wait for any crystal
settling time nor does it check to see if the hfxo actually
turned on.