### PR TITLE
 sys/metrics: Use SYS_E[...] return codes

### DIFF
--- a/sys/metrics/include/metrics/metrics.h
+++ b/sys/metrics/include/metrics/metrics.h
@@ -228,7 +228,7 @@ struct metrics_event_hdr {
  * @param count    Number of metrics definition
  * @param name     Printable event name
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_event_init(struct metrics_event_hdr *hdr,
                        const struct metrics_metric_def *metrics, uint8_t count,
@@ -242,7 +242,7 @@ int metrics_event_init(struct metrics_event_hdr *hdr,
  *
  * @param hdr  Event header
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_event_register(struct metrics_event_hdr *hdr);
 
@@ -258,7 +258,7 @@ int metrics_event_register(struct metrics_event_hdr *hdr);
  * @param module  Log module
  * @param level   Log level
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  *
  * @sa log_append
  */
@@ -274,7 +274,7 @@ int metrics_event_set_log(struct metrics_event_hdr *hdr, struct log *log,
  * @param hdr        Event header
  * @param timestamp  Event timestamp
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_event_start(struct metrics_event_hdr *hdr, uint32_t timestamp);
 
@@ -288,7 +288,7 @@ int metrics_event_start(struct metrics_event_hdr *hdr, uint32_t timestamp);
  *
  * @param hdr        Event header
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise.
  */
 int metrics_event_end(struct metrics_event_hdr *hdr);
 
@@ -304,7 +304,7 @@ int metrics_event_end(struct metrics_event_hdr *hdr);
  * @param metric  Metric identifier
  * @param state   New state for metric data collection
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_set_state(struct metrics_event_hdr *hdr, uint8_t metric,
                       bool state);
@@ -319,7 +319,7 @@ int metrics_set_state(struct metrics_event_hdr *hdr, uint8_t metric,
  * @param hdr   Event header
  * @param mask  Metrics bitmask
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_set_state_mask(struct metrics_event_hdr *hdr, uint32_t mask);
 
@@ -333,7 +333,7 @@ int metrics_set_state_mask(struct metrics_event_hdr *hdr, uint32_t mask);
  * @param hdr   Event header
  * @param mask  Metrics bitmask
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_clr_state_mask(struct metrics_event_hdr *hdr, uint32_t mask);
 /**
@@ -360,7 +360,7 @@ uint32_t metrics_get_state_mask(struct metrics_event_hdr *hdr);
  * @param metric  Metric identifier
  * @param val     Metric value
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_set_value(struct metrics_event_hdr *hdr, uint8_t metric,
                       uint32_t val);
@@ -375,7 +375,7 @@ int metrics_set_value(struct metrics_event_hdr *hdr, uint8_t metric,
  * @param metric  Metric identifier
  * @param val     Metric value
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_set_single_value(struct metrics_event_hdr *hdr, uint8_t metric,
                              uint32_t val);
@@ -391,7 +391,7 @@ int metrics_set_single_value(struct metrics_event_hdr *hdr, uint8_t metric,
  * @param metric  Metric identifier
  * @param val     Metric value
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_set_series_value(struct metrics_event_hdr *hdr, uint8_t metric,
                              uint32_t val);
@@ -412,7 +412,7 @@ int metrics_set_series_value(struct metrics_event_hdr *hdr, uint8_t metric,
  * @param hdr  Event header
  * @param om   Target mbuf
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on success, SYS_E[...] error otherwise
  */
 int metrics_event_to_cbor(struct metrics_event_hdr *hdr, struct os_mbuf *om);
 

--- a/sys/metrics/src/cli.c
+++ b/sys/metrics/src/cli.c
@@ -17,10 +17,13 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(METRICS_CLI)
+
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include "os/os.h"
 #include "shell/shell.h"
 #include "console/console.h"
 #include "metrics/metrics.h"
@@ -258,3 +261,4 @@ metrics_cli_init(void)
 
     return 0;
 }
+#endif

--- a/sys/metrics/src/metrics.c
+++ b/sys/metrics/src/metrics.c
@@ -124,10 +124,9 @@ metrics_event_end(struct metrics_event_hdr *hdr)
     if (hdr->log) {
         om = metrics_get_mbuf();
         if (om) {
-            os_mbuf_extend(om, sizeof(struct log_entry_hdr));
             if (!metrics_event_to_cbor(hdr, om)) {
-                log_append_mbuf_typed(hdr->log, hdr->log_module, hdr->log_level,
-                                      LOG_ETYPE_CBOR, om);
+                log_append_mbuf_body(hdr->log, hdr->log_module, hdr->log_level,
+                                     LOG_ETYPE_CBOR, om);
             } else {
                 ret = -1;
             }

--- a/sys/metrics/src/metrics.c
+++ b/sys/metrics/src/metrics.c
@@ -128,6 +128,7 @@ metrics_event_end(struct metrics_event_hdr *hdr)
                 log_append_mbuf_body(hdr->log, hdr->log_module, hdr->log_level,
                                      LOG_ETYPE_CBOR, om);
             } else {
+                os_mbuf_free_chain(om);
                 ret = -1;
             }
         } else {

--- a/sys/metrics/src/metrics.c
+++ b/sys/metrics/src/metrics.c
@@ -81,7 +81,11 @@ metrics_event_init(struct metrics_event_hdr *hdr,
 int
 metrics_event_register(struct metrics_event_hdr *hdr)
 {
+#if MYNEWT_VAL(METRICS_CLI)
     return metrics_cli_register_event(hdr);
+#else
+    return SYS_ENOTSUP;
+#endif
 }
 
 int


### PR DESCRIPTION
The main purpose of this PR is to change the `sys/metrics` API to use the `SYS_E[...]` return codes.  This is needed specifically so that the application can distinguish flash write failures from other error conditions.

I included a few other minor fixes as well.

There is one other commit I wanted to mention here: `f19b152 sys/metrics: Free mbuf on failure`.  I'm a bit perplexed by this... it seems I broke this myself a while back while fixing a double free.  Now, instead of freeing an mbuf trice, the code doesn't free it at all!  Anyway, I think the code is finally correct now, but since I got this wrong last time, I would appreciate a close look by the reviewer.