### PR TITLE
hw/mcu/nordic/nrf52xxx: Revert sequence of operations for i2c errors

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -469,10 +469,10 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     return 0;
 
 err:
-    regs->TASKS_STOP = 1;
 
     if (regs->EVENTS_ERROR) {
         nrf_status = regs->ERRORSRC;
+        regs->TASKS_STOP = 1;
         regs->ERRORSRC = nrf_status;
         rc = hal_i2c_convert_status(nrf_status);
     } else if (rc == HAL_I2C_ERR_TIMEOUT) {
@@ -482,6 +482,7 @@ err:
          * A clear operation is performed in case one of the devices on
          * the bus is in a bad state.
          */
+        regs->TASKS_STOP = 1;
         regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
         hal_i2c_clear_bus(regs->PSELSCL, regs->PSELSDA);
         regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;
@@ -553,11 +554,9 @@ hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     return (0);
 
 err:
-    regs->TASKS_STOP = 1;
-    regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
-
     if (regs->EVENTS_ERROR) {
         nrf_status = regs->ERRORSRC;
+        regs->TASKS_STOP = 1;
         regs->ERRORSRC = nrf_status;
         rc = hal_i2c_convert_status(nrf_status);
     } else if (rc == HAL_I2C_ERR_TIMEOUT) {
@@ -567,6 +566,8 @@ err:
         * A clear operation is performed in case one of the devices on
         * the bus is in a bad state.
         */
+        regs->TASKS_STOP = 1;
+        regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
         regs->ENABLE = TWI_ENABLE_ENABLE_Disabled;
         hal_i2c_clear_bus(regs->PSELSCL, regs->PSELSDA);
         regs->ENABLE = TWI_ENABLE_ENABLE_Enabled;


### PR DESCRIPTION
- Mynewt 1.5 changed the sequence of register operations for i2c error handling.

- This created a failure in our driver for the bno080 where an expected
read "soft error" during a reset loop was followed by an unexpected hard
error during a write.

- The old sequence of register operations restored functionality.