### PR TITLE
apps: Fix build

### DIFF
--- a/apps/flash_loader/pkg.yml
+++ b/apps/flash_loader/pkg.yml
@@ -27,3 +27,4 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/apps/pwm_test/pkg.yml
+++ b/apps/pwm_test/pkg.yml
@@ -29,3 +29,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/hw/drivers/pwm"
     - "@apache-mynewt-core/util/easing"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/apps/trng_test/pkg.yml
+++ b/apps/trng_test/pkg.yml
@@ -26,3 +26,4 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/hw/drivers/trng"
+    - "@apache-mynewt-core/sys/log/stub"


### PR DESCRIPTION
modlog requires logs.

Error: Unsatisfied APIs detected:
    * log, required by: sys/log/modlog