### PR TITLE
log: Add functions for log level manipulation

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -609,6 +609,23 @@ log_level_set(uint8_t module, uint8_t level)
 }
 #endif
 
+/**
+ * @brief Set log level for a logger.
+ *
+ * @param log                   The log to set level to.
+ * @param level                 New log level
+ */
+void log_set_level(struct log *log, uint8_t level);
+
+/**
+ * @brief Get log level for a logger.
+ *
+ * @param log                   The log to set level to.
+ *
+ * @return                      current value of log level.
+ */
+uint8_t log_get_level(const struct log *log);
+
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 /**
  * Return information about log storage

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -862,3 +862,17 @@ err:
     return (rc);
 }
 #endif
+
+void
+log_set_level(struct log *log, uint8_t level)
+{
+    assert(log);
+    log->l_level = level;
+}
+
+uint8_t
+log_get_level(const struct log *log)
+{
+    assert(log);
+    return log->l_level;
+}


### PR DESCRIPTION
Changing log level at runtime for specific logger could be
useful for blocking logs that normally would go to the console
while newtmgr over serial port is used.

Ideally function names should be log_level_set/get but those
are already taken by modlog related code.