### PR TITLE
spiflash performance improvements

### DIFF
--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -109,8 +109,6 @@ struct spiflash_chip {
 #define FLASH_CAPACITY_16MBIT       0x15
 #define FLASH_CAPACITY_32MBIT       0x16
 
-int spiflash_init(const struct hal_flash *dev);
-
 void spiflash_power_down(struct spiflash_dev *dev);
 void spiflash_release_power_down(struct spiflash_dev *dev);
 

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -89,6 +89,9 @@ extern struct spiflash_dev spiflash_dev;
 #define SPIFLASH_WRITE_ENABLE               0x06
 #define SPIFLASH_FAST_READ                  0x0B
 #define SPIFLASH_SECTOR_ERASE               0x20
+#define SPIFLASH_BLOCK_ERASE_32KB           MYNEWT_VAL(SPIFLASH_BLOCK_ERASE_32BK)
+#define SPIFLASH_BLOCK_ERASE_64KB           MYNEWT_VAL(SPIFLASH_BLOCK_ERASE_64BK)
+#define SPIFLASH_CHIP_ERASE                 0x60
 #define SPIFLASH_DEEP_POWER_DOWN            0xB9
 #define SPIFLASH_RELEASE_POWER_DOWN         0xAB
 #define SPIFLASH_READ_MANUFACTURER_ID       0x90
@@ -132,6 +135,16 @@ void spiflash_power_down(struct spiflash_dev *dev);
 void spiflash_release_power_down(struct spiflash_dev *dev);
 
 int spiflash_auto_power_down_set(struct spiflash_dev *dev, uint32_t timeout_ms);
+
+int spiflash_sector_erase(struct spiflash_dev *dev, uint32_t addr);
+#if MYNEWT_VAL(SPIFLASH_BLOCK_ERASE_32BK)
+int spiflash_block_32k_erase(struct spiflash_dev *dev, uint32_t addr);
+#endif
+#if MYNEWT_VAL(SPIFLASH_BLOCK_ERASE_64BK)
+int spiflash_block_64k_erase(struct spiflash_dev *dev, uint32_t addr);
+#endif
+int spiflash_chip_erase(struct spiflash_dev *dev);
+int spiflash_erase(struct spiflash_dev *dev, uint32_t addr, uint32_t size);
 
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
 int spiflash_create_spi_dev(struct bus_spi_node *node, const char *name,

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -33,6 +33,24 @@
 extern "C" {
 #endif
 
+/*
+ * Structure to hold typical and maximum time as stated in chip datasheet.
+ * Values are used for timeouts and are specified in micro seconds.
+ */
+struct spiflash_time_spec {
+    uint32_t typical;
+    uint32_t maximum;
+};
+
+struct spiflash_characteristics {
+    struct spiflash_time_spec tse;  /* Sector erase time (4KB) */
+    struct spiflash_time_spec tbe1; /* Block erase time (32KB) */
+    struct spiflash_time_spec tbe2; /* Block erase time (64KB) */
+    struct spiflash_time_spec tce;  /* Chip erase time */
+    struct spiflash_time_spec tpp;  /* Page program time */
+    struct spiflash_time_spec tbp1; /* Byte program time */
+};
+
 struct spiflash_dev {
     struct hal_flash hal;
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
@@ -49,6 +67,7 @@ struct spiflash_dev {
     const struct spiflash_chip *supported_chips;
     /* Pointer to one of the supported chips */
     const struct spiflash_chip *flash_chip;
+    const struct spiflash_characteristics *characteristics;
 #if MYNEWT_VAL(OS_SCHEDULING)
     struct os_mutex lock;
 #endif

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -63,6 +63,7 @@ struct spiflash_dev {
 #endif
     uint16_t sector_size;
     uint16_t page_size;
+    bool ready;
     /* Array of supported flash chips */
     const struct spiflash_chip *supported_chips;
     /* Pointer to one of the supported chips */

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -568,21 +568,22 @@ static struct spiflash_chip supported_chips[] = {
     { {0} },
 };
 
-static int spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr,
+static int hal_spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr,
         void *buf, uint32_t len);
-static int spiflash_write(const struct hal_flash *hal_flash_dev, uint32_t addr,
+static int hal_spiflash_write(const struct hal_flash *hal_flash_dev, uint32_t addr,
         const void *buf, uint32_t len);
-static int spiflash_erase_sector(const struct hal_flash *hal_flash_dev,
+static int hal_spiflash_erase_sector(const struct hal_flash *hal_flash_dev,
         uint32_t sector_address);
-static int spiflash_sector_info(const struct hal_flash *hal_flash_dev, int idx,
+static int hal_spiflash_sector_info(const struct hal_flash *hal_flash_dev, int idx,
         uint32_t *address, uint32_t *sz);
+static int hal_spiflash_init(const struct hal_flash *dev);
 
 static const struct hal_flash_funcs spiflash_flash_funcs = {
-    .hff_read         = spiflash_read,
-    .hff_write        = spiflash_write,
-    .hff_erase_sector = spiflash_erase_sector,
-    .hff_sector_info  = spiflash_sector_info,
-    .hff_init         = spiflash_init,
+    .hff_read         = hal_spiflash_read,
+    .hff_write        = hal_spiflash_write,
+    .hff_erase_sector = hal_spiflash_erase_sector,
+    .hff_sector_info  = hal_spiflash_sector_info,
+    .hff_init         = hal_spiflash_init,
 };
 
 struct spiflash_dev spiflash_dev = {
@@ -910,9 +911,9 @@ spiflash_write_enable(struct spiflash_dev *dev)
     return 0;
 }
 
-int
-spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr, void *buf,
-        uint32_t len)
+static int
+hal_spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr, void *buf,
+                  uint32_t len)
 {
     int err = 0;
     uint8_t cmd[] = { SPIFLASH_READ,
@@ -947,8 +948,8 @@ spiflash_read(const struct hal_flash *hal_flash_dev, uint32_t addr, void *buf,
     return 0;
 }
 
-int
-spiflash_write(const struct hal_flash *hal_flash_dev, uint32_t addr,
+static int
+hal_spiflash_write(const struct hal_flash *hal_flash_dev, uint32_t addr,
         const void *buf, uint32_t len)
 {
     uint8_t cmd[4] = { SPIFLASH_PAGE_PROGRAM };
@@ -1002,9 +1003,8 @@ err:
     return rc;
 }
 
-int
-spiflash_erase_sector(const struct hal_flash *hal_flash_dev,
-        uint32_t addr)
+static int
+hal_spiflash_erase_sector(const struct hal_flash *hal_flash_dev, uint32_t addr)
 {
     int rc = 0;
     struct spiflash_dev *dev;
@@ -1046,8 +1046,8 @@ err:
     return rc;
 }
 
-int
-spiflash_sector_info(const struct hal_flash *hal_flash_dev, int idx,
+static int
+hal_spiflash_sector_info(const struct hal_flash *hal_flash_dev, int idx,
         uint32_t *address, uint32_t *sz)
 {
     const struct spiflash_dev *dev = (const struct spiflash_dev *)hal_flash_dev;
@@ -1146,8 +1146,8 @@ err:
     return rc;
 }
 
-int
-spiflash_init(const struct hal_flash *hal_flash_dev)
+static int
+hal_spiflash_init(const struct hal_flash *hal_flash_dev)
 {
     int rc;
     struct spiflash_dev *dev;

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -70,3 +70,9 @@ syscfg.defs:
         description: >
             Expected SpiFlash memory capactity as read by Read JEDEC ID command 9FH
         value: 0
+
+    SPIFLASH_READ_STATUS_INTERVAL:
+        description: >
+            Time between Read Status Register commands when waiting for flash
+            to be ready (us)
+        value: 10

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -76,3 +76,39 @@ syscfg.defs:
             Time between Read Status Register commands when waiting for flash
             to be ready (us)
         value: 10
+    SPIFLASH_TBP1_TYPICAL:
+        description: 'Byte program time (first byte) (us)'
+        value: 15
+    SPIFLASH_TBP1_MAXIMUM:
+        description: 'Maximum byte program time (first byte)  (us)'
+        value: 30
+    SPIFLASH_TPP_TYPICAL:
+        description: 'Page program time (us)'
+        value: 800
+    SPIFLASH_TPP_MAXIMUM:
+        description: 'Maximum page program time (us)'
+        value: 3000
+    SPIFLASH_TSE_TYPICAL:
+        description: 'Sector erase time (4KB) (us)'
+        value: 45000
+    SPIFLASH_TSE_MAXIMUM:
+        description: 'Maximum sector erase time (us)'
+        value: 300000
+    SPIFLASH_TBE1_TYPICAL:
+        description: 'Block erase time (32KB) (us)'
+        value: 120000
+    SPIFLASH_TBE1_MAXIMUM:
+        description: 'Maximum block erase time (32KB) (us)'
+        value:  800000
+    SPIFLASH_TBE2_TYPICAL:
+        description: 'Block erase time (64KB) (us)'
+        value: 150000
+    SPIFLASH_TBE2_MAXIMUM:
+        description: 'Maximum block erase time (64KB) (us)'
+        value: 1000000
+    SPIFLASH_TCE_TYPICAL:
+        description: 'Chip erase time (us)'
+        value: 2000000
+    SPIFLASH_TCE_MAXIMUM:
+        description: 'Maximum chip erase time (us)'
+        value: 6000000

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -76,6 +76,12 @@ syscfg.defs:
             Time between Read Status Register commands when waiting for flash
             to be ready (us)
         value: 10
+    SPIFLASH_BLOCK_ERASE_32BK:
+        description: Block erase 32KB command, set to 0 if flash does not support this command.
+        value: 0x52
+    SPIFLASH_BLOCK_ERASE_64BK:
+        description: Block erase 64KB command, set to 0 if flash does not support this command.
+        value: 0xD8
     SPIFLASH_TBP1_TYPICAL:
         description: 'Byte program time (first byte) (us)'
         value: 15

--- a/hw/hal/include/hal/hal_flash_int.h
+++ b/hw/hal/include/hal/hal_flash_int.h
@@ -43,6 +43,8 @@ struct hal_flash_funcs {
     int (*hff_is_empty)(const struct hal_flash *dev, uint32_t address,
             void *dst, uint32_t num_bytes);
     int (*hff_init)(const struct hal_flash *dev);
+    int (*hff_erase)(const struct hal_flash *dev, uint32_t address,
+            uint32_t num_bytes);
 };
 
 struct hal_flash {


### PR DESCRIPTION
- Wait times after erase and program are not configurable as specified in spiflash datasheets.
this should optimize Read Status Register command after writes to actual timing requirements.

- hal_flash interface was extended to allow erases using block size instead of sector size only

- spiflash erase functions are not public and can be used by application

- waiting time should work better for bootloader where os_time_delay is not used any more.
