### PR TITLE
Export `id/target` setting if configured

### DIFF
--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -94,6 +94,10 @@ id_conf_get(int argc, char **argv, char *val, int val_len_max)
         } else if (!strcmp(argv[0], "model")) {
             return (char *)id_model;
 #endif
+#if MYNEWT_VAL(ID_TARGET_PRESENT)
+        } else if (!strcmp(argv[0], "target")) {
+            return MYNEWT_VAL(TARGET_NAME);
+#endif
         } else if (!strcmp(argv[0], "mfghash")) {
             return id_mfghash;
         }
@@ -141,6 +145,9 @@ id_conf_export(void (*export_func)(char *name, char *val),
         export_func("id/bsp", (char *)id_bsp_str);
         export_func("id/app", (char *)id_app_str);
         export_func("id/mfghash", (char *)id_mfghash);
+#if MYNEWT_VAL(ID_TARGET_PRESENT)
+        export_func("id/target", MYNEWT_VAL(TARGET_NAME));
+#endif
     }
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
     export_func("id/serial", id_serial);

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -45,3 +45,10 @@ syscfg.defs:
         value: 0
         restrictions:
             - 'ID_MODEL_PRESENT'
+
+    ID_TARGET_PRESENT:
+        description: 'Target name string exported as `id/target`.'
+        value: 0
+        restrictions:
+            # Older versions of newt don't export the target name.
+            - 'TARGET_NAME'


### PR DESCRIPTION
NOTE: This PR requires a newt PR to be merged first: https://github.com/apache/mynewt-newt/pull/250.  This PR won't break anything for older newt versions, but the feature won't work.

If the `ID_TARGET_PRESENT` syscfg setting is enabled, the target name is readable through the `id/target` config setting.

This feature requires a recent version of newt (prior versions did not inject the target name into the syscfg).  If an old version of newt is used in a build where `ID_TARGET_PRESENT` is enabled, the build will fail with a syscfg restriction violation error.