### PR TITLE
few sensor fixes

### DIFF
--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
@@ -161,92 +161,67 @@ lis2dh12_shell_cmd_read(int argc, char **argv)
     return 0;
 }
 
+static void lis2dh12_shell_dump_reg(const char *name, uint8_t addr)
+{
+    uint8_t val = 0;
+    int rc;
+
+    rc = lis2dh12_read8(&g_sensor_itf, addr, &val);
+    if (rc == 0) {
+        console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
+    } else {
+        console_printf("0x%02X (%s): failed (%d)\n", addr, name, rc);
+    }
+}
+
+#define DUMP_REG(name) lis2dh12_shell_dump_reg(#name, LIS2DH12_REG_ ## name)
+
 static int
 lis2dh12_shell_cmd_dump(int argc, char **argv)
 {
-    uint8_t val;
-    
     if (argc > 2) {
         return lis2dh12_shell_err_too_many_args(argv[1]);
     }
-    
+
     /* Dump all the register values for debug purposes */
-    val = 0;
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_TEMP_L, &val));
-    console_printf("0x%02X (OUT_TEMP_L): 0x%02X\n", LIS2DH12_REG_OUT_TEMP_L, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_TEMP_H, &val));
-    console_printf("0x%02X (OUT_TEMP_H): 0x%02X\n", LIS2DH12_REG_OUT_TEMP_H, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_WHO_AM_I, &val));
-    console_printf("0x%02X (WHO_AM_I): 0x%02X\n", LIS2DH12_REG_WHO_AM_I, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG0, &val));
-    console_printf("0x%02X (CTRL0): 0x%02X\n", LIS2DH12_REG_CTRL_REG0, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_TEMP_CFG, &val));
-    console_printf("0x%02X (TEMP_CFG): 0x%02X\n", LIS2DH12_REG_TEMP_CFG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG1, &val));
-    console_printf("0x%02X (CTRL1): 0x%02X\n", LIS2DH12_REG_CTRL_REG1, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG2, &val));
-    console_printf("0x%02X (CTRL2): 0x%02X\n", LIS2DH12_REG_CTRL_REG2, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG3, &val));
-    console_printf("0x%02X (CTRL3): 0x%02X\n", LIS2DH12_REG_CTRL_REG3, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG4, &val));
-    console_printf("0x%02X (CTRL4): 0x%02X\n", LIS2DH12_REG_CTRL_REG4, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG5, &val));
-    console_printf("0x%02X (CTRL5): 0x%02X\n", LIS2DH12_REG_CTRL_REG5, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CTRL_REG6, &val));
-    console_printf("0x%02X (CTRL6): 0x%02X\n", LIS2DH12_REG_CTRL_REG6, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_REFERENCE, &val));
-    console_printf("0x%02X (REFERENCE): 0x%02X\n", LIS2DH12_REG_REFERENCE, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_STATUS_REG, &val));
-    console_printf("0x%02X (STATUS): 0x%02X\n", LIS2DH12_REG_STATUS_REG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_X_L, &val));
-    console_printf("0x%02X (OUT_X_L): 0x%02X\n", LIS2DH12_REG_OUT_X_L, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_X_H, &val));
-    console_printf("0x%02X (OUT_X_H): 0x%02X\n", LIS2DH12_REG_OUT_X_H, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_Y_L, &val));
-    console_printf("0x%02X (OUT_Y_L): 0x%02X\n", LIS2DH12_REG_OUT_Y_L, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_Y_H, &val));
-    console_printf("0x%02X (OUT_Y_H): 0x%02X\n", LIS2DH12_REG_OUT_Y_H, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_Z_L, &val));
-    console_printf("0x%02X (OUT_Z_L): 0x%02X\n", LIS2DH12_REG_OUT_Z_L, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_OUT_Z_H, &val));
-    console_printf("0x%02X (OUT_Z_H): 0x%02X\n", LIS2DH12_REG_OUT_Z_H, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_FIFO_CTRL_REG, &val));
-    console_printf("0x%02X (FIFO_CTRL): 0x%02X\n", LIS2DH12_REG_FIFO_CTRL_REG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_FIFO_SRC_REG, &val));
-    console_printf("0x%02X (FIFO_SRC): 0x%02X\n", LIS2DH12_REG_FIFO_SRC_REG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT1_CFG, &val));
-    console_printf("0x%02X (INT1_CFG): 0x%02X\n", LIS2DH12_REG_INT1_CFG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT1_SRC, &val));
-    console_printf("0x%02X (INT1_SRC): 0x%02X\n", LIS2DH12_REG_INT1_SRC, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT1_THS, &val));
-    console_printf("0x%02X (INT1_THS): 0x%02X\n", LIS2DH12_REG_INT1_THS, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT1_DURATION, &val));
-    console_printf("0x%02X (INT1_DURATION): 0x%02X\n", LIS2DH12_REG_INT1_DURATION, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT2_CFG, &val));
-    console_printf("0x%02X (INT2_CFG): 0x%02X\n", LIS2DH12_REG_INT2_CFG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT2_SRC, &val));
-    console_printf("0x%02X (INT2_SRC): 0x%02X\n", LIS2DH12_REG_INT2_SRC, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT2_THS, &val));
-    console_printf("0x%02X (INT2_THS): 0x%02X\n", LIS2DH12_REG_INT2_THS, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_INT2_DURATION, &val));
-    console_printf("0x%02X (INT2_DURATION): 0x%02X\n", LIS2DH12_REG_INT2_DURATION, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CLICK_CFG, &val));
-    console_printf("0x%02X (CLICK_CFG): 0x%02X\n", LIS2DH12_REG_CLICK_CFG, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CLICK_SRC, &val));
-    console_printf("0x%02X (CLICK_SRC): 0x%02X\n", LIS2DH12_REG_CLICK_SRC, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_CLICK_THS, &val));
-    console_printf("0x%02X (CLICK_THS): 0x%02X\n", LIS2DH12_REG_CLICK_THS, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_TIME_LIMIT, &val));
-    console_printf("0x%02X (TIME_LIMIT): 0x%02X\n", LIS2DH12_REG_TIME_LIMIT, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_TIME_LATENCY, &val));
-    console_printf("0x%02X (TIME_LATENCY): 0x%02X\n", LIS2DH12_REG_TIME_LATENCY, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_TIME_WINDOW, &val));
-    console_printf("0x%02X (TIME_WINDOW): 0x%02X\n", LIS2DH12_REG_TIME_WINDOW, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_ACT_THS, &val));
-    console_printf("0x%02X (ACT_THS): 0x%02X\n", LIS2DH12_REG_ACT_THS, val);
-    assert(0 == lis2dh12_read8(&g_sensor_itf, LIS2DH12_REG_ACT_DUR, &val));
-    console_printf("0x%02X (ACT_DUR): 0x%02X\n", LIS2DH12_REG_ACT_DUR, val);
-    
+    DUMP_REG(OUT_TEMP_L);
+    DUMP_REG(OUT_TEMP_H);
+    DUMP_REG(WHO_AM_I);
+    DUMP_REG(CTRL_REG0);
+    DUMP_REG(TEMP_CFG);
+    DUMP_REG(CTRL_REG1);
+    DUMP_REG(CTRL_REG2);
+    DUMP_REG(CTRL_REG3);
+    DUMP_REG(CTRL_REG4);
+    DUMP_REG(CTRL_REG5);
+    DUMP_REG(CTRL_REG6);
+    DUMP_REG(REFERENCE);
+    DUMP_REG(STATUS_REG);
+    DUMP_REG(OUT_X_L);
+    DUMP_REG(OUT_X_H);
+    DUMP_REG(OUT_Y_L);
+    DUMP_REG(OUT_Y_H);
+    DUMP_REG(OUT_Z_L);
+    DUMP_REG(OUT_Z_H);
+    DUMP_REG(FIFO_CTRL_REG);
+    DUMP_REG(FIFO_SRC_REG);
+    DUMP_REG(INT1_CFG);
+    DUMP_REG(INT1_SRC);
+    DUMP_REG(INT1_THS);
+    DUMP_REG(INT1_DURATION);
+    DUMP_REG(INT2_CFG);
+    DUMP_REG(INT2_SRC);
+    DUMP_REG(INT2_THS);
+    DUMP_REG(INT2_DURATION);
+    DUMP_REG(CLICK_CFG);
+    DUMP_REG(CLICK_SRC);
+    DUMP_REG(CLICK_THS);
+    DUMP_REG(TIME_LIMIT);
+    DUMP_REG(TIME_LATENCY);
+    DUMP_REG(TIME_WINDOW);
+    DUMP_REG(ACT_THS);
+    DUMP_REG(ACT_DUR);
+
     return 0;
 }
 

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
@@ -161,76 +161,60 @@ lis2dw12_shell_cmd_read(int argc, char **argv)
     return 0;
 }
 
