### PR TITLE
kernel/os: Fix redundant checks in os_mempool_init

### DIFF
--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -125,7 +125,7 @@ os_mempool_init_internal(struct os_mempool *mp, uint16_t blocks,
     struct os_memblock *block_ptr;
 
     /* Check for valid parameters */
-    if (!mp || (blocks < 0) || (block_size <= 0)) {
+    if (!mp || (block_size == 0)) {
         return OS_INVALID_PARM;
     }
 


### PR DESCRIPTION
Unsigned arguments cannot be <0...