### PR TITLE
mbedtls; fix build warning of uninitialized variable.

### DIFF
--- a/crypto/mbedtls/src/x509_crt.c
+++ b/crypto/mbedtls/src/x509_crt.c
@@ -2014,7 +2014,7 @@ static int x509_crt_find_parent_in(
 {
     int ret;
     mbedtls_x509_crt *parent, *fallback_parent;
-    int signature_is_good, fallback_signature_is_good;
+    int signature_is_good = 0, fallback_signature_is_good;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     /* did we have something in progress? */


### PR DESCRIPTION
Error: repos/apache-mynewt-core/crypto/mbedtls/src/x509_crt.c: In function 'x509_crt_find_parent_in':
repos/apache-mynewt-core/crypto/mbedtls/src/x509_crt.c:2097:30: error: 'signature_is_good' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         *r_signature_is_good = signature_is_good;
         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

exit status 1
