### PR TITLE
nucleo-l476 bsp fixes

### DIFF
--- a/hw/bsp/nucleo-l476rg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l476rg/src/hal_bsp.c
@@ -150,6 +150,11 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 
+#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+
 #if MYNEWT_VAL(SPI_0_SLAVE)
     rc = hal_spi_init(0, &spi0_cfg, HAL_SPI_TYPE_SLAVE);
     assert(rc == 0);

--- a/hw/bsp/nucleo-l476rg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l476rg/src/hal_bsp.c
@@ -88,7 +88,7 @@ struct stm32_hal_spi_cfg spi0_cfg = {
     .ss_pin   = MCU_GPIO_PORTA(4),
     .sck_pin  = MCU_GPIO_PORTA(5),
     .miso_pin = MCU_GPIO_PORTA(6),
-    .mosi_pin = MCU_GPIO_PORTB(5),
+    .mosi_pin = MCU_GPIO_PORTA(7),
     .irq_prio = 2,
 };
 #endif


### PR DESCRIPTION
Two minor fixes.
- MOSI pin was not from the same group as MISO and CLK
- cpu timer was not initialized in bsp