### PR TITLE
hw/util/i2cn: Add write-read transaction support

### DIFF
--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -375,6 +375,12 @@ lps33thw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     rc = i2cn_master_write_read_transact(itf->si_num, &wdata, &rdata,
                                          MYNEWT_VAL(LPS33THW_I2C_TIMEOUT_TICKS) * (size + 1),
                                          1, MYNEWT_VAL(LPS33THW_I2C_RETRIES));
+    if (rc) {
+        LPS33THW_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+                     itf->si_addr);
+        STATS_INC(g_lps33thwstats, read_errors);
+        return rc;
+    }
 #endif
 
     return rc;

--- a/hw/util/i2cn/include/i2cn/i2cn.h
+++ b/hw/util/i2cn/include/i2cn/i2cn.h
@@ -35,8 +35,8 @@ extern "C" {
  * @param i2c_num               The index of the I2C interface to read from.
  * @param pdata                 Additional parameters describing the read
  *                                  operation.
- * @param timeout               The time, in OS ticks, to wait for the MCU to
- *                                  indicate completion of each clocked byte.
+ * @param timeout               The time, in OS ticks, to wait for operation
+ *                                  completion.
  * @param last_op               1 if this is the final message in the
  *                                  transaction.
  *
@@ -53,8 +53,8 @@ int i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
  * @param i2c_num               The index of the I2C interface to write to.
  * @param pdata                 Additional parameters describing the write
  *                                  operation.
- * @param timeout               The time, in OS ticks, to wait for the MCU to
- *                                  indicate completion of each clocked byte.
+ * @param timeout               The time, in OS ticks, to wait for operation
+ *                                  completion.
  * @param last_op               1 if this is the final message in the
  *                                  transaction.
  *

--- a/hw/util/i2cn/include/i2cn/i2cn.h
+++ b/hw/util/i2cn/include/i2cn/i2cn.h
@@ -64,6 +64,34 @@ int i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 int i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
                       os_time_t timeout, uint8_t last_op, int retries);
 
+/**
+ * @brief Writes to and then read from an I2C slave, retrying the specified
+ * number of times on failure.
+ *
+ * This should be used whenever sequence of write (e.g. register address on
+ * sensor) and read (e.g. data from that register) is required in favor of
+ * separate write and read as it guaranteed that in case of failed read, write
+ * will be performed once more to guarantee read is handled properly by device.
+ *
+ * @param i2c_num               The index of the I2C interface to write to.
+ * @param wdata                 Additional parameters describing the write
+ *                                  operation.
+ * @param rdata                 Additional parameters describing the read
+ *                                  operation.
+ * @param timeout               The time, in OS ticks, to wait for either read
+ *                                  or write operation completion.
+ * @param last_op               1 if read is the final message in the
+ *                                  transaction.
+ *
+ * @return                      0 on success;
+ *                              HAL_I2C_ERR_[...] code on failure.
+ */
+int i2cn_master_write_read_transact(uint8_t i2c_num,
+                                    struct hal_i2c_master_data *wdata,
+                                    struct hal_i2c_master_data *rdata,
+                                    os_time_t timeout, uint8_t last_op,
+                                    int retries);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/util/i2cn/include/i2cn/i2cn.h
+++ b/hw/util/i2cn/include/i2cn/i2cn.h
@@ -44,7 +44,7 @@ extern "C" {
  *                              HAL_I2C_ERR_[...] code on failure.
  */
 int i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                     uint32_t timeout, uint8_t last_op, int retries);
+                     os_time_t timeout, uint8_t last_op, int retries);
 
 /**
  * @brief Writes to an I2C slave, retrying the specified number of times on
@@ -62,7 +62,7 @@ int i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
  *                              HAL_I2C_ERR_[...] code on failure.
  */
 int i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                      uint32_t timeout, uint8_t last_op, int retries);
+                      os_time_t timeout, uint8_t last_op, int retries);
 
 #ifdef __cplusplus
 }

--- a/hw/util/i2cn/src/i2cn.c
+++ b/hw/util/i2cn/src/i2cn.c
@@ -63,3 +63,33 @@ i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 
     return rc;
 }
+
+int
+i2cn_master_write_read_transact(uint8_t i2c_num,
+                                struct hal_i2c_master_data *wdata,
+                                struct hal_i2c_master_data *rdata,
+                                os_time_t timeout, uint8_t last_op, int retries)
+{
+    int rc = 0;
+    int i;
+
+    /* Ensure at least one try. */
+    if (retries < 0) {
+        retries = 0;
+    }
+
+    for (i = 0; i <= retries; i++) {
+        rc = hal_i2c_master_write(i2c_num, wdata, timeout, 0);
+        if (rc != 0) {
+            continue;
+        }
+
+        rc = hal_i2c_master_read(i2c_num, rdata, timeout, last_op);
+        if (rc == 0) {
+            break;
+        }
+    }
+
+    return rc;
+
+}

--- a/hw/util/i2cn/src/i2cn.c
+++ b/hw/util/i2cn/src/i2cn.c
@@ -22,7 +22,7 @@
 
 int
 i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                 uint32_t timeout, uint8_t last_op, int retries)
+                 os_time_t timeout, uint8_t last_op, int retries)
 {
     int rc = 0;
     int i;
@@ -44,7 +44,7 @@ i2cn_master_read(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
 
 int
 i2cn_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
-                  uint32_t timeout, uint8_t last_op, int retries)
+                  os_time_t timeout, uint8_t last_op, int retries)
 {
     int rc = 0;
     int i;


### PR DESCRIPTION
New `i2cn_master_write_read_transact` should be used for reading from common sensors instead of separate write and read as it guarantees that in case of read failure write will be done before retrying. Without retry, it may happen that after writing register address, read fails after some bytes are already left and register pointer inside sensor already moved to new location. Reading again, without write, would then result in invalid registers being read.

Note: there are few more sensors to fix, I'll try to update soon