### PR TITLE
console newtmgr coexistance

### DIFF
--- a/kernel/os/include/os/os_mutex.h
+++ b/kernel/os/include/os/os_mutex.h
@@ -102,6 +102,26 @@ os_error_t os_mutex_release(struct os_mutex *mu);
  */
 os_error_t os_mutex_pend(struct os_mutex *mu, os_time_t timeout);
 
+/**
+ * Get mutex lock count.
+ *
+ * @note Function should be called from task owning the mutex (one that
+ * successfully called os_mutex_pend). Calling function from other task
+ * that does not own the mutex will return value that has little value
+ * to the caller since value can change at any time by other task.
+ *
+ * It can also be called from interrupt context to check if given mutex
+ * is taken.
+ *
+ * @param mu Pointer to mutex.
+ *
+ * @return number of times lock was called from current task
+ */
+static inline os_error_t os_mutex_get_level(struct os_mutex *mu)
+{
+    return mu->mu_level;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -86,6 +86,9 @@ extern int console_is_midline;
 extern int console_out(int character);
 extern void console_rx_restart(void);
 
+int console_lock(int timeout);
+int console_unlock(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -102,7 +102,7 @@ rtt_console_write_ch(char c)
 #endif
 
 int
-console_out(int character)
+console_out_nolock(int character)
 {
     char c = (char)character;
 

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -154,7 +154,7 @@ uart_console_non_blocking_mode(void)
 }
 
 int
-console_out(int c)
+console_out_nolock(int c)
 {
     if (g_silence_console) {
         return c;

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -93,6 +93,10 @@ syscfg.defs:
             affect device performance due to more frequent polling.
         value: 250
 
+    CONSOLE_DEFAULT_LOCK_TIMEOUT:
+        description: 'Default timeout (in ms) for console_lock() function used in console_write.'
+        value: 1000
+
     CONSOLE_SYSINIT_STAGE:
         description: >
             Sysinit stage for console functionality.

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -85,6 +85,8 @@ int console_handle_char(uint8_t byte);
 extern int console_is_midline;
 extern int console_out(int character);
 
+int console_lock(int timeout);
+int console_unlock(void);
 
 #ifdef __cplusplus
 }

--- a/sys/console/minimal/syscfg.yml
+++ b/sys/console/minimal/syscfg.yml
@@ -50,6 +50,10 @@ syscfg.defs:
         description: 'Console UART device.'
         value: '"uart0"'
 
+    CONSOLE_LOCK_TIMEOUT:
+        description: 'Default timeout (in ms) for console_lock() function used in console_write.'
+        value: 1000
+
     CONSOLE_SYSINIT_STAGE:
         description: >
             Sysinit stage for console functionality.

--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -117,6 +117,18 @@ console_silence(bool silent)
 {
 }
 
+static inline int
+console_lock(int timeout)
+{
+    return 0;
+}
+
+static inline int
+console_unlock(void)
+{
+    return 0;
+}
+
 #define console_is_midline  (0)
 
 #ifdef __cplusplus

--- a/sys/shell/src/shell_nlip.c
+++ b/sys/shell/src/shell_nlip.c
@@ -156,6 +156,10 @@ shell_nlip_mtx(struct os_mbuf *m)
     nwritten = 0;
     off = 0;
 
+    rc = console_lock(OS_TICKS_PER_SEC);
+    if (rc != OS_OK) {
+        goto err;
+    }
     /* Start a packet */
     console_write(pkt_seq, sizeof(pkt_seq));
 
@@ -170,7 +174,7 @@ shell_nlip_mtx(struct os_mbuf *m)
 
         rc = os_mbuf_copydata(m, off, dlen, readbuf + rb_off);
         if (rc != 0) {
-            goto err;
+            goto end;
         }
         off += dlen;
 
@@ -201,8 +205,8 @@ shell_nlip_mtx(struct os_mbuf *m)
     console_write(encodebuf, elen);
 
     console_write("\n", 1);
-
-    return (0);
+end:
+    (void)console_unlock();
 err:
     return (rc);
 }


### PR DESCRIPTION
When newtmgr is used over serial port it is easy to have errors when some task prints on serial console during newtmgr communication (for example during coredump download).

It happens due to lack of locks in console code.

This PR adds locking functionality to console and updates shell_nlip to actually lock console during packet transmission.
Without this locking transmitted packets byte could interleave with logs and that would lead to communication failure.