### PR TITLE
spiflash bus driver support

### DIFF
--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -25,6 +25,9 @@
 #endif
 #include <hal/hal_flash_int.h>
 #include <hal/hal_spi.h>
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include <bus/drivers/spi_common.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,10 +35,14 @@ extern "C" {
 
 struct spiflash_dev {
     struct hal_flash hal;
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_spi_node dev;
+#else
     struct hal_spi_settings spi_settings;
     int spi_num;
     void *spi_cfg;                  /** Low-level MCU SPI config */
     int ss_pin;
+#endif
     uint16_t sector_size;
     uint16_t page_size;
     /* Array of supported flash chips */
@@ -108,6 +115,11 @@ void spiflash_power_down(struct spiflash_dev *dev);
 void spiflash_release_power_down(struct spiflash_dev *dev);
 
 int spiflash_auto_power_down_set(struct spiflash_dev *dev, uint32_t timeout_ms);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+int spiflash_create_spi_dev(struct bus_spi_node *node, const char *name,
+                            const struct bus_spi_node_cfg *spi_cfg);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -1074,7 +1074,7 @@ spiflash_identify(struct spiflash_dev *dev)
 
     /* Only one chip specified, no need for search*/
     if ((sizeof(supported_chips) / sizeof(supported_chips[0])) == 2) {
-        spiflash_release_power_down_generic(dev);
+        supported_chips[0].fc_release_power_down(dev);
         spiflash_read_jedec_id(dev, &manufacturer, &memory_type, &capacity);
         /* If BSP defined SpiFlash manufacturer or memory type does not
          * match SpiFlash is most likely not connected, connected to


### PR DESCRIPTION
Code to enable bus driver in spiflash.

To use this bus package must be included and hal should add spiflash device with
call to bus_spi_node_create() with correct SPI parameters.