### PR TITLE
 compiler/sim: Use `gcc` in macOS, not `gcc-5`

### DIFF
--- a/compiler/sim/compiler.yml
+++ b/compiler/sim/compiler.yml
@@ -25,8 +25,7 @@ compiler.path.archive: "ar"
 compiler.path.objdump: "objdump"
 compiler.path.objsize: "size"
 compiler.path.objcopy: "objcopy"
-compiler.flags.base: >
-    -m32 -Wall -Werror -ggdb
+compiler.flags.base: [-m32, -Wall, -Werror, -ggdb]
 compiler.ld.resolve_circular_deps: true
 
 compiler.flags.default: [compiler.flags.base, -O1]
@@ -34,24 +33,21 @@ compiler.flags.debug: [compiler.flags.base, -O0]
 compiler.as.flags: [-x, assembler-with-cpp]
 compiler.ld.mapfile: false
 compiler.ld.binfile: false
-compiler.ld.flags: -lm
+compiler.ld.flags: [-lm]
 
 # Linux.
-compiler.flags.base.LINUX: >
-    -DMN_LINUX
-compiler.ld.flags.LINUX: -lutil
+compiler.flags.base.LINUX: [-DMN_LINUX]
+compiler.ld.flags.LINUX: [-lutil]
 
 # OS X.
 compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
-compiler.flags.base.DARWIN: >
-    -DMN_OSX
+compiler.flags.base.DARWIN: [-DMN_OSX]
 compiler.ld.resolve_circular_deps.DARWIN.OVERWRITE: false
 
 compiler.path.cc.FREEBSD.OVERWRITE: "gcc7"
 compiler.path.as.FREEBSD.OVERWRITE: "gcc7"
-compiler.flags.base.FREEBSD: >
-    -DMN_FreeBSD -D_WITH_DPRINTF
-compiler.ld.flags.FREEBSD.OVERWRITE: -L/usr/lib32 -B/usr/lib32 -lutil
+compiler.flags.base.FREEBSD: [-DMN_FreeBSD, -D_WITH_DPRINTF]
+compiler.ld.flags.FREEBSD.OVERWRITE: [-L/usr/lib32, -B/usr/lib32, -lutil]

--- a/compiler/sim/compiler.yml
+++ b/compiler/sim/compiler.yml
@@ -40,11 +40,11 @@ compiler.flags.base.LINUX: [-DMN_LINUX]
 compiler.ld.flags.LINUX: [-lutil]
 
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc"
+compiler.path.as.DARWIN.OVERWRITE: "gcc"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
-compiler.flags.base.DARWIN: [-DMN_OSX]
+compiler.flags.base.DARWIN: [-DMN_OSX, -Wno-missing-braces]
 compiler.ld.resolve_circular_deps.DARWIN.OVERWRITE: false
 
 compiler.path.cc.FREEBSD.OVERWRITE: "gcc7"


### PR DESCRIPTION
In macOS, the sim compiler package invokes the `gcc-5` binary.  This is not ideal - gcc5 is rather old now, so most mac users won't have it on their machine.

The reason the compiler package does not just specify `gcc` is that macOS ships with an "imposter" gcc binary: an outdated version of clang with the filename "gcc".  Until recently, much of the unit test code would not build with clang, so `gcc-5` was specified as a workaround.

To get the code building with clang, this commit adds some compiler flags in macOS:

* `-Wno-missing-braces`
* `-Wmissing-field-initializers`

The first flag silences a spurious warning caused by a bug in clang ("suggest braces around initialization of subobject").  This bug has supposedly been fixed in the latest clang: https://bugs.llvm.org/show_bug.cgi?id=21629.  However, it is difficult to replace the version of clang that ships with macOS, so I don't think we should require users to upgrade their compiler.

The second flag is not strictly necessary - it just scales back the effects of the first flag.  It re-adds legitimate warnings that were silenced by the first flag.