### PR TITLE
sys/log:Add MGMT_ERR_ECORRUPT for corrupt logentry

### DIFF
--- a/mgmt/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/mgmt/include/mgmt/mgmt.h
@@ -64,6 +64,7 @@ extern "C" {
 #define MGMT_ERR_ETIMEOUT   (4)
 #define MGMT_ERR_ENOENT     (5)
 #define MGMT_ERR_EBADSTATE  (6)     /* Current state disallows command. */
+#define MGMT_ERR_ECORRUPT   (7)
 #define MGMT_ERR_EPERUSER   (256)
 
 #define NMGR_HDR_SIZE           (8)

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -388,6 +388,8 @@ log_set_append_cb(struct log *log, log_append_cb *cb)
 static int
 log_chk_type(uint8_t etype)
 {
+
+#if MYNEWT_VAL(LOG_VERSION) > 2
     switch(etype) {
         case LOG_ETYPE_STRING:
         case LOG_ETYPE_BINARY:
@@ -396,7 +398,9 @@ log_chk_type(uint8_t etype)
         default:
             break;
     }
-
+#else
+    return OS_OK;
+#endif
     return OS_ERROR;
 }
 
@@ -411,10 +415,8 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 
     rc = 0;
 
-#if MYNEWT_VAL(LOG_VERSION) > 2
     rc = log_chk_type(etype);
     assert(rc == OS_OK);
-#endif
 
     if (log->l_name == NULL || log->l_log == NULL) {
         rc = -1;

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -386,6 +386,21 @@ log_set_append_cb(struct log *log, log_append_cb *cb)
 }
 
 static int
+log_chk_type(uint8_t etype)
+{
+    switch(etype) {
+        case LOG_ETYPE_STRING:
+        case LOG_ETYPE_BINARY:
+        case LOG_ETYPE_CBOR:
+            return OS_OK;
+        default:
+            break;
+    }
+
+    return OS_ERROR;
+}
+
+static int
 log_append_prepare(struct log *log, uint8_t module, uint8_t level,
                    uint8_t etype, struct log_entry_hdr *ue)
 {
@@ -395,6 +410,11 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     uint32_t idx;
 
     rc = 0;
+
+#if MYNEWT_VAL(LOG_VERSION) > 2
+    rc = log_chk_type(etype);
+    assert(rc == OS_OK);
+#endif
 
     if (log->l_name == NULL || log->l_log == NULL) {
         rc = -1;

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -388,20 +388,23 @@ log_set_append_cb(struct log *log, log_append_cb *cb)
 static int
 log_chk_type(uint8_t etype)
 {
+    int rc;
+
+    rc = OS_OK;
 
 #if MYNEWT_VAL(LOG_VERSION) > 2
     switch(etype) {
         case LOG_ETYPE_STRING:
         case LOG_ETYPE_BINARY:
         case LOG_ETYPE_CBOR:
-            return OS_OK;
+            break;
         default:
+            rc = OS_ERROR;
             break;
     }
-#else
-    return OS_OK;
 #endif
-    return OS_ERROR;
+
+    return rc;
 }
 
 static int

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -138,11 +138,12 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         g_err |= cbor_encode_text_stringz(&rsp, "bin");
         break;
     case LOG_ETYPE_STRING:
-    default:
-        /* no need for type here */
         g_err |= cbor_encode_text_stringz(&rsp, "type");
         g_err |= cbor_encode_text_stringz(&rsp, "str");
         break;
+    default:
+        ed->counter++;
+        return MGMT_ERR_ECORRUPT;
     }
 
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
@@ -201,11 +202,13 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         g_err |= cbor_encode_text_stringz(&rsp, "bin");
         break;
     case LOG_ETYPE_STRING:
-    default:
         /* no need for type here */
         g_err |= cbor_encode_text_stringz(&rsp, "type");
         g_err |= cbor_encode_text_stringz(&rsp, "str");
         break;
+    default:
+        ed->counter++;
+        return MGMT_ERR_ECORRUPT;
     }
 
     g_err |= cbor_encode_text_stringz(&rsp, "msg");


### PR DESCRIPTION
- if an entry type gets corrupted, we should assert() and not let it
through, it would be useful to analyze cores