### PR TITLE
Add stub log dependency to self tests

### DIFF
--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/boot/bootutil/test/pkg.yml
+++ b/boot/bootutil/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/crypto/mbedtls/test/pkg.yml
+++ b/crypto/mbedtls/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/encoding/base64/test/pkg.yml
+++ b/encoding/base64/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/encoding/cborattr/test/pkg.yml
+++ b/encoding/cborattr/test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/encoding/json/test/pkg.yml
+++ b/encoding/json/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/fs/fcb/test/pkg.yml
+++ b/fs/fcb/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/fs/fcb2/test/pkg.yml
+++ b/fs/fcb2/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/hw/drivers/flash/enc_flash/test/pkg.yml
+++ b/hw/drivers/flash/enc_flash/test/pkg.yml
@@ -30,3 +30,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/net/ip/mn_socket/test/pkg.yml
+++ b/net/ip/mn_socket/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/sys/config/test-fcb/pkg.yml
+++ b/sys/config/test-fcb/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/fs/fcb"
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/sys/flash_map/test/pkg.yml
+++ b/sys/flash_map/test/pkg.yml
@@ -27,3 +27,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/util/cbmem/test/pkg.yml
+++ b/util/cbmem/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/util/debounce/test/pkg.yml
+++ b/util/debounce/test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - '@apache-mynewt-core/sys/console/stub'
+    - "@apache-mynewt-core/sys/log/stub"

--- a/util/rwlock/test/pkg.yml
+++ b/util/rwlock/test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"


### PR DESCRIPTION
A recent change caused `sys/mfg` to depend on `sys/log/modlog`.  This introduces a LOG API requirement on several other packages, causing some self tests to fail to build.

This commit adds dependencies on `sys/log/stub` to several self tests.