### PR TITLE
bsp/nucleo-l476rg: Enable TIMER_0 by default

### DIFF
--- a/hw/bsp/nucleo-l476rg/syscfg.yml
+++ b/hw/bsp/nucleo-l476rg/syscfg.yml
@@ -28,7 +28,7 @@ syscfg.defs:
 
     TIMER_0:
         description: 'Whether to enable TIMER_0'
-        value: 0
+        value: 1
 
     TIMER_1:
         description: 'Whether to enable TIMER_1'


### PR DESCRIPTION
Recently added code to provide cputimer requires at least one
timer to be enabled.
OS_CPUTIME_TIMER_NUM has default value 0 so timer 0 is needed.