### PR TITLE
hw/bus: Simplify bus driver creation and usage

### DIFF
--- a/hw/battery/include/battery/battery_drv.h
+++ b/hw/battery/include/battery/battery_drv.h
@@ -30,9 +30,8 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #endif
 
 #ifdef __cplusplus

--- a/hw/bus/drivers/i2c_common/include/bus/drivers/i2c_common.h
+++ b/hw/bus/drivers/i2c_common/include/bus/drivers/i2c_common.h
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-#ifndef HW_BUS_I2C_H_
-#define HW_BUS_I2C_H_
+#ifndef HW_BUS_DRIVERS_I2C_COMMON_H_
+#define HW_BUS_DRIVERS_I2C_COMMON_H_
 
 #include <stddef.h>
 #include <stdint.h>
 #include "bus/bus.h"
 #include "bus/bus_driver.h"
+#include "bus/bus_debug.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,20 +45,6 @@ struct bus_i2c_dev_cfg {
 };
 
 /**
- * Bus I2C node configuration
- */
-struct bus_i2c_node_cfg {
-    /** General node configuration */
-    struct bus_node_cfg node_cfg;
-    /** I2C address of node */
-    uint8_t addr;
-    /** I2C frequency to be used for node */
-    uint16_t freq;
-    /** Quirks to be applied for device */
-    uint16_t quirks;
-};
-
-/**
  * Bus I2C device object state
  *
  * Contents of these objects are managed internally by bus driver and shall not
@@ -70,6 +57,20 @@ struct bus_i2c_dev {
 #if MYNEWT_VAL(BUS_DEBUG_OS_DEV)
     uint32_t devmagic;
 #endif
+};
+
+/**
+ * Bus I2C node configuration
+ */
+struct bus_i2c_node_cfg {
+    /** General node configuration */
+    struct bus_node_cfg node_cfg;
+    /** I2C address of node */
+    uint8_t addr;
+    /** I2C frequency to be used for node */
+    uint16_t freq;
+    /** Quirks to be applied for device */
+    uint16_t quirks;
 };
 
 /**
@@ -88,39 +89,6 @@ struct bus_i2c_node {
     uint32_t nodemagic;
 #endif
 };
-
-/**
- * Initialize os_dev as bus I2C device
- *
- * This can be passed as a parameter to os_dev_create() when creating os_dev
- * object for I2C device, however it's recommended to create devices using helper
- * like bus_i2c_dev_create().
- *
- * @param node  Node device object
- * @param arg   Node configuration struct (struct bus_node_cfg)
- */
-int
-bus_i2c_dev_init_func(struct os_dev *odev, void *arg);
-
-/**
- * Create bus I2C device
- *
- * This is a convenient helper and recommended way to create os_dev for bus I2C
- * device instead of calling os_dev_create() directly.
- *
- * @param name  Name of device
- * @param dev   Device state object
- * @param cfg   Configuration
- */
-static inline int
-bus_i2c_dev_create(const char *name, struct bus_i2c_dev *dev,
-                   struct bus_i2c_dev_cfg *cfg)
-{
-    struct os_dev *odev = (struct os_dev *)dev;
-
-    return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 0,
-                         bus_i2c_dev_init_func, cfg);
-}
 
 /**
  * Create bus I2C node
@@ -149,4 +117,4 @@ bus_i2c_node_create(const char *name, struct bus_i2c_node *node,
 }
 #endif
 
-#endif /* HW_BUS_I2C_H_ */
+#endif /* HW_BUS_DRIVERS_I2C_COMMON_H_ */

--- a/hw/bus/drivers/i2c_common/pkg.yml
+++ b/hw/bus/drivers/i2c_common/pkg.yml
@@ -17,29 +17,11 @@
 # under the License.
 #
 
-pkg.name: hw/drivers/bq27z561
-pkg.description: Driver for the BQ27Z561 fuel gauge
+pkg.name: hw/bus/drivers/i2c_common
+pkg.description: Common definitions for I2C bus drivers
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - bq27z561
-    - i2c
-    - fuel_gauge
 
 pkg.deps:
-    - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/hw/battery"
-    - "@apache-mynewt-core/sys/log/modlog"
-
-pkg.deps.!BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/util/i2cn"
-pkg.deps.BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
-
-pkg.req_apis:
-    - stats
-
-pkg.deps.BQ27Z561_CLI:
-    - "@apache-mynewt-core/util/parse"
-
-pkg.init:
-    bq27z561_pkg_init: 'MYNEWT_VAL(BQ27Z561_SYSINIT_STAGE)'
+    - hw/bus

