### PR TITLE
mcu/nordic: Add missig baud rates

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_uart.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_uart.c
@@ -194,18 +194,36 @@ static uint32_t
 hal_uart_baudrate(int baudrate)
 {
     switch (baudrate) {
+    case 1200:
+        return UART_BAUDRATE_BAUDRATE_Baud1200;
+    case 2400:
+        return UART_BAUDRATE_BAUDRATE_Baud2400;
+    case 4800:
+        return UART_BAUDRATE_BAUDRATE_Baud4800;
     case 9600:
         return UART_BAUDRATE_BAUDRATE_Baud9600;
+    case 14400:
+        return UART_BAUDRATE_BAUDRATE_Baud14400;
     case 19200:
         return UART_BAUDRATE_BAUDRATE_Baud19200;
+    case 28800:
+        return UART_BAUDRATE_BAUDRATE_Baud28800;
+    case 31250:
+        return UART_BAUDRATE_BAUDRATE_Baud31250;
     case 38400:
         return UART_BAUDRATE_BAUDRATE_Baud38400;
+    case 56000:
+        return UART_BAUDRATE_BAUDRATE_Baud56000;
     case 57600:
         return UART_BAUDRATE_BAUDRATE_Baud57600;
+    case 76800:
+        return UART_BAUDRATE_BAUDRATE_Baud76800;
     case 115200:
         return UART_BAUDRATE_BAUDRATE_Baud115200;
     case 230400:
         return UART_BAUDRATE_BAUDRATE_Baud230400;
+    case 250000:
+        return UART_BAUDRATE_BAUDRATE_Baud250000;
     case 460800:
         return UART_BAUDRATE_BAUDRATE_Baud460800;
     case 921600:

--- a/hw/mcu/nordic/nrf52xxx/src/hal_uart.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_uart.c
@@ -291,10 +291,16 @@ hal_uart_baudrate(int baudrate)
         return UARTE_BAUDRATE_BAUDRATE_Baud4800;
     case 9600:
         return UARTE_BAUDRATE_BAUDRATE_Baud9600;
+    case 14400:
+        return UARTE_BAUDRATE_BAUDRATE_Baud14400;
     case 19200:
         return UARTE_BAUDRATE_BAUDRATE_Baud19200;
+    case 28800:
+        return UARTE_BAUDRATE_BAUDRATE_Baud28800;
     case 38400:
         return UARTE_BAUDRATE_BAUDRATE_Baud38400;
+    case 56000:
+        return UARTE_BAUDRATE_BAUDRATE_Baud56000;
     case 57600:
         return UARTE_BAUDRATE_BAUDRATE_Baud57600;
     case 76800:
@@ -303,6 +309,8 @@ hal_uart_baudrate(int baudrate)
         return UARTE_BAUDRATE_BAUDRATE_Baud115200;
     case 230400:
         return UARTE_BAUDRATE_BAUDRATE_Baud230400;
+    case 250000:
+        return UARTE_BAUDRATE_BAUDRATE_Baud250000;
     case 460800:
         return UARTE_BAUDRATE_BAUDRATE_Baud460800;
     case 921600:


### PR DESCRIPTION
This PR addresses https://github.com/apache/mynewt-core/issues/1579
The added baud rates are not supported by minicom or screen, so these changes were tested on nRF52dk using [this pyserial script](https://gist.github.com/mlaz/84658bb75e258211e96870d78159584d).