### PR TITLE
hw/drivers: Add bus driver support to some of existing drivers

### DIFF
--- a/hw/battery/include/battery/battery_drv.h
+++ b/hw/battery/include/battery/battery_drv.h
@@ -29,6 +29,11 @@
 #define __BATTERY_DRV_H__
 
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#include "bus/spi.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,8 +145,17 @@ struct battery_driver_functions {
 };
 
 struct battery_driver {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    /* Underlying bus node */
+    union {
+        struct os_dev dev;
+        struct bus_i2c_node i2c_node;
+        struct bus_spi_node spi_node;
+    };
+#else
     /* Underlying OS device */
     struct os_dev dev;
+#endif
 
     const struct battery_driver_functions *bd_funcs;
     /* Array of properties supported by this battery */

--- a/hw/charge-control/include/charge-control/charge_control.h
+++ b/hw/charge-control/include/charge-control/charge_control.h
@@ -364,8 +364,10 @@ struct charge_control {
     /* Charge controller last reading timestamp */
     struct charge_control_timestamp cc_sts;
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     /* Charge controller interface structure */
     struct charge_control_itf cc_itf;
+#endif
 
     /* A list of listeners that are registered to receive data from this
      * charge controller
@@ -511,6 +513,7 @@ charge_control_check_type(struct charge_control *cc,
     return (cc->cc_types & cc->cc_mask & type);
 }
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 /**
  * Set interface type and number
  *
@@ -530,6 +533,7 @@ charge_control_set_interface(struct charge_control *cc,
 
     return (0);
 }
+#endif
 
 /**
  * Read the configuration for the charge control type "type," and return the

--- a/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
+++ b/hw/drivers/bq27z561/include/bq27z561/bq27z561.h
@@ -162,11 +162,13 @@ struct bq27z561_itf
     struct os_mutex *itf_lock;
 };
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 struct bq27z561_init_arg
 {
     struct bq27z561_itf itf;
     struct os_dev *battery;
 };
+#endif
 
 /* BQ27Z561 device */
 struct bq27z561
@@ -177,8 +179,10 @@ struct bq27z561
     /* Configuration values */
     struct bq27z561_cfg bq27_cfg;
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     /* Interface */
     struct bq27z561_itf bq27_itf;
+#endif
 
     /* Device initialization complete flag */
     uint8_t bq27_initialized;
@@ -603,6 +607,23 @@ int bq27z561_init(struct os_dev * dev, void * arg);
  * @return 0 on success, non-zero on failure.
  */
 int bq27z561_shell_init(void);
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for BQ27Z561
+ *
+ * @param node         Bus node
+ * @param name         Device name
+ * @param i2c_cfg      I2C node configuration
+ * @param battery_dev  Battery device
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+bq27z561_create_i2c_dev(struct bus_i2c_node *node, const char *name,
+                        const struct bus_i2c_node_cfg *i2c_cfg,
+                        struct os_dev *battery_dev);
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -23,8 +23,12 @@
 #include "os/mynewt.h"
 #include "bq27z561/bq27z561.h"
 #include "hal/hal_gpio.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"
+#endif
 
 #include "battery/battery_prop.h"
 
@@ -66,18 +70,7 @@ bq27z561_temp_to_celsius(uint16_t temp)
     return temp_c;
 }
 
-static int
-bq27z561_open(struct os_dev *dev, uint32_t timeout, void *arg)
-{
-    return 0;
-}
-
-static int
-bq27z561_close(struct os_dev *dev)
-{
-    return 0;
-}
-
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 /**
  * Lock access to the bq27z561_itf specified by si. Blocks until lock acquired.
  *
@@ -125,11 +118,16 @@ bq27z561_itf_unlock(struct bq27z561_itf *bi)
 
     os_mutex_release(bi->itf_lock);
 }
+#endif
 
 static int
 bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
 {
     int rc;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(&dev->dev.dev, &reg, 1, val, 1);
+#else
     struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_addr;
@@ -160,6 +158,8 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
 
 err:
     bq27z561_itf_unlock(&dev->bq27_itf);
+
+#endif
     return rc;
 }
 
@@ -167,6 +167,10 @@ int
 bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
 {
     int rc;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(&dev->dev.dev, &reg, 1, val, 2);
+#else
     struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_addr;
@@ -196,6 +200,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
 
 err:
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     /* XXX: add big-endian support */
 
@@ -207,10 +212,14 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
 {
     int rc;
     uint8_t buf[2];
-    struct hal_i2c_master_data i2c;
 
     buf[0] = reg;
     buf[1] = val;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(&dev->dev.dev, buf, 2);
+#else
+    struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_num;
     i2c.len     = 2;
@@ -228,6 +237,7 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
     }
 
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     return rc;
 }
@@ -237,11 +247,15 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
 {
     int rc;
     uint8_t buf[3];
-    struct hal_i2c_master_data i2c;
 
     buf[0] = reg;
     buf[1] = (uint8_t)val;
     buf[2] = (uint8_t)(val >> 8);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(&dev->dev.dev, buf, 3);
+#else
+    struct hal_i2c_master_data i2c;
 
     i2c.address = dev->bq27_itf.itf_num;
     i2c.len     = 3;
@@ -261,6 +275,7 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
 
 err:
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     return rc;
 }
