### PR TITLE
libc/baselibc: syscfg for stubbing out malloc/free

### DIFF
--- a/libc/baselibc/src/malloc.c
+++ b/libc/baselibc/src/malloc.c
@@ -10,6 +10,15 @@
 #include <stdint.h>
 #include "malloc.h"
 
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(BASELIBC_MALLOC_STUB)
+
+void *malloc(size_t size) { return NULL; }
+void free(void *ptr) { }
+
+#else
+
 /* Both the arena list and the free memory list are double linked
    list with head node.  This the head node. Note that the arena list
    is sorted in order of address. */
@@ -274,3 +283,4 @@ void set_malloc_locking(malloc_lock_t lock, malloc_unlock_t unlock)
     else
         malloc_unlock = &malloc_unlock_nop;
 }
+#endif /* MYNEWT_VAL(BASELIBC_MALLOC_STUB) */

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -22,6 +22,13 @@ syscfg.defs:
         description: "Indicates that baselibc is the libc implementation."
         value: 1
 
+    BASELIBC_MALLOC_STUB:
+        description: >
+            Replaces baselibc's implementations of `malloc()` and `free()` with
+            no-op stubs.  Useful for reducing code size in builds that do not
+            use dynamically allocated memory.
+        value: 0
+
     BASELIBC_ASSERT_FILE_LINE:
         defunct: 1
         description: 'Use OS_CRASH_FILE_LINE instead'


### PR DESCRIPTION
ld (linker) does appears to include `malloc()` and `free()` in all builds, even when these function are never used.  This commit adds a new syscfg setting (`BASELIBC_STUB_MALLOC`).  When this setting is enabled, `malloc()` and `free()` are replaced with no-op implementations.