### PR TITLE
hw/scripts; was using bash syntax when filtering EXTRA_JTAG_CMD.

### DIFF
--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -60,7 +60,7 @@ parse_extra_jtag_cmd() {
 		shift
 		;;
 	    *)
-		NEW_EXTRA_JTAG_CMD+=" $1"
+		NEW_EXTRA_JTAG_CMD="$NEW_EXTRA_JTAG_CMD $1"
 		shift
 		;;
 	esac


### PR DESCRIPTION
Pointed out by saul at cionic.com.