### PR TITLE
Bookmarks optimization for FCB-backed logs

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -78,6 +78,30 @@ struct fcb {
 
 int fcb_init(struct fcb *fcb);
 
+/** An individual fcb log bookmark. */
+struct fcb_log_bmark {
+    /* FCB entry that the bookmark points to. */
+    struct fcb_entry flb_entry;
+
+    /* The index of the log entry that the FCB entry contains. */
+    uint32_t flb_index;
+};
+
+/** A set of fcb log bookmarks. */
+struct fcb_log_bset {
+    /** Array of bookmarks. */
+    struct fcb_log_bmark *fls_bmarks;
+
+    /** The maximum number of bookmarks. */
+    int fls_cap;
+
+    /** The number of currently usable bookmarks. */
+    int fls_size;
+
+    /** The index where the next bookmark will get written. */
+    int fls_next;
+};
+
 /**
  * fcb_log is needed as the number of entries in a log
  */
@@ -88,6 +112,9 @@ struct fcb_log {
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
     /* Internal - tracking storage use */
     uint32_t fl_watermark_off;
+#endif
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+    struct fcb_log_bset fl_bset;
 #endif
 };
 
@@ -150,6 +177,65 @@ int fcb_clear(struct fcb *fcb);
  */
 int fcb_area_info(struct fcb *fcb, struct flash_area *fa, int *elemsp,
                   int *bytesp);
+
+
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+
+/**
+ * Bookmarks are an optimization to speed up lookups in FCB-backed logs.  The
+ * concept is simple: maintain a set of flash area+offset pairs corresponding
+ * to recently found log entries.  When we perform a log lookup, the walk
+ * starts from the bookmark closest to our desired entry rather than from the
+ * beginning of the log.
+ *
+ * Bookmarks are stored in a circular buffer in the fcb_log object.  Each time
+ * the log is walked, the starting point of the walk is added to the set of
+ * bookmarks. 
+ *
+ * FCB rotation invalidates all bookmarks.  It is up to the client code to
+ * clear a log's bookmarks whenever rotation occurs.
+ */
+
+/**
+ * @brief Configures an fcb_log to use the specified buffer for bookmarks.
+ *
+ * @param fcb_log               The log to configure.
+ * @param bmarks                The buffer to use for bookmarks.
+ * @param bmark_count           The bookmark capacity of the supplied buffer.
+ */
+void fcb_log_init_bmarks(struct fcb_log *fcb_log,
+                         struct fcb_log_bmark *buf, int bmark_count);
+
+/**
+ * @brief Erases all bookmarks from the supplied fcb_log.
+ *
+ * @param fcb_log               The fcb_log to clear.
+ */
+void fcb_log_clear_bmarks(struct fcb_log *fcb_log);
+
+/**
+ * @brief Searches an fcb_log for the closest bookmark that comes before or at
+ * the specified index.
+ *
+ * @param fcb_log               The log to search.
+ * @param index                 The index to look for.
+ *
+ * @return                      The closest bookmark on success;
+ *                              NULL if the log has no applicable bookmarks.
+ */
+const struct fcb_log_bmark *
+fcb_log_closest_bmark(const struct fcb_log *fcb_log, uint32_t index);
+
+/**
+ * Inserts a bookmark into the provided log.
+ *
+ * @param fcb_log               The log to insert a bookmark into.
+ * @param entry                 The entry the bookmark should point to.
+ * @param index                 The log entry index of the bookmark.
+ */
+void fcb_log_add_bmark(struct fcb_log *fcb_log, const struct fcb_entry *entry,
+                       uint32_t index);
+#endif
 
 #ifdef __cplusplus
 }

