### PR TITLE
hw/drivers: Fix spiflash initialization function

### DIFF
--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -1011,6 +1011,8 @@ spiflash_init(const struct hal_flash *hal_flash_dev)
 
     hal_gpio_init_out(dev->ss_pin, 1);
 
+    (void)hal_spi_disable(dev->spi_num);
+
     rc = hal_spi_config(dev->spi_num, &dev->spi_settings);
     if (rc) {
         return (rc);


### PR DESCRIPTION
Nordic hal requrires SPI to be disabled before hal_spi_config() is called.
hal_spi_disable() is called just before hal_spi_config() to satisfy this.