### PR TITLE
ADP5061 Macro Values

### DIFF
--- a/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
+++ b/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
@@ -312,10 +312,11 @@ int adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
 #define ADP5061_VTRM_4V08           0x1D
 #define ADP5061_VTRM_4V10           0x1E
 #define ADP5061_VTRM_4V12           0x1F
-#define ADP5061_VTRM_4V14           0x21
-#define ADP5061_VTRM_4V16           0x22
-#define ADP5061_VTRM_4V18           0x23
-#define ADP5061_VTRM_4V20           0x24
+#define ADP5061_VTRM_4V14           0x20
+#define ADP5061_VTRM_4V16           0x21
+#define ADP5061_VTRM_4V18           0x22
+#define ADP5061_VTRM_4V20           0x23
+#define ADP5061_VTRM_4V22           0x24
 #define ADP5061_VTRM_4V24           0x25
 #define ADP5061_VTRM_4V26           0x26
 #define ADP5061_VTRM_4V28           0x27
@@ -330,7 +331,6 @@ int adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
 #define ADP5061_VTRM_4V46           0x31
 #define ADP5061_VTRM_4V48           0x32
 #define ADP5061_VTRM_4V50           0x33
-
 /* CHG_VLIM */
 #define APD5061_CHG_VLIM_LEN        2
 #define APD5061_CHG_VLIM_OFFSET     0

--- a/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
+++ b/hw/drivers/chg_ctrl/adp5061/include/adp5061/adp5061.h
@@ -331,6 +331,7 @@ int adp5061_set_regs(struct adp5061_dev *dev, uint8_t addr,
 #define ADP5061_VTRM_4V46           0x31
 #define ADP5061_VTRM_4V48           0x32
 #define ADP5061_VTRM_4V50           0x33
+
 /* CHG_VLIM */
 #define APD5061_CHG_VLIM_LEN        2
 #define APD5061_CHG_VLIM_OFFSET     0


### PR DESCRIPTION
Missing macro value `ADP5061_VTRM_4V22`

Macro values 4.14V to 4.22V were off.