### PR TITLE
stm32f1xx: Fix sector erase

### DIFF
--- a/hw/mcu/stm/stm32f1xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f1xx/src/hal_flash.c
@@ -32,7 +32,7 @@ stm32_mcu_flash_erase_sector(const struct hal_flash *dev, uint32_t sector_addres
 
     (void)PageError;
 
-    if ((sector_address & (_FLASH_SECTOR_SIZE - 1)) == sector_address) {
+    if ((sector_address & ~(_FLASH_SECTOR_SIZE - 1)) == sector_address) {
         eraseinit.TypeErase = FLASH_TYPEERASE_PAGES;
         eraseinit.Banks = FLASH_BANK_1;
         eraseinit.PageAddress = sector_address;


### PR DESCRIPTION
Invalid pre-condition was used before sector erase.
This affects only f1xx platform, other STM32 versions
have correct condition if needed.