### PR TITLE
hw/drivers/bq27z561: Remove double precision constant

### DIFF
--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -66,7 +66,7 @@ bq27z561_temp_to_celsius(uint16_t temp)
 {
     float temp_c;
 
-    temp_c = ((float)temp * 0.1) - 273;
+    temp_c = temp * 0.1f - 273.0f;
     return temp_c;
 }
 


### PR DESCRIPTION

Code generated with this small change does not use double precision anymore that can benefit platforms that have single precision FPUs only.