### PR TITLE
Avoid resetting target when debugging with st-util

### DIFF
--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -53,25 +53,25 @@ parse_extra_jtag_cmd() {
 
     NEW_EXTRA_JTAG_CMD=""
     while [ "$1" != "" ]; do
-	case $1 in
-	    -port)
-		shift
-		# Many BSP scripts append their own things additional
-		# parameters. This is done in a way where openocd delimeter is
-		# immediatelly adjacent to parameters passed via newt.
-		# The following is to filter out the delimeter from
-		# PORT, but keep it present within the string passed
-		# to openocd.
-		PORT=`echo $1 | tr -c -d 0-9`
-		ADDITIONAL_CHARS=`echo $1 | tr -d 0-9`
-		NEW_EXTRA_JTAG_CMD="$NEW_EXTRA_JTAG_CMD $ADDITIONAL_CHARS"
-		shift
-		;;
-	    *)
-		NEW_EXTRA_JTAG_CMD="$NEW_EXTRA_JTAG_CMD $1"
-		shift
-		;;
-	esac
+        case $1 in
+            -port)
+                shift
+                # Many BSP scripts append their own things additional
+                # parameters. This is done in a way where openocd delimeter is
+                # immediatelly adjacent to parameters passed via newt.
+                # The following is to filter out the delimeter from
+                # PORT, but keep it present within the string passed
+                # to openocd.
+                PORT=`echo $1 | tr -c -d 0-9`
+                ADDITIONAL_CHARS=`echo $1 | tr -d 0-9`
+                NEW_EXTRA_JTAG_CMD="$NEW_EXTRA_JTAG_CMD $ADDITIONAL_CHARS"
+                shift
+                ;;
+            *)
+                NEW_EXTRA_JTAG_CMD="$NEW_EXTRA_JTAG_CMD $1"
+                shift
+                ;;
+        esac
     done
     echo $NEW_EXTRA_JTAG_CMD
     EXTRA_JTAG_CMD=$NEW_EXTRA_JTAG_CMD

--- a/hw/scripts/stlink.sh
+++ b/hw/scripts/stlink.sh
@@ -41,7 +41,7 @@ stlink_load () {
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
-    st-flash --reset write $FILE_NAME $FLASH_OFFSET 
+    st-flash --reset write $FILE_NAME $FLASH_OFFSET
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -55,6 +55,8 @@ stlink_load () {
 stlink_debug () {
     windows_detect
     PORT=3333
+
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 
     if [ -z "$NO_GDB" ]; then
         if [ -z $FILE_NAME ]; then
@@ -72,13 +74,13 @@ stlink_debug () {
             # it doesn't get killed by Ctrl-C signal from bash.
             #
 
-            $COMSPEC /C "start $COMSPEC /C st-util -p $PORT"
+            $COMSPEC /C "start $COMSPEC /C st-util --no-reset -p $PORT"
         else
             #
             # Block Ctrl-C from getting passed to openocd.
             #
             set -m
-            st-util -p $PORT >stlink.log 2>&1 & 
+            st-util --no-reset -p $PORT >stlink.log 2>&1 &
             stpid=$!
             set +m
         fi
@@ -106,8 +108,8 @@ stlink_debug () {
             fi
         fi
     else
-        # No GDB, wait for openocd to exit
-        st-util -p $PORT 
+        # No GDB, wait for st-util to exit
+        st-util --no-reset -p $PORT
         return $?
     fi
 


### PR DESCRIPTION
The default behaviour for st-util is to reset the target on startup, which should only be done when RESET shell variable is set.