### PR TITLE
Add missing include to fix build error with I2C_NRF52_TWIM_STAT: 1

### DIFF
--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -26,6 +26,7 @@
 #include "bus/drivers/i2c_common.h"
 #include "mcu/nrf52_hal.h"
 #include "nrfx.h"
+#include "stats/stats.h"
 
 #define TWIM_GPIO_PIN_CNF \
     ((GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos) |  \


### PR DESCRIPTION
Adding #include "stats/stats.h" to i2c_nrf52_twim.c. I encountered a build error with I2C_NRF52_TWIM_STAT: 1. I'm using arm-none-eabi-gcc v7.2.1. 

