### PR TITLE
hw/scripts: Issue 2nd reset after jlink load

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -64,6 +64,12 @@ jlink_load () {
     # XXXX 'newt run' was not always updating the flash on nrf52dk. With
     # 'info reg' in place it seems to work every time. Not sure why.
     echo "info reg" >> $GDB_CMD_FILE
+
+    # Reset the device a second time.  Some devices seem to be stuck in a weird
+    # state when they are programmed (e.g., looping in a default interrupt
+    # handler).  The reset clears the bad state.
+    echo "mon reset" >> $GDB_CMD_FILE
+
     echo "quit" >> $GDB_CMD_FILE
 
     msgs=`arm-none-eabi-gdb -x $GDB_CMD_FILE 2>&1`


### PR DESCRIPTION
After writing the binary to flash, reset the device a second time.  Some devices seem to be stuck in a weird state when they are programmed (e.g., looping in a default interrupt handler).  The reset clears the bad state.

This "weird state" mostly happens when the device's internal flash is automatically erased via JTAG lockout protection.  However, I have occasionally seen this issue even when JTAG lockout is disabled.

I did not test this on a wide variety of devices, but I think this is an innocuous change.

Also, do we need something similar in the openocd script?