### PR TITLE
LED_2 is used by the blemesh example application 

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -39,6 +39,7 @@ extern uint8_t _ram_start;
 
 /* LED pins */
 #define LED_1           (33)    /* P1_1 */
+#define LED_2           (33)    /* P1_1 */
 #define LED_BLINK_PIN   LED_1
 
 /* Button pin */

--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -39,7 +39,7 @@ extern uint8_t _ram_start;
 
 /* LED pins */
 #define LED_1           (33)    /* P1_1 */
-#define LED_2           (33)    /* P1_1 */
+#define LED_2           (43)    /* P1_11 */
 #define LED_BLINK_PIN   LED_1
 
 /* Button pin */


### PR DESCRIPTION
Unfortunately there is only 1 LED that can be controlled by a GPIO on the DA1469x development kit boards (daughter plus motherboard). Therefore LED_2 is defined to to use the same GPIO as LED_1, which will be ok as long as they are not both used by the same application...