### PR TITLE
kernel/os: Don't hang in os_time_delay() if OS scheduler disabled

### DIFF
--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -98,13 +98,6 @@ os_time_advance(int ticks)
         }
     }
 }
-#else
-void
-os_time_advance(int ticks)
-{
-    g_os_time += ticks;
-}
-#endif
 
 void
 os_time_delay(os_time_t osticks)
@@ -118,6 +111,21 @@ os_time_delay(os_time_t osticks)
         os_sched(NULL);
     }
 }
+
+#else
+
+void
+os_time_advance(int ticks)
+{
+    g_os_time += ticks;
+}
+
+void
+os_time_delay(os_time_t osticks)
+{
+}
+
+#endif
 
 /**
  * Searches the list of registered time change listeners for the specified


### PR DESCRIPTION
If the OS scheduler is disabled (`!MYNEWT_VAL(OS_SCHEDULING)`), then turn `os_time_delay()` into a no-op.

Prior to this PR, this function would hang forever when scheduling is disabled.

The motivation for this PR is the `flash_loader` app.  The scheduler is not enabled in this app.  If it is run on a device with SPI flash, the calls to `os_time_delay()` in the SPI flash driver cause the app to hang.