### PR TITLE
[FRDM-K64F] Increase size of bootloader slot

### DIFF
--- a/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
@@ -58,9 +58,9 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = 0x00008000, LENGTH = 0x00000420
-  m_flash_config        (RX)  : ORIGIN = 0x00008420, LENGTH = 0x00000010
-  FLASH                 (RX)  : ORIGIN = 0x00008430, LENGTH = 0x00100000-0x8430
+  m_interrupts          (RX)  : ORIGIN = 0x0000C000, LENGTH = 0x00000420
+  m_flash_config        (RX)  : ORIGIN = 0x0000C420, LENGTH = 0x00000010
+  FLASH                 (RX)  : ORIGIN = 0x0000C430, LENGTH = 0x00100000-0xC430
   RAM                   (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00040000
 }
 

--- a/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
@@ -60,7 +60,7 @@ MEMORY
 {
   m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
   m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
-  FLASH                 (RX)  : ORIGIN = 0x00000410, LENGTH = 0x000FFBF0
+  FLASH                 (RX)  : ORIGIN = 0x00000410, LENGTH = 0x00009BF0
   RAM                   (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00040000
 }
 

--- a/hw/bsp/frdm-k64f/bsp.yml
+++ b/hw/bsp/frdm-k64f/bsp.yml
@@ -32,19 +32,19 @@ bsp.flash_map:
         FLASH_AREA_BOOTLOADER:
             device: 0
             offset: 0x00000000
-            size: 24kB
+            size: 40kB
         FLASH_AREA_IMAGE_SCRATCH:
             device: 0
-            offset: 0x00006000
+            offset: 0x0000A000
             size: 8kB
         FLASH_AREA_IMAGE_0:
             device: 0
-            offset: 0x00008000
-            size: 480kB
+            offset: 0x0000C000
+            size: 472kB
         FLASH_AREA_IMAGE_1:
             device: 0
-            offset: 0x00080000
-            size: 480kB
+            offset: 0x00082000
+            size: 472kB
 
         # User areas
         FLASH_AREA_REBOOT_LOG:


### PR DESCRIPTION
This makes the bootloader 40kb (from 24kb) to have enough space to do encrypted image testing, and reduces slot 0/1 sizes from 480KB to 472KB which does not seem very significant.

Also the linker script size of the bootloader was correctly adjusted to what is defined on the BSP avoiding non-caught errors when the bootloader size is big enough to overflow the configured space.