### PR TITLE
kernel/os: Track most recent event in debug builds

### DIFF
--- a/kernel/os/include/os/os_eventq.h
+++ b/kernel/os/include/os/os_eventq.h
@@ -71,10 +71,13 @@ struct os_eventq {
      */
     struct os_task *evq_task;
 
+#if MYNEWT_VAL(OS_EVENTQ_DEBUG)
+    /** Most recently processed event. */
+    struct os_event *evq_prev;
+#endif
 
     STAILQ_HEAD(, os_event) evq_list;
 };
-
 
 /**
  * Initialize the event queue

--- a/kernel/os/src/os_eventq.c
+++ b/kernel/os/src/os_eventq.c
@@ -148,6 +148,10 @@ pull_one:
 
     os_trace_api_ret_u32(OS_TRACE_ID_EVENTQ_GET, (uint32_t)ev);
 
+#if MYNEWT_VAL(OS_EVENTQ_DEBUG)
+    evq->evq_prev = ev;
+#endif
+
     return (ev);
 }
 

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -138,6 +138,11 @@ syscfg.defs:
         description: >
             Enables debug runtime checks for time-related functionality.
         value: 0
+    OS_EVENTQ_DEBUG:
+        description: >
+            Enables debug runtime checks for eventq-related functionality.
+        value: 0
+
     OS_CRASH_FILE_LINE:
         description: >
             Include filename and line number in crash messages.  Aids in
@@ -154,3 +159,4 @@ syscfg.vals.OS_DEBUG_MODE:
     OS_MEMPOOL_CHECK: 1
     OS_MEMPOOL_POISON: 1
     OS_TIME_DEBUG: 1
+    OS_EVENTQ_DEBUG: 1


### PR DESCRIPTION
Add a new syscfg setting: `OS_EVENTQ_DEBUG`.  When this setting is enabled, each eventq remembers its most recently processed event.

This feature is only useful when debugging with gdb.