### PR TITLE
hw/mcu/nordic: Fix stop on I2C write

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -366,7 +366,7 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
         }
     }
 
-    rc = 0;
+    return 0;
 
 err:
     regs->TASKS_STOP = 1;


### PR DESCRIPTION
This seems to be done by mistake in some earlier commit, but we should
not put stop condition on bus after every write - only if we were asked
to (or in case of error).