--- a/hw/bus/drivers/i2c_hal/include/bus/drivers/i2c_hal.h
+++ b/hw/bus/drivers/i2c_hal/include/bus/drivers/i2c_hal.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HW_BUS_DRIVERS_I2C_HAL_H_
+#define HW_BUS_DRIVERS_I2C_HAL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include "os/os_dev.h"
+#include "bus/drivers/i2c_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize os_dev as I2C bus device using i2c_hal driver
+ *
+ * This can be passed as a parameter to os_dev_create() when creating os_dev
+ * object for I2C device, however it's recommended to create devices using helper
+ * like bus_i2c_hal_dev_create().
+ *
+ * @param node  Node device object
+ * @param arg   Node configuration struct (struct bus_node_cfg)
+ */
+int
+bus_i2c_hal_dev_init_func(struct os_dev *odev, void *arg);
+
+/**
+ * Create I2C bus device using i2c_hal driver
+ *
+ * This is a convenient helper and recommended way to create os_dev for bus I2C
+ * device instead of calling os_dev_create() directly.
+ *
+ * @param name  Name of device
+ * @param dev   Device state object
+ * @param cfg   Configuration
+ */
+static inline int
+bus_i2c_hal_dev_create(const char *name, struct bus_i2c_dev *dev,
+                       struct bus_i2c_dev_cfg *cfg)
+{
+    struct os_dev *odev = (struct os_dev *)dev;
+
+    return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 0,
+                         bus_i2c_hal_dev_init_func, cfg);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HW_BUS_DRIVERS_I2C_HAL_H_ */

--- a/hw/bus/drivers/i2c_hal/pkg.yml
+++ b/hw/bus/drivers/i2c_hal/pkg.yml
@@ -17,9 +17,12 @@
 # under the License.
 #
 
-pkg.name: hw/bus/i2c
-pkg.description: I2C bus implementation
+pkg.name: hw/bus/drivers/i2c_hal
+pkg.description: I2C bus driver using hal_i2c
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+
 pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/i2c_common

--- a/hw/bus/drivers/i2c_hal/src/i2c_hal.c
+++ b/hw/bus/drivers/i2c_hal/src/i2c_hal.c
@@ -207,10 +207,10 @@ bus_i2c_hal_dev_init_func(struct os_dev *odev, void *arg)
         return SYS_EINVAL;
     }
 
+    dev->cfg = *cfg;
+
     rc = bus_dev_init_func(odev, (void*)&bus_i2c_hal_ops);
     assert(rc == 0);
-
-    dev->cfg = *cfg;
 
     return 0;
 }

--- a/hw/bus/drivers/i2c_hal/src/i2c_hal.c
+++ b/hw/bus/drivers/i2c_hal/src/i2c_hal.c
@@ -23,7 +23,7 @@
 #include "hal/hal_i2c.h"
 #include "bus/bus.h"
 #include "bus/bus_debug.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_hal.h"
 
 static int
 bus_i2c_translate_hal_error(int hal_err)
@@ -178,7 +178,7 @@ static int bus_i2c_disable(struct bus_dev *bdev)
     return 0;
 }
 
