### PR TITLE
sys/stats: Fix build error due to circular #include

### DIFF
--- a/sys/stats/full/include/stats/stats.h
+++ b/sys/stats/full/include/stats/stats.h
@@ -21,7 +21,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "os/mynewt.h"
+#include "os/os.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
There's possible cicrular #include in stats.h which makes build fail:
  something.c -> stats/stats.h
  stats/stats.h -> os/mynewt.h
  os/mynewt.h with NEWT_FEATURE_LOGCFG -> logcfg/logcfg.h
  non-empty logcfg/logcfg.h -> modlog/modlog.h
  modlog/modlog.h -> log/log.h

log/log.h with LOG_STATS uses stats macros and tries to include stats.h
properly, but since it's implicitly included from stats.h these macros
are not yet defined thus there are a lot of build errors in different
files.

The solution is to include os/os.h since this is what stats.h really
needs.