### PR TITLE
NRF52 Timer - Achieve Low Power When Off

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -704,6 +704,7 @@ hal_timer_deinit(int timer_num)
         hwtimer = (NRF_TIMER_Type *)bsptimer->tmr_reg;
         hwtimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
         hwtimer->TASKS_STOP = 1;
+        hwtimer->TASKS_SHUTDOWN = 1;
     }
     bsptimer->tmr_enabled = 0;
     bsptimer->tmr_reg = NULL;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -581,6 +581,7 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
 
         /* Stop the timer first */
         rtctimer->TASKS_STOP = 1;
+        rtctimer->TASKS_CLEAR = 1;
 
         /* Always no prescaler */
         rtctimer->PRESCALER = 0;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -653,6 +653,7 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
 
     /* Stop the timer first */
     hwtimer->TASKS_STOP = 1;
+    hwtimer->TASKS_CLEAR = 1;
 
     /* Put the timer in timer mode using 32 bits. */
     hwtimer->MODE = TIMER_MODE_MODE_Timer;
@@ -703,7 +704,6 @@ hal_timer_deinit(int timer_num)
     } else {
         hwtimer = (NRF_TIMER_Type *)bsptimer->tmr_reg;
         hwtimer->INTENCLR = NRF_TIMER_INT_MASK(NRF_TIMER_CC_INT);
-        hwtimer->TASKS_STOP = 1;
         hwtimer->TASKS_SHUTDOWN = 1;
     }
     bsptimer->tmr_enabled = 0;


### PR DESCRIPTION
This PR implements a suggested work around to achieve low power with timer off.

**NRF52832 Errata v1.9 - 3.19 [78] TIMER: High current consumption when using
timer STOP task only**

**Symptoms**
Increased current consumption when the timer has been running and the STOP task is used to stop it.

**Conditions**
The timer has been running (after triggering a START task) and then it is stopped using a STOP task only.

**Consequences**
Increased current consumption.

**Workaround**
Use the SHUTDOWN task after the STOP task or instead of the STOP task.