### PR TITLE
kernel/os_msys: Improve finding mpool

### DIFF
--- a/kernel/os/src/os_msys.c
+++ b/kernel/os/src/os_msys.c
@@ -59,18 +59,22 @@ int
 os_msys_register(struct os_mbuf_pool *new_pool)
 {
     struct os_mbuf_pool *pool;
+    struct os_mbuf_pool *prev;
 
+    /* We want to have order from smallest to biggest mempool. */
+    prev = NULL;
     pool = NULL;
     STAILQ_FOREACH(pool, &g_msys_pool_list, omp_next) {
-        if (new_pool->omp_databuf_len > pool->omp_databuf_len) {
+        if (new_pool->omp_databuf_len < pool->omp_databuf_len) {
             break;
         }
+        prev = pool;
     }
 
-    if (pool) {
-        STAILQ_INSERT_AFTER(&g_msys_pool_list, pool, new_pool, omp_next);
+    if (prev) {
+        STAILQ_INSERT_AFTER(&g_msys_pool_list, prev, new_pool, omp_next);
     } else {
-        STAILQ_INSERT_TAIL(&g_msys_pool_list, new_pool, omp_next);
+        STAILQ_INSERT_HEAD(&g_msys_pool_list, new_pool, omp_next);
     }
 
     return (0);


### PR DESCRIPTION
This PR does two things
1) When it search for mpool for given data size it pick mempool with a databuf_len closes to requested datasize. With this Mynewt tries to me smart and not used mempools with big block size for small data 

2) When user requests msys mbuf with data size 0, Mynewt assumes that data might be big, therefore it will assign mempool with biggest block size. It is done because if there would be msys_2 available with small block size for e.g. some headers as in https://github.com/apache/mynewt-nimble/pull/380, those small msys blocks would be consumed by  others e.g. OIC, where datasize 0 is requested for the reason that it is hard to estimate how big mbuf is needed. 
