### PR TITLE
sys/fault: Only crash when in error state

### DIFF
--- a/sys/fault/src/fault.c
+++ b/sys/fault/src/fault.c
@@ -168,10 +168,11 @@ fault_process(struct fault_recorder *recorder, bool is_failure)
         /* The domain seems to be working; decrease chronic failure count. */
         fault_decrease_chronic_count(recorder->domain_id);
     } else {
-        /* Fault detected; trigger a crash in debug builds. */
-        DEBUG_PANIC();
-
         if (state == FAULT_STATE_ERROR) {
+            /* Fault detected; trigger a crash in debug builds. */
+            DEBUG_PANIC();
+
+            /* Increase chronic fail count and persist. */
             fault_increase_chronic_count(recorder->domain_id);
         }
     }


### PR DESCRIPTION
sys/fault: Only crash when in error state

This change only affects debug builds (when `DEBUG_PANIC_ENABLED` is set).

Prior to this change, (when debug mode is used) a crash was triggered whenever the a fault recorder changed state.  There are three fault states:

* GOOD
* WARN
* ERROR

Typically, an application is configured to log a message when a recorder enters the WARN state, and to reboot the system upon entering the ERROR state.  However, in debug mode, the device would crash as soon as the WARN state was entered.

After commit: debug builds only crash when the ERROR state is entered.  The WARN state behaves the same in debug and non-debug builds.  