-static const struct bus_dev_ops bus_i2c_ops = {
+static const struct bus_dev_ops bus_i2c_hal_ops = {
     .init_node = bus_i2c_init_node,
     .enable = bus_i2c_enable,
     .configure = bus_i2c_configure,
@@ -188,7 +188,7 @@ static const struct bus_dev_ops bus_i2c_ops = {
 };
 
 int
-bus_i2c_dev_init_func(struct os_dev *odev, void *arg)
+bus_i2c_hal_dev_init_func(struct os_dev *odev, void *arg)
 {
     struct bus_i2c_dev *dev = (struct bus_i2c_dev *)odev;
     struct bus_i2c_dev_cfg *cfg = arg;
@@ -207,7 +207,7 @@ bus_i2c_dev_init_func(struct os_dev *odev, void *arg)
         return SYS_EINVAL;
     }
 
-    rc = bus_dev_init_func(odev, (void*)&bus_i2c_ops);
+    rc = bus_dev_init_func(odev, (void*)&bus_i2c_hal_ops);
     assert(rc == 0);
 
     dev->cfg = *cfg;

--- a/hw/bus/drivers/spi_common/include/bus/drivers/spi_common.h
+++ b/hw/bus/drivers/spi_common/include/bus/drivers/spi_common.h
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#ifndef HW_BUS_SPI_H_
-#define HW_BUS_SPI_H_
+#ifndef HW_BUS_DRIVERS_SPI_COMMON_H_
+#define HW_BUS_DRIVERS_SPI_COMMON_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -83,19 +83,6 @@ struct bus_spi_node {
 #endif
 };
 
-int
-bus_spi_dev_init_func(struct os_dev *odev, void *arg);
-
-static inline int
-bus_spi_dev_create(const char *name, struct bus_spi_dev *dev,
-                   struct bus_spi_dev_cfg *cfg)
-{
-    struct os_dev *odev = (struct os_dev *)dev;
-
-    return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 0,
-                         bus_spi_dev_init_func, cfg);
-}
-
 static inline int
 bus_spi_node_create(const char *name, struct bus_spi_node *node,
                     const struct bus_spi_node_cfg *cfg, void *arg)
@@ -113,4 +100,4 @@ bus_spi_node_create(const char *name, struct bus_spi_node *node,
 }
 #endif
 
-#endif /* HW_BUS_SPI_H_ */
+#endif /* HW_BUS_DRIVERS_SPI_COMMON_H_ */

--- a/hw/bus/drivers/spi_common/pkg.yml
+++ b/hw/bus/drivers/spi_common/pkg.yml
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-pkg.name: hw/bus/spi
-pkg.description: SPI bus implementation
+pkg.name: hw/bus/drivers/spi_common
+pkg.description: Common definitions for SPI bus drivers
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-pkg.deps:
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/bus"
+    - hw/bus

--- a/hw/bus/drivers/spi_hal/include/bus/drivers/spi_hal.h
+++ b/hw/bus/drivers/spi_hal/include/bus/drivers/spi_hal.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HW_BUS_DRIVERS_SPI_HAL_H_
+#define HW_BUS_DRIVERS_SPI_HAL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include "os/os_dev.h"
+#include "bus/drivers/spi_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize os_dev as SPI bus device using spi_hal driver
+ *
+ * This can be passed as a parameter to os_dev_create() when creating os_dev
+ * object for SPI device, however it's recommended to create devices using helper
+ * like bus_spi_hal_dev_create().
+ *
+ * @param node  Node device object
+ * @param arg   Node configuration struct (struct bus_node_cfg)
+ */
+int
+bus_spi_hal_dev_init_func(struct os_dev *odev, void *arg);
+
+/**
+ * Create SPI bus device using spi_hal driver
+ *
+ * This is a convenient helper and recommended way to create os_dev for bus SPI
+ * device instead of calling os_dev_create() directly.
+ *
+ * @param name  Name of device
+ * @param dev   Device state object
+ * @param cfg   Configuration
+ */
+static inline int
+bus_spi_hal_dev_create(const char *name, struct bus_spi_dev *dev,
+                       struct bus_spi_dev_cfg *cfg)
+{
+    struct os_dev *odev = (struct os_dev *)dev;
+
+    return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 0,
+                         bus_spi_hal_dev_init_func, cfg);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HW_BUS_DRIVERS_SPI_HAL_H_ */

--- a/hw/bus/drivers/spi_hal/pkg.yml
+++ b/hw/bus/drivers/spi_hal/pkg.yml
@@ -17,29 +17,12 @@
 # under the License.
 #
 
-pkg.name: hw/drivers/bq27z561
-pkg.description: Driver for the BQ27Z561 fuel gauge
+pkg.name: hw/bus/drivers/spi_hal
+pkg.description: SPI bus driver using hal_spi
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - bq27z561
-    - i2c
-    - fuel_gauge
 
 pkg.deps:
-    - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/hw/battery"
-    - "@apache-mynewt-core/sys/log/modlog"
-
-pkg.deps.!BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/util/i2cn"
-pkg.deps.BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
-
-pkg.req_apis:
-    - stats
-
-pkg.deps.BQ27Z561_CLI:
-    - "@apache-mynewt-core/util/parse"
-
-pkg.init:
-    bq27z561_pkg_init: 'MYNEWT_VAL(BQ27Z561_SYSINIT_STAGE)'
+    - hw/bus
+    - hw/bus/drivers/spi_common