@@ -272,7 +287,6 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
     /* NOTE: add three here for register and two-byte command */
     int rc;
     uint8_t tmpbuf[BQ27Z561_MAX_ALT_MFG_CMD_LEN + 3];
-    struct hal_i2c_master_data i2c;
 
     if ((len > 0) && (buf == NULL)) {
         return BQ27Z561_ERR_INV_PARAMS;
@@ -291,6 +305,11 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
         memcpy(&tmpbuf[3], buf, len);
     }
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(&dev->dev.dev, tmpbuf, len + 3);
+#else
+    struct hal_i2c_master_data i2c;
+
     i2c.address = dev->bq27_itf.itf_addr;
     i2c.len = len + 3;
     i2c.buffer = tmpbuf;
@@ -308,6 +327,7 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
     }
 
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     return rc;
 }
@@ -316,48 +336,80 @@ bq27z561_err_t
 bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
                         int val_len)
 {
-    bq27z561_err_t rc;
+    bq27z561_err_t ret;
+    int rc;
     uint8_t tmpbuf[36];
     uint8_t len;
     uint16_t cmd_read;
     uint8_t chksum;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct os_dev *odev = &dev->dev.dev;
+#else
     struct hal_i2c_master_data i2c;
+#endif
 
     if ((val_len == 0) || (val == NULL)) {
         return BQ27Z561_ERR_INV_PARAMS;
     }
 
-    tmpbuf[0] = BQ27Z561_REG_CNTL;
-    tmpbuf[1] = (uint8_t)cmd;
-    tmpbuf[2] = (uint8_t)(cmd >> 8);
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_lock(odev, BUS_NODE_LOCK_DEFAULT_TIMEOUT);
+    if (rc) {
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
     i2c.address = dev->bq27_itf.itf_addr;
-    i2c.len = 3;
-    i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
     if (rc) {
         return rc;
     }
+#endif
 
+    tmpbuf[0] = BQ27Z561_REG_CNTL;
+    tmpbuf[1] = (uint8_t)cmd;
+    tmpbuf[2] = (uint8_t)(cmd >> 8);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(odev, tmpbuf, 3);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
+    i2c.len = 3;
+    i2c.buffer = tmpbuf;
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
+#endif
 
     tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(odev, tmpbuf, 1, tmpbuf, 36);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    (void)bus_node_unlock(odev);
+#else
     i2c.len = 1;
     i2c.buffer = tmpbuf;
-
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
@@ -368,19 +420,20 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     /* Verify that first two bytes are the command */
     cmd_read = tmpbuf[0];
     cmd_read |= ((uint16_t)tmpbuf[1]) << 8;
     if (cmd_read != cmd) {
         BQ27Z561_LOG(ERROR, "cmd mismatch (cmd=%x cmd_ret=%x\n", cmd, cmd_read);
-        rc = BQ27Z561_ERR_CMD_MISMATCH;
+        ret = BQ27Z561_ERR_CMD_MISMATCH;
         goto err;
     }
 
@@ -391,7 +444,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
      */
     len = tmpbuf[35];
     if (len < 5) {
-        rc = BQ27Z561_ERR_ALT_MFG_LEN;
+        ret = BQ27Z561_ERR_ALT_MFG_LEN;
         goto err;
     }
 
@@ -401,7 +454,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     if (chksum != tmpbuf[34]) {
         BQ27Z561_LOG(ERROR, "chksum failure for cmd %u (calc=%u read=%u)", cmd,
                        chksum, tmpbuf[34]);
-        rc = BQ27Z561_ERR_CHKSUM_FAIL;
+        ret = BQ27Z561_ERR_CHKSUM_FAIL;
     }
 
     /* Now copy returned data. We subtract command from length */
@@ -411,10 +464,10 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     }
     memcpy(val, &tmpbuf[2], val_len);
 
-    rc = BQ27Z561_OK;
+    ret = BQ27Z561_OK;
 
 err:
-    return rc;
+    return ret;
 }
 
 bq27z561_err_t
