### PR TITLE
couple of fixes and changes for RISCV platform

### DIFF
--- a/hw/bsp/hifive1/src/hal_bsp.c
+++ b/hw/bsp/hifive1/src/hal_bsp.c
@@ -96,3 +96,11 @@ hal_bsp_init(void)
 #endif
 #endif
 }
+
+int
+hal_bsp_hw_id(uint8_t *id, int max_len)
+{
+    /* XXX figure out what to put here */
+
+    return 0;
+}

--- a/hw/bsp/hifive1/src/hal_bsp.c
+++ b/hw/bsp/hifive1/src/hal_bsp.c
@@ -25,54 +25,9 @@
 #include <flash_map/flash_map.h>
 #include <hal/hal_bsp.h>
 #include <hal/hal_flash.h>
-#include <hal/hal_spi.h>
-#include <hal/hal_watchdog.h>
 #include <mcu/fe310_hal.h>
-#if MYNEWT_VAL(UART_0)
-#include <uart/uart.h>
-#include <uart_hal/uart_hal.h>
-#endif
+#include <mcu/fe310_periph.h>
 #include <bsp/bsp.h>
-#include <env/freedom-e300-hifive1/platform.h>
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#include "bus/bus.h"
-#if MYNEWT_VAL(SPI_0) || MYNEWT_VAL(SPI_1) || MYNEWT_VAL(SPI_2)
-#include "bus/spi.h"
-#endif
-#endif
-
-#if MYNEWT_VAL(UART_0)
-static struct uart_dev os_bsp_uart0;
-static const struct fe310_uart_cfg os_bsp_uart0_cfg = {
-    .suc_pin_tx = HIFIVE_UART0_TX,
-    .suc_pin_rx = HIFIVE_UART0_RX,
-};
-#endif
-
-#if MYNEWT_VAL(TIMER_0)
-extern struct fe310_hal_tmr fe310_pwm2;
-#endif
-#if MYNEWT_VAL(TIMER_1)
-extern struct fe310_hal_tmr fe310_pwm1;
-#endif
-#if MYNEWT_VAL(TIMER_2)
-extern struct fe310_hal_tmr fe310_pwm0;
-#endif
-
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-#if MYNEWT_VAL(SPI_1)
-static const struct bus_spi_dev_cfg spi1_cfg = {
-    .spi_num = 1,
-};
-static struct bus_spi_dev spi1_bus;
-#endif
-#if MYNEWT_VAL(SPI_2)
-static const struct bus_spi_dev_cfg spi2_cfg = {
-    .spi_num = 2,
-};
-static struct bus_spi_dev spi2_bus;
-#endif
-#endif
 
 /*
  * What memory to include in coredump.
@@ -106,50 +61,5 @@ hal_bsp_core_dump(int *area_cnt)
 void
 hal_bsp_init(void)
 {
-    int rc;
-
-    (void)rc;
-#if MYNEWT_VAL(TIMER_0)
-    rc = hal_timer_init(0, (void *)&fe310_pwm2);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_1)
-    rc = hal_timer_init(1, (void *)&fe310_pwm1);
-    assert(rc == 0);
-#endif
-#if MYNEWT_VAL(TIMER_2)
-    rc = hal_timer_init(2, (void *)&fe310_pwm0);
-    assert(rc == 0);
-#endif
-
-#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
-    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
-    assert(rc == 0);
-#endif
-
-#if MYNEWT_VAL(SPI_1)
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_spi_dev_create("spi1", &spi1_bus, (struct bus_spi_dev_cfg *)&spi1_cfg);
-    assert(rc == 0);
-#else
-    rc = hal_spi_init(1, NULL, HAL_SPI_TYPE_MASTER);
-    assert(rc == 0);
-#endif
-#endif
-#if MYNEWT_VAL(SPI_2)
-#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    rc = bus_spi_dev_create("spi2", &spi2_bus, (struct bus_spi_dev_cfg *)&spi2_cfg);
-    assert(rc == 0);
-#else
-    rc = hal_spi_init(2, NULL, HAL_SPI_TYPE_MASTER);
-    assert(rc == 0);
-#endif
-#endif
-
-#if MYNEWT_VAL(UART_0)
-    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
-      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&os_bsp_uart0_cfg);
-    assert(rc == 0);
-#endif
-
+    fe310_periph_create();
 }

--- a/hw/bsp/hifive1/syscfg.yml
+++ b/hw/bsp/hifive1/syscfg.yml
@@ -24,3 +24,11 @@ syscfg.vals:
     TIMER_0: 1
     TIMER_1: 1
     TIMER_2: 1
+
+syscfg.defs.BUS_DRIVER_PRESENT:
+    BSP_FLASH_SPI_NAME:
+        description: 'SPIFLASH device name'
+        value: '"spiflash0"'
+    BSP_FLASH_SPI_BUS:
+        description: 'bus name SPIFLASH is connected to'
+        value:

--- a/hw/mcu/sifive/fe310/include/mcu/fe310_periph.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310_periph.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __H_FE310_PERIPH_
+#define __H_FE310_PERIPH_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+void fe310_periph_create(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __H_FE310_PERIPH_ */

--- a/hw/mcu/sifive/fe310/pkg.yml
+++ b/hw/mcu/sifive/fe310/pkg.yml
@@ -29,4 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/sifive"
 
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
+
 pkg.cflags: -march=rv32imac -mabi=ilp32

