### PR TITLE
sys/config: Add API for conf_load_one()

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -190,9 +190,10 @@ int conf_load(void);
 
 /**
  * Load configuration from a specific registered persistence source.
- * Handlers will be called for configuration subtrees for
+ * Handlers will be called for configuration subtree for
  * encountered values.
  *
+ * @param name of the configuration subtree.
  * @return 0 on success, non-zero on failure.
  */
 int conf_load_one(char *name);

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -192,6 +192,8 @@ int conf_load(void);
  * Load configuration from a specific registered persistence source.
  * Handlers will be called for configuration subtrees for
  * encountered values.
+ *
+ * @return 0 on success, non-zero on failure.
  */
 int conf_load_one(char *name);
 

--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -189,6 +189,13 @@ int conf_register(struct conf_handler *cf);
 int conf_load(void);
 
 /**
+ * Load configuration from a specific registered persistence source.
+ * Handlers will be called for configuration subtrees for
+ * encountered values.
+ */
+int conf_load_one(char *name);
+
+/**
  * @brief Loads the configuration if it hasn't been loaded since reboot.
  *
  * @return 0 on success, non-zero on failure.

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -67,7 +67,38 @@ conf_dst_register(struct conf_store *cs)
 static void
 conf_load_cb(char *name, char *val, void *cb_arg)
 {
-    conf_set_value(name, val);
+    if ((cb_arg && !strcmp((char*)cb_arg, name)) ||
+        cb_arg == NULL) {
+        /* If cb_arg is set, set specific conf value
+         * If cb_arg is not set, just set the value
+         * anyways
+         */
+        conf_set_value(name, val);
+    }
+}
+
+int
+conf_load_one(char *name)
+{
+    struct conf_store *cs;
+
+    /*
+     * for every config store
+     *    load config
+     *    apply config
+     *    commit all
+     */
+    conf_lock();
+    conf_loading = true;
+    SLIST_FOREACH(cs, &conf_load_srcs, cs_next) {
+        cs->cs_itf->csi_load(cs, conf_load_cb, name);
+        if (SLIST_NEXT(cs, cs_next)) {
+            conf_commit(name);
+        }
+    }
+    conf_loading = false;
+    conf_unlock();
+    return conf_commit(name);
 }
 
 int

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -67,8 +67,7 @@ conf_dst_register(struct conf_store *cs)
 static void
 conf_load_cb(char *name, char *val, void *cb_arg)
 {
-    if ((cb_arg && !strcmp((char*)cb_arg, name)) ||
-        cb_arg == NULL) {
+    if (!cb_arg || !strcmp((char*)cb_arg, name)) {
         /* If cb_arg is set, set specific conf value
          * If cb_arg is not set, just set the value
          * anyways
@@ -83,7 +82,7 @@ conf_load_one(char *name)
     struct conf_store *cs;
 
     /*
-     * for every config store
+     * for this specific config store
      *    load config
      *    apply config
      *    commit all


### PR DESCRIPTION
- Earlier we would load all configuration values together, this API gives us a way to load just one value.
- conf_load() still loads everything the way it used to.