### PR TITLE
[DO NOT MERGE]LP5523 Engine pr_instruction fix

### DIFF
--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -635,20 +635,32 @@ lp5523_get_engine_mapping(struct led_itf *itf, uint8_t engine,
 static int
 lp5523_set_pr_instruction(struct led_itf *itf, uint8_t addr, uint16_t *ins)
 {
-    uint8_t mem[2] = { ((*ins) >> 8) & 0x00ff, (*ins) & 0x00ff };
+    int rc;
 
-    return lp5523_set_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr << 1), mem, 2);
+    uint8_t byte1[1] = { ((*ins) >> 8) & 0x00ff };
+    uint8_t byte2[1] = { (*ins) & 0x00ff };
+
+    addr = addr << 1;
+
+    rc = lp5523_set_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr), byte1, 1);
+    rc |= lp5523_set_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr + 1), byte2, 1);
+
+    return rc;
 }
 
 static int
 lp5523_get_pr_instruction(struct led_itf *itf, uint8_t addr, uint16_t *ins)
 {
     int rc;
-    uint8_t mem[2];
+    uint8_t byte1[1];
+    uint8_t byte2[1];
 
-    rc = lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr << 1), mem, 2);
+    addr = addr << 1;
 
-    *ins = (((uint16_t)mem[0]) << 8) | mem[1];
+    rc = lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr), byte1, 1);
+    rc |= lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr + 1), byte2, 1);
+
+    *ins = (((uint16_t)byte1[0]) << 8) | byte2[0];
 
     return rc;
 }
@@ -658,15 +670,18 @@ lp5523_verify_pr_instruction(struct led_itf *itf, uint8_t addr,
     uint16_t *ins)
 {
     int rc;
-    uint8_t mem[2];
+    uint8_t byte1[1];
+    uint8_t byte2[1];
     uint16_t ver;
 
-    rc = lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr << 1), mem, 2);
+    addr = addr << 1;
+    rc = lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr), byte1, 1);
+    rc |= lp5523_get_n_regs(itf, LP5523_PROGRAM_MEMORY + (addr + 1), byte2, 1);
     if (rc) {
         return rc;
     }
 
-    ver = ((((uint16_t)mem[0]) << 8) | mem[1]);
+    ver = ((((uint16_t)byte1[0]) << 8) | byte2[0]);
 
     return (*ins != ver) ? 1 : 0;
 }

--- a/mgmt/imgmgr/include/imgmgr/imgmgr.h
+++ b/mgmt/imgmgr/include/imgmgr/imgmgr.h
@@ -44,6 +44,16 @@ extern "C" {
 #define IMGMGR_STATE_F_ACTIVE           0x04
 #define IMGMGR_STATE_F_PERMANENT        0x08
 
+/** @brief Generic callback function for events */
+typedef void (*imgrmgr_dfu_cb)(void);
+
+/** Callback function pointers */
+typedef struct
+{
+    imgrmgr_dfu_cb dfu_started_cb;
+    imgrmgr_dfu_cb dfu_stopped_cb;
+} imgmgr_dfu_callbacks_t;
+
 /** @typedef imgr_upload_fn
  * @brief Application callback that is executed when an image upload request is
  * received.
@@ -111,7 +121,9 @@ int imgmgr_state_slot_in_use(int slot);
 int imgmgr_state_set_pending(int slot, int permanent);
 int imgmgr_state_confirm(void);
 int imgmgr_find_best_area_id(void);
-
+int imgmgr_register_callbacks(const imgmgr_dfu_callbacks_t *cb_struct);
+void imgr_dfu_stopped(void);
+void imgr_dfu_started(void);
 #ifdef __cplusplus
 }
 #endif

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -739,10 +739,7 @@ imgr_upload(struct mgmt_cbuf *cb)
     /* Determine what actions to take as a result of this request. */
     rc = imgr_upload_inspect(&req, &action, &errstr);
     if (rc != 0) {
-        if (imgmgr_dfu_callbacks_fn->dfu_stopped_cb != NULL)
-        {
-            imgmgr_dfu_callbacks_fn->dfu_stopped_cb();
-        }
+        imgr_dfu_stopped();
         return rc;
     }
 


### PR DESCRIPTION
The LP5523 does not like two-byte writes to the program memory. This PR changes lp5523_verify_pr_instruction, lp5523_set_pr_instruction and lp5523_get_pr_instruction to write the 2 byte instruction one byte at a time.

Also, added callbacks to imgmgr needed to signal that a DFU has started or stopped.