### PR TITLE
Fix a buffer overflow on EC point load

### DIFF
--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -96,10 +96,10 @@ tinycrypt_read_bigint(uint8_t i[NUM_ECC_BYTES], uint8_t **cp, uint8_t *end)
         return -3;
     }
 
-    if (len > NUM_ECC_BYTES) {
+    if (len >= NUM_ECC_BYTES) {
         memcpy(i, *cp + len - NUM_ECC_BYTES, NUM_ECC_BYTES);
     } else {
-        memset(i + NUM_ECC_BYTES, 0, NUM_ECC_BYTES - len);
+        memset(i, 0, NUM_ECC_BYTES - len);
         memcpy(i + NUM_ECC_BYTES - len, *cp, len);
     }
     *cp += len;


### PR DESCRIPTION
While loading a new EC point, when it was smaller than the expected number of bytes, a zero padding was being written beyond the end of the buffer instead of at the initial position.