### PR TITLE
openocd: Fix openocd_load for Windows

### DIFF
--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -27,8 +27,12 @@ GDB=arm-none-eabi-gdb
 openocd_load () {
     OCD_CMD_FILE=.openocd_cmds
 
+    windows_detect
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 
+    if [ $WINDOWS -eq 1 ] ; then
+        FILE_NAME=`cygpath -u $FILE_NAME`
+    fi
     echo "$EXTRA_JTAG_CMD" > $OCD_CMD_FILE
     echo "init" >> $OCD_CMD_FILE
     echo "$CFG_RESET" >> $OCD_CMD_FILE


### PR DESCRIPTION
openocd expects unix style file names even on Windows.

Before pathc:
$ newt load hifive1-boot
Loading bootloader
Error:
Downloading bin\targets\hifive1-boot\app\apps\boot\boot.elf.bin to 0x20000000
GNU MCU Eclipse 64-bit Open On-Chip Debugger 0.10.0+dev-00462-gdd1d90111 (2019-01-18-11:42)
Licensed under GNU GPL v2
...
...
auto erase enabled
Error: couldn't open bin        argetshifive1-bootppppoooot.elf.bin

Windows style path was passed and \ was treated as escape \t - tab

After patch is applied flashing of hifive1 and bluepill works