### PR TITLE
sys/config, date CLIs: add syscfgs for read/write

### DIFF
--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -94,18 +94,21 @@ shell_conf_command(int argc, char **argv)
 
     (void)rc;
     switch (argc) {
+#if (MYNEWT_VAL(CONFIG_CLI_RW) & 1) == 1
     case 2:
         name = argv[1];
         break;
+#endif
+#if (MYNEWT_VAL(CONFIG_CLI_RW) & 2) == 2
     case 3:
         name = argv[1];
         val = argv[2];
         break;
+#endif
     default:
         goto err;
     }
     if (!strcmp(name, "commit")) {
-#if (MYNEWT_VAL(CONFIG_CLI_RW) & 2) == 2
         rc = conf_commit(val);
         if (rc) {
             val = "Failed to commit\n";
@@ -114,10 +117,8 @@ shell_conf_command(int argc, char **argv)
         }
         console_printf("%s", val);
         return 0;
-#endif
     } else {
         if (!strcmp(name, "dump")) {
-#if (MYNEWT_VAL(CONFIG_CLI_RW) & 1) == 1
             if (!val || !strcmp(val, "running")) {
                 conf_dump_running();
             }
@@ -126,34 +127,27 @@ shell_conf_command(int argc, char **argv)
                 conf_dump_saved();
             }
 #endif
-#endif
             return 0;
         } else {
-#if (MYNEWT_VAL(CONFIG_CLI_RW) & 2) == 2
             if (!strcmp(name, "save")) {
                 conf_save();
                 return 0;
             }
-#endif
         }
     }
     if (!val) {
-#if (MYNEWT_VAL(CONFIG_CLI_RW) & 1) == 1
         val = conf_get_value(name, tmp_buf, sizeof(tmp_buf));
         if (!val) {
             console_printf("Cannot display value\n");
             goto err;
         }
         console_printf("%s\n", val);
-#endif
     } else {
-#if (MYNEWT_VAL(CONFIG_CLI_RW) & 2) == 2
         rc = conf_set_value(name, val);
         if (rc) {
             console_printf("Failed to set, err: %d\n", rc);
             goto err;
         }
-#endif
     }
     return 0;
 err:

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -58,6 +58,10 @@ syscfg.defs:
             Secondary sysinit stage for the config package; populates the
             underlying storage medium for config if it is has not been done.
         value: 220
+    CONFIG_CLI_RW:
+        description: >
+            Config CLI commands read 1, write 2, read/write 3
+        value: 3
 
 syscfg.defs.CONFIG_FCB:
     CONFIG_FCB_FLASH_AREA:

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -130,21 +130,26 @@ shell_os_mpool_display_cmd(int argc, char **argv)
 int
 shell_os_date_cmd(int argc, char **argv)
 {
+    int rc;
+#if MYNEWT_VAL(SHELL_OS_DATETIME_CMD)
     struct os_timeval tv;
     struct os_timezone tz;
     char buf[DATETIME_BUFSIZE];
-    int rc;
 
     argc--; argv++;     /* skip command name */
+    rc = -1;
 
     if (argc == 0) {
+#if (MYNEWT_VAL(SHELL_OS_DATETIME_CMD) & 1) == 1
         /* Display the current datetime */
         rc = os_gettimeofday(&tv, &tz);
         assert(rc == 0);
         rc = datetime_format(&tv, &tz, buf, sizeof(buf));
         assert(rc == 0);
         console_printf("%s\n", buf);
+#endif
     } else if (argc == 1) {
+#if (MYNEWT_VAL(SHELL_OS_DATETIME_CMD) & 2) == 2
         /* Set the current datetime */
         rc = datetime_parse(*argv, &tv, &tz);
         if (rc == 0) {
@@ -152,10 +157,11 @@ shell_os_date_cmd(int argc, char **argv)
         } else {
             console_printf("Invalid datetime\n");
         }
+#endif
     } else {
         rc = -1;
     }
-
+#endif
     return rc;
 }
 

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -219,15 +219,19 @@ static const struct shell_cmd_help mpool_help = {
     .params = mpool_params,
 };
 
+#if (MYNEWT_VAL(SHELL_OS_DATETIME_CMD) & 2) == 2
 static const struct shell_param date_params[] = {
     {"", "datetime to set"},
     {NULL, NULL}
 };
+#endif
 
 static const struct shell_cmd_help date_help = {
     .summary = "show system date",
     .usage = NULL,
+#if (MYNEWT_VAL(SHELL_OS_DATETIME_CMD) & 2) == 2
     .params = date_params,
+#endif
 };
 
 static const struct shell_param reset_params[] = {

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -68,6 +68,12 @@ syscfg.defs:
             Sysinit stage for shell functionality.
         value: 500
 
+    SHELL_OS_DATETIME_CMD:
+        description: >
+            Datetime command enabled, read 1,
+            write 2, read/write 3 (default)
+        value: 3 
+
 ## duplicated from boot/boot_serial
     BOOT_SERIAL_NVREG_MAGIC:
         description: >


### PR DESCRIPTION
Currently in a state of flux but the idea is fairly simple. We want to be able to compile out read/write capability of config and date commands in the CLI.