--- a/hw/bus/drivers/spi_hal/src/spi_hal.c
+++ b/hw/bus/drivers/spi_hal/src/spi_hal.c
@@ -23,7 +23,7 @@
 #include "hal/hal_spi.h"
 #include "bus/bus.h"
 #include "bus/bus_debug.h"
-#include "bus/spi.h"
+#include "bus/drivers/spi_hal.h"
 
 static int
 bus_spi_init_node(struct bus_dev *bdev, struct bus_node *bnode, void *arg)
@@ -187,7 +187,7 @@ static const struct bus_dev_ops bus_spi_ops = {
 };
 
 int
-bus_spi_dev_init_func(struct os_dev *odev, void *arg)
+bus_spi_hal_dev_init_func(struct os_dev *odev, void *arg)
 {
     struct bus_spi_dev *dev = (struct bus_spi_dev *)odev;
     struct bus_spi_dev_cfg *cfg = arg;

--- a/hw/bus/drivers/spi_hal/src/spi_hal.c
+++ b/hw/bus/drivers/spi_hal/src/spi_hal.c
@@ -207,12 +207,9 @@ bus_spi_hal_dev_init_func(struct os_dev *odev, void *arg)
 
     BUS_DEBUG_POISON_DEV(dev);
 
-    rc = bus_dev_init_func(odev, (void*)&bus_spi_ops);
-    assert(rc == 0);
-
     dev->cfg = *cfg;
 
-    rc = hal_spi_enable(dev->cfg.spi_num);
+    rc = bus_dev_init_func(odev, (void*)&bus_spi_ops);
     assert(rc == 0);
 
     return 0;

--- a/hw/bus/i2c/include/bus/i2c.h
+++ b/hw/bus/i2c/include/bus/i2c.h
@@ -123,19 +123,6 @@ bus_i2c_dev_create(const char *name, struct bus_i2c_dev *dev,
 }
 
 /**
- * Initialize os_dev as bus I2C node
- *
- * This can be passed as a parameter to os_dev_create() when creating os_dev
- * object for I2C node, however it's recommended to create devices using helper
- * like bus_i2c_node_create().
- *
- * @param node  Node device object
- * @param arg   Node configuration struct (struct bus_node_cfg)
- */
-int
-bus_i2c_node_init_func(struct os_dev *odev, void *arg);
-
-/**
  * Create bus I2C node
  *
  * This is a convenient helper and recommended way to create os_dev for bus I2C
@@ -155,7 +142,7 @@ bus_i2c_node_create(const char *name, struct bus_i2c_node *node,
     bnode->init_arg = arg;
 
     return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 1,
-                         bus_i2c_node_init_func, (void *)cfg);
+                         bus_node_init_func, (void *)cfg);
 }
 
 #ifdef __cplusplus

--- a/hw/bus/i2c/src/i2c.c
+++ b/hw/bus/i2c/src/i2c.c
@@ -47,6 +47,21 @@ bus_i2c_translate_hal_error(int hal_err)
 }
 
 static int
+bus_i2c_init_node(struct bus_dev *bdev, struct bus_node *bnode, void *arg)
+{
+    struct bus_i2c_node *node = (struct bus_i2c_node *)bnode;
+    struct bus_i2c_node_cfg *cfg = arg;
+
+    BUS_DEBUG_POISON_NODE(node);
+
+    node->freq = cfg->freq;
+    node->addr = cfg->addr;
+    node->quirks = cfg->quirks;
+
+    return 0;
+}
+
+static int
 bus_i2c_enable(struct bus_dev *bdev)
 {
     struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
@@ -164,6 +179,7 @@ static int bus_i2c_disable(struct bus_dev *bdev)
 }
 
 static const struct bus_dev_ops bus_i2c_ops = {
+    .init_node = bus_i2c_init_node,
     .enable = bus_i2c_enable,
     .configure = bus_i2c_configure,
     .read = bus_i2c_read,
@@ -195,28 +211,6 @@ bus_i2c_dev_init_func(struct os_dev *odev, void *arg)
     assert(rc == 0);
 
     dev->cfg = *cfg;
-
-    return 0;
-}
-
-int
-bus_i2c_node_init_func(struct os_dev *odev, void *arg)
-{
-    struct bus_i2c_node *node = (struct bus_i2c_node *)odev;
-    struct bus_i2c_node_cfg *cfg = arg;
-    struct bus_node_cfg *node_cfg = &cfg->node_cfg;
-    int rc;
-
-    BUS_DEBUG_POISON_NODE(node);
-
-    node->freq = cfg->freq;
-    node->addr = cfg->addr;
-    node->quirks = cfg->quirks;
-
-    rc = bus_node_init_func(odev, node_cfg);
-    if (rc) {
-        return rc;
-    }
 
     return 0;
 }

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -49,6 +49,8 @@ STATS_SECT_END
  * These operations shall be defined by bus driver
  */
 struct bus_dev_ops {
+    /* Initialize node */
+    int (* init_node)(struct bus_dev *bus, struct bus_node *node, void *arg);
     /* Enable bus device */
     int (* enable)(struct bus_dev *bus);
     /* Configure bus for node */

--- a/hw/bus/spi/include/bus/spi.h
+++ b/hw/bus/spi/include/bus/spi.h
@@ -96,9 +96,6 @@ bus_spi_dev_create(const char *name, struct bus_spi_dev *dev,
                          bus_spi_dev_init_func, cfg);
 }
 
-int
-bus_spi_node_init_func(struct os_dev *odev, void *arg);
-
 static inline int
 bus_spi_node_create(const char *name, struct bus_spi_node *node,
                     const struct bus_spi_node_cfg *cfg, void *arg)
@@ -109,7 +106,7 @@ bus_spi_node_create(const char *name, struct bus_spi_node *node,
     bnode->init_arg = arg;
 
     return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 1,
-                         bus_spi_node_init_func, (void *)cfg);
+                         bus_node_init_func, (void *)cfg);
 }
 
 #ifdef __cplusplus

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -151,10 +151,12 @@ bus_node_init_func(struct os_dev *odev, void *arg)
     struct bus_node *bnode = (struct bus_node *)odev;
     struct bus_node_cfg *node_cfg = arg;
     struct os_dev *parent_odev;