@@ -422,8 +475,13 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
 {
     uint8_t tmpbuf[BQ27Z561_MAX_FLASH_RW_LEN + 2];
     uint16_t addr_read;
-    bq27z561_err_t rc;
+    bq27z561_err_t ret;
+    int rc;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct os_dev *odev = &dev->dev.dev;
+#else
     struct hal_i2c_master_data i2c;
+#endif
 
     if ((buflen == 0) || !buf || (buflen > BQ27Z561_MAX_FLASH_RW_LEN)) {
         return BQ27Z561_ERR_INV_PARAMS;
@@ -433,29 +491,57 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return BQ27Z561_ERR_INV_FLASH_ADDR;
     }
 
-    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
-    tmpbuf[1] = (uint8_t)addr;
-    tmpbuf[2] = (uint8_t)(addr >> 8);
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_lock(odev, BUS_NODE_LOCK_DEFAULT_TIMEOUT);
+    if (rc) {
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
     i2c.address = dev->bq27_itf.itf_addr;
-    i2c.len = 3;
-    i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
     if (rc) {
         return rc;
     }
+#endif
 
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    tmpbuf[1] = (uint8_t)addr;
+    tmpbuf[2] = (uint8_t)(addr >> 8);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(odev, tmpbuf, 3);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
+    i2c.len = 3;
+    i2c.buffer = tmpbuf;
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
+#endif
 
     tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(odev, tmpbuf, 1, tmpbuf, buflen + 2);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    (void)bus_node_unlock(odev);
+#else
     i2c.len = 1;
     i2c.buffer = tmpbuf;
 
@@ -463,7 +549,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
@@ -474,12 +560,13 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
     }
 
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
     /* Verify that first two bytes are the address*/
     addr_read = tmpbuf[0];
@@ -487,17 +574,17 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     if (addr_read != addr) {
         BQ27Z561_LOG(ERROR, "addr mismatch (addr_read=%x addr_ret=%x\n", addr_read,
                         addr);
-        rc = BQ27Z561_ERR_FLASH_ADDR_MISMATCH;
+        ret = BQ27Z561_ERR_FLASH_ADDR_MISMATCH;
         goto err;
     }
 
     /* Now copy returned data. */
     memcpy(buf, &tmpbuf[2], buflen);
 
-    rc = BQ27Z561_OK;
+    ret = BQ27Z561_OK;
 
 err:
-    return rc;
+    return ret;
 }
 
 bq27z561_err_t
@@ -505,8 +592,13 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
 {
     uint8_t tmpbuf[BQ27Z561_MAX_FLASH_RW_LEN + 2];
     uint8_t chksum;
-    bq27z561_err_t rc;
+    bq27z561_err_t ret;
+    int rc;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct os_dev *odev = &dev->dev.dev;
+#else
     struct hal_i2c_master_data i2c;
+#endif
 
     if ((buflen == 0) || (!buf) || (buflen > BQ27Z561_MAX_FLASH_RW_LEN)) {
         return BQ27Z561_ERR_INV_PARAMS;
@@ -516,27 +608,44 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
         return BQ27Z561_ERR_INV_FLASH_ADDR;
     }
 
-    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
-    tmpbuf[1] = (uint8_t)addr;
-    tmpbuf[2] = (uint8_t)(addr >> 8);
-    memcpy(&tmpbuf[3], buf, buflen);
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_lock(odev, BUS_NODE_LOCK_DEFAULT_TIMEOUT);
+    if (rc) {
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
     i2c.address = dev->bq27_itf.itf_addr;
-    i2c.len = buflen + 3;
-    i2c.buffer = tmpbuf;
 
     rc = bq27z561_itf_lock(&dev->bq27_itf, MYNEWT_VAL(BQ27Z561_ITF_LOCK_TMO));
     if (rc) {
         return rc;
     }
+#endif
 
+    tmpbuf[0] = BQ27Z561_REG_MFRG_ACC;
+    tmpbuf[1] = (uint8_t)addr;
+    tmpbuf[2] = (uint8_t)(addr >> 8);
+    memcpy(&tmpbuf[3], buf, buflen);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(odev, tmpbuf, buflen + 3);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+#else
+    i2c.len = buflen + 3;
+    i2c.buffer = tmpbuf;
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
         goto err;
     }
+#endif
 
     /* Calculate checksum */
     chksum = bq27z561_calc_chksum(&tmpbuf[1], buflen + 2);
@@ -545,20 +654,35 @@ bq27x561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     tmpbuf[0] = BQ27Z561_REG_CHKSUM;
     tmpbuf[1] = chksum;
     tmpbuf[2] = buflen + 4;
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write(odev, tmpbuf, 3);
+    if (rc) {
+        (void)bus_node_unlock(odev);
+        ret = BQ27Z561_ERR_I2C_ERR;
+        goto err;
+    }
+
+    (void)bus_node_unlock(odev);
+
+    ret = BQ27Z561_OK;
+
+err:
+#else
     i2c.len = 3;
     i2c.buffer = tmpbuf;
-
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
         BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
-        rc = BQ27Z561_ERR_I2C_ERR;
+        ret = BQ27Z561_ERR_I2C_ERR;
     }
 
 err:
     bq27z561_itf_unlock(&dev->bq27_itf);
+#endif
 
-    return rc;
+    return ret;
 }
 
 #if 0
