### PR TITLE
nrf52: Add debugger override syscfg

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -47,7 +47,9 @@ hal_system_reset(void)
             /*
              * If debugger is attached, breakpoint here.
              */
+#if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
             asm("bkpt");
+#endif
         }
         NVIC_SystemReset();
     }
@@ -56,11 +58,7 @@ hal_system_reset(void)
 int
 hal_debugger_connected(void)
 {
-#if MYNEWT_VAL(NRF52_HAL_DEBUGGER_CHK)
     return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
-#else
-    return 0;
-#endif
 }
 
 /**

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -56,7 +56,11 @@ hal_system_reset(void)
 int
 hal_debugger_connected(void)
 {
+#if MYNEWT_VAL(NRF52_HAL_DEBUGGER_CHK)
     return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+#else
+    return 0;
+#endif
 }
 
 /**

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -60,6 +60,12 @@ syscfg.defs:
             Refer to nRF52xxx Product Specification document for more details.
         value: 0
 
+    NRF52_HAL_DEBUGGER_CHK:
+       description: >
+            When enabled, hal_debugger_connected() will check the debug registers
+            for a debugger. If not set, it will assume a debugger is not connected
+       value: 1
+
 # MCU peripherals definitions
     I2C_0:
         description: 'Enable nRF52xxx I2C (TWI) 0'

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -60,11 +60,11 @@ syscfg.defs:
             Refer to nRF52xxx Product Specification document for more details.
         value: 0
 
-    NRF52_HAL_DEBUGGER_CHK:
+    MCU_DEBUG_IGNORE_BKPT:
        description: >
-            When enabled, hal_debugger_connected() will check the debug registers
-            for a debugger. If not set, it will assume a debugger is not connected
-       value: 1
+            When enabled, asm(bkpt) will be ignored. If not set, it will hit
+            the breakpoint wherever it gets called, For example, reset and crash
+       value: 0
 
 # MCU peripherals definitions
     I2C_0:

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -151,7 +151,9 @@ __assert_func(const char *file, int line, const char *func, const char *e)
        /*
         * If debugger is attached, breakpoint before the trap.
         */
+#if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
        asm("bkpt");
+#endif
     }
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;
     asm("isb");


### PR DESCRIPTION
- Add MCU_DEBUG_IGNORE_BKPT syscfg
- To be set if one wants to ignore debugger check