### PR TITLE
hw/drivers/lps33thw: Fix CLI build

### DIFF
--- a/hw/drivers/sensors/lps33thw/src/lps33thw_shell.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw_shell.c
@@ -123,6 +123,7 @@ lps33thw_shell_cmd(int argc, char **argv)
         return lps33thw_shell_help();
     }
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (!g_sensor_itf.si_dev) {
         g_sensor_itf.si_dev = os_dev_open(MYNEWT_VAL(LPS33THW_SHELL_NODE_NAME),
                                           0, NULL);
@@ -133,6 +134,7 @@ lps33thw_shell_cmd(int argc, char **argv)
             return 0;
         }
     }
+#endif
 
     /* Read pressure */
     if (argc > 1 && strcmp(argv[1], "rp") == 0) {


### PR DESCRIPTION
Broken by another build fix (4a82c33c) so fixing again. Now it should build fine with and without bus driver...

This fixes https://github.com/apache/mynewt-core/issues/1569