### PR TITLE
hw/bus: Updates, fixes...

### DIFF
--- a/hw/bus/include/bus/bus.h
+++ b/hw/bus/include/bus/bus.h
@@ -221,7 +221,7 @@ bus_node_unlock(struct os_dev *node);
 /**
  * Get node configured lock timeout
  *
- * Returns lock timeout as configured for node. If not timeout is configured for
+ * Returns lock timeout as configured for node. If no timeout is configured for
  * give node or no node is specified, default timeout is returned.
  *
  * @param node  Node to get timeout for

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -22,6 +22,9 @@
 
 #include <stdint.h>
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BUS_STATS)
+#include "stats/stats.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,6 +32,16 @@ extern "C" {
 
 struct bus_dev;
 struct bus_node;
+
+#if MYNEWT_VAL(BUS_STATS)
+STATS_SECT_START(bus_stats_section)
+    STATS_SECT_ENTRY(lock_timeouts)
+    STATS_SECT_ENTRY(read_ops)
+    STATS_SECT_ENTRY(read_errors)
+    STATS_SECT_ENTRY(write_ops)
+    STATS_SECT_ENTRY(write_errors)
+STATS_SECT_END
+#endif
 
 /**
  * Bus device operations
@@ -88,6 +101,10 @@ struct bus_dev {
     struct os_mutex lock;
     struct bus_node *configured_for;
 
+#if MYNEWT_VAL(BUS_STATS)
+    STATS_SECT_DECL(bus_stats_section) stats;
+#endif
+
 #if MYNEWT_VAL(BUS_DEBUG_OS_DEV)
     uint32_t devmagic;
 #endif
@@ -111,6 +128,10 @@ struct bus_node {
         struct bus_dev *parent_bus;
         void *init_arg;
     };
+
+#if MYNEWT_VAL(BUS_STATS_PER_NODE)
+    STATS_SECT_DECL(bus_stats_section) stats;
+#endif
 
 #if MYNEWT_VAL(BUS_DEBUG_OS_DEV)
     uint32_t nodemagic;

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -86,6 +86,8 @@ struct bus_node_callbacks {
 struct bus_node_cfg {
     /** Bus device name where node is attached */
     const char *bus_name;
+    /** Lock timeout [ms], 0 = default timeout */
+    uint16_t lock_timeout_ms;
 };
 
 /**
@@ -128,6 +130,8 @@ struct bus_node {
         struct bus_dev *parent_bus;
         void *init_arg;
     };
+
+    os_time_t lock_timeout;
 
 #if MYNEWT_VAL(BUS_STATS_PER_NODE)
     STATS_SECT_DECL(bus_stats_section) stats;

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -167,6 +167,13 @@ bus_node_init_func(struct os_dev *odev, void *arg)
     init_arg = bnode->init_arg;
     bnode->parent_bus = (struct bus_dev *)parent_odev;
 
+    if (node_cfg->lock_timeout_ms) {
+        bnode->lock_timeout = os_time_ms_to_ticks32(node_cfg->lock_timeout_ms);
+    } else {
+        /* Use default */
+        bnode->lock_timeout = 0;
+    }
+
     odev->od_handlers.od_open = bus_node_open_func;
     odev->od_handlers.od_close = bus_node_close_func;
 
@@ -362,7 +369,9 @@ bus_node_unlock(struct os_dev *node)
 os_time_t
 bus_node_get_lock_timeout(struct os_dev *node)
 {
-    return g_bus_node_lock_timeout;
+    struct bus_node *bnode = (struct bus_node *)node;
+
+    return bnode->lock_timeout ? bnode->lock_timeout : g_bus_node_lock_timeout;
 }
 
 void

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -147,7 +147,7 @@ bus_node_read(struct os_dev *node, void *buf, uint16_t length,
         return SYS_ENOTSUP;
     }
 
-    rc = bus_node_lock(node, g_bus_node_lock_timeout);
+    rc = bus_node_lock(node, bus_node_get_lock_timeout(node));
     if (rc) {
         return rc;
     }
