### PR TITLE
log_fcb: Don't walk if requested index too great

### DIFF
--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -114,6 +114,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
 
     active->fe_elem_off = append_loc->fe_data_off + len;
     active->fe_data_off = append_loc->fe_data_off;
+    active->fe_data_len = len;
 
     os_mutex_release(&fcb->f_mtx);
 

--- a/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks_util.c
+++ b/sys/log/full/selftest/fcb_bookmarks/src/log_test_fcb_bookmarks_util.c
@@ -127,7 +127,9 @@ ltfbu_write_entry(void)
 {
     uint8_t body[LTFBU_MAX_BODY_LEN];
     uint32_t idx;
-    int rc; TEST_ASSERT_FATAL(ltfbu_num_entry_idxs < LTFBU_MAX_ENTRY_IDXS);
+    int rc;
+
+    TEST_ASSERT_FATAL(ltfbu_num_entry_idxs < LTFBU_MAX_ENTRY_IDXS);
 
     ltfbu_skip();
     idx = g_log_info.li_next_index;


### PR DESCRIPTION
If user tries to start a walk beyond the end of the log, return early without walking.