### PR TITLE
Fix disconnect during OTA by spacing out erases

### DIFF
--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -825,7 +825,9 @@ imgr_upload(struct mgmt_cbuf *cb)
         }
     }
 
+#if MYNEWT_VAL(IMGMGR_LAZY_ERASE)
 end:
+#endif
     flash_area_close(fa);
 
     if (rc != 0) {

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -30,6 +30,11 @@ syscfg.defs:
             The maximum amount of image or core data that can fit in a
             single NMP message
         value: 512
+    IMGMGR_LAZY_ERASE:
+        description: >
+            During a firmware upgrade, erase flash a sector at a time
+            prior to writing to it, rather than all at once at start
+        value: 1
     IMGMGR_VERBOSE_ERR:
         description: >
             Send verbose error message in responses.

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -34,7 +34,7 @@ syscfg.defs:
         description: >
             During a firmware upgrade, erase flash a sector at a time
             prior to writing to it, rather than all at once at start
-        value: 1
+        value: 0
     IMGMGR_VERBOSE_ERR:
         description: >
             Send verbose error message in responses.


### PR DESCRIPTION
* Erasing the entire flash image size at once can take significant time, causing a bluetooth disconnect or significant battery sag.  Instead, we erase immediately prior to crossing a sector while writing the image.

* We could check for empty to increase efficiency.  However, for simplicity and consistency we will always erase lazily.

* wrap with `MYNEWT_VAL(IMGMGR_LAZY_ERASE)`.  Set IMGMGR_LAZY_ERASE to 0 to disable (default, same as existing behavior), or 1 to enable.