### PR TITLE
Use stlink tooling for stm32l4

### DIFF
--- a/hw/bsp/nucleo-l476rg/nucleo-l476rg_debug.sh
+++ b/hw/bsp/nucleo-l476rg/nucleo-l476rg_debug.sh
@@ -27,11 +27,8 @@
 #  - RESET set if target should be reset when attaching
 #  - NO_GDB set if we should not start gdb to debug
 #
-. $CORE_PATH/hw/scripts/openocd.sh
+. $CORE_PATH/hw/scripts/stlink.sh
 
 FILE_NAME=$BIN_BASENAME.elf
-CFG="-f board/st_nucleo_l4.cfg"
-# Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32l4x.cpu configure -event gdb-detach {if {[stm32l4x.cpu curstate] eq \"halted\"} resume;shutdown}"
 
-openocd_debug
+stlink_debug

--- a/hw/bsp/nucleo-l476rg/nucleo-l476rg_download.sh
+++ b/hw/bsp/nucleo-l476rg/nucleo-l476rg_download.sh
@@ -29,14 +29,11 @@
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
 
-. $CORE_PATH/hw/scripts/openocd.sh
-
-CFG="-f board/st_nucleo_l4.cfg"
+. $CORE_PATH/hw/scripts/stlink.sh
 
 if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0x08000000
 fi
 
 common_file_to_load
-openocd_load
-openocd_reset_run
+stlink_load


### PR DESCRIPTION
As reported previously, openocd 0.10.0 and git master have changed the script name about one year ago which forces users to have to edit the configuration files according to the openocd version they have
installed. This switches to more friendly st-link based tooling which has more regular releases and does auto-detect the stm32 line MCU in use.