### PR TITLE
Redefine `flash_area_close()` as an empty macro

### DIFF
--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -75,7 +75,8 @@ void flash_map_init(void);
  */
 int flash_area_open(uint8_t id, const struct flash_area **);
 
-void flash_area_close(const struct flash_area *);
+/** nothing to do for now */
+#define flash_area_close(flash_area)
 
 /*
  * Read/write/erase. Offset is relative from beginning of flash area.

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -52,12 +52,6 @@ flash_area_open(uint8_t id, const struct flash_area **fap)
     return SYS_ENOENT;
 }
 
-void
-flash_area_close(const struct flash_area *fa)
-{
-    /* nothing to do for now */
-}
-
 int
 flash_area_to_sectors(int id, int *cnt, struct flash_area *ret)
 {


### PR DESCRIPTION
Prior to this PR, `flash_area_close()` was a function with an emptybody.

To save code space in the boot loader, remove this function, and define it as an empty macro instead.  If `flash_area_close()` ever needs to perform a task, the macro can be removed and the function re-implemented.

In my setup, this reduced the size of the boot loader from 16028 to 15876.