### PR TITLE
i2c_nrf52_twim: add dependency to stats. Turn off statistics by

### DIFF
--- a/hw/bus/drivers/i2c_nrf52_twim/pkg.yml
+++ b/hw/bus/drivers/i2c_nrf52_twim/pkg.yml
@@ -26,3 +26,6 @@ pkg.keywords:
 pkg.deps:
     - hw/bus
     - hw/bus/drivers/i2c_common
+
+pkg.req_apis.I2C_NRF52_TWIM_STAT:
+    - stats

--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -26,7 +26,9 @@
 #include "bus/drivers/i2c_common.h"
 #include "mcu/nrf52_hal.h"
 #include "nrfx.h"
+#if MYNEWT_VAL(I2C_NRF52_TWIM_STAT)
 #include "stats/stats.h"
+#endif
 
 #define TWIM_GPIO_PIN_CNF \
     ((GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos) |  \

--- a/hw/bus/drivers/i2c_nrf52_twim/syscfg.yml
+++ b/hw/bus/drivers/i2c_nrf52_twim/syscfg.yml
@@ -20,7 +20,7 @@ syscfg.defs:
     I2C_NRF52_TWIM_STAT:
         description: >
             Enable statistics for driver errors and applied workarounds.
-        value: 1
+        value: 0
     I2C_NRF52_TWIM_SCL_RECOVERY_DELAY_USEC:
         description: >
             Time to wait for activity on SCL line after triggering start task


### PR DESCRIPTION
default.