### PR TITLE
Use taskpool package in unit tests

### DIFF
--- a/kernel/os/selftest/src/testcases/os_mutex_test_basic.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_basic.c
@@ -18,11 +18,13 @@
  */
 
 #include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
-TEST_CASE_SELF(os_mutex_test_basic)
+TEST_CASE_TASK(os_mutex_test_basic)
 {
     os_mutex_init(&g_mutex1);
-    runtest_init_task(mutex_test_basic_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(mutex_test_basic_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_wait_assert(200);
 }

--- a/kernel/os/selftest/src/testcases/os_mutex_test_case_1.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_case_1.c
@@ -19,9 +19,10 @@
 
 #include "os/mynewt.h"
 #include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
-TEST_CASE_SELF(os_mutex_test_case_1)
+TEST_CASE_TASK(os_mutex_test_case_1)
 {
     int rc;
 
@@ -35,10 +36,12 @@ TEST_CASE_SELF(os_mutex_test_case_1)
     rc = os_mutex_init(&g_mutex2);
     TEST_ASSERT(rc == 0);
 
-    runtest_init_task(mutex_test1_task1_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(mutex_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(mutex_task3_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(mutex_test1_task1_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(mutex_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(mutex_task3_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+
+    taskpool_wait_assert(200);
 }

--- a/kernel/os/selftest/src/testcases/os_mutex_test_case_2.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_case_2.c
@@ -19,9 +19,10 @@
 
 #include "os/mynewt.h"
 #include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
-TEST_CASE_SELF(os_mutex_test_case_2)
+TEST_CASE_TASK(os_mutex_test_case_2)
 {
     g_mutex_test = 2;
     g_task1_val = 0;
@@ -30,12 +31,14 @@ TEST_CASE_SELF(os_mutex_test_case_2)
     os_mutex_init(&g_mutex1);
     os_mutex_init(&g_mutex2);
 
-    runtest_init_task(mutex_test2_task1_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(mutex_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(mutex_task3_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
-    runtest_init_task(mutex_task4_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+    taskpool_alloc_assert(mutex_test2_task1_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(mutex_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(mutex_task3_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+    taskpool_alloc_assert(mutex_task4_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 5);
+
+    taskpool_wait_assert(200);
 }

--- a/kernel/os/selftest/src/testcases/os_sem_test_basic.c
+++ b/kernel/os/selftest/src/testcases/os_sem_test_basic.c
@@ -18,7 +18,7 @@
  */
 
 #include "os/mynewt.h"
-#include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 #include "sem_test.h"
 
@@ -29,6 +29,6 @@ TEST_CASE_SELF(os_sem_test_basic)
     err = os_sem_init(&g_sem1, 1);
     TEST_ASSERT(err == OS_OK);
 
-    runtest_init_task(sem_test_basic_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(sem_test_basic_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
 }

--- a/kernel/os/selftest/src/testcases/os_sem_test_case_1.c
+++ b/kernel/os/selftest/src/testcases/os_sem_test_case_1.c
@@ -18,7 +18,7 @@
  */
 
 #include "os/mynewt.h"
-#include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
 TEST_CASE_SELF(os_sem_test_case_1)
@@ -28,10 +28,10 @@ TEST_CASE_SELF(os_sem_test_case_1)
     err = os_sem_init(&g_sem1, 1);
     TEST_ASSERT(err == OS_OK);
 
-    runtest_init_task(sem_test_1_task1_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(sem_test_1_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(sem_test_1_task3_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(sem_test_1_task1_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(sem_test_1_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(sem_test_1_task3_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
 }

--- a/kernel/os/selftest/src/testcases/os_sem_test_case_2.c
+++ b/kernel/os/selftest/src/testcases/os_sem_test_case_2.c
@@ -18,7 +18,7 @@
  */
 
 #include "os/mynewt.h"
-#include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
 TEST_CASE_SELF(os_sem_test_case_2)
@@ -28,12 +28,12 @@ TEST_CASE_SELF(os_sem_test_case_2)
     err = os_sem_init(&g_sem1, 1);
     TEST_ASSERT(err == OS_OK);
 
-    runtest_init_task(sem_test_sleep_task_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(sem_test_2_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(sem_test_2_task3_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
-    runtest_init_task(sem_test_2_task4_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+    taskpool_alloc_assert(sem_test_sleep_task_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(sem_test_2_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(sem_test_2_task3_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(sem_test_2_task4_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
 }

--- a/kernel/os/selftest/src/testcases/os_sem_test_case_3.c
+++ b/kernel/os/selftest/src/testcases/os_sem_test_case_3.c
@@ -18,7 +18,7 @@
  */
 
 #include "os/mynewt.h"
-#include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
 TEST_CASE_SELF(os_sem_test_case_3)
@@ -28,12 +28,12 @@ TEST_CASE_SELF(os_sem_test_case_3)
     err = os_sem_init(&g_sem1, 1);
     TEST_ASSERT(err == OS_OK);
 
-    runtest_init_task(sem_test_sleep_task_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(sem_test_3_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(sem_test_3_task3_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
-    runtest_init_task(sem_test_3_task4_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+    taskpool_alloc_assert(sem_test_sleep_task_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(sem_test_3_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(sem_test_3_task3_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(sem_test_3_task4_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
 }

--- a/kernel/os/selftest/src/testcases/os_sem_test_case_4.c
+++ b/kernel/os/selftest/src/testcases/os_sem_test_case_4.c
@@ -18,7 +18,7 @@
  */
 
 #include "os/mynewt.h"
-#include "runtest/runtest.h"
+#include "taskpool/taskpool.h"
 #include "os_test_priv.h"
 
 TEST_CASE_SELF(os_sem_test_case_4)
@@ -28,12 +28,12 @@ TEST_CASE_SELF(os_sem_test_case_4)
     err = os_sem_init(&g_sem1, 1);
     TEST_ASSERT(err == OS_OK);
 
-    runtest_init_task(sem_test_sleep_task_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
-    runtest_init_task(sem_test_4_task2_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    runtest_init_task(sem_test_4_task4_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
-    runtest_init_task(sem_test_4_task4_handler,
-                      MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
+    taskpool_alloc_assert(sem_test_sleep_task_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 1);
+    taskpool_alloc_assert(sem_test_4_task2_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
+    taskpool_alloc_assert(sem_test_4_task4_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 3);
+    taskpool_alloc_assert(sem_test_4_task4_handler,
+                          MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
 }

--- a/kernel/os/selftest/syscfg.yml
+++ b/kernel/os/selftest/syscfg.yml
@@ -18,3 +18,4 @@
 
 syscfg.vals:
     OS_TIME_DEBUG: 1
+    TASKPOOL_STACK_SIZE: 1024

--- a/test/runtest/include/runtest/runtest.h
+++ b/test/runtest/include/runtest/runtest.h
@@ -62,11 +62,6 @@ struct os_eventq *runtest_evq_get(void);
 void runtest_evq_set(struct os_eventq *evq);
 
 /**
- * Initializes a new task from the runtest task pool.
- */
-struct os_task *runtest_init_task(os_task_func_t task_handler, uint8_t prio);
-
-/**
  * Enqueues a single test for immediate execution.
  *
  * @param test_name             The name of the test to run.
@@ -81,6 +76,10 @@ int runtest_run(const char *test_name, const char *token);
  * Retrieves the total number of test failures.
  */
 int runtest_total_fails_get(void);
+
+/* XXX: Deprecated API.  Remove after next release. */
+struct os_task *runtest_init_task(
+    os_task_func_t task_handler, uint8_t prio) __attribute__((deprecated));
 
 #ifdef __cplusplus
 }

--- a/test/runtest/pkg.yml
+++ b/test/runtest/pkg.yml
@@ -24,6 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/encoding/cborattr"
+    - "@apache-mynewt-core/util/taskpool"
 pkg.deps.RUNTEST_CLI:
     - "@apache-mynewt-core/sys/shell"
 pkg.deps.RUNTEST_NEWTMGR:

--- a/test/runtest/syscfg.yml
+++ b/test/runtest/syscfg.yml
@@ -41,12 +41,6 @@ syscfg.defs:
             prefix is constructed from the legacy C macros `BUILD_TARGET` and
             `BUILD_TEST`.
         value:
-    RUNTEST_NUM_TASKS:
-        description: 'The number of generic tasks available to unit tests.'
-        value: 4
-    RUNTEST_STACK_SIZE:
-        description: 'The stack size, in words, of each generic test task.'
-        value: 256
     RUNTEST_MAX_TEST_NAME_LEN:
         description: 'The maximum length, in characters, of each test name.'
         value: 32

--- a/test/testutil/src/case.c
+++ b/test/testutil/src/case.c
@@ -173,7 +173,7 @@ tu_case_append_file_info(const char *file, int line)
 {
     int rc;
 
-    rc = tu_case_append_buf("|%s:%d| ", file, line);
+    rc = tu_case_append_buf("[%s:%d] ", file, line);
     assert(rc == 0);
 }
 
@@ -221,7 +221,7 @@ tu_case_fail_assert(int fatal, const char *file, int line,
     tu_case_append_assert_msg(expr);
 
     if (format != NULL) {
-        rc = tu_case_append_buf("\n");
+        rc = tu_case_append_buf("; ");
         assert(rc == 0);
 
         va_start(ap, format);
@@ -229,9 +229,6 @@ tu_case_fail_assert(int fatal, const char *file, int line,
         assert(rc == 0);
         va_end(ap);
     }
-
-    rc = tu_case_append_buf("\n");
-    assert(rc == 0);
 
     tu_case_fail();
 

--- a/util/cbmem/hosttest/include/cbmem_test/cbmem_test.h
+++ b/util/cbmem/hosttest/include/cbmem_test/cbmem_test.h
@@ -28,8 +28,8 @@
 #include "testutil/testutil.h"
 #include "cbmem/cbmem.h"
 
-#define CBMEM1_ENTRY_COUNT  32
-#define CBMEM1_ENTRY_SIZE   64
+#define CBMEM1_ENTRY_COUNT  8
+#define CBMEM1_ENTRY_SIZE   128
 #define CBMEM1_BUF_SIZE     (CBMEM1_ENTRY_COUNT * CBMEM1_ENTRY_SIZE)
 
 extern struct cbmem cbmem1;

--- a/util/cbmem/hosttest/src/cbmem_test.c
+++ b/util/cbmem/hosttest/src/cbmem_test.c
@@ -48,11 +48,9 @@ setup_cbmem1(void *arg)
 
     memset(cbmem1_entry, 0xff, sizeof(cbmem1_entry));
 
-    /* Insert 65 1024 entries, and overflow buffer.
-     * This should overflow two entries, because the buffer is sized for 64
-     * entries, and then the headers themselves will eat into one of the
-     * entries, so there should be a total of 63 entries.
-     * Ensure no data corruption.
+    /* Insert max+1 entries and overflow buffer.  This should overflow.  The
+     * last header will eat into one of the entries, so there should be a total
+     * of max-1 entries.  Ensure no data corruption.
      */
     for (i = 0; i < CBMEM1_ENTRY_COUNT + 1; i++) {
         cbmem1_entry[0] = i;

--- a/util/cbmem/hosttest/src/testcases/cbmem_test_case_1.c
+++ b/util/cbmem/hosttest/src/testcases/cbmem_test_case_1.c
@@ -28,6 +28,6 @@ TEST_CASE(cbmem_test_case_1)
     i = 2;
     rc = cbmem_walk(&cbmem1, cbmem_test_case_1_walk, &i);
     TEST_ASSERT_FATAL(rc == 0, "Could not walk cbmem tree!  rc = %d", rc);
-    TEST_ASSERT_FATAL(i == 65,
+    TEST_ASSERT_FATAL(i == CBMEM1_ENTRY_COUNT + 1,
             "Did not go through every element of walk, %d processed", i - 2);
 }

--- a/util/cbmem/hosttest/src/testcases/cbmem_test_case_2.c
+++ b/util/cbmem/hosttest/src/testcases/cbmem_test_case_2.c
@@ -44,7 +44,7 @@ TEST_CASE(cbmem_test_case_2)
     }
 
     /* i starts at 2, for the 2 overwritten entries */
-    TEST_ASSERT_FATAL(i == 65,
-            "Did not iterate through all 63 elements of CBMEM1, processed %d",
-            i - 2);
+    TEST_ASSERT_FATAL(i == CBMEM1_ENTRY_COUNT + 1,
+            "Did not iterate through all %d elements of CBMEM1, processed %d",
+            CBMEM1_ENTRY_COUNT - 1, i - 2);
 }

--- a/util/cbmem/hosttest/src/testcases/cbmem_test_case_3.c
+++ b/util/cbmem/hosttest/src/testcases/cbmem_test_case_3.c
@@ -51,12 +51,13 @@ TEST_CASE(cbmem_test_case_3)
             off += rc;
             len += rc;
         }
-        TEST_ASSERT_FATAL(len == 1024,
-                "Couldn't read full entry, expected %d got %d", 1024, len);
+        TEST_ASSERT_FATAL(len == CBMEM1_ENTRY_SIZE,
+                "Couldn't read full entry, expected %d got %d",
+                CBMEM1_ENTRY_SIZE, len);
         i++;
 
         /* go apesh*t, and read data out of bounds, see what we get. */
-        rc = cbmem_read(&cbmem1, hdr, buf, 2048, sizeof(buf));
+        rc = cbmem_read(&cbmem1, hdr, buf, CBMEM1_ENTRY_SIZE * 2, sizeof(buf));
         TEST_ASSERT_FATAL(rc < 0,
                 "Reading invalid should return error, instead %d returned.",
                 rc);

--- a/util/cbmem/selftest/src/cbmem_test.c
+++ b/util/cbmem/selftest/src/cbmem_test.c
@@ -48,11 +48,9 @@ setup_cbmem1(void *arg)
 
     memset(cbmem1_entry, 0xff, sizeof(cbmem1_entry));
 
-    /* Insert 65 1024 entries, and overflow buffer.
-     * This should overflow two entries, because the buffer is sized for 64
-     * entries, and then the headers themselves will eat into one of the
-     * entries, so there should be a total of 63 entries.
-     * Ensure no data corruption.
+    /* Insert max+1 entries and overflow buffer.  This should overflow.  The
+     * last header will eat into one of the entries, so there should be a total
+     * of max-1 entries.  Ensure no data corruption.
      */
     for (i = 0; i < CBMEM1_ENTRY_COUNT + 1; i++) {
         cbmem1_entry[0] = i;

--- a/util/cbmem/selftest/src/testcases/cbmem_test_case_1.c
+++ b/util/cbmem/selftest/src/testcases/cbmem_test_case_1.c
@@ -28,6 +28,6 @@ TEST_CASE_SELF(cbmem_test_case_1)
     i = 2;
     rc = cbmem_walk(&cbmem1, cbmem_test_case_1_walk, &i);
     TEST_ASSERT_FATAL(rc == 0, "Could not walk cbmem tree!  rc = %d", rc);
-    TEST_ASSERT_FATAL(i == 65,
+    TEST_ASSERT_FATAL(i == CBMEM1_ENTRY_COUNT + 1,
             "Did not go through every element of walk, %d processed", i - 2);
 }

--- a/util/cbmem/selftest/src/testcases/cbmem_test_case_2.c
+++ b/util/cbmem/selftest/src/testcases/cbmem_test_case_2.c
@@ -44,7 +44,7 @@ TEST_CASE_SELF(cbmem_test_case_2)
     }
 
     /* i starts at 2, for the 2 overwritten entries */
-    TEST_ASSERT_FATAL(i == 65,
-            "Did not iterate through all 63 elements of CBMEM1, processed %d",
-            i - 2);
+    TEST_ASSERT_FATAL(i == CBMEM1_ENTRY_COUNT + 1,
+            "Did not iterate through all %d elements of CBMEM1, processed %d",
+            CBMEM1_ENTRY_COUNT - 1, i - 2);
 }

--- a/util/cbmem/selftest/src/testcases/cbmem_test_case_3.c
+++ b/util/cbmem/selftest/src/testcases/cbmem_test_case_3.c
@@ -51,12 +51,13 @@ TEST_CASE_SELF(cbmem_test_case_3)
             off += rc;
             len += rc;
         }
-        TEST_ASSERT_FATAL(len == 1024,
-                "Couldn't read full entry, expected %d got %d", 1024, len);
+        TEST_ASSERT_FATAL(len == CBMEM1_ENTRY_SIZE,
+                "Couldn't read full entry, expected %d got %d",
+                CBMEM1_ENTRY_SIZE, len);
         i++;
 
         /* go apesh*t, and read data out of bounds, see what we get. */
-        rc = cbmem_read(&cbmem1, hdr, buf, 2048, sizeof(buf));
+        rc = cbmem_read(&cbmem1, hdr, buf, CBMEM1_ENTRY_SIZE * 2, sizeof(buf));
         TEST_ASSERT_FATAL(rc < 0,
                 "Reading invalid should return error, instead %d returned.",
                 rc);

--- a/util/taskpool/include/taskpool/taskpool.h
+++ b/util/taskpool/include/taskpool/taskpool.h
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_TASKPOOL_
+#define H_TASKPOOL_
+
+#include "os/mynewt.h"
+
+/**
+ * @file taskpool.h
+ * @brief Allows you to create and remove generic tasks at runtime.
+ *
+ * This package creates a single global task pool.  Each allocated task
+ * uses the same size stack.  The task count and stack size settings are
+ * specified via syscfg.
+ */
+
+/**
+ * @brief Allocates a new task from the global task pool.
+ *
+ * A task allocated with this function is allowed to terminate via return.
+ * That is, if its handler function runs to completion, the task complete and
+ * can be collected.
+ *
+ * @param task_handler          The function to be executed by the new task.
+ * @param prio                  The priority to assign to the new task.
+ * @param out_task              On success, the address ofthe newly allocated
+ *                                  task gets written here.  Pass NULL if you
+ *                                  don't require this information.
+ *
+ * @return                      0 on success; SYS_E[...] error code on failure.
+ */
+int taskpool_alloc(os_task_func_t task_handler, uint8_t prio,
+                   struct os_task **out_task);
+
+/**
+ * @brief Allocates a new task and asserts success.
+ *
+ * See taskpool_alloc() for details.
+ *
+ * @param task_handler          The function to be executed by the new task.
+ * @param prio                  The priority to assign to the new task.
+ *
+ * @return                      The newly allocateed task.
+ */
+struct os_task *taskpool_alloc_assert(os_task_func_t task_handler,
+                                      uint8_t prio);
+
+/**
+ * @brief Waits for all allocated tasks to complete.
+ *
+ * @param max_ticks             The maximum duration to wait before the wait
+ *                                  operation times out.  Units are OS ticks.
+ *
+ * @return                      0 on success; 
+ *                              OS_TIMEOUT on timeout.
+ */
+int taskpool_wait(os_time_t max_ticks);
+
+/**
+ * @brief Waits for all allocated tasks to complete and asserts success.
+ *
+ * @param max_ticks             The maximum duration to wait before the wait
+ *                                  operation times out.  Units are OS ticks.
+ */
+void taskpool_wait_assert(os_time_t max_ticks);
+
+#endif

--- a/util/taskpool/pkg.yml
+++ b/util/taskpool/pkg.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+pkg.name: util/taskpool
+pkg.description: "Reusable task pool"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps: 
+    - "@apache-mynewt-core/kernel/os"
+
+pkg.init:
+    taskpool_init: 1000

--- a/util/taskpool/src/taskpool.c
+++ b/util/taskpool/src/taskpool.c
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The taskpool module implements a reusable task pool.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "os/mynewt.h"
+#include "taskpool/taskpool.h"
+
+#define TASKPOOL_STATE_UNUSED   0
+#define TASKPOOL_STATE_ACTIVE   1
+#define TASKPOOL_STATE_DONE     2
+
+/** Ensures thread safety across the taskpool API. */
+static struct os_mutex taskpool_mtx;
+
+/** Signals completion of final task to waiters. */
+static struct os_sem taskpool_wait_sem;
+
+/** The number of tasks waiting for all taskpool tasks to complete. */
+static int taskpool_waiter_count;
+
+/** Represents a single taskpool task. */
+struct taskpool_entry {
+    OS_TASK_STACK_DEFINE_NOSTATIC(stack, MYNEWT_VAL(TASKPOOL_STACK_SIZE));
+    os_task_func_t fn;
+    struct os_task task;
+    uint8_t state;
+    char name[sizeof "taskXX"];
+};
+
+static struct taskpool_entry taskpool_entries[MYNEWT_VAL(TASKPOOL_NUM_TASKS)];
+
+static void
+taskpool_lock(void)
+{
+    int rc;
+
+    rc = os_mutex_pend(&taskpool_mtx, OS_TIMEOUT_NEVER);
+    assert(rc == 0 || rc == OS_NOT_STARTED);
+}
+
+static void
+taskpool_unlock(void)
+{
+    int rc;
+
+    rc = os_mutex_release(&taskpool_mtx);
+    assert(rc == 0 || rc == OS_NOT_STARTED);
+}
+
+static bool
+taskpool_locked(void)
+{
+    struct os_task *owner;
+
+    owner = taskpool_mtx.mu_owner;
+    return owner != NULL && owner == os_sched_get_current_task();
+}
+
+#define TASKPOOL_ASSERT_LOCKED() do  \
+{                                   \
+    if (os_started()) {             \
+        assert(taskpool_locked());   \
+    }                               \
+} while (0)
+
+static int
+taskpool_find_state(uint8_t state)
+{
+    int i;
+
+    TASKPOOL_ASSERT_LOCKED();
+
+    for (i = 0; i < MYNEWT_VAL(TASKPOOL_NUM_TASKS); i++) {
+        if (taskpool_entries[i].state == state) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static void
+taskpool_wrapper(void *arg)
+{
+    struct taskpool_entry *entry;
+
+    entry = arg;
+
+    /* Execute wrapped task handler. */
+    entry->fn(NULL);
+
+    taskpool_lock();
+
+    /* Mark task done. */
+    entry->state = TASKPOOL_STATE_DONE;
+
+    /* If this was the last running task, signal that the test is complete. */
+    if (taskpool_find_state(TASKPOOL_STATE_ACTIVE) == -1) {
+        while (taskpool_waiter_count > 0) {
+            os_sem_release(&taskpool_wait_sem);
+            taskpool_waiter_count--;
+        }
+    }
+
+    taskpool_unlock();
+
+    /* Block forever.  This task can now be collected with os_task_remove(). */
+    while (1) {
+        os_time_delay(OS_STIME_MAX);
+    }
+}
+
+int
+taskpool_alloc(os_task_func_t task_handler, uint8_t prio,
+               struct os_task **out_task)
+{
+    struct taskpool_entry *entry;
+    int idx;
+    int rc;
+
+    taskpool_lock();
+
+    idx = taskpool_find_state(TASKPOOL_STATE_UNUSED);
+    if (idx != -1) {
+        entry = &taskpool_entries[idx];
+        entry->state = TASKPOOL_STATE_ACTIVE;
+    }
+
+    taskpool_unlock();
+
+    if (idx == -1) {
+        return SYS_ENOMEM;
+    }
+
+    entry->fn = task_handler;
+    snprintf(entry->name, sizeof entry->name, "task%02d", idx);
+
+    rc = os_task_init(&entry->task, entry->name, taskpool_wrapper,
+                      entry, prio, OS_WAIT_FOREVER, entry->stack,
+                      MYNEWT_VAL(TASKPOOL_STACK_SIZE));
+    if (rc != 0) {
+        taskpool_lock();
+        entry->state = TASKPOOL_STATE_UNUSED;
+        taskpool_unlock();
+
+        return rc;
+    }
+
+    *out_task = &entry->task;
+    return 0;
+}
+
+struct os_task *
+taskpool_alloc_assert(os_task_func_t task_handler, uint8_t prio)
+{
+    struct os_task *task;
+    int rc;
+
+    rc = taskpool_alloc(task_handler, prio, &task);
+    assert(rc == 0);
+
+    return task;
+}
+
+static void
+taskpool_reset(void)
+{
+    int rc;
+    int i;
+
+    taskpool_lock();
+
+    for (i = 0; i < MYNEWT_VAL(TASKPOOL_NUM_TASKS); i++) {
+        if (taskpool_entries[i].state != TASKPOOL_STATE_UNUSED) {
+            rc = os_task_remove(&taskpool_entries[i].task);
+            assert(rc == OS_OK);
+
+            taskpool_entries[i].state = TASKPOOL_STATE_UNUSED;
+        }
+    }
+
+    taskpool_unlock();
+}
+
+int
+taskpool_wait(os_time_t max_ticks)
+{
+    int any_tasks;
+    int rc;
+
+    taskpool_lock();
+
+    any_tasks = taskpool_find_state(TASKPOOL_STATE_ACTIVE) != -1;
+    if (any_tasks) {
+        taskpool_waiter_count++;
+    }
+
+    taskpool_unlock();
+
+    if (!any_tasks) {
+        /* No active tasks; nothing to wait on. */
+        return 0;
+    }
+
+    rc = os_sem_pend(&taskpool_wait_sem, max_ticks);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* Collect all the completed taskpool tasks. */
+    taskpool_reset();
+
+    return 0;
+}
+
+void
+taskpool_wait_assert(os_time_t max_ticks)
+{
+    int rc;
+
+    rc = taskpool_wait(max_ticks);
+    assert(rc == 0);
+}
+
+/*
+ * Package init routine to register newtmgr "run" commands
+ */
+void
+taskpool_init(void)
+{
+    int rc;
+    int i;
+
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    rc = os_mutex_init(&taskpool_mtx);
+    SYSINIT_PANIC_ASSERT(rc == 0 || rc == OS_NOT_STARTED);
+
+    rc = os_sem_init(&taskpool_wait_sem, 0);
+    SYSINIT_PANIC_ASSERT(rc == 0 || rc == OS_NOT_STARTED);
+
+    for (i = 0; i < MYNEWT_VAL(TASKPOOL_NUM_TASKS); i++) {
+        taskpool_entries[i].state = TASKPOOL_STATE_UNUSED;
+    }
+}

--- a/util/taskpool/syscfg.yml
+++ b/util/taskpool/syscfg.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    TASKPOOL_NUM_TASKS:
+        description: 'The number of tasks available in the task pool.'
+        value: 4
+    TASKPOOL_STACK_SIZE:
+        description: 'The stack size, in words, of each task pool task.'
+        value: 256


### PR DESCRIPTION
Remove the task pool functionality from `test/runtest` and use `util/taskpool` instead.

Convert unit test packages to use `util/taskpool`.