@@ -1196,26 +1320,35 @@ int
 bq27z561_init(struct os_dev *dev, void *arg)
 {
     struct bq27z561 *bq27;
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     struct bq27z561_init_arg *init_arg = (struct bq27z561_init_arg *)arg;
+#endif
+    struct os_dev *battery;
 
     if (!dev || !arg) {
         return SYS_ENODEV;
     }
 
-    OS_DEV_SETHANDLERS(dev, bq27z561_open, bq27z561_close);
-
     bq27 = (struct bq27z561 *)dev;
 
     bq27->bq27_initialized = 0;
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     /* Copy the interface struct */
     bq27->bq27_itf = init_arg->itf;
+#endif
 
     bq27->dev.bd_funcs = &bq27z561_drv_funcs;
     bq27->dev.bd_driver_properties = bq27z561_battery_properties;
     bq27->dev.bd_driver_data = bq27;
 
-    battery_add_driver(init_arg->battery, &bq27->dev);
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    battery = arg;
+#else
+    battery = init_arg->battery;
+#endif
+
+    battery_add_driver(battery, &bq27->dev);
 
     return 0;
 }
@@ -1228,3 +1361,28 @@ int bq27z561_pkg_init(void)
     return 0;
 #endif
 }
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static void
+init_node_cb(struct bus_node *bnode, void *arg)
+{
+    bq27z561_init((struct os_dev *)bnode, arg);
+}
+
+int
+bq27z561_create_i2c_dev(struct bus_i2c_node *node, const char *name,
+                        const struct bus_i2c_node_cfg *i2c_cfg,
+                        struct os_dev *battery_dev)
+{
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_i2c_node_create(name, node, i2c_cfg, battery_dev);
+
+    return rc;
+}
+#endif

--- a/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
+++ b/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
@@ -25,6 +25,10 @@
 #include "syscfg/syscfg.h"
 #include "os/os_time.h"
 #include "charge-control/charge_control.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 
 /**
 * Struct for ADP50961 configuration
@@ -43,7 +47,11 @@ struct adp5061_config {
 };
 
 struct adp5061_dev {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node     a_node;
+#else
     struct os_dev           a_dev;
+#endif
     struct charge_control   a_chg_ctrl;
     struct adp5061_config   a_cfg;
     os_time_t               a_last_read_time;
@@ -978,5 +986,20 @@ int adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
                                             >> ADP5061_SYS_EN_OFFSET)
 #define ADP5061_SYS_EN_SET(a)           ((a & ((1 << ADP5061_SYS_EN_LEN)-1)) \
                                             << ADP5061_SYS_EN_OFFSET)
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for ADP5061
+ *
+ * @param node  Bus node
+ * @param name  Device name
+ * @param cfg   I2C node configuration
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+adp5061_create_i2c_dev(struct bus_i2c_node *node, const char *name,
+                       const struct bus_i2c_node_cfg *cfg);
+#endif
 
 #endif /* _ADP5061_H */

--- a/hw/drivers/led/include/led/led_itf.h
+++ b/hw/drivers/led/include/led/led_itf.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#include "syscfg/syscfg.h"
+
 /**
  * LED interfaces
  */