+    struct bus_dev *bdev;
     void *init_arg;
 #if MYNEWT_VAL(BUS_STATS_PER_NODE)
     char *stats_name;
 #endif
+    int rc;
 
     parent_odev = os_dev_lookup(node_cfg->bus_name);
     if (!parent_odev) {
@@ -166,6 +168,12 @@ bus_node_init_func(struct os_dev *odev, void *arg)
     /* We need to save init_arg here since it will be overwritten by parent_bus */
     init_arg = bnode->init_arg;
     bnode->parent_bus = (struct bus_dev *)parent_odev;
+
+    bdev = (struct bus_dev *)parent_odev;
+    rc = bdev->dops->init_node(bdev, bnode, arg);
+    if (rc) {
+        return rc;
+    }
 
     if (node_cfg->lock_timeout_ms) {
         bnode->lock_timeout = os_time_ms_to_ticks32(node_cfg->lock_timeout_ms);

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -142,6 +142,10 @@ bus_dev_init_func(struct os_dev *odev, void *arg)
                        stats_name);
 #endif
 
+    if (bdev->dops->enable) {
+        bdev->dops->enable(bdev);
+    }
+
     return 0;
 }
 

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -24,7 +24,7 @@
 #include "bq27z561/bq27z561.h"
 #include "hal/hal_gpio.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"

