### PR TITLE
sys/flash_map: Don't replace default flash map with empty flash map

### DIFF
--- a/sys/fault/src/fault.c
+++ b/sys/fault/src/fault.c
@@ -20,7 +20,6 @@
 #include "os/mynewt.h"
 
 #include "modlog/modlog.h"
-#include "data_recorder/faults.h"
 #include "fault/fault.h"
 #include "fault_priv.h"
 

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -423,7 +423,7 @@ flash_map_init(void)
      */
     rc = flash_map_read_mfg(sizeof mfg_areas / sizeof mfg_areas[0],
                             mfg_areas, &num_areas);
-    if (rc == 0) {
+    if (rc == 0 && num_areas > 0) {
         flash_map = mfg_areas;
         flash_map_entries = num_areas;
     }


### PR DESCRIPTION
If no flash areas were found in the MMR, keep using the hardcoded flash map instead of an empty one.