### PR TITLE
Fix nrf52 qspi erase

### DIFF
--- a/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx-compat/syscfg.yml
@@ -153,7 +153,7 @@ syscfg.defs:
         value: 0
     QSPI_FLASH_PAGE_SIZE:
         description: >
-            QSPI page size. Writes can only be perfrmed to one page at a time.
+            QSPI page size. Writes can only be performed to one page at a time.
             In most cases it should be 256.
         value: 0
 

--- a/hw/mcu/nordic/nrf52xxx/src/hal_qspi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_qspi.c
@@ -222,14 +222,20 @@ static int
 nrf52k_qspi_erase_sector(const struct hal_flash *dev,
         uint32_t sector_address)
 {
-    while ((NRF_QSPI->STATUS & QSPI_STATUS_READY_Msk) == 0)
-        ;
-    NRF_QSPI->EVENTS_READY = 0;
-    NRF_QSPI->ERASE.PTR = sector_address;
-    NRF_QSPI->ERASE.LEN = MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE);
-    NRF_QSPI->TASKS_ERASESTART = 1;
-    while (NRF_QSPI->EVENTS_READY == 0)
-        ;
+    int8_t erases;
+
+    erases = MYNEWT_VAL(QSPI_FLASH_SECTOR_SIZE) / 4096;
+    while (erases-- > 0) {
+        while ((NRF_QSPI->STATUS & QSPI_STATUS_READY_Msk) == 0)
+            ;
+        NRF_QSPI->EVENTS_READY = 0;
+        NRF_QSPI->ERASE.PTR = sector_address;
+        NRF_QSPI->ERASE.LEN = NRF_QSPI_ERASE_LEN_4KB;
+        NRF_QSPI->TASKS_ERASESTART = 1;
+        while (NRF_QSPI->EVENTS_READY == 0)
+            ;
+        sector_address += 4096;
+    }
     return 0;
 }
 

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -333,7 +333,7 @@ syscfg.defs:
         value: 0
     QSPI_FLASH_PAGE_SIZE:
         description: >
-            QSPI page size. Writes can only be perfrmed to one page at a time.
+            QSPI page size. Writes can only be performed to one page at a time.
             In most cases it should be 256.
         value: 0
 


### PR DESCRIPTION
I found this issue while trying to "emulate" a 8KB sector sized device on the QSPI flash (`QSPI_FLASH_SECTOR_SIZE: 8192`). While mcuboot was able to swap the images, the resulting image in slot1 is corrupted because not all sectors were erased. The current implementation seems to work by coincidence because the 2 LSb of 4096 are zero!