### PR TITLE
Fix nimble host unit tests

### DIFF
--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -94,18 +94,9 @@ static void
 flash_native_file_open(char *name)
 {
     int created = 0;
-    char tmpl[256];
-    const char *tmpdir;
+    char tmpl[] = "/tmp/native_flash.XXXXXX";
 
     extern int ftruncate(int fd, off_t length);
-
-    /* Attempt to use the current macOS user's temporary directory. */
-    tmpdir = getenv("TMPDIR");
-    if (tmpdir == NULL) {
-        tmpdir = "/tmp";
-    }
-
-    snprintf(tmpl, sizeof tmpl, "%s/native_flash.XXXXXX", tmpdir);
 
     if (name) {
         file = open(name, O_RDWR);

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "os/mynewt.h"
 
@@ -30,7 +31,7 @@
 #include "mcu/mcu_sim.h"
 
 char *native_flash_file;
-static int file;
+static int file = -1;
 static void *file_loc;
 
 static int native_flash_init(const struct hal_flash *dev);
@@ -97,6 +98,11 @@ flash_native_file_open(char *name)
     char tmpl[] = "/tmp/native_flash.XXXXXX";
 
     extern int ftruncate(int fd, off_t length);
+
+    if (file != -1) {
+        close(file);
+        file = -1;
+    }
 
     if (name) {
         file = open(name, O_RDWR);


### PR DESCRIPTION
Prior to this commit, the native hal flash implementation was not closing the simulated flash file.  If the code repeatedly opened a flash file (e.g., if `sysinit()` is called more than once), the old file descriptor is leaked.  This was eventually causing calls to `mkstemp()` to fail due to too many open files.  This caused the nimble host unit tests to fail.