### PR TITLE
hw/mcu/nrf52: Add option to use GPIOTE port event

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -51,6 +51,15 @@ syscfg.defs:
             If disabled, standard i2c_hal driver is used.
         value: 0
 
+    MCU_GPIO_USE_PORT_EVENT:
+        description: >
+            When enabled, hal_gpio will use GPIOTE PORT event instead of PIN
+            events for interrupts. This mode may be less accurate (i.e. pulse
+            length needs to be longer in order to be detected) but it reduces
+            power consumption since it does not require HFCLK to be running.
+            Refer to nRF52xxx Product Specification document for more details.
+        value: 0
+
 # MCU peripherals definitions
     I2C_0:
         description: 'Enable nRF52xxx I2C (TWI) 0'


### PR DESCRIPTION
Current implementation of interrupts in `hal_gpio` uses `GPIOTE` pin events which allows for easier and more accurate handling of multiple pins but in this mode HFCLK is always running which increases power consumption.

Another option is to use `GPIOTE` port event which does not require HFCLK but has some limitations like less accurate detection, level state sensing only and uses single event (or-ed) for all pins.

This patch adds syscfg option which enables `hal_gpio` to use `GPIOTE` port event for handling interrupts. This involves some extra logic which is required to translate single event into events for specific pin.

To enable set `MCU_GPIO_USE_PORT_EVENT: 1`.