### PR TITLE
apollo2; remove dependency for compiler from MCU package;

### DIFF
--- a/hw/mcu/ambiq/apollo2/pkg.yml
+++ b/hw/mcu/ambiq/apollo2/pkg.yml
@@ -29,4 +29,3 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/ambiq"
     - "@apache-mynewt-core/hw/cmsis-core"
-    - "@apache-mynewt-core/compiler/arm-none-eabi-m4"


### PR DESCRIPTION
this is now specified in bsp.yml