--- a/hw/mcu/sifive/fe310/src/fe310_periph.c
+++ b/hw/mcu/sifive/fe310/src/fe310_periph.c
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <assert.h>
+
+#include <hal/hal_spi.h>
+
+#include <defs/error.h>
+#include <syscfg/syscfg.h>
+
+#include <mcu/fe310_hal.h>
+#include <mcu/sys_clock.h>
+#include <sifive/devices/spi.h>
+#include <env/freedom-e300-hifive1/platform.h>
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#if MYNEWT_VAL(SPI_0) || MYNEWT_VAL(SPI_1) || MYNEWT_VAL(SPI_2)
+#include "bus/drivers/spi_common.h"
+#include "bus/drivers/spi_hal.h"
+#endif
+#endif
+#if MYNEWT_VAL(UART_0)
+#include <uart/uart.h>
+#include <uart_hal/uart_hal.h>
+#endif
+
+#if MYNEWT_VAL(TIMER_0)
+extern struct fe310_hal_tmr fe310_pwm2;
+#endif
+#if MYNEWT_VAL(TIMER_1)
+extern struct fe310_hal_tmr fe310_pwm1;
+#endif
+#if MYNEWT_VAL(TIMER_2)
+extern struct fe310_hal_tmr fe310_pwm0;
+#endif
+
+#if MYNEWT_VAL(UART_0)
+static struct uart_dev os_bsp_uart0;
+#endif
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#if MYNEWT_VAL(SPI_1)
+static const struct bus_spi_dev_cfg spi1_cfg = {
+    .spi_num = 1,
+};
+static struct bus_spi_dev spi1_bus;
+#endif
+#if MYNEWT_VAL(SPI_2)
+static const struct bus_spi_dev_cfg spi2_cfg = {
+    .spi_num = 2,
+};
+static struct bus_spi_dev spi2_bus;
+#endif
+#endif
+
+static void
+fe310_periph_create_timers(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(TIMER_0)
+    rc = hal_timer_init(0, (void *)&fe310_pwm2);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_1)
+    rc = hal_timer_init(1, (void *)&fe310_pwm1);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(TIMER_2)
+    rc = hal_timer_init(2, (void *)&fe310_pwm0);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+}
+
+static void
+fe310_periph_create_uart(void)
+{
+#if MYNEWT_VAL(UART_0)
+    int rc;
+
+    rc = os_dev_create((struct os_dev *) &os_bsp_uart0, "uart0",
+        OS_DEV_INIT_PRIMARY, 0, uart_hal_init, NULL);
+    assert(rc == 0);
+#endif
+
+}
+
+static void
+fe310_periph_create_spi(void)
+{
+    int rc;
+
+    (void)rc;
+#if MYNEWT_VAL(SPI_1)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_spi_hal_dev_create("spi1", &spi1_bus,
+                                (struct bus_spi_dev_cfg *)&spi1_cfg);
+    assert(rc == 0);
+#else
+    rc = hal_spi_init(1, NULL, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+#endif
+
+#if MYNEWT_VAL(SPI_2)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_spi_hal_dev_create("spi2", &spi2_bus,
+                                (struct bus_spi_dev_cfg *)&spi2_cfg);
+    assert(rc == 0);
+#else
+    rc = hal_spi_init(2, NULL, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+#endif
+}
+
+void
+fe310_periph_create(void)
+{
+    fe310_periph_create_timers();
+    fe310_periph_create_uart();
+    fe310_periph_create_spi();
+}

--- a/hw/mcu/sifive/fe310/src/hal_uart.c
+++ b/hw/mcu/sifive/fe310/src/hal_uart.c
@@ -182,14 +182,14 @@ int
 hal_uart_init(int port, void *arg)
 {
     uint32_t mask;
-    struct fe310_uart_cfg *cfg = (struct fe310_uart_cfg *)arg;
+    (void)arg;
 
     if (port != 0) {
         return -1;
     }
 
     /* Configure RX/TX pins */
-    mask = (1 << cfg->suc_pin_tx) | (1 << cfg->suc_pin_rx);
+    mask = (1U << IOF_UART0_RX) | (1U << IOF_UART0_TX);
     GPIO_REG(GPIO_IOF_EN) |= mask;
     GPIO_REG(GPIO_IOF_SEL) &= ~mask;
 

--- a/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
+++ b/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
@@ -226,14 +226,6 @@ os_arch_start(void)
 
     /* Get the highest priority ready to run to set the current task */
     t = os_sched_next_task();
-    /*
-     * First time setup fake os_task struct that only has one pointer for SP
-     * Having that will make context switch function work same for first
-     * and every other time.
-     * This fake SP will be used during initial context switch to store SP
-     * that will never be used.
-     */
-    os_sched_set_current_task(&fake_task);
 
     /* Clean software interrupt, and enable it */
     CLINT_REG(CLINT_MSIP) = 0;
@@ -249,6 +241,15 @@ os_arch_start(void)
 
     /* Perform context switch */
     os_arch_ctx_sw(t);
+
+    /*
+     * First time setup fake os_task struct that only has one pointer for SP
+     * Having that will make context switch function work same for first
+     * and every other time.
+     * This fake SP will be used during initial context switch to store SP
+     * that will never be used.
+     */
+    os_sched_set_current_task(&fake_task);
 
     /* Enable interrupts */
     set_csr(mstatus, MSTATUS_MIE);


### PR DESCRIPTION
- MCU specific devices are not created in mcu_periph.c (like in nordic platform)
- fix that allow to use stack checking
- small code reduction in UART
- spiflash now can be easily enabled on hifive1 board
- added hwl_bsp_hw_id() stub function