### PR TITLE
kernel/os: Fix os_trace APIs

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/nrf51_clock.c
+++ b/hw/mcu/nordic/nrf51xxx/src/nrf51_clock.c
@@ -17,7 +17,9 @@
  * under the License.
  */
 #include <assert.h>
+#include <stdint.h>
 #include "mcu/nrf51_hal.h"
+#include "nrfx.h"
 
 static uint8_t nrf51_clock_hfxo_refcnt;
 

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
@@ -17,7 +17,9 @@
  * under the License.
  */
 #include <assert.h>
+#include <stdint.h>
 #include "mcu/nrf52_hal.h"
+#include "nrfx.h"
 
 static uint8_t nrf52_clock_hfxo_refcnt;
 

--- a/kernel/os/include/os/os_fault.h
+++ b/kernel/os/include/os/os_fault.h
@@ -20,6 +20,8 @@
 #ifndef _OS_FAULT_H
 #define _OS_FAULT_H
 
+#include "syscfg/syscfg.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -21,7 +21,7 @@ extern "C" {
 
 #else
 #include <stddef.h>
-#include "os/mynewt.h"
+#include "os/os_fault.h"
 
 #define assert(x) ((x) ? (void)0 : OS_CRASH())
 


### PR DESCRIPTION
os_trace_api.h uses local #defined symbols from .c file to determine
whether traces should be enabled for given file or not. In order for
this to work properly it has to be included only after such symbols
are #defined.

However, assert.h includes os/mynewt.h and the nasty side-effect is
that we have os_everything included by including one of std library
includes.

Let's assert.h just include os_fault.h instead as this should not have
any side-effects.