### PR TITLE
hw/mcu/nordic: Fix invalid cast for data length

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -156,13 +156,13 @@ nrf52_irqm_handler(struct nrf52_hal_spi *spi)
             len = spi->nhs_buflen - spi->nhs_bytes_txd;
             len = min(SPIM_TXD_MAXCNT_MAX, len);
             spim->TXD.PTR = (uint32_t)spi->nhs_txbuf;
-            spim->TXD.MAXCNT = (uint8_t)len;
+            spim->TXD.MAXCNT = len;
 
             /* If no rxbuf, we need to set rxbuf and maxcnt to 1 */
             if (spi->nhs_rxbuf) {
                 spi->nhs_rxbuf += xfr_bytes;
                 spim->RXD.PTR    = (uint32_t)spi->nhs_rxbuf;
-                spim->RXD.MAXCNT = (uint8_t)len;
+                spim->RXD.MAXCNT = len;
             }
             spim->TASKS_START = 1;
         } else {


### PR DESCRIPTION
Cast when writing data length to register is redundant on nRF52832 but
also can cause truncation on nRF52840 since that register is 16-bit
long.