### PR TITLE
hw/bus: Add power management for bus devices

### DIFF
--- a/hw/bus/include/bus/bus.h
+++ b/hw/bus/include/bus/bus.h
@@ -38,6 +38,29 @@ extern "C" {
 /* Use as default timeout to lock node */
 #define BUS_NODE_LOCK_DEFAULT_TIMEOUT        ((os_time_t) -1)
 
+/** Bus PM mode */
+typedef enum {
+    /* Bus device enable/disable is controlled by application */
+    BUS_PM_MODE_MANUAL = 0,
+    /*
+     * Bus device enable/disable is controlled automatically by driver.
+     * The bus device is enabled when locked for a first time and disabled when
+     * last lock is released.
+     */
+    BUS_PM_MODE_AUTO = 1,
+} bus_pm_mode_t;
+
+/** Extra options for bus PM modes */
+union bus_pm_options {
+    struct {
+        /* XXX nothing here for now */
+    } pm_mode_manual;
+    struct {
+        /* Inactivity timeout to disable bus device. 0 means immediately. */
+        os_time_t disable_tmo;
+    } pm_mode_auto;
+};
+
 /**
  * Read data from node
  *
@@ -228,6 +251,19 @@ bus_node_unlock(struct os_dev *node);
  */
 os_time_t
 bus_node_get_lock_timeout(struct os_dev *node);
+
+/**
+ * Set power management settings for bus device
+ *
+ * @param bus      Bus device object
+ * @param pm_mode  PM mode to set
+ * @param pm_opts  Selected mode PM options
+ *
+ * @return 0 on success
+ */
+int
+bus_dev_set_pm(struct os_dev *bus, bus_pm_mode_t pm_mode,
+               union bus_pm_options *pm_opts);
 
 #ifdef __cplusplus
 }

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -105,6 +105,12 @@ struct bus_dev {
     struct os_mutex lock;
     struct bus_node *configured_for;
 
+#if MYNEWT_VAL(BUS_PM)
+    bus_pm_mode_t pm_mode;
+    union bus_pm_options pm_opts;
+    struct os_callout inactivity_tmo;
+#endif
+
 #if MYNEWT_VAL(BUS_STATS)
     STATS_SECT_DECL(bus_stats_section) stats;
 #endif

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -109,6 +109,8 @@ struct bus_dev {
     STATS_SECT_DECL(bus_stats_section) stats;
 #endif
 
+    bool enabled;
+
 #if MYNEWT_VAL(BUS_DEBUG_OS_DEV)
     uint32_t devmagic;
 #endif

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -144,17 +144,15 @@ bus_dev_inactivity_tmo_func(struct os_event *ev)
     struct bus_dev *bdev = (struct bus_dev *)ev->ev_arg;
     int rc;
 
-    /* Just in case PM was changed while timer was running */
-    if (bdev->pm_mode != BUS_PM_MODE_AUTO) {
-        return;
-    }
-
     rc = os_mutex_pend(&bdev->lock, OS_TIMEOUT_NEVER);
     if (rc) {
         return;
     }
 
-    bus_dev_disable(bdev);
+    /* Just in case PM was changed while timer was running */
+    if (bdev->pm_mode == BUS_PM_MODE_AUTO) {
+        bus_dev_disable(bdev);
+    }
 
     os_mutex_release(&bdev->lock);
 }

--- a/hw/bus/syscfg.yml
+++ b/hw/bus/syscfg.yml
@@ -31,6 +31,12 @@ syscfg.defs:
             Default timeout for transaction on bus. This is used for simple
             transaction APIs (i.e. without timeout set explicitly)
         value: 50
+    BUS_PM:
+        description: >
+            Enable extra power management capabilities for bus driver. This
+            allows for some automatic management of bus device state instead of
+            implementing this manually.
+        value: 0
 
     BUS_STATS:
         description: >

--- a/kernel/os/include/os/os_mutex.h
+++ b/kernel/os/include/os/os_mutex.h
@@ -102,6 +102,26 @@ os_error_t os_mutex_release(struct os_mutex *mu);
  */
 os_error_t os_mutex_pend(struct os_mutex *mu, os_time_t timeout);
 
+/**
+ * Get mutex lock count.
+ *
+ * @note Function should be called from task owning the mutex (one that
+ * successfully called os_mutex_pend). Calling function from other task
+ * that does not own the mutex will return value that has little value
+ * to the caller since value can change at any time by other task.
+ *
+ * It can also be called from interrupt context to check if given mutex
+ * is taken.
+ *
+ * @param mu Pointer to mutex.
+ *
+ * @return number of times lock was called from current task
+ */
+static inline os_error_t os_mutex_get_level(struct os_mutex *mu)
+{
+    return mu->mu_level;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This adds some power management capabilities to bus devices. By default, it just allows to disable bus device by calling `os_dev_suspend` and enable it by calling `os_dev_resume`.

Extra pm capabilities can be enabled with `BUS_PM: 1` which adds automatic pm mode. It can be enabled in runtime at any time and allows to control enabled state of bus device automatically depending on its inactivity, i.e. it will enable bus device before transaction and will disable it when not needed. This allows for simpler app and avoids duplicating code unnecessarily.