### PR TITLE
compiler: Disable DSP extension for Cortex-M33

### DIFF
--- a/compiler/arm-none-eabi-m33/compiler.yml
+++ b/compiler/arm-none-eabi-m33/compiler.yml
@@ -25,7 +25,7 @@ compiler.path.objdump: arm-none-eabi-objdump
 compiler.path.objsize: arm-none-eabi-size
 compiler.path.objcopy: arm-none-eabi-objcopy
 
-compiler.flags.base: -mcpu=cortex-m33 -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
+compiler.flags.base: -mcpu=cortex-m33+nodsp -mthumb-interwork -mthumb -Wall -Werror -fno-exceptions -ffunction-sections -fdata-sections
 compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
 compiler.flags.speed: [compiler.flags.base, -O3, -ggdb]


### PR DESCRIPTION
DSP extension is optional and thus may not be supported by some MCUs.
Let's make this package generic one and disable DSP extension by
default - those who want to use DSP extension in their BSP can create
own compiler package with proper settings.