--- a/fs/fcb/src/fcb_bmark.c
+++ b/fs/fcb/src/fcb_bmark.c
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+
+#include "fcb/fcb.h"
+#include "fcb_priv.h"
+#include "string.h"
+
+void
+fcb_log_init_bmarks(struct fcb_log *fcb_log,
+                    struct fcb_log_bmark *buf, int bmark_count)
+{
+    fcb_log->fl_bset = (struct fcb_log_bset) {
+        .fls_bmarks = buf,
+        .fls_cap = bmark_count,
+    };
+}
+
+void
+fcb_log_clear_bmarks(struct fcb_log *fcb_log)
+{
+    fcb_log->fl_bset.fls_size = 0;
+    fcb_log->fl_bset.fls_next = 0;
+}
+
+const struct fcb_log_bmark *
+fcb_log_closest_bmark(const struct fcb_log *fcb_log, uint32_t index)
+{
+    const struct fcb_log_bmark *closest;
+    const struct fcb_log_bmark *bmark;
+    uint32_t min_diff;
+    uint32_t diff;
+    int i;
+
+    min_diff = UINT32_MAX;
+    closest = NULL;
+
+    for (i = 0; i < fcb_log->fl_bset.fls_size; i++) {
+        bmark = &fcb_log->fl_bset.fls_bmarks[i];
+        if (bmark->flb_index <= index) {
+            diff = index - bmark->flb_index;
+            if (diff < min_diff) {
+                min_diff = diff;
+                closest = bmark;
+            }
+        }
+    }
+
+    return closest;
+}
+
+void
+fcb_log_add_bmark(struct fcb_log *fcb_log, const struct fcb_entry *entry,
+                  uint32_t index)
+{
+    struct fcb_log_bset *bset;
+
+    bset = &fcb_log->fl_bset;
+
+    if (bset->fls_cap == 0) {
+        return;
+    }
+
+    bset->fls_bmarks[bset->fls_next] = (struct fcb_log_bmark) {
+        .flb_entry = *entry,
+        .flb_index = index,
+    };
+
+    if (bset->fls_size < bset->fls_cap) {
+        bset->fls_size++;
+    }
+
+    bset->fls_next++;
+    if (bset->fls_next >= bset->fls_cap) {
+        bset->fls_next = 0;
+    }
+}
+
+#endif /* MYNEWT_VAL(LOG_FCB_BOOKMARKS) */

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -117,6 +117,10 @@ flash_native_file_open(char *name)
         }
     }
 
+    if (file_loc != NULL) {
+        munmap(file_loc, native_flash_dev.hf_size);
+    }
+
     file_loc = mmap(0, native_flash_dev.hf_size,
           PROT_READ | PROT_WRITE, MAP_SHARED, file, 0);
     assert(file_loc != MAP_FAILED);

--- a/sys/log/full/selftest/fcb_bookmarks/pkg.yml
+++ b/sys/log/full/selftest/fcb_bookmarks/pkg.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/fcb_bookmarks
+pkg.type: unittest
+pkg.description: "Log unit tests; flash-alignment=8."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps: 
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"

--- a/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks.c
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_SUITE(log_test_suite_fcb_bookmarks)
+{
+    log_test_case_fcb_bookmarks_s0_l1_b0_p100();
+    log_test_case_fcb_bookmarks_s0_l1_b1_p100();
+    log_test_case_fcb_bookmarks_s10_l100_b1_p200();
+    log_test_case_fcb_bookmarks_s10_l100_b10_p2000();
+    log_test_case_fcb_bookmarks_s100_l500_b10_p2000();
+}
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_fcb_bookmarks();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks.h
+++ b/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_LOG_TEST_FCB_BOOKMARKS_
+#define H_LOG_TEST_FCB_BOOKMARKS_
+
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+
+struct ltfbu_cfg {
+    int skip_mod;
+    int body_len;
+    int bmark_count;
+    int pop_count;
+};
+
+void ltfbu_populate_log(int count);
+void ltfbu_verify_log(uint32_t start_idx);
+void ltfbu_init(const struct ltfbu_cfg *cfg);
+void ltfbu_test_once(const struct ltfbu_cfg *cfg);
+
+TEST_CASE_DECL(log_test_case_fcb_bookmarks_s0_l1_b0_p100);
+TEST_CASE_DECL(log_test_case_fcb_bookmarks_s0_l1_b1_p100);
+TEST_CASE_DECL(log_test_case_fcb_bookmarks_s10_l100_b1_p200);
+TEST_CASE_DECL(log_test_case_fcb_bookmarks_s10_l100_b10_p2000);
+TEST_CASE_DECL(log_test_case_fcb_bookmarks_s100_l500_b10_p2000);
+
+#endif

