### PR TITLE
mempool_tests: Fix stack corruption bug

### DIFF
--- a/kernel/os/test/src/testcases/os_mempool_test_case.c
+++ b/kernel/os/test/src/testcases/os_mempool_test_case.c
@@ -36,6 +36,7 @@ mempool_test(int num_blocks, int block_size, bool clear)
     void *block;
     os_error_t rc;
 
+    /* Attempt to unregister the pool in case this test has already run. */
     os_mempool_unregister(&g_TstMempool);
 
     /* Check for too many blocks */

--- a/kernel/os/test/src/testcases/os_mempool_test_ext_basic.c
+++ b/kernel/os/test/src/testcases/os_mempool_test_ext_basic.c
@@ -21,6 +21,7 @@
 
 static struct os_mempool_ext *freed_pool;
 static void *freed_block;
+static struct os_mempool_ext pool;
 
 static os_error_t
 put_cb(struct os_mempool_ext *mpe, void *block, void *arg)
@@ -39,9 +40,11 @@ put_cb(struct os_mempool_ext *mpe, void *block, void *arg)
 TEST_CASE(os_mempool_test_ext_basic)
 {
     uint8_t buf[OS_MEMPOOL_BYTES(10, 32)];
-    struct os_mempool_ext pool;
     int *ip;
     int rc;
+
+    /* Attempt to unregister the pool in case this test has already run. */
+    os_mempool_unregister(&pool.mpe_mp);
 
     rc = os_mempool_ext_init(&pool, 10, 32, buf, "test_ext_basic");
     TEST_ASSERT_FATAL(rc == 0);

--- a/kernel/os/test/src/testcases/os_mempool_test_ext_nested.c
+++ b/kernel/os/test/src/testcases/os_mempool_test_ext_nested.c
@@ -19,6 +19,7 @@
 #include "os_test_priv.h"
 
 static int num_frees;
+static struct os_mempool_ext pool;
 
 static os_error_t
 put_cb(struct os_mempool_ext *mpe, void *block, void *arg)
@@ -45,9 +46,11 @@ put_cb(struct os_mempool_ext *mpe, void *block, void *arg)
 TEST_CASE(os_mempool_test_ext_nested)
 {
     uint8_t buf[OS_MEMPOOL_BYTES(10, 32)];
-    struct os_mempool_ext pool;
     int *elem;
     int rc;
+
+    /* Attempt to unregister the pool in case this test has already run. */
+    os_mempool_unregister(&pool.mpe_mp);
 
     rc = os_mempool_ext_init(&pool, 10, 32, buf, "test_ext_nested");
     TEST_ASSERT_FATAL(rc == 0);


### PR DESCRIPTION
The "extended mempool" tests were causing stack corruption.  These tests registered mempools that were allocated on the stack and never unregistered them.  So, after these tests ran, the global mempool list contained some invalid entries.  Subsequently attempting to iterate or append to the list resulted in a crash or other unpredictable behavior.

The solution is:
1. Statically allocate the mempools.
2. Always unregister the relevant mempool at the start of each test.

This is now the non-extended tests are already implemented.