@@ -174,7 +174,7 @@ bus_node_write(struct os_dev *node, const void *buf, uint16_t length,
         return SYS_ENOTSUP;
     }
 
-    rc = bus_node_lock(node, g_bus_node_lock_timeout);
+    rc = bus_node_lock(node, bus_node_get_lock_timeout(node));
     if (rc) {
         return rc;
     }
@@ -202,7 +202,7 @@ bus_node_write_read_transact(struct os_dev *node, const void *wbuf,
         return SYS_ENOTSUP;
     }
 
-    rc = bus_node_lock(node, g_bus_node_lock_timeout);
+    rc = bus_node_lock(node, bus_node_get_lock_timeout(node));
     if (rc) {
         return rc;
     }

--- a/hw/bus/syscfg.yml
+++ b/hw/bus/syscfg.yml
@@ -32,6 +32,18 @@ syscfg.defs:
             transaction APIs (i.e. without timeout set explicitly)
         value: 50
 
+    BUS_STATS:
+        description: >
+            Enable statistics for bus devices. By default only global per-device
+            statistics are enabled. Use BUS_STATS_PER_NODE to enable statistics
+            for each node also.
+        value: 0
+    BUS_STATS_PER_NODE:
+        description: >
+            Enable per-node statistics for each bus node.
+        value: 0
+        restrictions: BUS_STATS
+
     BUS_DEBUG_OS_DEV:
         description: >
             Enable additional debugging for os_dev objects.

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -274,6 +274,9 @@ struct lis2dh12 {
     struct lis2dh12_int intr;
     os_time_t last_read_time;
     struct lis2dh12_pdd pdd;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    bool node_is_spi;
+#endif
 };
 
 /**

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12_priv.h
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12_priv.h
@@ -171,8 +171,8 @@ extern "C" {
 #define LIS2DH12_REG_ACT_DUR                 0x3F
 
 #define LIS2DH12_SPI_READ_CMD_BIT            0x80
-
-#define LIS2DH12_SPI_ADR_INC                 0x40
+#define LIS2DH12_SPI_ADDR_INC                0x40
+#define LIS2DH12_I2C_ADDR_INC                0x80
 
 int lis2dh12_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload, uint8_t len);
 int lis2dh12_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload, uint8_t len);

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -285,6 +285,9 @@ struct lis2dw12 {
     struct lis2dw12_cfg cfg;
     struct lis2dw12_int intr;
     struct lis2dw12_pdd pdd;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    bool node_is_spi;
+#endif
 };
 
 /**

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -515,6 +515,12 @@ lis2dw12_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     int rc;
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct lis2dw12 *dev = (struct lis2dw12 *)itf->si_dev;
+
+    if (dev->node_is_spi) {
+        reg |= LIS2DW12_SPI_READ_CMD_BIT;
+    }
+
     rc = bus_node_simple_write_read_transact(itf->si_dev, &reg, 1, buffer, len);
 #else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LIS2DW12_ITF_LOCK_TMO));
@@ -3362,10 +3368,13 @@ lis2dw12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
                                const struct bus_i2c_node_cfg *i2c_cfg,
                                struct sensor_itf *sensor_itf)
 {
+    struct lis2dw12 *dev = (struct lis2dw12 *)node;
     struct bus_node_callbacks cbs = {
         .init = init_node_cb,
     };
     int rc;
+
+    dev->node_is_spi = false;
 
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
@@ -3379,10 +3388,13 @@ lis2dw12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
                                const struct bus_spi_node_cfg *spi_cfg,
                                struct sensor_itf *sensor_itf)
 {
+    struct lis2dw12 *dev = (struct lis2dw12 *)node;
     struct bus_node_callbacks cbs = {
         .init = init_node_cb,
     };
     int rc;
+
+    dev->node_is_spi = true;
 
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 

--- a/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
+++ b/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
@@ -82,7 +82,10 @@ struct lps33hw_private_driver_data {
 
 struct lps33hw {
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    struct bus_i2c_node i2c_node;
+    union {
+        struct bus_i2c_node i2c_node;
+        struct bus_spi_node spi_node;
+    };
 #else
     struct os_dev dev;
 #endif
@@ -90,6 +93,9 @@ struct lps33hw {
     struct lps33hw_cfg cfg;
     os_time_t last_read_time;
     struct lps33hw_private_driver_data pdd;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    bool node_is_spi;
+#endif
 };
 
 /**
@@ -234,6 +240,21 @@ int lps33hw_shell_init(void);
 int
 lps33hw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
                               const struct bus_i2c_node_cfg *i2c_cfg,
+                              struct sensor_itf *sensor_itf);
+
+/**
+ * Create SPI bus node for LPS33HW sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param spi_cfg     SPI node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int
+lps33hw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                              const struct bus_spi_node_cfg *spi_cfg,
                               struct sensor_itf *sensor_itf);
 #endif
 

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -404,6 +404,12 @@ lps33hw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     int rc;
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct lps33hw *dev = (struct lps33hw *)itf->si_dev;
+
+    if (dev->node_is_spi) {
+        reg |= LPS33HW_SPI_READ_CMD_BIT;
+    }
+
     rc = bus_node_simple_write_read_transact(itf->si_dev, &reg, 1, buffer, size);
 #else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33HW_ITF_LOCK_TMO));
@@ -1121,14 +1127,37 @@ lps33hw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
                               const struct bus_i2c_node_cfg *i2c_cfg,
                               struct sensor_itf *sensor_itf)
 {
+    struct lps33hw *dev = (struct lps33hw *)node;
     struct bus_node_callbacks cbs = {
         .init = init_node_cb,
     };
     int rc;
 
+    dev->node_is_spi = false;
+
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
+
+    return rc;
+}
+
+int
+lps33hw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                              const struct bus_spi_node_cfg *spi_cfg,
+                              struct sensor_itf *sensor_itf)
+{
+    struct lps33hw *dev = (struct lps33hw *)node;
+    struct bus_node_callbacks cbs = {
+        .init = init_node_cb,
+    };
+    int rc;
+
+    dev->node_is_spi = true;
+
+    bus_node_set_callbacks((struct os_dev *)node, &cbs);
+
+    rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);
 
     return rc;
 }

--- a/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
+++ b/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
@@ -94,6 +94,9 @@ struct lps33thw {
     struct lps33thw_cfg cfg;
     os_time_t last_read_time;
     struct lps33thw_private_driver_data pdd;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    bool node_is_spi;
+#endif
 };
 
 /**

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -411,6 +411,12 @@ lps33thw_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     int rc;
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct lps33thw *dev = (struct lps33thw *)itf->si_dev;
+
+    if (dev->node_is_spi) {
+        reg |= LPS33THW_SPI_READ_CMD_BIT;
+    }
+
     rc = bus_node_simple_write_read_transact(itf->si_dev, &reg, 1, buffer, size);
 #else
     rc = sensor_itf_lock(itf, MYNEWT_VAL(LPS33THW_ITF_LOCK_TMO));
@@ -1128,10 +1134,13 @@ lps33thw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
                                const struct bus_i2c_node_cfg *i2c_cfg,
                                struct sensor_itf *sensor_itf)
 {
+    struct lps33thw *dev = (struct lps33thw *)node;
     struct bus_node_callbacks cbs = {
         .init = init_node_cb,
     };
     int rc;
+
+    dev->node_is_spi = false;
 
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
@@ -1145,10 +1154,13 @@ lps33thw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
                                const struct bus_spi_node_cfg *spi_cfg,
                                struct sensor_itf *sensor_itf)
 {
+    struct lps33thw *dev = (struct lps33thw *)node;
     struct bus_node_callbacks cbs = {
         .init = init_node_cb,
     };
     int rc;
+
+    dev->node_is_spi = true;
 
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 


### PR DESCRIPTION
small batch of fixes for bus driver (some "inherited" from previous PR) and new features: statistics and per-node lock timeout

two kinds of statistics can be enabled: cumulative statistics for each bus device or statistics for each node. those include read, write ops and errors as well as lock timeouts.