### PR TITLE
mgmt/imgmgr: Allow upgrade-only requests

### DIFF
--- a/mgmt/oicmgr/include/oicmgr/oicmgr.h
+++ b/mgmt/oicmgr/include/oicmgr/oicmgr.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_OICMGR_
+#define H_OICMGR_
+
+#include "oic/oc_ri.h"
+#include "mgmt/mgmt.h"
+
+/**
+ * Process an oicmgr request.  On completion, an oicmgr response is sent back
+ * to the client.
+ *
+ * @param req                   The oicmgr request to process.
+ * @param mask                  The oicmgr mask supported by the CoAP request
+ *                                  handler.
+ */
+void omgr_oic_put(oc_request_t *req, oc_interface_mask_t mask);
+
+/**
+ * Parses an oicmgr request and copies out the NMP header.
+ *
+ * @param req                   The oicmgr request to parse.
+ * @param out_hdr               On success, the extracted NMP header gets
+ *                                  written here.
+ *
+ * @return                      0 on success;
+ *                              MGMT_ERR_EINVAL on parse failure.
+ */
+int omgr_extract_req_hdr(oc_request_t *req, struct nmgr_hdr *out_hdr);
+
+#endif

--- a/net/oic/include/oic/port/mynewt/serial.h
+++ b/net/oic/include/oic/port/mynewt/serial.h
@@ -26,6 +26,11 @@ extern "C" {
 
 extern uint8_t oc_serial_transport_id;
 
+/**
+ * Indicates whether the given CoAP endpoint uses the serial transport.
+ */
+int oc_endpoint_is_serial(const struct oc_endpoint *oe);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/oic/src/port/mynewt/serial_adaptor.c
+++ b/net/oic/src/port/mynewt/serial_adaptor.c
@@ -64,6 +64,12 @@ oc_ep_serial_size(const struct oc_endpoint *oe)
     return sizeof(struct oc_endpoint_plain);
 }
 
+int
+oc_endpoint_is_serial(const struct oc_endpoint *oe)
+{
+    return oe->ep.oe_type == oc_serial_transport_id;
+}
+
 static int
 oc_serial_in(struct os_mbuf *m, void *arg)
 {


### PR DESCRIPTION
This commit adds an additional boolean field to the "image upload" request: `upgrade`.  If this field is true, the firmware will only accept an upload attempt if the new image's version number is greater than that of the currently running image (using a semver-compatible comparision).

If the `upgrade` field is false or missing, no version check is performed.

The firmware only processes the `upgrade` field on the first image chunk.  It is harmless, but pointless, for a client to specify `upgrade` in any subsequent chunks.

Note: This PR has siblings:
* newtmgr: https://github.com/apache/mynewt-newtmgr/pull/120
* mcumgr: https://github.com/apache/mynewt-mcumgr/pull/25