### PR TITLE
hw/bus: Make proper fix for bus driver enable...

### DIFF
--- a/hw/bus/syscfg.yml
+++ b/hw/bus/syscfg.yml
@@ -21,7 +21,7 @@ syscfg.defs:
         description: >
             This indicated that hw/bus package is present in build.
             Do not override this settings.
-        value: 0
+        value: 1
 
     BUS_DEBUG_OS_DEV:
         description: >

--- a/hw/drivers/sensors/bme280/pkg.yml
+++ b/hw/drivers/sensors/bme280/pkg.yml
@@ -39,6 +39,3 @@ pkg.req_apis:
 pkg.deps.BME280_CLI:
     - "@apache-mynewt-core/util/parse"
 
-pkg.deps.BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/bus/i2c"
-    - "@apache-mynewt-core/hw/bus/spi"

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -68,14 +68,3 @@ pkg.deps.PWM_2:
 pkg.deps.PWM_3:
     - "@apache-mynewt-core/hw/drivers/pwm/pwm_nrf52"
 
-pkg.deps.I2C_0:
-    - "@apache-mynewt-core/hw/bus"
-    - "@apache-mynewt-core/hw/bus/i2c"
-
-pkg.deps.I2C_1:
-    - "@apache-mynewt-core/hw/bus"
-    - "@apache-mynewt-core/hw/bus/i2c"
-
-pkg.deps.SPI_1_MASTER:
-    - "@apache-mynewt-core/hw/bus"
-    - "@apache-mynewt-core/hw/bus/spi"

--- a/hw/sensor/pkg.yml
+++ b/hw/sensor/pkg.yml
@@ -33,12 +33,6 @@ pkg.deps.SENSOR_CLI:
     - "@apache-mynewt-core/sys/shell"
     - "@apache-mynewt-core/util/parse"
 
-# XXX probably both do not need to be always included, but let's keep it like
-# this for now to make things simpler
-pkg.deps.BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/bus/i2c"
-    - "@apache-mynewt-core/hw/bus/spi"
-
 pkg.req_apis:
     - console
     


### PR DESCRIPTION
My previous patch was just plain stupid since bus driver is enabled by
package dependencies, not by BUS_DRIVER_PRESENT which shall always be
set to 1...

So, in order to enable bus driver one has to pull proper dependencies
and other packages will just use it.