### PR TITLE
Hal gpio deinit

### DIFF
--- a/hw/hal/include/hal/hal_gpio.h
+++ b/hw/hal/include/hal/hal_gpio.h
@@ -102,6 +102,15 @@ int hal_gpio_init_in(int pin, hal_gpio_pull_t pull);
 int hal_gpio_init_out(int pin, int val);
 
 /**
+ * Deinitialize the specified pin to revert the previous initialization
+ *
+ * @param pin Pin number to unset
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int hal_gpio_deinit(int pin);
+
+/**
  * Write a value (either high or low) to the specified pin.
  *
  * @param pin Pin to set

--- a/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
@@ -104,7 +104,7 @@ hal_gpio_init_out(int pin, int val)
 }
 
 /**
- * Deinitialize the specified pin to revert the previous initialization
+ * Deinitialize the specified pin to revert to default configuration
  *
  * @param pin Pin number to unset
  *

--- a/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
@@ -104,6 +104,27 @@ hal_gpio_init_out(int pin, int val)
 }
 
 /**
+ * Deinitialize the specified pin to revert the previous initialization
+ *
+ * @param pin Pin number to unset
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int
+hal_gpio_deinit(int pin)
+{
+    uint32_t conf;
+    NRF_GPIO_Type *port;
+
+    conf = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
+    port = HAL_GPIO_PORT(pin);
+    port->PIN_CNF[pin] = conf;
+    port->DIRCLR = HAL_GPIO_MASK(pin);
+
+    return 0;
+}
+
+/**
  * gpio write
  *
  * Write a value (either high or low) to the specified pin.

--- a/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_gpio.c
@@ -113,14 +113,7 @@ hal_gpio_init_out(int pin, int val)
 int
 hal_gpio_deinit(int pin)
 {
-    uint32_t conf;
-    NRF_GPIO_Type *port;
-
-    conf = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
-    port = HAL_GPIO_PORT(pin);
-    port->PIN_CNF[pin] = conf;
-    port->DIRCLR = HAL_GPIO_MASK(pin);
-
+    NRF_GPIO->PIN_CNF[pin] = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
     return 0;
 }
 

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -151,6 +151,27 @@ hal_gpio_init_out(int pin, int val)
 }
 
 /**
+ * Deinitialize the specified pin to revert the previous initialization
+ *
+ * @param pin Pin number to unset
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int
+hal_gpio_deinit(int pin)
+{
+    uint32_t conf;
+    NRF_GPIO_Type *port;
+
+    conf = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
+    port = HAL_GPIO_PORT(pin);
+    port->PIN_CNF[pin] = conf;
+    port->DIRCLR = HAL_GPIO_MASK(pin);
+
+    return 0;
+}
+
+/**
  * gpio write
  *
  * Write a value (either high or low) to the specified pin.

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -151,7 +151,7 @@ hal_gpio_init_out(int pin, int val)
 }
 
 /**
- * Deinitialize the specified pin to revert the previous initialization
+ * Deinitialize the specified pin to revert to default configuration
  *
  * @param pin Pin number to unset
  *

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -162,10 +162,11 @@ hal_gpio_deinit(int pin)
 {
     uint32_t conf;
     NRF_GPIO_Type *port;
+    int pin_index = HAL_GPIO_INDEX(pin);
 
     conf = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
     port = HAL_GPIO_PORT(pin);
-    port->PIN_CNF[pin] = conf;
+    port->PIN_CNF[pin_index] = conf;
     port->DIRCLR = HAL_GPIO_MASK(pin);
 
     return 0;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_gpio.c
@@ -167,7 +167,6 @@ hal_gpio_deinit(int pin)
     conf = GPIO_PIN_CNF_INPUT_Disconnect << GPIO_PIN_CNF_INPUT_Pos;
     port = HAL_GPIO_PORT(pin);
     port->PIN_CNF[pin_index] = conf;
-    port->DIRCLR = HAL_GPIO_MASK(pin);
 
     return 0;
 }

--- a/hw/mcu/stm/stm32_common/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32_common/src/hal_gpio.c
@@ -642,7 +642,7 @@ hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od)
 }
 
 /**
- * Deinitialize the specified pin to revert the previous initialization
+ * Deinitialize the specified pin to revert to default configuration
  *
  * @param pin Pin number to unset
  *

--- a/hw/mcu/stm/stm32_common/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32_common/src/hal_gpio.c
@@ -642,6 +642,20 @@ hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od)
 }
 
 /**
+ * Deinitialize the specified pin to revert the previous initialization
+ *
+ * @param pin Pin number to unset
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+int
+hal_gpio_deinit(int pin)
+{
+    GPIO_InitTypeDef gpio;
+    return hal_gpio_deinit_stm(pin, &gpio);
+}
+
+/**
  * gpio write
  *
  * Write a value (either high or low) to the specified pin.


### PR DESCRIPTION
Current implementation does not allow to uninitialize a pin which has been previously initialized.
An uninitialized pin means a pin in state "unconnected", or at least in the same state after a boot (not input, not output, not analog...).

It is useful in some cases to be able to revert a `hal_gpio_init_*()` call.

I created the prototype in the `hal/hal_gpio.h`.
Then, I have implemented this into 2 different MCU references (stm32 + nrf51/52) as the first step, but it is not blocking if your MCU doesn't implement it, as long as you don't call the `hal_gpio_deinit()`.

We can discuss about it with pleasure if you have other questions.