### PR TITLE
compiler/gdbmacros: Fix printf formatting problem

### DIFF
--- a/compiler/gdbmacros/os.gdb
+++ b/compiler/gdbmacros/os.gdb
@@ -17,15 +17,14 @@
 
 define os_tasks
 	set $task = g_os_task_list.stqh_first
-	printf " %4s %5s %10s %6s ", "prio", "state", "stack", "stksz"
-	printf "%10s %s\n", "task", "name"
+	printf " prio state stack       stksz       task name\n"
 	while $task != 0
 		if $task == g_current_task
-			set $marker = "*"
+			printf "*"
 		else
-			set $marker = " "
+			printf " "
 		end
-		printf "%s%4d %5p ", $marker, $task->t_prio, $task->t_state
+		printf "%4d %5p ", $task->t_prio, $task->t_state
 		printf "%10p %6d ", $task->t_stacktop, $task->t_stacksize
 		printf "%10p %s\n", $task, $task->t_name
 		set $task = $task->t_os_task_list.stqe_next
@@ -40,7 +39,7 @@ end
 define os_callouts
 	set $c = g_callout_list.tqh_first
 	printf "Callouts:\n"
-	printf " %8s %10s %10s\n", "tick", "callout", "func"
+	printf "     tick    callout       func\n"
 	while $c != 0
 		printf " %8d %10p %10p\n", $c->c_ticks, $c, $c->c_ev.ev_cb
 		set $c = $c->c_next.tqe_next
@@ -49,7 +48,7 @@ end
 
 define os_sleep_list
 	printf "Tasks:\n"
-	printf " %8s %10s %10s\n", "tick", "task", "taskname"
+	printf "     tick       task taskname\n"
 	set $t = g_os_sleep_list.tqh_first
 	while $t != 0
 		set $no_timo = $t->t_flags & 0x1


### PR DESCRIPTION
Using %s to print debugger generated strings does not work
to well.
printf "%s", "gdbstring"
on stlink it does not work at all
on jlink+arm, openocd+riscv it works except that it allocates memory
on the platform being debugged and memory is not freed.

This is output of os_tasks command exectued 3 times on HiFive1 board:
(gdb) os_tasks
 prio state      stack  stksz       task name
* 255   0x1 0x80000a38     64 0x800029d0 idle
  127   0x2 0x80000ef8    304 0x80000ef8 main
  130   0x2 0x800029d0    240 0x800025b8 Ftsk0
    8   0x2 0x800031e0    192 0x80001ddc task1
    9   0x2 0x800032f0     64 0x80001e2c task2
(gdb) p brk
$2 = 0x800035b0 ""
(gdb) os_tasks
 prio state      stack  stksz       task name
* 255   0x1 0x80000a38     64 0x800029d0 idle
  127   0x2 0x80000ef8    304 0x80000ef8 main
  130   0x2 0x800029d0    240 0x800025b8 Ftsk0
    8   0x2 0x800031e0    192 0x80001ddc task1
    9   0x2 0x800032f0     64 0x80001e2c task2
(gdb) p brk
$3 = 0x80003710 ""
(gdb) os_tasks
 prio state      stack  stksz       task name
* 255   0x1 0x80000a38     64 0x800029d0 idle
No memory available to program: call to malloc failed

Now printf do not use debugger generated string (except for formatting one).