### PR TITLE
spiflash: Remove delay when reading ready status

### DIFF
--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -876,8 +876,6 @@ spiflash_wait_ready(struct spiflash_dev *dev, uint32_t timeout_ms)
     spiflash_lock(dev);
 
     while (!spiflash_device_ready(dev)) {
-        /* If not ready let's give it 10ms */
-        os_time_delay(os_time_ms_to_ticks32(10));
         if (os_time_get() > exp_time) {
             rc = -1;
             goto err;


### PR DESCRIPTION
Assume that when spiflash_wait_ready() is called in general flash should
be ready, therfore while() in this function should not take long.
If any delay is needed for given operation it should be applied outside
this function e.g. erase