### PR TITLE
time/timepersist; allow user to persist device time.

### DIFF
--- a/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
+++ b/mgmt/newtmgr/nmgr_os/src/newtmgr_os.c
@@ -33,6 +33,9 @@
 #if MYNEWT_VAL(LOG_SOFT_RESET)
 #include <reboot/log_reboot.h>
 #endif
+#if MYNEWT_VAL(TIMEPERSIST)
+#include <timepersist/timepersist.h>
+#endif
 
 #include "nmgr_os/nmgr_os.h"
 
@@ -292,6 +295,10 @@ nmgr_datetime_set(struct mgmt_cbuf *cb)
         if (rc) {
           return MGMT_ERR_EINVAL;
         }
+#if MYNEWT_VAL(TIMEPERSIST)
+        timepersist();
+#endif
+
     } else {
         return MGMT_ERR_EINVAL;
     }

--- a/time/timepersist/include/timepersist/timepersist.h
+++ b/time/timepersist/include/timepersist/timepersist.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef _TIMEPERSIST_H_
+#define _TIMEPERSIST_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Persist the current system time (if set).
+ */
+void timepersist(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/time/timepersist/pkg.yml
+++ b/time/timepersist/pkg.yml
@@ -17,25 +17,23 @@
 # under the License.
 #
 
-pkg.name: mgmt/newtmgr/nmgr_os
-pkg.description: Default newtmgr command.
+pkg.name: time/timepersist
+pkg.description: Persist wallclock time
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+    - date
+    - datetime
 
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/time/datetime"
     - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/mgmt/mgmt"
-    - "@apache-mynewt-core/encoding/tinycbor"
-    - "@apache-mynewt-core/encoding/cborattr"
 
-pkg.deps.LOG_SOFT_RESET:
-    - "@apache-mynewt-core/sys/reboot"
+pkg.deps.TIMEPERSIST_SYS_CONFIG:
+    - "@apache-mynewt-core/time/datetime"
 
-pkg.deps.TIMEPERSIST:
-    - "@apache-mynewt-core/time/timepersist"
+pkg.init:
+    timepersist_init: 'MYNEWT_VAL(TIMEPERSIST_SYSINIT_STAGE)'
 
-pkg.req_apis:
-    - newtmgr
+pkg.down:
+    timepersist: 'MYNEWT_VAL(TIMEPERSIST_SYSDOWN_STAGE)'

--- a/time/timepersist/src/time_persist_config.c
+++ b/time/timepersist/src/time_persist_config.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#if MYNEWT_VAL(TIMEPERSIST_SYS_CONFIG)
+
+#include <config/config.h>
+#include <datetime/datetime.h>
+
+static struct os_callout timepersist_timer;
+
+static int timepersist_conf_set(int argc, char **argv, char *val);
+static struct conf_handler timepersist_conf = {
+    .ch_name = "time",
+    .ch_set = timepersist_conf_set,
+};
+
+/*
+ * Called when config is read in. This persists timezone info also.
+ */
+static int
+timepersist_conf_set(int argc, char **argv, char *val)
+{
+    struct os_timeval tv;
+    struct os_timezone tz;
+
+    if (argc != 1) {
+        return OS_ENOENT;
+    }
+    if (!conf_set_from_storage()) {
+        /*
+         * Only allow sys/config to set time using this interface.
+         */
+        return OS_ERR_PRIV;
+    }
+    if (!strcmp(argv[0], "s")) {
+        if (!datetime_parse(val, &tv, &tz)) {
+            os_settimeofday(&tv, &tz);
+        }
+        return OS_OK;
+    }
+    return OS_ENOENT;
+}
+
+void
+timepersist(void)
+{
+    struct os_timeval tv;
+    struct os_timezone tz;
+    char str[DATETIME_BUFSIZE];
+
+    if (os_time_is_set()) {
+        os_gettimeofday(&tv, &tz);
+        if (!datetime_format(&tv, &tz, str, DATETIME_BUFSIZE)) {
+            conf_save_one("time/s", str);
+        }
+    }
+}
+
+static void
+timepersist_tmo(struct os_event *ev)
+{
+    timepersist();
+    os_callout_reset(&timepersist_timer,
+                     MYNEWT_VAL(TIMEPERSIST_FREQ) * OS_TICKS_PER_SEC);
+}
+
+/*
+ * Periodically store system wallclock to non-volatile storage.
+ */
+void
+timepersist_init(void)
+{
+    conf_register(&timepersist_conf);
+
+    os_callout_init(&timepersist_timer, os_eventq_dflt_get(), timepersist_tmo,
+                    NULL);
+    os_callout_reset(&timepersist_timer,
+                     MYNEWT_VAL(TIMEPERSIST_FREQ) * OS_TICKS_PER_SEC);
+}
+
+#endif

--- a/time/timepersist/src/time_persist_nvreg.c
+++ b/time/timepersist/src/time_persist_nvreg.c
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#if MYNEWT_VAL(TIMEPERSIST_NVREG_INDEX) >= 0
+
+#include <hal/hal_nvreg.h>
+
+static struct os_callout timepersist_timer;
+
+/*
+ * Note that not all MCUs support this size writes.
+ * System uses 64bit value as seconds since 1970, while most MCUs will
+ * have 32bit non-volatile registers (and some 8bit).
+ * With 32 bits storage you get time pretty far in to the future.
+ * Also, not storing timezone at the moment.
+ */
+void
+timepersist(void)
+{
+    struct os_timeval tv;
+
+    if (os_time_is_set()) {
+        os_gettimeofday(&tv, NULL);
+        hal_nvreg_write(MYNEWT_VAL(TIMEPERSIST_NVREG_INDEX), tv.tv_sec);
+    }
+}
+
+static void
+timepersist_tmo(struct os_event *ev)
+{
+    timepersist();
+    os_callout_reset(&timepersist_timer,
+                     MYNEWT_VAL(TIMEPERSIST_FREQ) * OS_TICKS_PER_SEC);
+}
+
+/*
+ * Periodically store system wallclock to non-volatile storage.
+ */
+void
+timepersist_init(void)
+{
+    struct os_timeval tv;
+
+    tv.tv_sec = hal_nvreg_read(MYNEWT_VAL(TIMEPERSIST_NVREG_INDEX));
+    if (tv.tv_sec != 0) {
+        tv.tv_usec = 0;
+        os_settimeofday(&tv, NULL);
+    }
+    os_callout_init(&timepersist_timer, os_eventq_dflt_get(), timepersist_tmo,
+                    NULL);
+    os_callout_reset(&timepersist_timer,
+                     MYNEWT_VAL(TIMEPERSIST_FREQ) * OS_TICKS_PER_SEC);
+}
+
+#endif

--- a/time/timepersist/syscfg.yml
+++ b/time/timepersist/syscfg.yml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    TIMEPERSIST:
+        description: >
+            Report to other packages that timepersist() is available.
+        value: 1
+    TIMEPERSIST_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for restoring persisted wallclock time.
+        value: 501
+    TIMEPERSIST_SYSDOWN_STAGE:
+        description: >
+            Sysinit stage for persisting wallclock time.
+        value: 500
+    TIMEPERSIST_FREQ:
+        description: >
+            How frequently should the wallclock be persisted.
+            Unit is in seconds.
+        value: 60
+
+#
+# You can use either nvreg or sys/config for time persistence.
+#
+    TIMEPERSIST_NVREG_INDEX:
+        description: >
+            Index of retained register to use (using hal_nvreg) for storing
+            lower 32 bits of wallclock time.
+        value: -1
+    TIMEPERSIST_SYS_CONFIG:
+        description: >
+            Use sys/config to persist wallclock time.
+        value: 0
+
+syscfg.restrictions:
+    - "TIMEPERSIST_SYS_CONFIG ^^ (TIMEPERSIST_NVREG_INDEX != -1)"


### PR DESCRIPTION
This is to help platforms which don't have RTC retaining time over resets.
Offer 2 options initially, sys/config (works for all, remembers time from long time back) or nvreg (will work for some architectures).


