### PR TITLE
mgmt/oicmgr: make omgr_oic_put() return status

### DIFF
--- a/mgmt/oicmgr/include/oicmgr/oicmgr.h
+++ b/mgmt/oicmgr/include/oicmgr/oicmgr.h
@@ -30,8 +30,11 @@
  * @param req                   The oicmgr request to process.
  * @param mask                  The oicmgr mask supported by the CoAP request
  *                                  handler.
+ *
+ * @return                      0 on success;
+ *                              nonzero on failure (not consistent code sets).
  */
-void omgr_oic_put(oc_request_t *req, oc_interface_mask_t mask);
+int omgr_oic_process_put(oc_request_t *req, oc_interface_mask_t mask);
 
 /**
  * Parses an oicmgr request and copies out the NMP header.

--- a/mgmt/oicmgr/src/oicmgr.c
+++ b/mgmt/oicmgr/src/oicmgr.c
@@ -154,8 +154,8 @@ omgr_extract_req_hdr(oc_request_t *req, struct nmgr_hdr *out_hdr)
     return 0;
 }
 
-void
-omgr_oic_put(oc_request_t *req, oc_interface_mask_t mask)
+int
+omgr_oic_process_put(oc_request_t *req, oc_interface_mask_t mask)
 {
     struct omgr_state *o = &omgr_state;
     const struct mgmt_handler *handler;
@@ -272,6 +272,14 @@ done:
 
     cbor_encoder_close_container(&g_encoder, &o->os_cbuf.ob_mj.encoder);
     oc_send_response(req, rc);
+
+    return rc;
+}
+
+static void
+omgr_oic_put(oc_request_t *req, oc_interface_mask_t mask)
+{
+    omgr_oic_process_put(req, mask);
 }
 
 int


### PR DESCRIPTION
This function would include status in the CoAP response that it sent, but would not indicate status to the caller.  It may be helpful to return a status code here in case the caller wants to perform additional work after successfully processing an oicmgr request.