### PR TITLE
[Do Not Merge] - Change HAL I2C driver to use TWIM+EasyDMA

### DIFF
--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -58,7 +58,11 @@ struct bus_dev_ops {
                  uint16_t length, os_time_t timeout, uint16_t flags);
     /* Write data to node */
     int (* write)(struct bus_dev *dev, struct bus_node *node, const uint8_t *buf,
-                  uint16_t length, os_time_t timeout,  uint16_t flags);
+                  uint16_t length, os_time_t timeout, uint16_t flags);
+    /* Write and read data to node */
+    int (* write_read)(struct bus_dev *dev, struct bus_node *node, const uint8_t *wbuf,
+                       uint16_t wlength, const uint8_t *rbuf, uint16_t rlength,
+                       os_time_t timeout,  uint16_t flags);
     /* Disable bus device */
     int (* disable)(struct bus_dev *bus);
 };

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -276,6 +276,7 @@ bus_node_write_read_transact(struct os_dev *node, const void *wbuf,
         return rc;
     }
 
+#if 0
     /*
      * XXX we probably should pass flags here but with some of them stripped,
      * e.g. BUS_F_NOSTOP should not be present here, but since we do not have
@@ -295,6 +296,17 @@ bus_node_write_read_transact(struct os_dev *node, const void *wbuf,
         BUS_STATS_INC(bdev, bnode, read_errors);
         goto done;
     }
+#else
+    BUS_STATS_INC(bdev, bnode, write_ops);
+    BUS_STATS_INC(bdev, bnode, read_ops);
+    rc = bdev->dops->write_read(bdev, bnode, wbuf, wlength,
+                                rbuf, rlength, timeout, flags);
+    if (rc) {
+        BUS_STATS_INC(bdev, bnode, read_errors);
+        goto done;
+    }
+
+#endif
 
 done:
     (void)bus_node_unlock(node);

--- a/hw/hal/include/hal/hal_i2c.h
+++ b/hw/hal/include/hal/hal_i2c.h
@@ -79,6 +79,9 @@ extern "C" {
 /** Slave responded to data byte with NACK. */
 #define HAL_I2C_ERR_DATA_NACK           5
 
+/** Overrun error */
+#define HAL_I2C_ERR_OVERRUN             6
+
 /** I2C controller hardware settings */
 struct hal_i2c_hw_settings {
     int pin_scl;
@@ -90,6 +93,9 @@ struct hal_i2c_settings {
     /** Frequency in kHz */
     uint32_t frequency;
 };
+
+/* Prototype for tx/rx callback */
+typedef void (*hal_i2c_txrx_cb)(void *arg);
 
 /**
  * When sending a packet, use this structure to pass the arguments.
@@ -107,10 +113,14 @@ struct hal_i2c_master_data {
      * only the top 7-bits to this function as 0x40
      */
     uint8_t  address;
-    /** Number of buffer bytes to transmit or receive */
+    /** Number of bytes to transmit or receive using buffer */
     uint16_t len;
+    /** Number of bytes to receive using buffer2 during double buffered transactions */
+    uint16_t len2;
     /** Buffer space to hold the transmit or receive */
     uint8_t *buffer;
+    /** Buffer space to hold the receive data during double buffered transactions */
+    uint8_t *buffer2;
 };
 
 /**
@@ -219,6 +229,9 @@ int hal_i2c_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
  */
 int hal_i2c_master_probe(uint8_t i2c_num, uint8_t address,
                          uint32_t timeout);
+int
+hal_i2c_master_write_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata, uint32_t timo);
+
 
 #ifdef __cplusplus
 }

--- a/hw/util/i2cn/include/i2cn/i2cn.h
+++ b/hw/util/i2cn/include/i2cn/i2cn.h
@@ -64,6 +64,11 @@ int i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 int i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                       uint32_t timeout, uint8_t last_op, int retries);
 
+
+int
+i2cn_master_write_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                       uint32_t timeout, int retries);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/util/i2cn/src/i2cn.c
+++ b/hw/util/i2cn/src/i2cn.c
@@ -63,3 +63,26 @@ i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 
     return rc;
 }
+
+int
+i2cn_master_write_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
+                       uint32_t timeout, int retries)
+{
+    int rc = 0;
+    int i;
+
+    /* Ensure at least one try. */
+    if (retries < 0) {
+        retries = 0;
+    }
+
+    for (i = 0; i <= retries; i++) {
+        rc = hal_i2c_master_write_read(i2c_num, pdata, timeout);
+        if (rc == 0) {
+            break;
+        }
+//        console_printf("wr addr: %02x n: %u rc: %d\n", pdata->address, retries, rc);
+    }
+
+    return rc;
+}

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -330,5 +330,3 @@ shell_log_storage_cmd(int argc, char **argv)
 #endif
 
 #endif
-
-


### PR DESCRIPTION
This PR is a first draft of a TWIM-EasyDMA driver for I2C, which uses interrupts and an OS semaphore to provide non-blocking capability. 

Some improvements will be required before it is ready to merge. The OS semaphore should probably not reside in the driver, but instead the driver should provide for registering 1 or more callbacks so that a semaphore or other synchronization mechanism may reside in a higher layer such as the bus driver. 

A decision will need to be made about whether this driver is added along side the existing blocking TWI driver, or should become a replacement for it. Since the nRF51 has only the TWI, it probably makes sense to keep some version of driver for both TWI and TWIM. How that gets implemented is TBD.

**Known Issues:**
* An I2C timeout followed by a ADDR_NAK error will happen during BSP init (after the LP5523 is reset), and once before the pod remove and pod insert animations. These errors might also exist with the existing TWI driver.
* An I2C timeout happens after the bq27x561 is enabled. This might also exist with the TWI driver.
* The driver uses <console_printf> to display I2C errors. This is temporary debug code. 
* The code expects the bus driver to be enabled and won't build with <BUS_DRIVER_PRESENT: 0>
* The workaround for TWIM Anomaly 109 is not implemented. To my knowledge, this anomaly should only appear if PPI is configured to start TWIM transactions. We don't use PPI with TWIM, so a workaround shouldn't be needed.
* The TWI driver uses a workaround that disables/enables the TWI peripheral if it becomes unresponsive. This workaround has been left in place for now (and should do no harm), though the TWIM may not require it. 