@@ -35,7 +37,10 @@ extern "C" {
  * LED interface
  */
 struct led_itf {
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    /* Device */
+    struct os_dev *li_dev;
+#else
     /* LED interface type */
     uint8_t li_type;
 
@@ -50,6 +55,7 @@ struct led_itf {
 
     /* Mutex for shared interface access */
     struct os_mutex *li_lock;
+#endif
 };
 
 /**
@@ -63,7 +69,9 @@ struct led_itf {
 static inline int
 led_itf_lock(struct led_itf *li, uint32_t timeout)
 {
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    return 0;
+#else
     int rc;
     os_time_t ticks;
 
@@ -82,6 +90,7 @@ led_itf_lock(struct led_itf *li, uint32_t timeout)
     }
 
     return (rc);
+#endif
 }
 
 /**
@@ -94,11 +103,13 @@ led_itf_lock(struct led_itf *li, uint32_t timeout)
 static inline void
 led_itf_unlock(struct led_itf *li)
 {
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (!li->li_lock) {
         return;
     }
 
     os_mutex_release(li->li_lock);
+#endif
 }
 
 #endif

--- a/hw/drivers/led/lp5523/include/lp5523/lp5523.h
+++ b/hw/drivers/led/lp5523/include/lp5523/lp5523.h
@@ -25,6 +25,10 @@ extern "C" {
 #endif
 
 #include <led/led_itf.h>
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 
 #define LP5523_MAX_PAYLOAD   (10)
 
@@ -108,7 +112,11 @@ struct lp5523_cfg {
 };
 
 struct lp5523 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct lp5523_cfg cfg;
 };
 
@@ -1469,6 +1477,21 @@ int lp5523_shell_init(void);
  */
 #define LP5523_INS_SUB(target_variable, variable1, variable2) \
     LP5523_INS_ARITH(0x9310, target_variable, variable1, variable2)
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for LP5523
+ *
+ * @param node     Bus node
+ * @param name     Device name
+ * @param i2c_cfg  I2C node configuration
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lp5523_create_i2c_dev(struct bus_i2c_node *node, const char *name,
+                      const struct bus_i2c_node_cfg *i2c_cfg);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/sensors/bma253/include/bma253/bma253.h
+++ b/hw/drivers/sensors/bma253/include/bma253/bma253.h
@@ -201,8 +201,12 @@ struct bma253_private_driver_data {
 
 /* The device itself */
 struct bma253 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node node;
+#else
     /* Underlying OS device */
     struct os_dev dev;
+#endif
     /* The sensor infrastructure */
     struct sensor sensor;
     /* Default configuration values */
@@ -463,6 +467,22 @@ int
 bma253_shell_init(void);
 #endif
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for BMA253 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+bma253_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                             const struct bus_i2c_node_cfg *i2c_cfg,
+                             struct sensor_itf *sensor_itf);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
+++ b/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
@@ -22,6 +22,11 @@
 #define __bmp280_H__
 
 #include "os/mynewt.h"
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#include "bus/i2c.h"
+#include "bus/spi.h"
+#endif
 #include "sensor/sensor.h"
 
 #define BMP280_SPI_READ_CMD_BIT 0x80
@@ -257,6 +262,38 @@ bmp280_forced_mode_measurement(struct sensor_itf *itf);
 
 #if MYNEWT_VAL(BMP280_CLI)
 int bmp280_shell_init(void);
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for BMP280 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+bmp280_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                             const struct bus_i2c_node_cfg *i2c_cfg,
+                             struct sensor_itf *sensor_itf);
+
+/**
+ * Create SPI bus node for BMP280 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param spi_cfg     SPI node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+bmp280_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                             const struct bus_spi_node_cfg *spi_cfg,
+                             struct sensor_itf *sensor_itf);
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -22,6 +22,11 @@
 
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#include "bus/spi.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -256,7 +261,14 @@ struct lis2dh12_pdd {
 };
 
 struct lis2dh12 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    union {
+        struct bus_i2c_node i2c_node;
+        struct bus_spi_node spi_node;
+    };
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct lis2dh12_cfg cfg;
     struct lis2dh12_int intr;
@@ -627,6 +639,38 @@ lis2dh12_get_fifo_samples(struct sensor_itf *itf, uint8_t *samples);
 
 #if MYNEWT_VAL(LIS2DH12_CLI)
 int lis2dh12_shell_init(void);
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for LIS2DH12 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                               const struct bus_i2c_node_cfg *i2c_cfg,
+                               struct sensor_itf *sensor_itf);
+
+/**
+ * Create SPI bus node for LIS2DH12 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param spi_cfg     SPI node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dh12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                               const struct bus_spi_node_cfg *spi_cfg,
+                               struct sensor_itf *sensor_itf);
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -23,9 +23,13 @@
 #include <string.h>
 
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#else
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"
+#endif
 #include "sensor/sensor.h"
 #include "sensor/accel.h"
 #include "lis2dh12/lis2dh12.h"
@@ -129,12 +133,14 @@ static const struct lis2dh12_notif_cfg dflt_notif_cfg[] = {
     }
 };
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 static struct hal_spi_settings spi_lis2dh12_settings = {
     .data_order = HAL_SPI_MSB_FIRST,
     .data_mode  = HAL_SPI_MODE3,
     .baudrate   = 4000,
     .word_size  = HAL_SPI_WORD_SIZE_8BIT,
 };
+#endif
 
 /* Define the stats section and records */
 STATS_SECT_START(lis2dh12_stat_section)
@@ -212,6 +218,7 @@ static const struct sensor_driver g_lis2dh12_sensor_driver = {
     .sd_handle_interrupt   = lis2dh12_sensor_handle_interrupt
 };
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 /**
  * Read multiple length data from LIS2DH12 sensor over I2C
  *
@@ -449,6 +456,7 @@ err:
 
     return rc;
 }
+#endif
 
 /**
  * Write multiple length data to LIS2DH12 sensor over different interfaces
@@ -466,6 +474,25 @@ lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct {
+        uint8_t addr;
+        /*
+         * XXX lis2dh12_i2c_writelen has max payload of 20 including addr, not
+         * sure where it comes from
+         */
+        uint8_t payload[19];
+    } write_data;
+
+    if (len > sizeof(write_data.payload)) {
+        return -1;
+    }
+
+    write_data.addr = addr;
+    memcpy(write_data.payload, payload, len);
+
+    rc = bus_node_simple_write(itf->si_dev, &write_data, len + 1);
+#else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
     if (rc) {
         return rc;
@@ -478,6 +505,7 @@ lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     }
 
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
@@ -497,6 +525,9 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 {
     int rc;
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(itf->si_dev, &addr, 1, payload, len);
+#else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
     if (rc) {
         return rc;
@@ -509,6 +540,7 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     }
 
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
@@ -525,22 +557,7 @@ lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
 int
 lis2dh12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 {
-    int rc;
-
-    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
-    if (rc) {
-        return rc;
-    }
-
-    if (itf->si_type == SENSOR_ITF_I2C) {
-        rc = lis2dh12_i2c_writelen(itf, reg, &value, 1);
-    } else {
-        rc = lis2dh12_spi_writelen(itf, reg, &value, 1);
-    }
-
-    sensor_itf_unlock(itf);
-
-    return rc;
+    return lis2dh12_writelen(itf, reg, &value, 1);
 }
 
 /**
@@ -555,22 +572,7 @@ lis2dh12_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 int
 lis2dh12_read8(struct sensor_itf *itf, uint8_t addr, uint8_t *reg)
 {
-    int rc;
-
-    rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DH12_ITF_LOCK_TMO));
-    if (rc) {
-        return rc;
-    }
-
-    if (itf->si_type == SENSOR_ITF_I2C) {
-        rc = lis2dh12_i2c_readlen(itf, addr, reg, 1);
-    } else {
-        rc = lis2dh12_spi_readlen(itf, addr, reg, 1);
-    }
-
-    sensor_itf_unlock(itf);
-
-    return rc;
+    return lis2dh12_readlen(itf, addr, reg, 1);
 }
 
 /**
@@ -1286,6 +1288,7 @@ lis2dh12_init(struct os_dev *dev, void *arg)
         goto err;
     }
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (sensor->s_itf.si_type == SENSOR_ITF_SPI) {
 
         rc = hal_spi_disable(sensor->s_itf.si_num);
@@ -1311,6 +1314,7 @@ lis2dh12_init(struct os_dev *dev, void *arg)
             goto err;
         }
     }
+#endif
 
     init_interrupt(&lis2dh12->intr, lis2dh12->sensor.s_itf.si_ints);
 
@@ -1749,7 +1753,9 @@ lis2dh12_sensor_read(struct sensor *sensor, sensor_type_t type,
     }
 
     itf = SENSOR_GET_ITF(sensor);
+    (void)itf;
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (itf->si_type == SENSOR_ITF_SPI) {
 
         rc = hal_spi_disable(sensor->s_itf.si_num);
@@ -1770,6 +1776,7 @@ lis2dh12_sensor_read(struct sensor *sensor, sensor_type_t type,
             goto err;
         }
     }
+#endif
 
     lis2dh12 = (struct lis2dh12 *)SENSOR_GET_DEVICE(sensor);
     cfg = &lis2dh12->cfg;
@@ -2796,7 +2803,9 @@ lis2dh12_config(struct lis2dh12 *lis2dh12, struct lis2dh12_cfg *cfg)
 
     itf = SENSOR_GET_ITF(&(lis2dh12->sensor));
     sensor = &(lis2dh12->sensor);
+    (void)sensor;
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (itf->si_type == SENSOR_ITF_SPI) {
 
         rc = hal_spi_disable(sensor->s_itf.si_num);
@@ -2817,6 +2826,7 @@ lis2dh12_config(struct lis2dh12 *lis2dh12, struct lis2dh12_cfg *cfg)
             goto err;
         }
     }
+#endif
 
     rc = lis2dh12_get_chip_id(itf, &chip_id);
     if (rc) {
@@ -2994,3 +3004,47 @@ err:
 
     return rc;
 }
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static void
+init_node_cb(struct bus_node *bnode, void *arg)
+{
+    struct sensor_itf *itf = arg;
+
+    lis2dh12_init((struct os_dev *)bnode, itf);
+}
+
+int
+lis2dh12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                               const struct bus_i2c_node_cfg *i2c_cfg,
+                               struct sensor_itf *sensor_itf)
+{
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
+
+    return rc;
+}
+
+int
+lis2dh12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                               const struct bus_spi_node_cfg *spi_cfg,
+                               struct sensor_itf *sensor_itf)
+{
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);
+
+    return rc;
+}
+#endif

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -22,6 +22,10 @@
 
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -272,7 +276,11 @@ struct lis2dw12_pdd {
 };
 
 struct lis2dw12 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct lis2dw12_cfg cfg;
     struct lis2dw12_int intr;
@@ -917,6 +925,37 @@ int lis2dw12_config(struct lis2dw12 *lis2dw12, struct lis2dw12_cfg *cfg);
 int lis2dw12_shell_init(void);
 #endif
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for LIS2DW12 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                               const struct bus_i2c_node_cfg *i2c_cfg,
+                               struct sensor_itf *sensor_itf);
+
+/**
+ * Create SPI bus node for LIS2DW12 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param spi_cfg     SPI node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lis2dw12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                               const struct bus_spi_node_cfg *spi_cfg,
+                               struct sensor_itf *sensor_itf);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
+++ b/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
@@ -22,6 +22,10 @@
 
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 #include "hal/hal_gpio.h"
 
 #ifdef __cplusplus
@@ -77,7 +81,11 @@ struct lps33hw_private_driver_data {
 };
 
 struct lps33hw {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct lps33hw_cfg cfg;
     os_time_t last_read_time;
@@ -210,6 +218,23 @@ int lps33hw_config(struct lps33hw *, struct lps33hw_cfg *);
 
 #if MYNEWT_VAL(LPS33HW_CLI)
 int lps33hw_shell_init(void);
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for LPS33HW sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lps33hw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                              const struct bus_i2c_node_cfg *i2c_cfg,
+                              struct sensor_itf *sensor_itf);
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -23,10 +23,14 @@
 #include <math.h>
 
 #include "os/mynewt.h"
+#include "hal/hal_gpio.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#else
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"
-#include "hal/hal_gpio.h"
 #include "i2cn/i2cn.h"
+#endif
 #include "sensor/sensor.h"
 #include "sensor/pressure.h"
 #include "sensor/temperature.h"
@@ -36,12 +40,14 @@
 #include "stats/stats.h"
 #include <syscfg/syscfg.h>
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 static struct hal_spi_settings spi_lps33hw_settings = {
     .data_order = HAL_SPI_MSB_FIRST,
     .data_mode  = HAL_SPI_MODE3,
     .baudrate   = 4000,
     .word_size  = HAL_SPI_WORD_SIZE_8BIT,
 };
+#endif
 
 /* Define the stats section and records */
 STATS_SECT_START(lps33hw_stat_section)
@@ -154,6 +160,7 @@ lps33hw_reg_to_degc(int16_t reg)
     return reg / LPS33HW_TEMP_OUT_DIV;
 }
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 /**
  * Writes a single byte to the specified register using i2c
  * interface
@@ -237,6 +244,7 @@ err:
 
     return rc;
 }
+#endif
 
 /**
  * Writes a single byte to the specified register using specified
@@ -253,6 +261,11 @@ lps33hw_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
 {
     int rc;
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    uint8_t data[2] = { reg, value };
+
+    rc = bus_node_simple_write(itf->si_dev, data, 2);
+#else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33HW_ITF_LOCK_TMO));
     if (rc) {
         return rc;
@@ -265,10 +278,12 @@ lps33hw_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     }
 
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
 /**
  *
  * Read bytes from the specified register using SPI interface
@@ -370,6 +385,7 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     }
     return rc;
 }
+#endif
 
 /**
  * Read bytes from the specified register using specified interface
@@ -387,6 +403,9 @@ lps33hw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
 {
     int rc;
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(itf->si_dev, &reg, 1, buffer, size);
+#else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33HW_ITF_LOCK_TMO));
     if (rc) {
         return rc;
@@ -399,6 +418,7 @@ lps33hw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     }
 
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
@@ -907,6 +927,7 @@ lps33hw_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
+#if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (sensor->s_itf.si_type == SENSOR_ITF_SPI) {
         rc = hal_spi_config(sensor->s_itf.si_num, &spi_lps33hw_settings);
         if (rc == EINVAL) {
@@ -926,6 +947,7 @@ lps33hw_init(struct os_dev *dev, void *arg)
             return rc;
         }
     }
+#endif
 
     return rc;
 }
@@ -1084,3 +1106,30 @@ lps33hw_sensor_get_config(struct sensor *sensor, sensor_type_t type,
 
     return 0;
 }
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static void
+init_node_cb(struct bus_node *bnode, void *arg)
+{
+    struct sensor_itf *itf = arg;
+
+    lps33hw_init((struct os_dev *)bnode, itf);
+}
+
+int
+lps33hw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                              const struct bus_i2c_node_cfg *i2c_cfg,
+                              struct sensor_itf *sensor_itf)
+{
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
+
+    return rc;
+}
+#endif

--- a/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
+++ b/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
@@ -23,6 +23,11 @@
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
 #include "hal/hal_gpio.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#include "bus/spi.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,7 +85,11 @@ struct lps33thw_private_driver_data {
 };
 
 struct lps33thw {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct lps33thw_cfg cfg;
     os_time_t last_read_time;
@@ -213,6 +222,38 @@ int lps33thw_config(struct lps33thw *, struct lps33thw_cfg *);
 
 #if MYNEWT_VAL(LPS33THW_CLI)
 int lps33thw_shell_init(void);
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for LPS33THW sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lps33thw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                               const struct bus_i2c_node_cfg *i2c_cfg,
+                               struct sensor_itf *sensor_itf);
+
+/**
+ * Create SPI bus node for LPS33THW sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param spi_cfg     SPI node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lps33thw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                               const struct bus_spi_node_cfg *spi_cfg,
+                               struct sensor_itf *sensor_itf);
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
+++ b/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
@@ -23,6 +23,10 @@
 
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 
 #define MS5837_I2C_ADDRESS		0x76
 #define MS5837_NUMBER_COEFFS     7
@@ -42,7 +46,11 @@ struct ms5837_cfg {
 };
 
 struct ms5837 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct ms5837_cfg cfg;
     struct ms5837_pdd pdd;
@@ -163,6 +171,23 @@ ms5837_compensate_pressure(uint16_t *coeffs, int32_t temp,
 float
 ms5837_compensate_temperature(uint16_t *coeffs, uint32_t rawtemp,
                               int32_t *comptemp, int32_t *deltat);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for MS5837 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+ms5837_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                             const struct bus_i2c_node_cfg *i2c_cfg,
+                             struct sensor_itf *sensor_itf);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -23,8 +23,12 @@
 #include <string.h>
 
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"
+#endif
 #include "sensor/sensor.h"
 #include "ms5837/ms5837.h"
 #include "sensor/temperature.h"
@@ -324,6 +328,11 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 {
     int rc;
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    assert(len == 0);
+
+    rc = bus_node_simple_write(itf->si_dev, &addr, 1);
+#else
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
         .len = 1,
@@ -345,6 +354,7 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     }
 
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
@@ -364,8 +374,11 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
                uint8_t len)
 {
     int rc;
-    uint8_t payload[3] = {addr, 0, 0};
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_node_simple_write_read_transact(itf->si_dev, &addr, 1, buffer, len);
+#else
+    uint8_t payload[3] = {addr, 0, 0};
     struct hal_i2c_master_data data_struct = {
         .address = itf->si_addr,
         .len = 1,
@@ -407,6 +420,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
 
 err:
     sensor_itf_unlock(itf);
+#endif
 
     return rc;
 }
@@ -697,3 +711,30 @@ ms5837_crc_check(uint16_t *prom, uint8_t crc)
 
     return  (rem != crc);
 }
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static void
+init_node_cb(struct bus_node *bnode, void *arg)
+{
+    struct sensor_itf *itf = arg;
+
+    ms5837_init((struct os_dev *)bnode, itf);
+}
+
+int
+ms5837_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                             const struct bus_i2c_node_cfg *i2c_cfg,
+                             struct sensor_itf *sensor_itf)
+{
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
+
+    return rc;
+}
+#endif

--- a/hw/drivers/sensors/ms5840/include/ms5840/ms5840.h
+++ b/hw/drivers/sensors/ms5840/include/ms5840/ms5840.h
@@ -24,6 +24,10 @@
 #include <os/os.h>
 #include "os/os_dev.h"
 #include "sensor/sensor.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus_driver.h"
+#include "bus/i2c.h"
+#endif
 
 #define MS5840_I2C_ADDRESS		0x76
 #define MS5840_NUMBER_COEFFS     7
@@ -43,7 +47,11 @@ struct ms5840_cfg {
 };
 
 struct ms5840 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct ms5840_cfg cfg;
     struct ms5840_pdd pdd;
@@ -164,6 +172,23 @@ ms5840_compensate_pressure(uint16_t *coeffs, int32_t temp,
 float
 ms5840_compensate_temperature(uint16_t *coeffs, uint32_t rawtemp,
                               int32_t *comptemp, int32_t *deltat);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+/**
+ * Create I2C bus node for MS5840 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+ms5840_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                             const struct bus_i2c_node_cfg *i2c_cfg,
+                             struct sensor_itf *sensor_itf);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -512,6 +512,7 @@ struct sensor_itf {
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
     /* Device configuration is stored in bus node */
