### PR TITLE
kernel/os: MSYS memory pool not in mempool list

### DIFF
--- a/kernel/os/src/os.c
+++ b/kernel/os/src/os.c
@@ -286,8 +286,8 @@ os_pkg_init(void)
     err = os_dev_initialize_all(OS_DEV_INIT_KERNEL);
     assert(err == OS_OK);
 
-    os_msys_init();
     os_mempool_module_init();
+    os_msys_init();
 }
 
 /**

--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -36,8 +36,7 @@
 #define OS_MEMPOOL_TRUE_BLOCK_SIZE(mp) OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size)
 #endif
 
-STAILQ_HEAD(, os_mempool) g_os_mempool_list =
-    STAILQ_HEAD_INITIALIZER(g_os_mempool_list);
+STAILQ_HEAD(, os_mempool) g_os_mempool_list;
 
 #if MYNEWT_VAL(OS_MEMPOOL_POISON)
 static uint32_t os_mem_poison = 0xde7ec7ed;


### PR DESCRIPTION
Change the order of os_msys_init() and os_mempool_module_init() so that memory pools allocated by msys show up in the mempool list. Removed the initialization of g_os_mempool_list as it is initialized when the module init function is called. Looking at the code I wonder if the order of where things are done in os_pkg_init() might be an issue. For example, os_dev_initialize_all() is called which will call os device initialization functions if their init stage is OS_DEV_INIT_KERNEL.