### PR TITLE
util/cbmem: Fix hosted test

### DIFF
--- a/util/cbmem/hosttest/include/cbmem_test/cbmem_test.h
+++ b/util/cbmem/hosttest/include/cbmem_test/cbmem_test.h
@@ -28,8 +28,9 @@
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
 
-#define CBMEM1_BUF_SIZE (64 * 1024)
-#define CBMEM1_ENTRY_SIZE 1024
+#define CBMEM1_ENTRY_COUNT  32
+#define CBMEM1_ENTRY_SIZE   64
+#define CBMEM1_BUF_SIZE     (CBMEM1_ENTRY_COUNT * CBMEM1_ENTRY_SIZE)
 
 extern struct cbmem cbmem1;
 extern uint8_t cbmem1_buf[CBMEM1_BUF_SIZE];

--- a/util/cbmem/hosttest/src/cbmem_test.c
+++ b/util/cbmem/hosttest/src/cbmem_test.c
@@ -54,7 +54,7 @@ setup_cbmem1(void *arg)
      * entries, so there should be a total of 63 entries.
      * Ensure no data corruption.
      */
-    for (i = 0; i < 65; i++) {
+    for (i = 0; i < CBMEM1_ENTRY_COUNT + 1; i++) {
         cbmem1_entry[0] = i;
         rc = cbmem_append(&cbmem1, cbmem1_entry, sizeof(cbmem1_entry));
         TEST_ASSERT_FATAL(rc == 0, "Could not append entry %d, rc = %d", i, rc);

--- a/util/cbmem/selftest/include/cbmem_test/cbmem_test.h
+++ b/util/cbmem/selftest/include/cbmem_test/cbmem_test.h
@@ -28,8 +28,9 @@
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
 
-#define CBMEM1_BUF_SIZE (64 * 1024)
-#define CBMEM1_ENTRY_SIZE 1024
+#define CBMEM1_ENTRY_COUNT  64
+#define CBMEM1_ENTRY_SIZE   1024
+#define CBMEM1_BUF_SIZE     (CBMEM1_ENTRY_COUNT * CBMEM1_ENTRY_SIZE)
 
 extern struct cbmem cbmem1;
 extern uint8_t cbmem1_buf[CBMEM1_BUF_SIZE];

--- a/util/cbmem/selftest/src/cbmem_test.c
+++ b/util/cbmem/selftest/src/cbmem_test.c
@@ -54,7 +54,7 @@ setup_cbmem1(void *arg)
      * entries, so there should be a total of 63 entries.
      * Ensure no data corruption.
      */
-    for (i = 0; i < 65; i++) {
+    for (i = 0; i < CBMEM1_ENTRY_COUNT + 1; i++) {
         cbmem1_entry[0] = i;
         rc = cbmem_append(&cbmem1, cbmem1_entry, sizeof(cbmem1_entry));
         TEST_ASSERT_FATAL(rc == 0, "Could not append entry %d, rc = %d", i, rc);


### PR DESCRIPTION
The hosted cbmem test tries to allocate a 64kB buffer in BSS.   This is due to a blind copy and paste from the cbmem self test.

This commit reduces this buffer to 2kB.