--- a/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
+++ b/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
@@ -28,8 +28,7 @@
 #include "charge-control/charge_control.h"
 #endif
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 
 /**

--- a/hw/drivers/chg_ctrl/adp5061/pkg.yml
+++ b/hw/drivers/chg_ctrl/adp5061/pkg.yml
@@ -27,7 +27,11 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - '@apache-mynewt-core/hw/hal'
-    - '@apache-mynewt-core/hw/util/i2cn'
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.deps.!BUS_DRIVER_PRESENT||ADP5061_USE_CHARGE_CONTROL:
     - '@apache-mynewt-core/hw/charge-control'

--- a/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
+++ b/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
@@ -26,8 +26,7 @@
 #include <mcu/nrf52_hal.h>
 #include <hal/hal_gpio.h>
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"

--- a/hw/drivers/led/lp5523/include/lp5523/lp5523.h
+++ b/hw/drivers/led/lp5523/include/lp5523/lp5523.h
@@ -26,8 +26,7 @@ extern "C" {
 
 #include <led/led_itf.h>
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 
 #define LP5523_MAX_PAYLOAD   (10)

--- a/hw/drivers/led/lp5523/pkg.yml
+++ b/hw/drivers/led/lp5523/pkg.yml
@@ -30,8 +30,12 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/drivers/led"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.deps.LP5523_CLI:
     - "@apache-mynewt-core/util/parse"

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -19,8 +19,13 @@
 
 #include <string.h>
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
+#else
 #include <hal/hal_i2c.h>
 #include <i2cn/i2cn.h>
+#endif
 #include <modlog/modlog.h>
 #include <stats/stats.h>
 

--- a/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
+++ b/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
@@ -23,9 +23,8 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #endif
 #include "sensor/sensor.h"
 

--- a/hw/drivers/sensors/bmp280/pkg.yml
+++ b/hw/drivers/sensors/bmp280/pkg.yml
@@ -34,8 +34,10 @@ pkg.deps:
     - "@apache-mynewt-core/hw/sensor"
     - "@apache-mynewt-core/sys/log/modlog"
 
-#pkg.deps.!BUS_DRIVER_PRESENT:
-#    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -24,7 +24,8 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"

--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -23,9 +23,8 @@
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dh12/pkg.yml
+++ b/hw/drivers/sensors/lis2dh12/pkg.yml
@@ -28,8 +28,13 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/sensor"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
+    - "@apache-mynewt-core/hw/bus/drivers/spi_common"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -24,7 +24,8 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #else
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"

--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -23,8 +23,7 @@
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lis2dw12/pkg.yml
+++ b/hw/drivers/sensors/lis2dw12/pkg.yml
@@ -29,8 +29,12 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/sensor"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -24,7 +24,7 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
 #else
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"

--- a/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
+++ b/hw/drivers/sensors/lps33hw/include/lps33hw/lps33hw.h
@@ -23,8 +23,7 @@
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 #include "hal/hal_gpio.h"
 

--- a/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
+++ b/hw/drivers/sensors/lps33thw/include/lps33thw/lps33thw.h
@@ -24,9 +24,8 @@
 #include "sensor/sensor.h"
 #include "hal/hal_gpio.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #endif
 
 #ifdef __cplusplus

--- a/hw/drivers/sensors/lps33thw/pkg.yml
+++ b/hw/drivers/sensors/lps33thw/pkg.yml
@@ -35,6 +35,12 @@ pkg.deps:
     - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
 
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
+    - "@apache-mynewt-core/hw/bus/drivers/spi_common"
+
 pkg.req_apis:
     - stats
 

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -25,7 +25,8 @@
 #include "os/mynewt.h"
 #include "hal/hal_gpio.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"

--- a/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
+++ b/hw/drivers/sensors/ms5837/include/ms5837/ms5837.h
@@ -24,8 +24,7 @@
 #include "os/mynewt.h"
 #include "sensor/sensor.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 
 #define MS5837_I2C_ADDRESS		0x76

--- a/hw/drivers/sensors/ms5837/pkg.yml
+++ b/hw/drivers/sensors/ms5837/pkg.yml
@@ -31,8 +31,12 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/sensor"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -24,7 +24,7 @@
 
 #include "os/mynewt.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"

--- a/hw/drivers/sensors/ms5840/include/ms5840/ms5840.h
+++ b/hw/drivers/sensors/ms5840/include/ms5840/ms5840.h
@@ -25,8 +25,7 @@
 #include "os/os_dev.h"
 #include "sensor/sensor.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus_driver.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #endif
 
 #define MS5840_I2C_ADDRESS		0x76

--- a/hw/drivers/sensors/ms5840/pkg.yml
+++ b/hw/drivers/sensors/ms5840/pkg.yml
@@ -31,8 +31,12 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/sensor"
-    - "@apache-mynewt-core/hw/util/i2cn"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.!BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/util/i2cn"
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
 
 pkg.req_apis:
     - stats

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -26,7 +26,7 @@
 #include "os/os.h"
 #include "sysinit/sysinit.h"
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
+#include "bus/drivers/i2c_common.h"
 #else
 #include "hal/hal_i2c.h"
 #include "i2cn/i2cn.h"

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -30,6 +30,10 @@ pkg.deps:
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
 
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_hal"
+    - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
+
 # NRF52810 doesn't support SPI/I2C (Use SPIM/I2CM instead)
 pkg.ign_files.BSP_NRF52810:
     - "hal_spi.c"

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
@@ -27,10 +27,10 @@
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
 #include "bus/bus.h"
 #if MYNEWT_VAL(I2C_0) || MYNEWT_VAL(I2C_1)
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_hal.h"
 #endif
 #if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER)
-#include "bus/spi.h"
+#include "bus/drivers/spi_hal.h"
 #endif
 #endif
 #include "nrfx.h"
@@ -337,7 +337,8 @@ nrf52_periph_create_i2c(void)
 
 #if MYNEWT_VAL(I2C_0)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_i2c_dev_create("i2c0", &i2c0_bus, (struct bus_i2c_dev_cfg *)&i2c0_cfg);
+    rc = bus_i2c_hal_dev_create("i2c0", &i2c0_bus,
+                                (struct bus_i2c_dev_cfg *)&i2c0_cfg);
     assert(rc == 0);
 #else
     rc = hal_i2c_init(0, (void *)&hal_i2c0_cfg);
@@ -346,7 +347,8 @@ nrf52_periph_create_i2c(void)
 #endif
 #if MYNEWT_VAL(I2C_1)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_i2c_dev_create("i2c1", &i2c1_bus, (struct bus_i2c_dev_cfg *)&i2c1_cfg);
+    rc = bus_i2c_hal_dev_create("i2c1", &i2c1_bus,
+                                (struct bus_i2c_dev_cfg *)&i2c1_cfg);
     assert(rc == 0);
 #else
     rc = hal_i2c_init(1, (void *)&hal_i2c1_cfg);
@@ -364,7 +366,8 @@ nrf52_periph_create_spi(void)
 
 #if MYNEWT_VAL(SPI_0_MASTER)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_spi_dev_create("spi0", &spi0_bus, (struct bus_spi_dev_cfg *)&spi0_cfg);
+    rc = bus_spi_hal_dev_create("spi0",
+                                &spi0_bus, (struct bus_spi_dev_cfg *)&spi0_cfg);
     assert(rc == 0);
 #else
     rc = hal_spi_init(0, (void *)&os_bsp_spi0m_cfg, HAL_SPI_TYPE_MASTER);
@@ -377,7 +380,8 @@ nrf52_periph_create_spi(void)
 #endif
 #if MYNEWT_VAL(SPI_1_MASTER)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_spi_dev_create("spi1", &spi1_bus, (struct bus_spi_dev_cfg *)&spi1_cfg);
+    rc = bus_spi_hal_dev_create("spi1", &spi1_bus,
+                                (struct bus_spi_dev_cfg *)&spi1_cfg);
     assert(rc == 0);
 #else
     rc = hal_spi_init(1, (void *)&os_bsp_spi1m_cfg, HAL_SPI_TYPE_MASTER);
@@ -390,7 +394,8 @@ nrf52_periph_create_spi(void)
 #endif
 #if MYNEWT_VAL(SPI_2_MASTER)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_spi_dev_create("spi2", &spi2_bus, (struct bus_spi_dev_cfg *)&spi2_cfg);
+    rc = bus_spi_hal_dev_create("spi2", &spi2_bus,
+                                (struct bus_spi_dev_cfg *)&spi2_cfg);
     assert(rc == 0);
 #else
     rc = hal_spi_init(2, (void *)&os_bsp_spi2m_cfg, HAL_SPI_TYPE_MASTER);

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -24,8 +24,8 @@
 #include "os/mynewt.h"
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #endif
 #if MYNEWT_VAL(SENSOR_OIC)
 #include "oic/oc_ri.h"


### PR DESCRIPTION
This reorganizes `hw/bus` packages structure and includes few fixes to make bus driver creation and usage easier.

To use bus driver it's now enough to only include `hw/bus/drivers/(i2c|spi)_common` package dependency and include `bus/drivers/(i2c|spi)_common.h` header file and all other dependencies should be automatically pulled in.

Also, creating bus node now calls generic `init` function first which then calls `init` function assigned by bus device driver. This allows to easily swap drivers for each bus device without need to modify any code which uses bus nodes, i.e. there may be two I2C bus drivers (HAL and something optimized) and the same call to create node will works properly no matter which bus device this node is attached to.