+    struct os_dev *si_dev;
 #else
     /* Sensor interface type */
     uint8_t si_type;
@@ -524,6 +525,9 @@ struct sensor_itf {
 
     /* Sensor address */
     uint16_t si_addr;
+
+    /* Mutex for interface access */
+    struct os_mutex *si_lock;
 #endif
 
     /* Sensor interface low int pin */
@@ -532,28 +536,11 @@ struct sensor_itf {
     /* Sensor interface high int pin */
     uint8_t si_high_pin;
 
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    /* No need for mutex - locking is done by bus driver */
-#else
-    /* Mutex for interface access */
-    struct os_mutex *si_lock;
-#endif
-
     /* Sensor interface interrupts pins */
     /* XXX We should probably remove low/high pins and replace it with those
      */
     struct sensor_int si_ints[MYNEWT_VAL(SENSOR_MAX_INTERRUPTS_PINS)];
 };
-
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-struct sensor_node_cfg {
-    struct sensor_itf itf;
-    union {
-        struct bus_i2c_node_cfg i2c_node_cfg;
-        struct bus_spi_node_cfg spi_node_cfg;
-    };
-};
-#endif
 
 /*
  * Return the OS device structure corresponding to this sensor
@@ -564,16 +551,6 @@ struct sensor_node_cfg {
  * Return the interface for this sensor
  */
 #define SENSOR_GET_ITF(__s) (&((__s)->s_itf))
-
-/*
- * Return original sensor from sensor interface
- */
-#define SENSOR_ITF_GET_SENSOR(__itf)    CONTAINER_OF((__itf), struct sensor, s_itf)
-
-/*
- * Return OS device for original sensor from sensor interface
- */
-#define SENSOR_ITF_GET_DEVICE(__itf)    SENSOR_GET_DEVICE(SENSOR_ITF_GET_SENSOR((__itf)))
 
 /*
  * Checks if the sensor data is valid and then compares if it is greater than


### PR DESCRIPTION
This updates some of drivers to support new bus driver. Old code is still there and thus they can still work just fine without bus driver - the proper way to access bus is selected automatically in build time depending if bus driver is included or not.

Each driver have now helper function to quickly create bus node so there's no need to figure out how to call `os_dev_create` properly - just use helper instead.

Modified drivers seem to work fine, however I was not able to check each and every single functionality there - just ran this on few existing device with sensors I have here and they all work fine.