### PR TITLE
apps/boot: Add `sys/log/stub` dependency

### DIFF
--- a/apps/boot/pkg.yml
+++ b/apps/boot/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"
 
 pkg.deps.BOOT_SERIAL:
     - "@apache-mynewt-core/boot/boot_serial"


### PR DESCRIPTION
A recent commit (`b10cbea5ef882e7f91d1c34ffcf2506d3e183003`) imposes the `LOG` API requirement on the `sys/mfg` package. To fix broken builds, make the boot app depend on `sys/log/stub`.