### PR TITLE
compiler/gdbmacros: scripts to dump stacks

### DIFF
--- a/compiler/gdbmacros/os.gdb
+++ b/compiler/gdbmacros/os.gdb
@@ -71,3 +71,53 @@ document os_wakeups
 usage: os_wakeups
 Displays scheduled OS callouts, and next scheduled task wakeups
 end
+
+define os_stack_dump_range
+    set $start = (uintptr_t)$arg0
+    set $num_words = $arg1
+
+    set $cur = 0
+    while $cur < $num_words
+        set $addr = ((os_stack_t *)$start) + $cur
+        printf "0x%08x: ", $addr
+        x/a *$addr
+
+        set $cur++
+    end
+end
+
+define os_task_stack_dump
+    set $task = $arg0
+
+    set $stackptr = $task.t_stackptr
+    set $num_words = $task.t_stacktop - $stackptr
+
+    os_stack_dump_range $stackptr $num_words
+end
+
+document os_task_stack_dump
+usage: os_task_stack_dump <task>
+Dumps the specified task's stack, including symbol info.
+end
+
+define os_task_stack_dump_all
+    set $first = 1
+    set $task = g_os_task_list.stqh_first
+    while $task != 0
+        if $first
+            set $first = 0
+        else
+            printf "\n"
+        end
+
+        printf "[%s]\n", $task.t_name
+        os_task_stack_dump $task
+
+        set $task = $task.t_os_task_list.stqe_next
+    end
+end
+
+document os_task_stack_dump_all
+usage: os_task_stack_dump_all
+Dumps all task stacks, including symbol info.
+end


### PR DESCRIPTION
This commit adds two public gdb scripts:
```
    usage: os_task_stack_dump <task>
    Dumps the specified task's stack, including symbol info.
```
```
    usage: os_task_stack_dump_all
    Dumps all task stacks, including symbol info.
```