### PR TITLE
sys/defs: Add common def for section to place code in RAM

### DIFF
--- a/sys/defs/include/defs/sections.h
+++ b/sys/defs/include/defs/sections.h
@@ -44,6 +44,11 @@ extern "C" {
 #define sec_bss_nz_core
 #endif
 
+/* Code which should be placed and executed from RAM */
+#ifndef sec_text_ram_core
+#define sec_text_ram_core
+#endif
+
 /**
  * Sensitive data (eg keys), which should be excluded from corefiles.
  */

--- a/sys/defs/include/defs/sections.h
+++ b/sys/defs/include/defs/sections.h
@@ -20,6 +20,7 @@
 #ifndef H_DEFS_SECTIONS_
 #define H_DEFS_SECTIONS_
 
+#include <mcu/mcu.h>
 #include <bsp/bsp.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
In some cases it is desired or required to put some code in RAM and
execute it from there thus we should have a common def for section which
can be then handled in MCU package, i.e. be defined to proper section
name and put in proper place in linker script.