### PR TITLE
bsp/hifive1: Fix linker warning

### DIFF
--- a/hw/bsp/hifive1/bsp.yml
+++ b/hw/bsp/hifive1/bsp.yml
@@ -20,11 +20,11 @@
 bsp.arch: rv32imac
 bsp.compiler: compiler/riscv64
 bsp.linkerscript:
-    - "hw/bsp/hifive1/hifive1.ld"
     - "hw/bsp/hifive1/hifive1_app.ld"
-bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/hifive1/hifive1.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/hifive1/hifive1_boot.ld"
+    - "hw/bsp/hifive1/hifive1.ld"
 bsp.downloadscript: "hw/bsp/hifive1/hifive1_download.sh"
 bsp.debugscript: "hw/bsp/hifive1/hifive1_debug.sh"
 


### PR DESCRIPTION
Order of linker script entries in bsp.yml result in warning that is
visible during build only when some other link error happens.
repos/apache-mynewt-core/hw/bsp/hifive1/hifive1.ld:32: warning: memory region `flash' not declared
repos/apache-mynewt-core/hw/bsp/hifive1/hifive1.ld:131: warning: memory region `ram' not declared
repos/apache-mynewt-core/hw/bsp/hifive1/hifive1_boot.ld:22: warning: redeclaration of memory region `flash'
repos/apache-mynewt-core/hw/bsp/hifive1/hifive1_boot.ld:23: warning: redeclaration of memory region `ram'
Changing order of entries in bsp fixes this.