### PR TITLE
CoAP; cleanups for observing resources when using transport(s) with connections

### DIFF
--- a/net/oic/include/oic/messaging/coap/observe.h
+++ b/net/oic/include/oic/messaging/coap/observe.h
@@ -77,6 +77,8 @@ int coap_notify_observers(oc_resource_t *resource,
 int coap_observe_handler(struct coap_packet_rx *req, coap_packet_t *response,
                          oc_resource_t *resource, oc_endpoint_t *endpoint);
 
+void coap_observer_walk(int (*walk_func)(struct coap_observer *, void *),
+                        void *arg);
 void coap_observe_init(void);
 
 #ifdef __cplusplus

--- a/net/oic/include/oic/port/mynewt/adaptor.h
+++ b/net/oic/include/oic/port/mynewt/adaptor.h
@@ -26,6 +26,8 @@ extern "C" {
 
 struct os_eventq *oc_evq_get(void);
 
+void oc_conn_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/oic/include/oic/port/mynewt/ble.h
+++ b/net/oic/include/oic/port/mynewt/ble.h
@@ -42,6 +42,18 @@ struct oc_endpoint_ble {
  */
 int oc_endpoint_is_gatt(const struct oc_endpoint *oe);
 
+
+/**
+ * @brief Indicates whether the endpoints belong to same GATT (BLE) connection.
+ *
+ * @param oe1                   The endpoint to compare.
+ * @param oe2                   The endpoint to compare.
+ *
+ * @return                      1 if yes; 0 otherwise.
+ */
+int oc_endpoint_gatt_conn_eq(const struct oc_endpoint *oe1,
+                             const struct oc_endpoint *oe2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/oic/include/oic/port/mynewt/transport.h
+++ b/net/oic/include/oic/port/mynewt/transport.h
@@ -37,6 +37,7 @@ struct oc_endpoint;
 struct oc_transport {
     uint8_t ot_flags;
     uint8_t (*ot_ep_size)(const struct oc_endpoint *);
+    int (*ot_ep_has_conn)(const struct oc_endpoint *);
     void (*ot_tx_ucast)(struct os_mbuf *);
     void (*ot_tx_mcast)(struct os_mbuf *);
     enum oc_resource_properties

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -61,10 +61,30 @@ oc_endpoint_size(struct oc_endpoint *oe)
     return oc_transports[oe->ep.oe_type]->ot_ep_size(oe);
 }
 
+/*
+ * Whether transport uses TCP-style headers or not.
+ */
 static inline int
 oc_endpoint_use_tcp(struct oc_endpoint *oe)
 {
     return oc_transports[oe->ep.oe_type]->ot_flags & OC_TRANSPORT_USE_TCP;
+}
+
+/*
+ * Whether underlying transport has connections or not.
+ * This normally is indicated by whether TCP style header are used or not.
+ * Allowing transport to override that.
+ */
+static inline int
+oc_endpoint_has_conn(struct oc_endpoint *oe)
+{
+    const struct oc_transport *ot;
+
+    ot = oc_transports[oe->ep.oe_type];
+    if (ot->ot_ep_has_conn) {
+        return ot->ot_ep_has_conn(oe);
+    }
+    return oc_endpoint_use_tcp(oe);
 }
 
 #define OC_MBUF_ENDPOINT(m)                                            \

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -75,6 +75,32 @@ oc_endpoint_use_tcp(struct oc_endpoint *oe)
 uint16_t oc_connectivity_get_dtls_port(void);
 #endif /* OC_SECURITY */
 
+/*
+ * Callback mechanism for connection-oriented transports, to be
+ * called when new connection is established, and when an existing
+ * connection is closed
+ */
+#define OC_ENDPOINT_CONN_EV_OPEN        1
+#define OC_ENDPOINT_CONN_EV_CLOSE       2
+struct oc_conn_cb {
+    SLIST_ENTRY(oc_conn_cb) occ_next;
+    void (*occ_func)(struct oc_endpoint *, int ev);
+};
+void oc_conn_cb_register(struct oc_conn_cb *cb);
+
+struct oc_conn_ev {
+    STAILQ_ENTRY(oc_conn_ev) oce_next;
+    struct oc_endpoint oce_oe;
+    int oce_type;
+};
+/*
+ * Called by underlying connection-oriented transports to notify
+ * about connection state changes.
+ */
+struct oc_conn_ev *oc_conn_ev_alloc(void);
+void oc_conn_created(struct oc_conn_ev *);
+void oc_conn_removed(struct oc_conn_ev *);
+
 enum oc_resource_properties oc_get_trans_security(const struct oc_endpoint *oe);
 int oc_connectivity_init(void);
 void oc_connectivity_shutdown(void);

--- a/net/oic/src/messaging/coap/observe.c
+++ b/net/oic/src/messaging/coap/observe.c
@@ -184,6 +184,24 @@ coap_remove_observer_by_mid(oc_endpoint_t *endpoint, uint16_t mid)
     }
     return removed;
 }
+
+void
+coap_observer_walk(int (*walk_func)(struct coap_observer *, void *), void *arg)
+{
+    struct coap_observer *obs, *next;
+    int rc;
+
+    obs = SLIST_FIRST(&oc_observers);
+    while (obs) {
+        next = SLIST_NEXT(obs, next);
+        rc = walk_func(obs, arg);
+        if (rc) {
+            break;
+        }
+        obs = next;
+    }
+}
+
 /*---------------------------------------------------------------------------*/
 /*- Notification ------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/net/oic/src/messaging/coap/observe.c
+++ b/net/oic/src/messaging/coap/observe.c
@@ -295,7 +295,7 @@ coap_notify_observers(oc_resource_t *resource,
                 coap_init_message(notification, COAP_TYPE_NON, CONTENT_2_05, 0);
 
                 notification->mid = transaction->mid;
-                if (!oc_endpoint_use_tcp(&obs->endpoint) &&
+                if (!oc_endpoint_has_conn(&obs->endpoint) &&
                     obs->obs_counter % COAP_OBSERVE_REFRESH_INTERVAL == 0) {
                     OC_LOG(DEBUG, "coap_observe_notify: forcing CON "
                                  "notification to check for client liveness\n");

--- a/net/oic/src/port/mynewt/adaptor.c
+++ b/net/oic/src/port/mynewt/adaptor.c
@@ -176,6 +176,7 @@ oc_connectivity_init(void)
     int i;
     const struct oc_transport *ot;
 
+    oc_conn_init();
     for (i = 0; i < OC_TRANSPORT_MAX; i++) {
         if (!oc_transports[i]) {
             continue;

--- a/net/oic/src/port/mynewt/conns.c
+++ b/net/oic/src/port/mynewt/conns.c
@@ -75,7 +75,7 @@ oc_conn_created(struct oc_conn_ev *oce)
 {
     OC_LOG(DEBUG, "oc_conn_created: ");
     OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, &oce->oce_oe);
-    oce->oce_type = OC_ENDPOINT_CONN_EV_CLOSE;
+    oce->oce_type = OC_ENDPOINT_CONN_EV_OPEN;
     oc_conn_ev_queue(oce);
 }
 

--- a/net/oic/src/port/mynewt/conns.c
+++ b/net/oic/src/port/mynewt/conns.c
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include <string.h>
+#include <os/mynewt.h>
+#include <log/log.h>
+
+#include "oic/oc_log.h"
+#include "oic/port/oc_connectivity.h"
+#include "oic/port/mynewt/adaptor.h"
+
+#define OC_CONN_EV_CB   MYNEWT_VAL(OC_CONN_EV_CB_CNT)
+
+static SLIST_HEAD(, oc_conn_cb) oc_conn_cbs =
+    SLIST_HEAD_INITIALIZER(oc_conn_cbs);
+static STAILQ_HEAD(, oc_conn_ev) oc_conn_evs =
+    STAILQ_HEAD_INITIALIZER(oc_conn_evs);
+
+static void oc_conn_ev_deliver(struct os_event *);
+static struct os_event oc_conn_cb_ev = {
+    .ev_cb = oc_conn_ev_deliver,
+};
+static struct os_mempool oc_conn_ev_pool;
+static uint8_t oc_conn_ev_area[OS_MEMPOOL_BYTES(OC_CONN_EV_CB,
+                                                sizeof(struct oc_conn_ev))];
+
+void
+oc_conn_cb_register(struct oc_conn_cb *cb)
+{
+    SLIST_INSERT_HEAD(&oc_conn_cbs, cb, occ_next);
+}
+
+void
+oc_conn_init(void)
+{
+    os_mempool_init(&oc_conn_ev_pool, OC_CONN_EV_CB, sizeof(struct oc_conn_ev),
+                    oc_conn_ev_area, "oc_conn_ev");
+}
+
+struct oc_conn_ev *
+oc_conn_ev_alloc(void)
+{
+    return os_memblock_get(&oc_conn_ev_pool);
+}
+
+static void
+oc_conn_ev_queue(struct oc_conn_ev *oce)
+{
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+    STAILQ_INSERT_TAIL(&oc_conn_evs, oce, oce_next);
+    OS_EXIT_CRITICAL(sr);
+    os_eventq_put(oc_evq_get(), &oc_conn_cb_ev);
+}
+
+void
+oc_conn_created(struct oc_conn_ev *oce)
+{
+    OC_LOG(DEBUG, "oc_conn_created: ");
+    OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, &oce->oce_oe);
+    oce->oce_type = OC_ENDPOINT_CONN_EV_CLOSE;
+    oc_conn_ev_queue(oce);
+}
+
+void
+oc_conn_removed(struct oc_conn_ev *oce)
+{
+    OC_LOG(DEBUG, "oc_conn_removed: ");
+    OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, &oce->oce_oe);
+    oce->oce_type = OC_ENDPOINT_CONN_EV_CLOSE;
+    oc_conn_ev_queue(oce);
+}
+
+static void
+oc_conn_ev_deliver(struct os_event *ev)
+{
+    struct oc_conn_ev *oce;
+    struct oc_conn_cb *occ;
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+    while ((oce = STAILQ_FIRST(&oc_conn_evs))) {
+        STAILQ_REMOVE_HEAD(&oc_conn_evs, oce_next);
+        OS_EXIT_CRITICAL(sr);
+        SLIST_FOREACH(occ, &oc_conn_cbs, occ_next) {
+            occ->occ_func(&oce->oce_oe, oce->oce_type);
+        }
+        os_memblock_put(&oc_conn_ev_pool, oce);
+        OS_ENTER_CRITICAL(sr);
+    }
+    OS_EXIT_CRITICAL(sr);
+}

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -105,8 +105,8 @@ syscfg.defs:
 
     OC_CONN_EV_CB_CNT:
         description: >
-            How many connection callback events for connecreated/removed events
-            can be queued at the same time.
+            How many connection callback events for connection reated/removed
+            events can be queued at the same time.
         value: 4
 
     OC_SYSINIT_STAGE_MAIN:

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -103,6 +103,12 @@ syscfg.defs:
         description: 'How many seconds before client request times out'
         value: 4
 
+    OC_CONN_EV_CB_CNT:
+        description: >
+            How many connection callback events for connecreated/removed events
+            can be queued at the same time.
+        value: 4
+
     OC_SYSINIT_STAGE_MAIN:
         description: >
             Main sysinit stage for OIC functionality.


### PR DESCRIPTION
- observer cleanup when BLE connection is going away was running (potentially) in wrong task context
- add a generic mechanism for init/cleanup notifications for connections when using coap
- allow more flexibility for transport to report whether particular endpoint is running over a connection or if it is connectionless