+
+static void lis2dw12_shell_dump_reg(const char *name, uint8_t addr)
+{
+    uint8_t val = 0;
+    int rc;
+
+    rc = lis2dw12_read8(&g_sensor_itf, addr, &val);
+    if (rc == 0) {
+        console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
+    } else {
+        console_printf("0x%02X (%s): failed (%d)\n", addr, name, rc);
+    }
+}
+
+#define DUMP_REG(name) lis2dw12_shell_dump_reg(#name, LIS2DW12_REG_ ## name)
+
 static int
 lis2dw12_shell_cmd_dump(int argc, char **argv)
 {
-    uint8_t val;
-    
     if (argc > 2) {
         return lis2dw12_shell_err_too_many_args(argv[1]);
     }
-    
+
     /* Dump all the register values for debug purposes */
-    val = 0;
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_TEMP_L, &val));
-    console_printf("0x%02X (OUT_TEMP_L): 0x%02X\n", LIS2DW12_REG_OUT_TEMP_L, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_TEMP_H, &val));
-    console_printf("0x%02X (OUT_TEMP_H): 0x%02X\n", LIS2DW12_REG_OUT_TEMP_H, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_WHO_AM_I, &val));
-    console_printf("0x%02X (WHO_AM_I): 0x%02X\n", LIS2DW12_REG_WHO_AM_I, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG1, &val));
-    console_printf("0x%02X (CTRL1): 0x%02X\n", LIS2DW12_REG_CTRL_REG1, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG2, &val));
-    console_printf("0x%02X (CTRL2): 0x%02X\n", LIS2DW12_REG_CTRL_REG2, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG3, &val));
-    console_printf("0x%02X (CTRL3): 0x%02X\n", LIS2DW12_REG_CTRL_REG3, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG4, &val));
-    console_printf("0x%02X (CTRL4): 0x%02X\n", LIS2DW12_REG_CTRL_REG4, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG5, &val));
-    console_printf("0x%02X (CTRL5): 0x%02X\n", LIS2DW12_REG_CTRL_REG5, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG6, &val));
-    console_printf("0x%02X (CTRL6): 0x%02X\n", LIS2DW12_REG_CTRL_REG6, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_TEMP_OUT, &val));
-    console_printf("0x%02X (TEMP_OUT): 0x%02X\n", LIS2DW12_REG_TEMP_OUT, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_STATUS_REG, &val));
-    console_printf("0x%02X (STATUS): 0x%02X\n", LIS2DW12_REG_STATUS_REG, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_X_L, &val));
-    console_printf("0x%02X (OUT_X_L): 0x%02X\n", LIS2DW12_REG_OUT_X_L, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_X_H, &val));
-    console_printf("0x%02X (OUT_X_H): 0x%02X\n", LIS2DW12_REG_OUT_X_H, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_Y_L, &val));
-    console_printf("0x%02X (OUT_Y_L): 0x%02X\n", LIS2DW12_REG_OUT_Y_L, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_Y_H, &val));
-    console_printf("0x%02X (OUT_Y_H): 0x%02X\n", LIS2DW12_REG_OUT_Y_H, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_Z_L, &val));
-    console_printf("0x%02X (OUT_Z_L): 0x%02X\n", LIS2DW12_REG_OUT_Z_L, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_OUT_Z_H, &val));
-    console_printf("0x%02X (OUT_Z_H): 0x%02X\n", LIS2DW12_REG_OUT_Z_H, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_FIFO_CTRL, &val));
-    console_printf("0x%02X (FIFO_CTRL): 0x%02X\n", LIS2DW12_REG_FIFO_CTRL, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_FIFO_SAMPLES, &val));
-    console_printf("0x%02X (FIFO_SAMPLES): 0x%02X\n", LIS2DW12_REG_FIFO_SAMPLES, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_TAP_THS_X, &val));
-    console_printf("0x%02X (TAP_THS_X): 0x%02X\n", LIS2DW12_REG_TAP_THS_X, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_TAP_THS_Y, &val));
-    console_printf("0x%02X (TAP_THS_Y): 0x%02X\n", LIS2DW12_REG_TAP_THS_Y, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_TAP_THS_Z, &val));
-    console_printf("0x%02X (TAP_THS_Z): 0x%02X\n", LIS2DW12_REG_TAP_THS_Z, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_INT_DUR, &val));
-    console_printf("0x%02X (INT_DUR): 0x%02X\n", LIS2DW12_REG_INT_DUR, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_FREEFALL, &val));
-    console_printf("0x%02X (FREEFALL): 0x%02X\n", LIS2DW12_REG_FREEFALL, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_INT_SRC, &val));
-    console_printf("0x%02X (INT_SRC): 0x%02X\n", LIS2DW12_REG_INT_SRC, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_X_OFS, &val));
-    console_printf("0x%02X (X_OFS): 0x%02X\n", LIS2DW12_REG_X_OFS, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_Y_OFS, &val));
-    console_printf("0x%02X (Y_OFS): 0x%02X\n", LIS2DW12_REG_Y_OFS, val);
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_Z_OFS, &val));
-    console_printf("0x%02X (Z_OFS): 0x%02X\n", LIS2DW12_REG_Z_OFS, val);    
-    assert(0 == lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_CTRL_REG7, &val));
-    console_printf("0x%02X (CTRL7): 0x%02X\n", LIS2DW12_REG_CTRL_REG7, val);
-    
+    DUMP_REG(OUT_TEMP_L);
+    DUMP_REG(OUT_TEMP_H);
+    DUMP_REG(WHO_AM_I);
+    DUMP_REG(CTRL_REG1);
+    DUMP_REG(CTRL_REG2);
+    DUMP_REG(CTRL_REG3);
+    DUMP_REG(CTRL_REG4);
+    DUMP_REG(CTRL_REG5);
+    DUMP_REG(CTRL_REG6);
+    DUMP_REG(TEMP_OUT);
+    DUMP_REG(STATUS_REG);
+    DUMP_REG(OUT_X_L);
+    DUMP_REG(OUT_X_H);
+    DUMP_REG(OUT_Y_L);
+    DUMP_REG(OUT_Y_H);
+    DUMP_REG(OUT_Z_L);
+    DUMP_REG(OUT_Z_H);
+    DUMP_REG(FIFO_CTRL);
+    DUMP_REG(FIFO_SAMPLES);
+    DUMP_REG(TAP_THS_X);
+    DUMP_REG(TAP_THS_Y);
+    DUMP_REG(TAP_THS_Z);
+    DUMP_REG(INT_DUR);
+    DUMP_REG(FREEFALL);
+    DUMP_REG(INT_SRC);
+    DUMP_REG(X_OFS);
+    DUMP_REG(Y_OFS);
+    DUMP_REG(Z_OFS);
+    DUMP_REG(CTRL_REG7);
+
     return 0;
 }
 

