### PR TITLE
spiflash: Include bsp.h

### DIFF
--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "os/mynewt.h"
+#include <bsp/bsp.h>
 #include <hal/hal_spi.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_flash.h>


### PR DESCRIPTION
This is small change that allows to specify constants often
defined in bsp.h for pins.