### PR TITLE
hw/mcu/nordic/nrf52xxx: Fix possible SPI lockup

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -941,9 +941,7 @@ hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int len)
         spim = hal_spi->nhs_spi.spim;
         enabled = spim->ENABLE;
         if (enabled == SPIM_ENABLE_ENABLE_Enabled) {
-            spim->INTENCLR = NRF_SPI_IRQ_DISABLE_ALL;
-            hal_spi_stop_transfer(spim);
-            spim->ENABLE = 0;
+            hal_spi_disable(spi_num);
             enabled = 0;
         }
 


### PR DESCRIPTION
When switching between the blocking and non-blocking interfaces
it is possible to lockup the SPI in hal_spi_stop_transfer() if
the SPI master is enabled but no transfer started as setting
TASKS_STOP will not always generate an EVENTS_STOPPED. Calling
hal_spi_disable() will check to see if the xfr_flag is set before
calling hal_spi_stop_transfer().