--- a/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
@@ -404,59 +404,51 @@ err:
     return rc;
 }
 
+static void tcs34725_shell_dump_reg(const char *name, uint8_t addr)
+{
+    uint8_t val = 0;
+    int rc;
+
+    rc = tcs34725_read8(&g_sensor_itf, addr, &val);
+    if (rc == 0) {
+        console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
+    } else {
+        console_printf("0x%02X (%s): failed (%d)\n", addr, name, rc);
+    }
+}
+
+#define DUMP_REG(name) tcs34725_shell_dump_reg(#name, TCS34725_REG_ ## name)
+
 static int
 tcs34725_shell_cmd_dump(int argc, char **argv)
 {
-  uint8_t val;
+    if (argc > 2) {
+        return tcs34725_shell_err_too_many_args(argv[1]);
+    }
 
-  if (argc > 3) {
-      return tcs34725_shell_err_too_many_args(argv[1]);
-  }
+    /* Dump all the register values for debug purposes */
+    DUMP_REG(ENABLE);
+    DUMP_REG(ATIME);
+    DUMP_REG(WTIME);
+    DUMP_REG(AILTL);
+    DUMP_REG(AILTH);
+    DUMP_REG(AIHTL);
+    DUMP_REG(AIHTH);
+    DUMP_REG(PERS);
+    DUMP_REG(CONFIG);
+    DUMP_REG(CONTROL);
+    DUMP_REG(ID);
+    DUMP_REG(STATUS);
+    DUMP_REG(CDATAL);
+    DUMP_REG(CDATAH);
+    DUMP_REG(RDATAL);
+    DUMP_REG(RDATAH);
+    DUMP_REG(GDATAL);
+    DUMP_REG(GDATAH);
+    DUMP_REG(BDATAL);
+    DUMP_REG(BDATAH);
 
-  /* Dump all the register values for debug purposes */
-  val = 0;
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_ENABLE, &val));
-  console_printf("0x%02X (ENABLE): 0x%02X\n", TCS34725_REG_ENABLE, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_ATIME, &val));
-  console_printf("0x%02X (ATIME):  0x%02X\n", TCS34725_REG_ATIME, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_WTIME, &val));
-  console_printf("0x%02X (WTIME):   0x%02X\n", TCS34725_REG_WTIME, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_AILTL, &val));
-  console_printf("0x%02X (AILTL):   0x%02X\n", TCS34725_REG_AILTL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_AILTH, &val));
-  console_printf("0x%02X (AILTH):   0x%02X\n", TCS34725_REG_AILTH, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_AIHTL, &val));
-  console_printf("0x%02X (AIHTL):   0x%02X\n", TCS34725_REG_AIHTL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_AIHTH, &val));
-  console_printf("0x%02X (AIHTH):   0x%02X\n", TCS34725_REG_AIHTH, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_PERS, &val));
-  console_printf("0x%02X (PERS):   0x%02X\n", TCS34725_REG_PERS, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_CONFIG, &val));
-  console_printf("0x%02X (CONFIG):   0x%02X\n", TCS34725_REG_CONFIG, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_CONTROL, &val));
-  console_printf("0x%02X (CONTROL):   0x%02X\n", TCS34725_REG_CONTROL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_ID, &val));
-  console_printf("0x%02X (ID):    0x%02X\n", TCS34725_REG_ID, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_STATUS, &val));
-  console_printf("0x%02X (STATUS):    0x%02X\n", TCS34725_REG_STATUS, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_CDATAL, &val));
-  console_printf("0x%02X (CDATAL):    0x%02X\n", TCS34725_REG_CDATAL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_CDATAH, &val));
-  console_printf("0x%02X (CDATAH):    0x%02X\n", TCS34725_REG_CDATAH, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_RDATAL, &val));
-  console_printf("0x%02X (RDATAL):    0x%02X\n", TCS34725_REG_RDATAL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_RDATAH, &val));
-  console_printf("0x%02X (RDATAH):    0x%02X\n", TCS34725_REG_RDATAH, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_GDATAL, &val));
-  console_printf("0x%02X (GDATAL):    0x%02X\n", TCS34725_REG_GDATAL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_GDATAH, &val));
-  console_printf("0x%02X (GDATAH):    0x%02X\n", TCS34725_REG_GDATAH, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_BDATAL, &val));
-  console_printf("0x%02X (BDATAL):    0x%02X\n", TCS34725_REG_BDATAL, val);
-  assert(0 == tcs34725_read8(&g_sensor_itf, TCS34725_REG_BDATAH, &val));
-  console_printf("0x%02X (BDATAH):    0x%02X\n", TCS34725_REG_BDATAH, val);
-
-  return 0;
+    return 0;
 }
 
 static int

--- a/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725_shell.c
@@ -392,8 +392,7 @@ tcs34725_shell_cmd_en(int argc, char **argv)
     /* Update the enable state */
     if (argc == 3) {
         lval = strtol(argv[2], &endptr, 10); /* Base 10 */
-        if (argv[2] != '\0' && *endptr == '\0' &&
-            lval >= 0 && lval <= 1) {
+        if (*endptr == '\0' && lval >= 0 && lval <= 1) {
                 tcs34725_enable(&g_sensor_itf, lval);
         } else {
             return tcs34725_shell_err_invalid_arg(argv[2]);


### PR DESCRIPTION
Three sensor had code inside assert macro that could be removed while code was expected to be executed always.

tcs34725 would not compile for obvious reason and this is fixed now.