### PR TITLE
spiflash: Add simple cache

### DIFF
--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -79,6 +79,10 @@ struct spiflash_dev {
 #endif
     bool pd_active;                 /* Power down active */
 #endif
+#if MYNEWT_VAL(SPIFLASH_CACHE_SIZE)
+    uint32_t cached_addr;
+    uint8_t cache[MYNEWT_VAL(SPIFLASH_CACHE_SIZE)];
+#endif
 };
 
 extern struct spiflash_dev spiflash_dev;

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -44,6 +44,12 @@ syscfg.defs:
         description: 'Requested baudrate, value must be supported by SPI driver'
         value: 0
 
+    SPIFLASH_CACHE_SIZE:
+        description:
+            When this value is set to value other then 0, all reads that are
+            smaller then this size are rounded up to this value.
+            Subsequent reads from cached adress range is much faster.
+        value: 0
     SPIFLASH_AUTO_POWER_DOWN:
         description: >
             Enables auto power down feature which allows to power down flash


### PR DESCRIPTION
Reading 1 byte from spiflash generates 5 bytes of SPI traffic.
Reading 8 bytes on by one is 40 bytes on SPI.
Reading 8 bytes at once is 12 bytes on SPI.
This change improves reading time when there are a lot of small
read requests.
This can be useful if FCB is stored on external spiflash.
Tested on 440KB FCB that stored CBOR data
fcb_walk time in ms
no cache:   53625     100%
 4 bytes:   41570      77%
 8 bytes:   38695      72%
12 bytes:   36695      68%
16 bytes:   37031      69%
20 bytes:   36875      68%