### PR TITLE
mcu/fe310: Adjust mcu to api changes in bus driver

### DIFF
--- a/hw/mcu/sifive/fe310/src/fe310_periph.c
+++ b/hw/mcu/sifive/fe310/src/fe310_periph.c
@@ -60,10 +60,10 @@ static struct uart_dev os_bsp_uart0;
 static const struct bus_spi_dev_cfg spi1_cfg = {
     .spi_num = 1,
 };
-static struct bus_spi_dev spi1_bus;
+static struct bus_spi_hal_dev spi1_bus;
 #endif
 #if MYNEWT_VAL(SPI_2)
-static const struct bus_spi_dev_cfg spi2_cfg = {
+static const struct bus_spi_hal_dev spi2_cfg = {
     .spi_num = 2,
 };
 static struct bus_spi_dev spi2_bus;


### PR DESCRIPTION
Argument change in function bus_spi_hal_dev_create() for asynchronous
spi handling.

This simply changes old type of argument to new one.