### PR TITLE
hw/mcu/nordic: Rework workaround for unresponsive TWI

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -410,35 +410,10 @@ hal_i2c_config(uint8_t i2c_num, const struct hal_i2c_settings *cfg)
     return 0;
 }
 
-static bool
-hal_i2c_check_scl(int pin_scl)
-{
-    uint32_t end_ticks;
-    int toggled = 0;
-
-    /*
-     * Wait a bit for low state on SCL as this indicates that controller has
-     * started writing something one the bus. It does not matter whether low
-     * state is due to START condition on bus or one of clock cycles when
-     * writing address on bus - in any case this means controller seems to
-     * write something on bus.
-     */
-
-    end_ticks = os_cputime_get32() +
-                os_cputime_usecs_to_ticks(MYNEWT_VAL(MCU_I2C_RECOVERY_DELAY_USEC));
-
-    do {
-        if (!hal_gpio_read(pin_scl)) {
-            toggled = 1;
-        }
-    } while (!toggled && CPUTIME_LT(os_cputime_get32(), end_ticks));
-
-    return toggled;
-}
-
 static inline void
 hal_i2c_trigger_start(NRF_TWI_Type *twi, __O uint32_t *task)
 {
+    uint32_t end_ticks;
     int retry = 2;
 
     /*
@@ -453,10 +428,40 @@ hal_i2c_trigger_start(NRF_TWI_Type *twi, __O uint32_t *task)
      */
 
     do {
+        twi->EVENTS_BB = 0;
         *task = 1;
-        if (hal_i2c_check_scl(twi->PSELSCL)) {
-            break;
-        }
+
+        /*
+         * Wait a bit for low state on SCL as this indicates that controller has
+         * started writing something one the bus. It does not matter whether low
+         * state is due to START condition on bus or one of clock cycles when
+         * writing address on bus - in any case this means controller seems to
+         * write something on bus.
+         */
+
+        end_ticks = os_cputime_get32() +
+                    os_cputime_usecs_to_ticks(MYNEWT_VAL(MCU_I2C_RECOVERY_DELAY_USEC));
+
+        do {
+            /*
+             * For write op controller will always keep SCL low after writing
+             * START and address on bus and until we write 1st byte of data to
+             * TXD. This allows to reliably detect activity on bus by using SCL
+             * only.
+             *
+             * For read op with only single byte to read it's possible that it
+             * will be read before we start checking SCL line and thus we'll
+             * never detect any activity this way. To avoid this, we'll also
+             * check BB event which in such case indicates that some activity
+             * on bus happened. This won't work for writes since BB is generated
+             * after byte is transmitted, so we need to use both methods to be
+             * able to handle unresponsive TWI controller for both reads and
+             * writes.
+             */
+            if (!hal_gpio_read(twi->PSELSCL) || twi->EVENTS_BB) {
+                return;
+            }
+        } while (CPUTIME_LT(os_cputime_get32(), end_ticks));
 
         twi->ENABLE = TWI_ENABLE_ENABLE_Disabled;
         /*

--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -435,7 +435,6 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     regs->SHORTS = 0;
 
     regs->TASKS_STARTTX = 1;
-    regs->TASKS_RESUME = 1;
 
     start = os_time_get();
     for (i = 0; i < pdata->len; i++) {

--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -553,7 +553,7 @@ hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 
 err:
     regs->TASKS_STOP = 1;
-    regs->SHORTS = TWI_SHORTS_BB_STOP_Msk;
+    regs->SHORTS = 0;
 
     if (regs->EVENTS_ERROR) {
         nrf_status = regs->ERRORSRC;

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -37,6 +37,14 @@ syscfg.defs:
             expected to be overridden by the BSP.
         value: 0
 
+    MCU_I2C_RECOVERY_DELAY_USEC:
+        description: >
+            Time to wait for activity on SCL line after triggering start task
+            before restarting TWI controller. This is to recover from state
+            where controller is unresponsive due to glitch on I2C bus.
+            Note: Default value seems to work fine, but may need to be tuned.
+        value: 100
+
 # MCU peripherals definitions
     I2C_0:
         description: 'Enable nRF52xxx I2C (TWI) 0'


### PR DESCRIPTION
Current workaround for unresponsive TWI will be triggered every time
there is operation timeout which has some drawbacks: it will be
applied to every operation that times out, it takes entire operation
time to recover and it will make operation fail so caller needs to
retry.

It is possible to detect this condition and apply workaround quicker
without making operation fail by using simple hack: after triggering
START task SCL line should be pulled low to make START condition and
also when address is written. We can just wait a moment to see if SCL
is pulled low during this time - if not, restart controller and try
again.

This seems to work fine with LP5523 on the bus which can be used to
easily trigger this condition by sending reset command.