--- a/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks_util.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks_util.c
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+#define LTFBU_MAX_ENTRY_IDXS    20480
+#define LTFBU_MAX_BODY_LEN      1024
+#define LTFBU_MAX_BMARKS        1024
+
+#define LTFBU_SECTOR_SIZE       (16 * 1024)
+
+struct ltfbu_slice {
+    const uint32_t *idxs;
+    int count;
+};
+
+static struct ltfbu_cfg ltfbu_cfg;
+
+static uint32_t ltfbu_entry_idxs[LTFBU_MAX_ENTRY_IDXS];
+static int ltfbu_num_entry_idxs;
+
+static struct fcb_log ltfbu_fcb_log;
+static struct log ltfbu_log;
+
+static struct fcb_log_bmark ltfbu_bmarks[LTFBU_MAX_BMARKS];
+
+static struct flash_area ltfbu_fcb_areas[] = {
+    [0] = {
+        .fa_off = 0 * LTFBU_SECTOR_SIZE,
+        .fa_size = LTFBU_SECTOR_SIZE,
+    },
+    [1] = {
+        .fa_off = 1 * LTFBU_SECTOR_SIZE,
+        .fa_size = LTFBU_SECTOR_SIZE,
+    }
+};
+
+static int
+ltfbu_max_entries(void)
+{
+    int entry_space;
+    int entry_size;
+    int len_size;
+    int crc_size;
+
+    if (ltfbu_cfg.body_len > 127) {
+        len_size = 2;
+    } else {
+        len_size = 1;
+    }
+    crc_size = 1;
+
+    /* "+ 1" for CRC. */
+    entry_size = sizeof (struct log_entry_hdr) + ltfbu_cfg.body_len +
+                 len_size + crc_size;
+    entry_space = LTFBU_SECTOR_SIZE - 8;
+
+    return entry_space / entry_size;
+}
+
+static void
+ltfbu_expected_entry_range(int *first, int *count)
+{
+    int max_entries;
+    int rollovers;
+
+    max_entries = ltfbu_max_entries();
+    rollovers = ltfbu_num_entry_idxs / max_entries;
+
+    *first = rollovers * max_entries;
+    *count = ltfbu_num_entry_idxs % max_entries;
+}
+
+static struct ltfbu_slice
+ltfbu_expected_idxs(uint32_t start_idx)
+{
+    int first;
+    int count;
+
+    ltfbu_expected_entry_range(&first, &count);
+
+    while (ltfbu_entry_idxs[first] < start_idx) {
+        first++;
+        count--;
+    }
+    
+    return (struct ltfbu_slice) {
+        .idxs = &ltfbu_entry_idxs[first],
+        .count = count,
+    };
+}
+
+static int
+ltfbu_skip_amount(void)
+{
+    if (ltfbu_cfg.skip_mod == 0) {
+        return 0;
+    } else {
+        return rand() % ltfbu_cfg.skip_mod;
+    }
+}
+
+static void
+ltfbu_skip(void)
+{
+    g_log_info.li_next_index += ltfbu_skip_amount();
+}
+
+static void
+ltfbu_write_entry(void)
+{
+    uint8_t body[LTFBU_MAX_BODY_LEN];
+    uint32_t idx;
+    int rc; TEST_ASSERT_FATAL(ltfbu_num_entry_idxs < LTFBU_MAX_ENTRY_IDXS);
+
+    ltfbu_skip();
+    idx = g_log_info.li_next_index;
+
+    memset(body, idx, ltfbu_cfg.body_len);
+
+    rc = log_append_body(&ltfbu_log, 0, 255, LOG_ETYPE_BINARY, body,
+                         ltfbu_cfg.body_len);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    ltfbu_entry_idxs[ltfbu_num_entry_idxs++] = idx;
+}
+
+void
+ltfbu_populate_log(int count)
+{
+    int i;
+
+    for (i = 0; i < count; i++) {
+        ltfbu_write_entry();
+    }
+}
+
+struct ltfbu_walk_arg {
+    struct ltfbu_slice slice;
+    int cur;
+};
+
+static int
+ltfbu_verify_log_walk(struct log *log, struct log_offset *log_offset,
+                      const struct log_entry_hdr *hdr, void *dptr,
+                      uint16_t len)
+{
+    struct ltfbu_walk_arg *arg;
+
+    arg = log_offset->lo_arg;
+
+    TEST_ASSERT_FATAL(arg->cur < arg->slice.count);
+    TEST_ASSERT_FATAL(hdr->ue_index == arg->slice.idxs[arg->cur]);
+
+    arg->cur++;
+
+    return 0;
+}
+
+void
+ltfbu_verify_log(uint32_t start_idx)
+{
+    struct ltfbu_walk_arg arg;
+    struct ltfbu_slice slice;
+    struct log_offset log_offset;
+    int rc;
+
+    slice = ltfbu_expected_idxs(start_idx);
+    arg = (struct ltfbu_walk_arg) {
+        .slice = slice,
+        .cur = 0,
+    };
+
+    log_offset = (struct log_offset) {
+        .lo_arg = &arg,
+        .lo_index = start_idx,
+        .lo_ts = 0,
+        .lo_data_len = 0,
+    };
+
+    rc = log_walk_body(&ltfbu_log, ltfbu_verify_log_walk, &log_offset);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    TEST_ASSERT_FATAL(arg.cur == slice.count);
+}
+
+void
+ltfbu_init(const struct ltfbu_cfg *cfg)
+{
+    int rc;
+    int i;
+
+    /* Ensure tests are repeatable. */
+    srand(0);
+
+    ltfbu_cfg = *cfg;
+    ltfbu_num_entry_idxs = 0;
+
+    ltfbu_fcb_log = (struct fcb_log) {
+        .fl_fcb.f_scratch_cnt = 1,
+        .fl_fcb.f_sectors = ltfbu_fcb_areas,
+        .fl_fcb.f_sector_cnt = sizeof(ltfbu_fcb_areas) / sizeof(ltfbu_fcb_areas[0]),
+        .fl_fcb.f_magic = 0x7EADBADF,
+        .fl_fcb.f_version = 0,
+    };
+
+    for (i = 0; i < ltfbu_fcb_log.fl_fcb.f_sector_cnt; i++) {
+        rc = flash_area_erase(&ltfbu_fcb_areas[i], 0,
+                              ltfbu_fcb_areas[i].fa_size);
+        TEST_ASSERT_FATAL(rc == 0);
+    }
+    rc = fcb_init(&ltfbu_fcb_log.fl_fcb);
+    TEST_ASSERT_FATAL(rc == 0);
+
+    if (cfg->bmark_count > 0) {
+        fcb_log_init_bmarks(&ltfbu_fcb_log, ltfbu_bmarks, cfg->bmark_count);
+    }
+
+    log_register("log", &ltfbu_log, &log_fcb_handler, &ltfbu_fcb_log,
+                 LOG_SYSLEVEL);
+}
+
+void
+ltfbu_test_once(const struct ltfbu_cfg *cfg)
+{
+    uint32_t start_idx;
+    int i;
+
+    ltfbu_init(cfg);
+
+    /* Do this three times:
+     * 1. Write a bunch of entries to the log.
+     * 2. Walk the log, starting from various entry indices
+     * 3. Verify results of walk:
+     *     a. All expected entries are visited.
+     *     b. No extra entries are visited.
+     *
+     * This procedure is repeated three times to ensure that the FCB is rotated
+     * between walks.
+     */
+    for (i = 0; i < 3; i++) {
+        ltfbu_populate_log(cfg->pop_count);
+
+        start_idx = 0;
+        while (start_idx < ltfbu_entry_idxs[ltfbu_num_entry_idxs - 1]) {
+            ltfbu_verify_log(start_idx);
+            start_idx += ltfbu_skip_amount() + 1;
+        }
+    }
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/testcases/s0_l1_b0_p100.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/testcases/s0_l1_b0_p100.c
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_CASE_SELF(log_test_case_fcb_bookmarks_s0_l1_b0_p100)
+{
+    struct ltfbu_cfg cfg = {
+        .skip_mod = 0,
+        .body_len = 10,
+        .bmark_count = 0,
+        .pop_count = 100,
+    };
+    ltfbu_test_once(&cfg);
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/testcases/s0_l1_b1_p100.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/testcases/s0_l1_b1_p100.c
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_CASE_SELF(log_test_case_fcb_bookmarks_s0_l1_b1_p100)
+{
+    struct ltfbu_cfg cfg = {
+        .skip_mod = 0,
+        .body_len = 10,
+        .bmark_count = 1,
+        .pop_count = 100,
+    };
+    ltfbu_test_once(&cfg);
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/testcases/s100_l500_b10_p2000.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/testcases/s100_l500_b10_p2000.c
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_CASE_SELF(log_test_case_fcb_bookmarks_s100_l500_b10_p2000)
+{
+    struct ltfbu_cfg cfg = {
+        .skip_mod = 100,
+        .body_len = 500,
+        .bmark_count = 10,
+        .pop_count = 2000,
+    };
+    ltfbu_test_once(&cfg);
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/testcases/s10_l100_b10_p2000.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/testcases/s10_l100_b10_p2000.c
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_CASE_SELF(log_test_case_fcb_bookmarks_s10_l100_b10_p2000)
+{
+    struct ltfbu_cfg cfg = {
+        .skip_mod = 10,
+        .body_len = 100,
+        .bmark_count = 10,
+        .pop_count = 2000,
+    };
+    ltfbu_test_once(&cfg);
+}

--- a/sys/log/full/selftest/fcb_bookmarks/src/testcases/s10_l100_b1_p200.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/testcases/s10_l100_b1_p200.c
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log_test_util/log_test_util.h"
+#include "log_test_fcb_bookmarks.h"
+
+TEST_CASE_SELF(log_test_case_fcb_bookmarks_s10_l100_b1_p200)
+{
+    struct ltfbu_cfg cfg = {
+        .skip_mod = 10,
+        .body_len = 100,
+        .bmark_count = 1,
+        .pop_count = 200,
+    };
+    ltfbu_test_once(&cfg);
+}

--- a/sys/log/full/selftest/fcb_bookmarks/syscfg.yml
+++ b/sys/log/full/selftest/fcb_bookmarks/syscfg.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_VERSION: 3
+    LOG_FCB: 1
+    LOG_FCB_BOOKMARKS: 1

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -34,6 +34,84 @@ static struct flash_area sector;
 
 static int log_fcb_rtr_erase(struct log *log, void *arg);
 
+/**
+ * Finds the first log entry whose "offset" is >= the one specified.  A log
+ * offset consists of two parts:
+ *     o timestamp
+ *     o index
+ *
+ * The "timestamp" field is misnamed.  If it has a value of -1, then the offset
+ * always points to the latest entry.  If this value is not -1, then it is
+ * ignored; the "index" field is used instead.
+ *
+ * XXX: We should rename "timestamp" or make it an actual timestamp.
+ *
+ * The "index" field corresponds to a log entry index.
+ *
+ * If bookmarks are enabled, this function uses them in the search.
+ *
+ * @return                      0 if an entry was found
+ *                              SYS_ENOENT if there are no suitable entries.
+ *                              Other error on failure.
+ */
+static int
+log_fcb_find_gte(struct log *log, struct log_offset *log_offset,
+                 struct fcb_entry *out_entry)
+{
+    const struct fcb_log_bmark *bmark;
+    struct log_entry_hdr hdr;
+    struct fcb_log *fcb_log;
+    struct fcb *fcb;
+    int rc;
+
+    fcb_log = log->l_arg;
+    fcb = &fcb_log->fl_fcb;
+
+    /*
+     * if timestamp for request is < 0, return last log entry
+     */
+    if (log_offset->lo_ts < 0) {
+        if (fcb_log->fl_entries == 0) {
+            return SYS_ENOENT;
+        } else {
+            *out_entry = fcb->f_active;
+            return 0;
+        }
+    }
+
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+    bmark = fcb_log_closest_bmark(fcb_log, log_offset->lo_index);
+    if (bmark != NULL) {
+        *out_entry = bmark->flb_entry;
+    }
+#else
+    bmark = NULL;
+#endif
+
+    if (bmark == NULL) {
+        /* No bookmark.  Read the first entry in the log. */
+        memset(out_entry, 0, sizeof *out_entry);
+        rc = fcb_getnext(fcb, out_entry);
+        if (rc != 0) {
+            return SYS_ENOENT;
+        }
+    }
+
+    /* Keep advancing until we find an entry with a great enough index. */
+    do {
+        rc = log_read_hdr(log, out_entry, &hdr);
+        if (rc != 0) {
+            return rc;
+        }
+
+        if (hdr.ue_index >= log_offset->lo_index) {
+            return 0;
+        }
+    } while (fcb_getnext(fcb, out_entry) == 0);
+
+    return SYS_ENOENT;
+}
+
 static int
 log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
 {
@@ -75,6 +153,12 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
             LOG_STATS_INCN(log, lost, cnt);
         }
 #endif
+
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+        /* The FCB needs to be rotated.  Invalidate all bookmarks. */
+        fcb_log_clear_bmarks(fcb_log);
+#endif
+
         rc = fcb_rotate(fcb);
         if (rc) {
             goto err;
@@ -381,30 +465,39 @@ log_fcb_walk(struct log *log, log_walk_func_t walk_func,
              struct log_offset *log_offset)
 {
     struct fcb *fcb;
+    struct fcb_log *fcb_log;
     struct fcb_entry loc;
-    struct fcb_entry *locp;
     int rc;
 
-    rc = 0;
-    fcb = &((struct fcb_log *)log->l_arg)->fl_fcb;
+    fcb_log = log->l_arg;
+    fcb = &fcb_log->fl_fcb;
 
-    memset(&loc, 0, sizeof(loc));
-
-    /*
-     * if timestamp for request is < 0, return last log entry
-     */
-    if (log_offset->lo_ts < 0) {
-        locp = &fcb->f_active;
-        rc = walk_func(log, log_offset, (void *)locp, locp->fe_data_len);
-    } else {
-        while (fcb_getnext(fcb, &loc) == 0) {
-            rc = walk_func(log, log_offset, (void *) &loc, loc.fe_data_len);
-            if (rc) {
-                break;
-            }
-        }
+    /* Locate the starting point of the walk. */
+    rc = log_fcb_find_gte(log, log_offset, &loc);
+    switch (rc) {
+    case 0:
+        /* Found a starting point. */
+        break;
+    case SYS_ENOENT:
+        /* No entries match the offset criteria; nothing to walk. */
+        return 0;
+    default:
+        return rc;
     }
-    return (rc);
+
+#if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
+    /* Add a bookmark pointing to this walk's start location. */
+    fcb_log_add_bmark(fcb_log, &loc, log_offset->lo_index);
+#endif
+
+    do {
+        rc = walk_func(log, log_offset, &loc, loc.fe_data_len);
+        if (rc != 0) {
+            return rc;
+        }
+    } while (fcb_getnext(fcb, &loc) == 0);
+
+    return 0;
 }
 
 static int

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -47,6 +47,15 @@ syscfg.defs:
         restrictions:
             - "LOG_FCB"
 
+    LOG_FCB_BOOKMARKS:
+        description: >
+            Enables the bookmarks optimization for FCB-backed log lookups.  To
+            use this optimization, the application must configure FCB logs with
+            bookmark storage at runtime.
+        value: 0
+        restrictions:
+            - LOG_FCB
+
     LOG_CONSOLE:
         description: 'Support logging to console.'
         value: 1


### PR DESCRIPTION
Bookmarks are an optimization to speed up lookups in FCB-backed logs.  The concept is simple: maintain a set of flash area+offset pairs corresponding to recently found log entries.  When we perform a log lookup, the walk starts from the bookmark closest to our desired entry rather than from the beginning of the log.

Bookmarks are stored in a circular buffer in the fcb_log object.  Each time the log is walked, the starting point of the walk is added to the set of bookmarks.

FCB rotation invalidates all bookmarks.

By default, this optimization is disabled.  To enable it, set the `LOG_FCB_BOOKMARKS` syscfg setting to 1.  Each FCB-backed log must then be configured with bookmark storage at runtime.