### PR TITLE
adp5061: Make charge_control dependency optional

### DIFF
--- a/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
+++ b/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
@@ -24,7 +24,9 @@
 #include "os/os_dev.h"
 #include "syscfg/syscfg.h"
 #include "os/os_time.h"
+#if MYNEWT_VAL(ADP5061_USE_CHARGE_CONTROL)
 #include "charge-control/charge_control.h"
+#endif
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
 #include "bus/bus_driver.h"
 #include "bus/i2c.h"
@@ -49,10 +51,13 @@ struct adp5061_config {
 struct adp5061_dev {
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
     struct bus_i2c_node     a_node;
+#if MYNEWT_VAL(ADP5061_USE_CHARGE_CONTROL)
+    struct charge_control   a_chg_ctrl;
+#endif
 #else
     struct os_dev           a_dev;
-#endif
     struct charge_control   a_chg_ctrl;
+#endif
     struct adp5061_config   a_cfg;
     os_time_t               a_last_read_time;
 };

--- a/hw/drivers/chg_ctrl/adp5061/pkg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/pkg.yml
@@ -27,8 +27,10 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - '@apache-mynewt-core/hw/hal'
-    - '@apache-mynewt-core/hw/charge-control'
     - '@apache-mynewt-core/hw/util/i2cn'
+
+pkg.deps.!BUS_DRIVER_PRESENT||ADP5061_USE_CHARGE_CONTROL:
+    - '@apache-mynewt-core/hw/charge-control'
 
 pkg.deps.ADP5061_CLI:
     - '@apache-mynewt-core/sys/shell'

--- a/hw/drivers/chg_ctrl/adp5061/syscfg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/syscfg.yml
@@ -39,3 +39,6 @@ syscfg.defs:
     ADP5061_CLI_DECODE:
         description: 'Decode registere fields in shell'
         value: 0
+    ADP5061_USE_CHARGE_CONTROL:
+        description: 'Enable charge control integration'
+        value: 1


### PR DESCRIPTION
This change allows to disable all code related charge_control.
It will be possible to used ADP5061 API with alternative
charging manager, possibly reducing code size of application.