### PR TITLE
kernel/os: Add helper CONTAINER_OF macro

### DIFF
--- a/kernel/os/include/os/util.h
+++ b/kernel/os/include/os/util.h
@@ -26,4 +26,8 @@
 #define POINTER_TO_INT(p) ((int) ((intptr_t) (p)))
 #define INT_TO_POINTER(u) ((void *) ((intptr_t) (u)))
 
+/* Helper to retrieve pointer to "parent" object in structure */
+#define CONTAINER_OF(ptr, type, field) \
+        ((type *)(((char *)(ptr)) - offsetof(type, field)))
+
 #endif


### PR DESCRIPTION
This is a convenience macro to calculate original pointer of "parent"
object using a pointer to one of its members. It's commonly used in
e.g. Linux kernel and Zephyr Project so it should be also useful in
Mynewt :)

For example, with following structure:
```
struct foo {
    int a;
    struct bar bar;
    int c;
}
```
Let's assume we have:
```
struct foo g_foo;
struct bar *x = &g_foo.bar;
```
And we can use `CONTAINER_OF` to calculate pointer to `g_foo` using `x`:
```
struct foo *foo = CONTAINER_OF(x, struct foo, bar);
```