### PR TITLE
fix bmp280 bme280 issues

### DIFF
--- a/hw/drivers/sensors/bme280/pkg.yml
+++ b/hw/drivers/sensors/bme280/pkg.yml
@@ -33,6 +33,9 @@ pkg.deps:
     - "@apache-mynewt-core/hw/sensor"
     - "@apache-mynewt-core/sys/log/modlog"
 
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+
 pkg.req_apis:
     - stats
 

--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -199,7 +199,7 @@ bme280_compensate_temperature(int32_t rawtemp, struct bme280_pdd *pdd)
 {
     double var1, var2, comptemp;
 
-    if (rawtemp == 0x800000) {
+    if (rawtemp == 0x80000) {
         BME280_LOG(ERROR, "Invalid temp data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
@@ -234,7 +234,7 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     double var1, var2, p;
     int32_t temp;
 
-    if (rawpress == 0x800000) {
+    if (rawpress == 0x80000) {
         BME280_LOG(ERROR, "Invalid press data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
@@ -335,8 +335,6 @@ bme280_compensate_temperature(int32_t rawtemp, struct bme280_pdd *pdd)
         return NAN;
     }
 
-    rawtemp >>= 4;
-
     var1 = ((((rawtemp>>3) - ((int32_t)pdd->bcd.bcd_dig_T1 <<1))) *
             ((int32_t)pdd->bcd.bcd_dig_T2)) >> 11;
 
@@ -366,7 +364,7 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int64_t var1, var2, p;
     int32_t temp;
 
-    if (rawpress == 0x800000) {
+    if (rawpress == 0x80000) {
         BME280_LOG(ERROR, "Invalid pressure data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
@@ -377,8 +375,6 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
             (void)bme280_compensate_temperature(temp, pdd);
         }
     }
-
-    rawpress >>= 4;
 
     var1 = ((int64_t)pdd->t_fine) - 128000;
     var2 = var1 * var1 * (int64_t)pdd->bcd.bcd_dig_P6;
@@ -976,13 +972,9 @@ bme280_get_temperature(struct sensor_itf *itf, int32_t *temp)
         goto err;
     }
 
-#if MYNEWT_VAL(BME280_SPEC_CALC)
     *temp = (int32_t)((((uint32_t)(tmp[0])) << 12) |
                       (((uint32_t)(tmp[1])) <<  4) |
                        ((uint32_t)tmp[2] >> 4));
-#else
-    *temp = ((tmp[0] << 16) | (tmp[1] << 8) | tmp[2]);
-#endif
 
     return 0;
 err:
@@ -1006,11 +998,7 @@ bme280_get_humidity(struct sensor_itf *itf, int32_t *humid)
     if (rc) {
         goto err;
     }
-#if MYNEWT_VAL(BME280_SPEC_CALC)
     *humid = (tmp[0] << 8 | tmp[1]);
-#else
-    *humid = (tmp[0] << 8 | tmp[1]);
-#endif
 
     return 0;
 err:
@@ -1035,13 +1023,9 @@ bme280_get_pressure(struct sensor_itf *itf, int32_t *press)
         goto err;
     }
 
-#if MYNEWT_VAL(BME280_SPEC_CALC)
     *press = (int32_t)((((uint32_t)(tmp[0])) << 12) |
                       (((uint32_t)(tmp[1])) <<  4)  |
                        ((uint32_t)tmp[2] >> 4));
-#else
-    *press = ((tmp[0] << 16) | (tmp[1] << 8) | tmp[2]);
-#endif
 
     return 0;
 err:

--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -409,7 +409,7 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
  */
 static float
 bme280_compensate_humidity(struct sensor_itf *itf, uint32_t rawhumid,
-                           struct bme280_calib_data *bcd)
+                           struct bme280_pdd *pdd)
 {
     int32_t h;
     int32_t temp;
@@ -421,13 +421,13 @@ bme280_compensate_humidity(struct sensor_itf *itf, uint32_t rawhumid,
         return NAN;
     }
 
-    if (!g_t_fine) {
-        if(!bme280_get_temperature(&temp)) {
-            (void)bme280_compensate_temperature(temp, bcd);
+    if (!pdd->t_fine) {
+        if(!bme280_get_temperature(itf, &temp)) {
+            (void)bme280_compensate_temperature(temp, pdd);
         }
     }
 
-    tmp32 = (g_t_fine - ((int32_t)76800));
+    tmp32 = (pdd->t_fine - ((int32_t)76800));
 
     tmp32 = (((((rawhumid << 14) - (((int32_t)pdd->bcd.bcd_dig_H4) << 20) -
              (((int32_t)pdd->bcd.bcd_dig_H5) * tmp32)) + ((int32_t)16384)) >> 15) *

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -34,7 +34,9 @@ syscfg.defs:
         description: 'Enable shell support for the BME280'
         value: 0
     BME280_SPEC_CALC:
-        description: 'BME280 Spec calculation insetad of built in one'
+        description:
+            When set to 1 compensation functions use double precission floating point arithmetic recomended by specification.
+            When set to 0 compensation functions use integer arithmetic.
         value : 1
     BME280_LOG_MODULE:
         description: 'Numeric module ID to use for BME280 log messages'

--- a/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
+++ b/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
@@ -102,7 +102,14 @@ struct bmp280_pdd {
 };
 
 struct bmp280 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    union {
+        struct bus_i2c_node i2c_node;
+        struct bus_spi_node spi_node;
+    };
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct bmp280_cfg cfg;
     struct bmp280_pdd pdd;

--- a/hw/drivers/sensors/bmp280/pkg.yml
+++ b/hw/drivers/sensors/bmp280/pkg.yml
@@ -32,8 +32,10 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/sensor"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+#pkg.deps.!BUS_DRIVER_PRESENT:
+#    - "@apache-mynewt-core/hw/util/i2cn"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -206,7 +206,7 @@ bmp280_compensate_temperature(int32_t rawtemp, struct bmp280_pdd *pdd)
 {
     double var1, var2, comptemp;
 
-    if (rawtemp == 0x800000) {
+    if (rawtemp == 0x80000) {
         BMP280_LOG(ERROR, "Invalid temp data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
@@ -241,7 +241,7 @@ bmp280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     double var1, var2, compp;
     int32_t temp;
 
-    if (rawpress == 0x800000) {
+    if (rawpress == 0x80000) {
         BMP280_LOG(ERROR, "Invalid press data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
@@ -292,13 +292,11 @@ bmp280_compensate_temperature(int32_t rawtemp, struct bmp280_pdd *pdd)
 {
     int32_t var1, var2, comptemp;
 
-    if (rawtemp == 0x800000) {
+    if (rawtemp == 0x80000) {
         BMP280_LOG(ERROR, "Invalid temp data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
     }
-
-    rawtemp >>= 4;
 
     var1 = ((((rawtemp>>3) - ((int32_t)pdd->bcd.bcd_dig_T1 <<1))) *
             ((int32_t)pdd->bcd.bcd_dig_T2)) >> 11;
@@ -330,7 +328,7 @@ bmp280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int64_t var1, var2, p;
     int32_t temp;
 
-    if (rawpress == 0x800000) {
+    if (rawpress == 0x80000) {
         BMP280_LOG(ERROR, "Invalid pressure data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
@@ -341,8 +339,6 @@ bmp280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
             (void)bmp280_compensate_temperature(temp, pdd);
         }
     }
-
-    rawpress >>= 4;
 
     var1 = ((int64_t)pdd->t_fine) - 128000;
     var2 = var1 * var1 * (int64_t)pdd->bcd.bcd_dig_P6;
@@ -996,13 +992,9 @@ bmp280_get_temperature(struct sensor_itf *itf, int32_t *temp)
         goto err;
     }
 
-#if MYNEWT_VAL(BMP280_SPEC_CALC)
     *temp = (int32_t)((((uint32_t)(tmp[0])) << 12) |
                       (((uint32_t)(tmp[1])) <<  4) |
                        ((uint32_t)tmp[2] >> 4));
-#else
-    *temp = ((tmp[0] << 16) | (tmp[1] << 8) | tmp[2]);
-#endif
 
     return 0;
 err:
@@ -1027,13 +1019,9 @@ bmp280_get_pressure(struct sensor_itf *itf, int32_t *press)
         goto err;
     }
 
-#if MYNEWT_VAL(BMP280_SPEC_CALC)
     *press = (int32_t)((((uint32_t)(tmp[0])) << 12) |
                       (((uint32_t)(tmp[1])) <<  4)  |
                        ((uint32_t)tmp[2] >> 4));
-#else
-    *press = ((tmp[0] << 16) | (tmp[1] << 8) | tmp[2]);
-#endif
 
     return 0;
 err:

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -37,7 +37,9 @@ syscfg.defs:
         description: 'Enable shell support for the BMP280'
         value: 0
     BMP280_SPEC_CALC:
-        description: 'BMP280 Spec calculation instead of built in one'
+        description:
+            When set to 1 compensation functions use double precission floating point arithmetic recomended by specification.
+            When set to 0 compensation functions use integer arithmetic.
         value : 1
     BMP280_ITF_LOCK_TMO:
         description: 'BMP280 interface lock timeout in milliseconds'


### PR DESCRIPTION
There were couple of issues in bme280 and bmp280 drivers:
- unneeded difference of return value of temperature and pressure between different compilation variants
- unclear syscfg description
- incorrect constant was used to check for invalid value of temperature and pressure
- computation of pressure and humidity could be incorrect if temperature was not requested by the user of was read at very slow rate