### PR TITLE
hw/drivers/sensors: Changes if/else to if for sensor type checks in s…

### DIFF
--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -1042,7 +1042,8 @@ lps33hw_sensor_read(struct sensor *sensor, sensor_type_t type,
 
             rc = data_func(sensor, data_arg, &spd, SENSOR_TYPE_PRESSURE);
         }
-    } else if (type & SENSOR_TYPE_TEMPERATURE) {
+    }
+    if (type & SENSOR_TYPE_TEMPERATURE) {
         struct sensor_temp_data std;
 
         rc = lps33hw_get_temperature(itf, &std.std_temp);
@@ -1054,7 +1055,8 @@ lps33hw_sensor_read(struct sensor *sensor, sensor_type_t type,
 
         rc = data_func(sensor, data_arg, &std,
                 SENSOR_TYPE_TEMPERATURE);
-    } else {
+    }
+    if (!(type & SENSOR_TYPE_TEMPERATURE) && !(type & SENSOR_TYPE_PRESSURE)) {
          return SYS_EINVAL;
     }
 

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -1042,7 +1042,8 @@ lps33thw_sensor_read(struct sensor *sensor, sensor_type_t type,
 
             rc = data_func(sensor, data_arg, &spd, SENSOR_TYPE_PRESSURE);
         }
-    } else if (type & SENSOR_TYPE_TEMPERATURE) {
+    }
+    if (type & SENSOR_TYPE_TEMPERATURE) {
         struct sensor_temp_data std;
 
         rc = lps33thw_get_temperature(itf, &std.std_temp);
@@ -1054,7 +1055,8 @@ lps33thw_sensor_read(struct sensor *sensor, sensor_type_t type,
 
         rc = data_func(sensor, data_arg, &std,
                 SENSOR_TYPE_TEMPERATURE);
-    } else {
+    }
+    if (!(type & SENSOR_TYPE_PRESSURE) && !(type & SENSOR_TYPE_TEMPERATURE)) {
          return SYS_EINVAL;
     }
 


### PR DESCRIPTION
…ensor read function. Previously, sensor read would only callback to PRESSURE type listeners unless the sensor was initialized exclusively as a TEMPERATURE type.