### PR TITLE
hw/ruuvitag_rev_b: Fix typo in board restrictions

### DIFF
--- a/hw/bsp/ruuvitag_rev_b/syscfg.yml
+++ b/hw/bsp/ruuvitag_rev_b/syscfg.yml
@@ -97,4 +97,4 @@ syscfg.restrictions:
     - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"
     - "!BME280_ONB || SPI_0_MASTER"
     - "!LIS2DH12_ONB || SPI_0_MASTER"
-    - "!LIS2DH12_ONB || BSP_RUUVITAG_REV >= 3"
+    - "!LIS2DH12_ONB || BSP_RUUVITAG_REV_B_NUM >= 3"


### PR DESCRIPTION
WARNING: Ignoring illegal expression for setting "": `!LIS2DH12_ONB ||
  BSP_RUUVITAG_REV >= 3` cannot apply >= to `BSP_RUUVITAG_REV`; operand
  not a number