### PR TITLE
kernel/os: Move os_arch_in_isr() for sim to arch

### DIFF
--- a/kernel/os/include/os/arch/common.h
+++ b/kernel/os/include/os/arch/common.h
@@ -63,7 +63,6 @@ void os_arch_ctx_sw(struct os_task *);
 os_sr_t os_arch_save_sr(void);
 void os_arch_restore_sr(os_sr_t);
 int os_arch_in_critical(void);
-int os_arch_in_isr(void);
 void os_arch_init(void);
 uint32_t os_arch_start(void);
 os_error_t os_arch_os_init(void);

--- a/kernel/os/include/os/arch/rv32imac/os/os_arch.h
+++ b/kernel/os/include/os/arch/rv32imac/os/os_arch.h
@@ -42,6 +42,15 @@ void plic_default_isr(int num);
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"
 
+static inline int
+os_arch_in_isr(void)
+{
+    /*
+     * TODO: Not implemented yet, add actual code to check it
+     */
+    return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/include/os/arch/sim-armv7/os/os_arch.h
+++ b/kernel/os/include/os/arch/sim-armv7/os/os_arch.h
@@ -64,6 +64,12 @@ void os_arch_frame_init(struct stack_frame *sf);
 /* for unittests */
 void os_arch_os_stop(void);
 
+static inline int
+os_arch_in_isr(void)
+{
+    return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/include/os/arch/sim-mips/os/os_arch.h
+++ b/kernel/os/include/os/arch/sim-mips/os/os_arch.h
@@ -64,6 +64,12 @@ void os_arch_frame_init(struct stack_frame *sf);
 /* for unittests */
 void os_arch_os_stop(void);
 
+static inline int
+os_arch_in_isr(void)
+{
+    return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/include/os/arch/sim/os/os_arch.h
+++ b/kernel/os/include/os/arch/sim/os/os_arch.h
@@ -64,6 +64,12 @@ void os_arch_frame_init(struct stack_frame *sf);
 /* for unittests */
 void os_arch_os_stop(void);
 
+static inline int
+os_arch_in_isr(void)
+{
+    return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Sim build, unlike other architectures, had only prototype for
os_arch_in_isr while other architectures have static inline version
of this function.
Once function was started to be used in some code sim build stared to
fail since there is no actual non-static-inline implementation anywhere.

Now sim also have this function present as static inline returning always 0.