### PR TITLE
hw/drivers/spiflash: Add auto power down

### DIFF
--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -45,6 +45,13 @@ struct spiflash_dev {
 #if MYNEWT_VAL(OS_SCHEDULING)
     struct os_mutex lock;
 #endif
+#if MYNEWT_VAL(SPIFLASH_AUTO_POWER_DOWN)
+#if MYNEWT_VAL(OS_SCHEDULING)
+    struct os_callout apd_tmo_co;   /* Auto power down timeout callout */
+    os_time_t apd_tmo;              /* Auto power down timeout value (ticks) */
+#endif
+    bool pd_active;                 /* Power down active */
+#endif
 };
 
 extern struct spiflash_dev spiflash_dev;
@@ -99,6 +106,8 @@ int spiflash_init(const struct hal_flash *dev);
 
 void spiflash_power_down(struct spiflash_dev *dev);
 void spiflash_release_power_down(struct spiflash_dev *dev);
+
+int spiflash_auto_power_down_set(struct spiflash_dev *dev, uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -97,6 +97,9 @@ struct spiflash_chip {
 
 int spiflash_init(const struct hal_flash *dev);
 
+void spiflash_power_down(struct spiflash_dev *dev);
+void spiflash_release_power_down(struct spiflash_dev *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -44,6 +44,17 @@ syscfg.defs:
         description: 'Requested baudrate, value must be supported by SPI driver'
         value: 0
 
+    SPIFLASH_AUTO_POWER_DOWN:
+        description: >
+            Enables auto power down feature which allows to power down flash
+            automatically when not used. It will be also automatically released
+            from power down on any access. The power down timeout is configurable
+            in runtime to allow for adjusting behavior of this feature depending
+            on power state.
+            Note: if enabled without OS_SCHEDULING, only automatic release from
+                  power down will be supported (i.e. no automatic power down).
+        value: 0
+
     SPIFLASH_MANUFACTURER:
         description: >
             Expected SpiFlash manufacturer as read by Read JEDEC ID command 9FH.


### PR DESCRIPTION
This adds new API which allows to enable auto power down for SPI flash.
Application can define timeout after which power down command will be
sent to flash. It will be automatically release from power down for any
new request from application.

Note: There should be some delay between sending power down release
command and using flash, but the required delay was so small on flashes
I tested that it does not really matter. If required at some point, we
should add this to SPI flash configuration matrix.