### PR TITLE
da1469x: Add some power saving (M33 deep sleep + power rails)

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -105,6 +105,7 @@ mon reset
 mon halt
 restore $FLASH_LOADER.bin binary 0x20000000
 symbol-file $FLASH_LOADER
+set *(int *)0x500000BC = 4
 set \$sp=*(int *)0x20000000
 set \$pc=*(int *)0x20000004
 b main

--- a/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
@@ -29,7 +29,6 @@
 #else
     .equ    Stack_Size, 0xC00
 #endif
-    .equ    NVIC_VTOR, 0xE000ED08
     .equ    SYS_CTRL_REG, 0x50000024
     .equ    CACHE_FLASH_REG, 0x100C0040
 
@@ -137,10 +136,10 @@ __isr_vector:
     .globl Reset_Handler
     .type  Reset_Handler, %function
 Reset_Handler:
-/* Disable remapping of intvect to 0x0 */
+ /* Make sure interrupt vector is remapped at 0x0 */
     ldr     r1, =SYS_CTRL_REG
     ldrh    r2, [r1, #0]
-    bic     r2, r2, #8
+    orrs    r2, r2, #8
     strh    r2, [r1, #0]
 
 #if !MYNEWT_VAL(RAM_RESIDENT)
@@ -160,19 +159,11 @@ Reset_Handler:
     lsr     r2, r2, #2
     orr     r4, r4, r2
 
-/*
- * Copy ISR vector from flash to RAM
- *
- * ISR vector is placed at the start for SYSRAM which is remapped (512 bytes)
- * at 0x0 and thus overrides 512 bytes fo Flash which is also remapped at 0x0.
- * In bootloader this means that copying ISR vector from 0x0 to RAM will load
- * and store values at exactly the same physical location. To avoid this we
- * just need to add calculated flash offset to ISR vector area addresses so
- * they are read directly from Flash address space.
- */
+/* Copy ISR vector from flash to RAM */
     ldr     r1, =__isr_vector_start     /* src ptr */
     ldr     r2, =__isr_vector_end       /* src end */
-    ldr     r3, =0x20000000             /* dst ptr */
+    ldr     r3, =__intvect_start__      /* dst ptr */
+/* Make sure we copy from QSPIC address range, not from remapped range */
     cmp     r1, r4
     itt     lt
     addlt   r1, r1, r4
@@ -206,11 +197,6 @@ Reset_Handler:
     strlt   r0, [r2], #4
     blt     .loop_data_copy
 #endif
-
-/* Set VTOR */
-    ldr     r0, =NVIC_VTOR
-    ldr     r1, =0x20000000
-    str     r1, [r0]
 
 /* Clear BSS */
     movs    r0, 0

--- a/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
@@ -29,8 +29,9 @@
 #else
     .equ    Stack_Size, 0xC00
 #endif
-    .equ    SYS_CTRL_REG, 0x50000024
-    .equ    CACHE_FLASH_REG, 0x100C0040
+    .equ    SYS_CTRL_REG,       0x50000024
+    .equ    CACHE_FLASH_REG,    0x100C0040
+    .equ    RESET_STAT_REG,     0x500000BC
 
     .globl  __StackTop
     .globl  __StackLimit
@@ -129,6 +130,23 @@ __isr_vector:
     .long   0                       /* Reserved */
     .size   __isr_vector, . - __isr_vector
 
+    .section .text_ram
+    .thumb
+    .thumb_func
+    .align 2
+    .globl wakeup_handler
+    .type  wakeup_handler, %function
+wakeup_handler:
+    ldr     r0, =RESET_STAT_REG
+    ldr     r0, [r0, #0]
+    teq     r0, #0
+    ite     eq
+    ldreq   r3, =da1469x_m33_wakeup
+    ldrne   r3, =Reset_Handler
+    bx      r3
+
+    .size   wakeup_handler, . - wakeup_handler
+
     .text
     .thumb
     .thumb_func
@@ -211,6 +229,11 @@ Reset_Handler:
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit
     bl      _sbrkInit
+
+/* Set reset handler to wakeup handler so we can handle wake up from deep sleep */
+    ldr     r0, =__intvect_start__
+    ldr     r1, =wakeup_handler
+    str     r1, [r0, #4]
 
     bl      SystemInit
     bl      hal_system_init

--- a/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
@@ -19,6 +19,7 @@
 
 syscfg.vals:
     MCU_TARGET: DA14699
+    MCU_DCDC_ENABLE: 1
     # Setting for QSPI Flash
     QSPI_FLASH_ADDRESS_LENGTH: 24
     QSPI_FLASH_SECTOR_SIZE: 4096

--- a/hw/mcu/dialog/da1469x/da1469x.ld
+++ b/hw/mcu/dialog/da1469x/da1469x.ld
@@ -108,10 +108,10 @@ SECTIONS
     } > FLASH
     __exidx_end = .;
 
-    .vector_relocation :
+    .intvect :
     {
         . = ALIGN(4);
-        __vector_tbl_reloc__ = .;
+        __intvect_start__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);
     } > RAM
@@ -224,5 +224,8 @@ SECTIONS
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+
+    /* Check that intvect is at the beginning of RAM */
+    ASSERT(__intvect_start__ == ORIGIN(RAM), "intvect is not at beginning of RAM")
 }
 

--- a/hw/mcu/dialog/da1469x/da1469x.ld
+++ b/hw/mcu/dialog/da1469x/da1469x.ld
@@ -116,6 +116,12 @@ SECTIONS
         . = ALIGN(4);
     } > RAM
 
+    .sleep_state (NOLOAD) :
+    {
+        . = ALIGN(4);
+        *(sleep_state)
+    } > RAM
+
     /* This section will be zeroed by RTT package init */
     .rtt (NOLOAD):
     {

--- a/hw/mcu/dialog/da1469x/da1469x_ram_resident.ld
+++ b/hw/mcu/dialog/da1469x/da1469x_ram_resident.ld
@@ -23,7 +23,8 @@ SECTIONS
 {
     .text :
     {
-	__text = .;
+        __text = .;
+        __intvect_start__ = .;
         __isr_vector_start = .;
         KEEP(*(.isr_vector))
         /* ISR vector shall have exactly 512 bytes */
@@ -162,5 +163,8 @@ SECTIONS
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+
+    /* Check that intvect is at the beginning of RAM */
+    ASSERT(__intvect_start__ == ORIGIN(RAM), "intvect is not at beginning of RAM")
 }
 

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_PD_H_
+#define __MCU_DA1469X_PD_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "DA1469xAB.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Available (controllable) power domains */
+#define MCU_PD_DOMAIN_PER           0
+#define MCU_PD_DOMAIN_RAD           1
+#define MCU_PD_DOMAIN_TIM           2
+#define MCU_PD_DOMAIN_COM           3
+
+#define MCU_PD_DOMAIN_COUNT         4
+
+int da1469x_pd_acquire(uint8_t pd);
+int da1469x_pd_release(uint8_t pd);
+int da1469x_pd_release_nowait(uint8_t pd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_PD_H_ */

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
@@ -20,6 +20,7 @@
 #ifndef __MCU_DA1469X_PDC_H_
 #define __MCU_DA1469X_PDC_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "DA1469xAB.h"
 
@@ -125,6 +126,19 @@ static inline void
 da1469x_pdc_set(int idx)
 {
     PDC->PDC_SET_PENDING_REG = idx;
+}
+
+/**
+ * Check if PDC lookup table entry is pending
+ *
+ * @param idx  Entry index
+ *
+ * @return true if entry is pending, false otherwise
+ */
+static inline bool
+da1469x_pdc_is_pending(int idx)
+{
+    return PDC->PDC_PENDING_REG & (1 << idx);
 }
 
 /**

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
@@ -127,6 +127,11 @@ da1469x_pdc_set(int idx)
     PDC->PDC_SET_PENDING_REG = idx;
 }
 
+/**
+ * Acknowledge all pending entries on M33 core
+ */
+void da1469x_pdc_ack_all_m33(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
@@ -20,12 +20,29 @@
 #ifndef __MCU_DA1469X_PRAIL_H_
 #define __MCU_DA1469X_PRAIL_H_
 
+#include "syscfg/syscfg.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void da1469x_prail_initialize(void);
+
+#if MYNEWT_VAL(MCU_DCDC_ENABLE)
+
+/**
+ * Enable DCDC
+ */
+void da1469x_prail_dcdc_enable(void);
+
+/**
+ * Restore DCDC settings
+ *
+ * This assumes DCDC was enabled before.
+ */
+void da1469x_prail_dcdc_restore(void);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_PRAIL_H_
+#define __MCU_DA1469X_PRAIL_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void da1469x_prail_initialize(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_PRAIL_H_ */

--- a/hw/mcu/dialog/da1469x/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/mcu.h
@@ -116,6 +116,8 @@ typedef enum {
 #define MCU_GPIO_PORT1(pin)		((1 * 32) + (pin))
 
 void mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func);
+void mcu_gpio_apply_latches(void);
+void mcu_gpio_restore_latches(void);
 
 #define MCU_MEM_QSPIF_M_START_ADDRESS   (0x16000000)
 #define MCU_MEM_QSPIF_M_END_ADDRESS     (0x18000000)

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    .syntax unified
+    .arch   armv7-m
+
+    .section sleep_state, "aw"
+    .align  3
+    .globl  da1469x_m33_sleep_state
+    .type   da1469x_m33_sleep_state, %object
+da1469x_m33_sleep_state:
+.saved_primask:
+    .space 4    /* PRIMASK */
+.saved_msp:
+    .space 4    /* MSP */
+.saved_psp:
+    .space 4    /* PSP */
+.saved_control:
+    .space 4    /* CONTROL */
+.saved_regs:
+    .space 40   /* R4-R12, LR */
+.saved_nvic:
+    .space 8    /* ISER[0..1] */
+    .space 40   /* IPR[0..39] */
+.saved_scb:
+    .space 28   /* SCR, CCR, SHPR[0..11], CPACR */
+.saved_fpu:
+    .space 8    /* FPCCR, FPDSCR */
+
+    .size   da1469x_m33_sleep_state, . - da1469x_m33_sleep_state
+
+    .equ RESET_STAT_REG,            0x500000BC
+    .equ NVIC_BASE,                 0xE000E100
+    .equ NVIC_IPR_OFFSET,           0x300
+    .equ SCB_BASE,                  0xE000ED00
+    .equ SCB_SCR_OFFSET,            0x010
+    .equ SCB_SHCSR_OFFSET,          0x024
+    .equ SCB_CPACR_OFFSET,          0x088
+    .equ FPU_BASE,                  0xE000EF30
+    .equ FPU_FPCCR_OFFSET,          0x004
+    .equ FPU_FPDSCR_OFFSET,         0x00C
+    .equ QSPIC_BASE,                0x38000000
+    .equ QSPIC_CTRLBUS_OFFSET,      0x000
+    .equ QSPIC_CTRLMOD_OFFSET,      0x004
+    .equ QSPIC_WRITEDATA_OFFSET,    0x018
+
+    .equ SCB_CPACR_MASK,            0x00F00000  /* CP10 and CP11 */
+    .equ SCB_SHCSR_MASK,            0x000F0000  /* xxxFAULTENA */
+    .equ FPU_FPCCR_MASK,            0xF0000000  /* ASPEN, LSPEN, LSPENS, CLRONRET */
+
+    .section .text_ram
+    .thumb
+    .thumb_func
+    .align  2
+    .globl  da1469x_m33_sleep
+    .type   da1469x_m33_sleep, %function
+da1469x_m33_sleep:
+    ldr     r3, =da1469x_m33_sleep_state
+
+/* Disable interrupts and save original PRIMASK */
+    mrs     r0, PRIMASK
+    cpsid   i
+    stmia   r3!, {r0}
+
+/* Save MSP, PSP, CONTROL and general purpose registers */
+    mrs     r0, MSP
+    mrs     r1, PSP
+    mrs     r2, CONTROL
+    stmia   r3!, {r0-r2,r4-r12, lr}
+
+/* Save NVIC state (ISER[0..1] and IPR[0..39]) */
+    ldr     r0, =NVIC_BASE
+    add     r1, r0, NVIC_IPR_OFFSET
+    ldmia   r0!, {r4-r5}
+    stmia   r3!, {r4-r5}
+    ldmia   r1!, {r2, r4-r12}
+    stmia   r3!, {r2, r4-r12}
+
+/* Save SCB state (SCR, CCR, SHPR and SHCSR) */
+    ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
+    ldmia   r0!, {r4-r9}
+    and     r9, r9, #(SCB_SHCSR_MASK)
+    ldr     r10, [r1, #(SCB_CPACR_OFFSET - SCB_SCR_OFFSET)]
+    and     r10, r10, #(SCB_CPACR_MASK)
+    stmia   r3!, {r4-r10}
+
+/* Save NVIC state (FPCCR and FPDSCR) */
+    ldr     r0, =FPU_BASE
+    ldr     r4, [r0, #(FPU_FPCCR_OFFSET)]
+    and     r4, r4, #(FPU_FPCCR_MASK)
+    ldr     r5, [r0, #(FPU_FPDSCR_OFFSET)]
+    stmia   r3!, {r4-r5}
+
+/* Clear RESET_STAT_REG so wakeup handler can detect wakeup from deep sleep */
+    ldr     r0, =RESET_STAT_REG
+    movs    r3, #0
+    str     r3, [r0, #0]
+
+/* Set SCB->SCR[SLEEPDEEP] so we can enter deep sleep */
+    ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
+    ldr     r1, [r0, #0]
+    mov     r2, r1
+    orr     r2, r1, #4      /* SLEEPDEEP */
+    str     r2, [r0, #0]
+
+/* Sleep! */
+    dsb
+    wfi
+
+/*
+ * If deep sleep was executed we'll restart in reset handler, otherwise we just
+ * restore registers and continue by returning false to caller to indicate we
+ * did not sleep.
+ */
+    str     r1, [r0, #0]
+    mov     r0, #0
+    b       da1469x_m33_restore
+
+    .section .text_ram
+    .thumb
+    .thumb_func
+    .align  2
+    .globl  da1469x_m33_wakeup
+    .type   da1469x_m33_wakeup, %function
+da1469x_m33_wakeup:
+/* Disable interrupts, we'll restore proper PRIMASK at the end */
+    cpsid   i
+
+ /*
+  * Temporarily restore saved MSP as temporary stack pointer to allow proper
+  * stacking in case of an exception.
+  */
+    ldr     r3, =.saved_msp
+    ldr     sp, [r3, #0]
+
+ /* Restore NVIC state */
+    ldr     r3, =.saved_nvic
+    ldr     r0, =NVIC_BASE
+    add     r1, r0, NVIC_IPR_OFFSET
+    ldmia   r3!, {r4-r5}
+    stmia   r0!, {r4-r5}
+    ldmia   r3!, {r2, r4-r12}
+    stmia   r1!, {r2, r4-r12}
+
+ /* Restore SCB state */
+    ldmia   r3!, {r4-r10}
+    ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
+    ldr     r1, [r0, #(SCB_CPACR_OFFSET - SCB_SCR_OFFSET)]
+    orr     r10, r10, r1
+    str     r10, [r0, #(SCB_CPACR_OFFSET - SCB_SCR_OFFSET)]
+    ldr     r1, [r0, #(SCB_SHCSR_OFFSET - SCB_SCR_OFFSET)]
+    orr     r9, r9, r1
+    stmia   r0!, {r4-r9}
+
+/* Restore FPU state */
+    ldmia   r3!, {r4-r5}
+    ldr     r0, =FPU_BASE
+    ldr     r1, [r0, #(FPU_FPCCR_OFFSET)]
+    orr     r4, r4, r1
+    str     r4, [r0, #(FPU_FPCCR_OFFSET)]
+    str     r5, [r0, #(FPU_FPDSCR_OFFSET)]
+
+/* Restore MSP, PSP and CONTROL */
+    ldr     r3, =.saved_msp
+    ldmia   r3!, {r0-r2}
+    msr     MSP, r0
+    msr     PSP, r1
+    msr     CONTROL, r2
+
+/*
+ * Flash is likely in QPI mode but QSPIC assumes it is in single mode so we
+ * should make sure both are in sync by forcing exit from QPI mode and then
+ * re-enter it. We need to do this before we start executing code from flash
+ * again.
+ */
+    ldr     r0, =QSPIC_BASE
+    ldr     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    bic     r1, r1, #1      /* Clear automode */
+    orr     r1, r1, #0x3c   /* Set IO2/IO3 DAT and OEN */
+    str     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    mov     r1, #1          /* Set single */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #8          /* Enable CS */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #0xff       /* Exit QPI mode */
+    strb    r1, [r0, #(QSPIC_WRITEDATA_OFFSET)]
+    mov     r1, #16         /* Disable CS */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #4          /* Set quad */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    ldr     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    bic     r1, r1, #0xc    /* Clear IO2/IO3 OEN */
+    orr     r1, r1, #1      /* Enable automode */
+    str     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+
+/* Finish restore, return true to caller to indicate we slept */
+    mov     r0, #1
+    ldr     r3, =da1469x_m33_restore
+    bx      r3
+
+    .section .text_ram
+    .thumb
+    .thumb_func
+    .align  2
+    .globl  da1469x_m33_restore
+    .type   da1469x_m33_restore, %function
+da1469x_m33_restore:
+    ldr     r3, =.saved_regs
+    ldmia   r3!, {r4-r12, lr}
+
+    ldr     r3, =.saved_primask
+    ldr     r3, [r3, #0]
+    msr     PRIMASK, r3
+
+    bx      lr

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -45,6 +45,7 @@ da1469x_m33_sleep_state:
 
     .size   da1469x_m33_sleep_state, . - da1469x_m33_sleep_state
 
+    .equ CLK_AMBA_REG,              0x50000000
     .equ RESET_STAT_REG,            0x500000BC
     .equ NVIC_BASE,                 0xE000E100
     .equ NVIC_IPR_OFFSET,           0x300
@@ -112,6 +113,12 @@ da1469x_m33_sleep:
     movs    r3, #0
     str     r3, [r0, #0]
 
+/* Disable QSPI controller clock */
+    ldr     r0, =CLK_AMBA_REG
+    ldr     r1, [r0, #0]
+    bic     r1, r1, #0x1000
+    str     r1, [r0, #0]
+
 /* Set SCB->SCR[SLEEPDEEP] so we can enter deep sleep */
     ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
     ldr     r1, [r0, #0]
@@ -130,6 +137,13 @@ da1469x_m33_sleep:
  */
     str     r1, [r0, #0]
     mov     r0, #0
+
+/* Enable QSPI controller clock */
+    ldr     r2, =CLK_AMBA_REG
+    ldr     r1, [r2, #0]
+    orr     r1, r1, #0x1000
+    str     r1, [r2, #0]
+
     b       da1469x_m33_restore
 
     .section .text_ram
@@ -182,6 +196,12 @@ da1469x_m33_wakeup:
     msr     MSP, r0
     msr     PSP, r1
     msr     CONTROL, r2
+
+/* Enable QSPI controller clock */
+    ldr     r0, =CLK_AMBA_REG
+    ldr     r1, [r0, #0]
+    orr     r1, r1, #0x1000
+    str     r1, [r0, #0]
 
 /*
  * Flash is likely in QPI mode but QSPIC assumes it is in single mode so we

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv7-m
 
@@ -40,8 +42,10 @@ da1469x_m33_sleep_state:
     .space 40   /* IPR[0..39] */
 .saved_scb:
     .space 28   /* SCR, CCR, SHPR[0..11], CPACR */
+#if MYNEWT_VAL(HARDFLOAT)
 .saved_fpu:
     .space 8    /* FPCCR, FPDSCR */
+#endif
 
     .size   da1469x_m33_sleep_state, . - da1469x_m33_sleep_state
 
@@ -101,12 +105,14 @@ da1469x_m33_sleep:
     and     r10, r10, #(SCB_CPACR_MASK)
     stmia   r3!, {r4-r10}
 
-/* Save NVIC state (FPCCR and FPDSCR) */
+#if MYNEWT_VAL(HARDFLOAT)
+/* Save FPU state (FPCCR and FPDSCR) */
     ldr     r0, =FPU_BASE
     ldr     r4, [r0, #(FPU_FPCCR_OFFSET)]
     and     r4, r4, #(FPU_FPCCR_MASK)
     ldr     r5, [r0, #(FPU_FPDSCR_OFFSET)]
     stmia   r3!, {r4-r5}
+#endif
 
 /* Clear RESET_STAT_REG so wakeup handler can detect wakeup from deep sleep */
     ldr     r0, =RESET_STAT_REG
@@ -182,6 +188,7 @@ da1469x_m33_wakeup:
     orr     r9, r9, r1
     stmia   r0!, {r4-r9}
 
+#if MYNEWT_VAL(HARDFLOAT)
 /* Restore FPU state */
     ldmia   r3!, {r4-r5}
     ldr     r0, =FPU_BASE
@@ -189,6 +196,7 @@ da1469x_m33_wakeup:
     orr     r4, r4, r1
     str     r4, [r0, #(FPU_FPCCR_OFFSET)]
     str     r5, [r0, #(FPU_FPDSCR_OFFSET)]
+#endif
 
 /* Restore MSP, PSP and CONTROL */
     ldr     r3, =.saved_msp

--- a/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
@@ -222,22 +222,23 @@ da1469x_cmac_init(void)
     struct cmac_config *cmac_config;
     struct cmac_config_dynamic *cmac_config_dyn;
 
-    /* Set PDC entries to wakeup CMAC from M33 and M33 from CMAC */
+    /* Add PDC entry to wake up CMAC from M33 */
     g_da1469x_pdc_sys2cmac = da1469x_pdc_add(MCU_PDC_TRIGGER_MAC_TIMER,
                                              MCU_PDC_MASTER_CMAC,
                                              MCU_PDC_EN_XTAL);
     da1469x_pdc_set(g_da1469x_pdc_sys2cmac);
     da1469x_pdc_ack(g_da1469x_pdc_sys2cmac);
 
-    g_da1469x_pdc_cmac2sys = da1469x_pdc_add(MCU_PDC_TRIGGER_COMBO,
-                                             MCU_PDC_MASTER_M33,
-                                             MCU_PDC_EN_XTAL);
-    da1469x_pdc_set(g_da1469x_pdc_cmac2sys);
-    da1469x_pdc_ack(g_da1469x_pdc_cmac2sys);
-
-    /* Enable PD_RAD */
-    CRG_TOP->PMU_CTRL_REG &= ~CRG_TOP_PMU_CTRL_REG_RADIO_SLEEP_Msk;
-    while (!(CRG_TOP->SYS_STAT_REG & CRG_TOP_SYS_STAT_REG_RAD_IS_UP_Msk));
+    /* Add PDC entry to wake up M33 from CMAC, if does not exist yet */
+    g_da1469x_pdc_cmac2sys = da1469x_pdc_find(MCU_PDC_TRIGGER_COMBO,
+                                              MCU_PDC_MASTER_M33, 0);
+    if (g_da1469x_pdc_cmac2sys < 0) {
+        g_da1469x_pdc_cmac2sys = da1469x_pdc_add(MCU_PDC_TRIGGER_COMBO,
+                                                 MCU_PDC_MASTER_M33,
+                                                 MCU_PDC_EN_XTAL);
+        da1469x_pdc_set(g_da1469x_pdc_cmac2sys);
+        da1469x_pdc_ack(g_da1469x_pdc_cmac2sys);
+    }
 
     /* Enable Radio LDO */
     CRG_TOP->POWER_CTRL_REG |= CRG_TOP_POWER_CTRL_REG_LDO_RADIO_ENABLE_Msk;

--- a/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
@@ -103,12 +103,6 @@ da1469x_cmac_pdc_signal(void)
     da1469x_pdc_set(g_da1469x_pdc_sys2cmac);
 }
 
-static inline void
-da1469x_cmac_pdc_ack(void)
-{
-    da1469x_pdc_ack(g_da1469x_pdc_cmac2sys);
-}
-
 static void
 cmac2sys_isr(void)
 {
@@ -118,8 +112,6 @@ cmac2sys_isr(void)
     uint16_t len;
 
     os_trace_isr_enter();
-
-    da1469x_cmac_pdc_ack();
 
     /* Clear CMAC2SYS interrupt */
     *(volatile uint32_t *)0x40002000 = 2;

--- a/hw/mcu/dialog/da1469x/src/da1469x_pd.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_pd.c
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "defs/error.h"
+#include "mcu/da1469x_hal.h"
+#include "mcu/da1469x_pd.h"
+#include "os/util.h"
+
+struct da1469x_pd_desc {
+    uint8_t pmu_sleep_bit;
+    uint8_t stat_down_bit; /* up is +1 */
+};
+
+static const struct da1469x_pd_desc g_da1469x_pd_desc[] = {
+    [MCU_PD_DOMAIN_PER] = { CRG_TOP_PMU_CTRL_REG_PERIPH_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_PER_IS_DOWN_Pos },
+    [MCU_PD_DOMAIN_RAD] = { CRG_TOP_PMU_CTRL_REG_RADIO_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_RAD_IS_DOWN_Pos},
+    [MCU_PD_DOMAIN_TIM] = { CRG_TOP_PMU_CTRL_REG_TIM_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_TIM_IS_DOWN_Pos },
+    [MCU_PD_DOMAIN_COM] = { CRG_TOP_PMU_CTRL_REG_COM_SLEEP_Pos,
+                            CRG_TOP_SYS_STAT_REG_COM_IS_DOWN_Pos},
+};
+
+static uint8_t g_da1469x_pd_refcnt[ ARRAY_SIZE(g_da1469x_pd_desc) ];
+
+int
+da1469x_pd_acquire(uint8_t pd)
+{
+    uint8_t *refcnt;
+    uint32_t primask;
+    uint32_t bitmask;
+    int ret = 0;
+
+    assert(pd < ARRAY_SIZE(g_da1469x_pd_desc));
+    refcnt = &g_da1469x_pd_refcnt[pd];
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+
+    assert(*refcnt < UINT8_MAX);
+    if ((*refcnt)++ == 0) {
+        bitmask = 1 << g_da1469x_pd_desc[pd].pmu_sleep_bit;
+        CRG_TOP->PMU_CTRL_REG &= ~bitmask;
+
+        bitmask = 1 << (g_da1469x_pd_desc[pd].stat_down_bit + 1);
+        while ((CRG_TOP->SYS_STAT_REG & bitmask) == 0);
+
+        ret = 1;
+    }
+
+    __HAL_ENABLE_INTERRUPTS(primask);
+
+    return ret;
+}
+
+int
+da1469x_pd_release(uint8_t pd)
+{
+    uint8_t *refcnt;
+    uint32_t primask;
+    uint32_t bitmask;
+    int ret = 0;
+
+    assert(pd < MCU_PD_DOMAIN_COUNT);
+    refcnt = &g_da1469x_pd_refcnt[pd];
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+
+    assert(*refcnt > 0);
+    if (--(*refcnt) == 0) {
+        bitmask = 1 << g_da1469x_pd_desc[pd].pmu_sleep_bit;
+        CRG_TOP->PMU_CTRL_REG |= bitmask;
+
+        bitmask = 1 << g_da1469x_pd_desc[pd].stat_down_bit;
+        while ((CRG_TOP->SYS_STAT_REG & bitmask) == 0);
+
+        ret = 1;
+    }
+
+    __HAL_ENABLE_INTERRUPTS(primask);
+
+    return ret;
+}
+
+int
+da1469x_pd_release_nowait(uint8_t pd)
+{
+    uint8_t *refcnt;
+    uint32_t primask;
+    uint32_t bitmask;
+    int ret = 0;
+
+    assert(pd < MCU_PD_DOMAIN_COUNT);
+    refcnt = &g_da1469x_pd_refcnt[pd];
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+
+    assert(*refcnt > 0);
+    if (--(*refcnt) == 0) {
+        bitmask = 1 << g_da1469x_pd_desc[pd].pmu_sleep_bit;
+        CRG_TOP->PMU_CTRL_REG |= bitmask;
+
+        ret = 1;
+    }
+
+    __HAL_ENABLE_INTERRUPTS(primask);
+
+    return ret;
+}

--- a/hw/mcu/dialog/da1469x/src/da1469x_pdc.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_pdc.c
@@ -93,3 +93,15 @@ da1469x_pdc_reset(void)
         da1469x_pdc_ack(idx);
     }
 }
+
+void
+da1469x_pdc_ack_all_m33(void)
+{
+    int idx;
+
+    for (idx = 0; idx < MCU_PDC_CTRL_REGS_COUNT; idx++) {
+        if (PDC->PDC_PENDING_CM33_REG & (1 << idx)) {
+            da1469x_pdc_ack(idx);
+        }
+    }
+}

--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "mcu/da1469x_hal.h"
+#include "mcu/da1469x_prail.h"
+#include "DA1469xAB.h"
+
+#define POWER_CTRL_REG_SET(_field, _val)                                        \
+    CRG_TOP->POWER_CTRL_REG =                                                   \
+    (CRG_TOP->POWER_CTRL_REG & ~CRG_TOP_POWER_CTRL_REG_ ## _field ## _Msk) |    \
+    ((_val) << CRG_TOP_POWER_CTRL_REG_ ## _field ## _Pos)
+
+static void
+da1469x_prail_configure_3v0(void)
+{
+    /* 150mA max load active, 10mA max load sleep */
+    /* XXX make rail configurable */
+
+    POWER_CTRL_REG_SET(LDO_3V0_MODE, 3);                /* Automatic */
+    POWER_CTRL_REG_SET(LDO_3V0_REF, 1);                 /* Bandgap */
+    POWER_CTRL_REG_SET(V30_LEVEL, 0);                   /* 3.000 V */
+    POWER_CTRL_REG_SET(LDO_3V0_RET_ENABLE_ACTIVE, 0);
+    POWER_CTRL_REG_SET(LDO_3V0_RET_ENABLE_SLEEP, 1);
+    POWER_CTRL_REG_SET(CLAMP_3V0_VBAT_ENABLE, 0);
+}
+
+static void
+da1469x_prail_configure_1v8(void)
+{
+    /* 10mA max load active, 10mA max load sleep */
+    /* XXX make rail configurable */
+
+    POWER_CTRL_REG_SET(V18_LEVEL, 1);                   /* 1.800 V */
+    POWER_CTRL_REG_SET(LDO_1V8_RET_ENABLE_ACTIVE, 1);
+    POWER_CTRL_REG_SET(LDO_1V8_RET_ENABLE_SLEEP, 1);
+    POWER_CTRL_REG_SET(LDO_1V8_ENABLE, 0);
+}
+
+static void
+da1469x_prail_configure_1v8p(void)
+{
+    /* 50mA max load active, 10mA max load sleep */
+    /* XXX make rail configurable */
+
+    POWER_CTRL_REG_SET(LDO_1V8P_RET_ENABLE_ACTIVE, 0);
+    POWER_CTRL_REG_SET(LDO_1V8P_RET_ENABLE_SLEEP, 1);
+    POWER_CTRL_REG_SET(LDO_1V8P_ENABLE, 1);
+}
+
+static void
+da1469x_prail_configure_1v2(void)
+{
+    /* 50mA max load active, 50mA max load sleep */
+    /* XXX make rail configurable */
+
+    /*
+     * LDO_CORE_RET will be used instead of clamp when sleeping if VDD level
+     * set for clamp is lower than set for sleep LDO.
+     */
+
+    POWER_CTRL_REG_SET(VDD_SLEEP_LEVEL, 0);             /* 0.750 V */
+    POWER_CTRL_REG_SET(VDD_CLAMP_LEVEL, 15);            /* 0.706 V */
+    POWER_CTRL_REG_SET(VDD_LEVEL, 3);                   /* 1.200 V */
+    POWER_CTRL_REG_SET(LDO_CORE_RET_ENABLE_ACTIVE, 0);
+    POWER_CTRL_REG_SET(LDO_CORE_RET_ENABLE_SLEEP, 1);
+    POWER_CTRL_REG_SET(LDO_CORE_ENABLE, 1);
+}
+
+static void
+da1469x_prail_configure_1v4(void)
+{
+    POWER_CTRL_REG_SET(V14_LEVEL, 4);                   /* 1.400 V */
+    /*
+     * XXX LDO_RADIO will be enabled when CMAC is initialized, but probably
+     *     we'll need it for PLL as well.
+     */
+//    POWER_CTRL_REG_SET(LDO_RADIO_ENABLE, 1);
+}
+
+void
+da1469x_prail_initialize(void)
+{
+    da1469x_prail_configure_3v0();
+    da1469x_prail_configure_1v8();
+    da1469x_prail_configure_1v8p();
+    da1469x_prail_configure_1v2();
+    da1469x_prail_configure_1v4();
+}

--- a/hw/mcu/dialog/da1469x/src/da1469x_priv.h
+++ b/hw/mcu/dialog/da1469x/src/da1469x_priv.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_PRIV_H_
+#define __MCU_DA1469X_PRIV_H_
+
+#include <stdint.h>
+#include "os/os_time.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint8_t g_mcu_pdc_combo_idx;
+extern bool g_mcu_lpclk_available;
+
+void da1469x_sleep(os_time_t ticks);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __MCU_DA1469X_PRIV_H_ */

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -21,6 +21,7 @@
 #include "mcu/da1469x_clock.h"
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
+#include "mcu/mcu.h"
 #include "hal/hal_system.h"
 #include "DA1469xAB.h"
 #include "da1469x_priv.h"
@@ -65,7 +66,9 @@ da1469x_sleep(os_time_t ticks)
         return;
     }
 
+    mcu_gpio_apply_latches();
     ret = da1469x_m33_sleep();
+    mcu_gpio_restore_latches();
     if (!ret) {
         /* We were not sleeping, just return */
         return;

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "mcu/da1469x_clock.h"
+#include "mcu/da1469x_pdc.h"
+#include "hal/hal_system.h"
+#include "DA1469xAB.h"
+#include "da1469x_priv.h"
+
+#if MYNEWT_VAL(MCU_DEEP_SLEEP)
+
+extern int da1469x_m33_sleep(void) __attribute__((naked));
+
+uint8_t g_mcu_pdc_combo_idx;
+
+static bool g_mcu_wait_for_jtag;
+static os_time_t g_mcu_wait_for_jtag_until;
+
+static inline bool
+da1469x_sleep_any_irq_pending(void)
+{
+    return ((NVIC->ISPR[0] & NVIC->ISER[0]) | (NVIC->ISPR[1] & NVIC->ISER[1]));
+}
+
+static bool
+da1469x_sleep_is_blocked(void)
+{
+    if (g_mcu_wait_for_jtag &&
+        OS_TIME_TICK_GEQ(os_time_get(), g_mcu_wait_for_jtag_until)) {
+        g_mcu_wait_for_jtag = false;
+    }
+
+    return hal_debugger_connected() || da1469x_sleep_any_irq_pending() ||
+           !g_mcu_lpclk_available || g_mcu_wait_for_jtag;
+}
+
+void
+da1469x_sleep(os_time_t ticks)
+{
+    int ret;
+
+    da1469x_pdc_ack_all_m33();
+
+    if (da1469x_sleep_is_blocked() || ticks < 3) {
+        __DSB();
+        __WFI();
+        return;
+    }
+
+    ret = da1469x_m33_sleep();
+    if (!ret) {
+        /* We were not sleeping, just return */
+        return;
+    }
+
+    /*
+     * If PDC entry for "combo" wakeup is pending, but none of CMAC2SYS, WKUP
+     * or VBUS is pending it means we were woken up from JTAG. We need to block
+     * deep sleep for a moment so debugger can attach.
+     */
+    if (da1469x_pdc_is_pending(g_mcu_pdc_combo_idx) &&
+        !(NVIC->ISPR[0] & ((1 << CMAC2SYS_IRQn) |
+                           (1 << KEY_WKUP_GPIO_IRQn) |
+                           (1 << VBUS_IRQn)))) {
+        g_mcu_wait_for_jtag = true;
+        g_mcu_wait_for_jtag_until = os_time_get() + os_time_ms_to_ticks32(100);
+    }
+
+    /* XXX for now we always run on XTAL32M and assume PDC was configure to enable it */
+    da1469x_clock_sys_xtal32m_switch_safe();
+}
+
+#else
+
+void
+da1469x_sleep(os_time_t ticks)
+{
+    __DSB();
+    __WFI();
+}
+
+#endif

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include "mcu/da1469x_clock.h"
 #include "mcu/da1469x_pdc.h"
+#include "mcu/da1469x_prail.h"
 #include "hal/hal_system.h"
 #include "DA1469xAB.h"
 #include "da1469x_priv.h"
@@ -69,6 +70,10 @@ da1469x_sleep(os_time_t ticks)
         /* We were not sleeping, just return */
         return;
     }
+
+#if MYNEWT_VAL(MCU_DCDC_ENABLE)
+    da1469x_prail_dcdc_restore();
+#endif
 
     /*
      * If PDC entry for "combo" wakeup is pending, but none of CMAC2SYS, WKUP

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -73,6 +73,8 @@ struct hal_gpio_irq {
 
 static struct hal_gpio_irq hal_gpio_irqs[HAL_GPIO_MAX_IRQ];
 
+static uint32_t hal_gpio_latch_state[2];
+
 int
 hal_gpio_init_in(int pin, hal_gpio_pull_t pull)
 {
@@ -288,4 +290,20 @@ mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func)
     GPIO_PIN_MODE_REG(pin) = (func & GPIO_P0_00_MODE_REG_PID_Msk) |
         (mode & (GPIO_P0_00_MODE_REG_PUPD_Msk | GPIO_P0_00_MODE_REG_PPOD_Msk));
     GPIO_PIN_UNLATCH(pin);
+}
+
+void
+mcu_gpio_apply_latches(void)
+{
+    hal_gpio_latch_state[0] = CRG_TOP->P0_PAD_LATCH_REG;
+    hal_gpio_latch_state[1] = CRG_TOP->P1_PAD_LATCH_REG;
+    CRG_TOP->P0_RESET_PAD_LATCH_REG = CRG_TOP_P0_PAD_LATCH_REG_P0_LATCH_EN_Msk;
+    CRG_TOP->P1_RESET_PAD_LATCH_REG = CRG_TOP_P1_PAD_LATCH_REG_P1_LATCH_EN_Msk;
+}
+
+void
+mcu_gpio_restore_latches(void)
+{
+    CRG_TOP->P0_PAD_LATCH_REG = hal_gpio_latch_state[0];
+    CRG_TOP->P1_PAD_LATCH_REG = hal_gpio_latch_state[1];
 }

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -111,6 +111,17 @@ hal_gpio_init_out(int pin, int val)
     return 0;
 }
 
+int
+hal_gpio_deinit(int pin)
+{
+    /* Reset mode to default value and latch pin */
+    GPIO_PIN_MODE_REG(pin) = 0x200;
+    GPIO_PIN_RESET_DATA_REG(pin) = 1 << (pin & 31);
+    GPIO_PIN_LATCH(pin);
+
+    return 0;
+}
+
 void
 hal_gpio_write(int pin, int val)
 {

--- a/hw/mcu/dialog/da1469x/src/hal_os_tick.c
+++ b/hw/mcu/dialog/da1469x/src/hal_os_tick.c
@@ -23,6 +23,7 @@
 #include "hal/hal_os_tick.h"
 #include "hal/hal_system.h"
 #include "os/os_trace_api.h"
+#include "da1469x_priv.h"
 #include "DA1469xAB.h"
 
 struct hal_os_tick {
@@ -149,8 +150,7 @@ os_tick_idle(os_time_t ticks)
         hal_os_tick_set_timer_trigger_val(new_trigger_val);
     }
 
-    __DSB();
-    __WFI();
+    da1469x_sleep(ticks);
 
     if (ticks > 0) {
         hal_os_tick_handler();

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -60,10 +60,6 @@ hal_system_init(void)
         g_hal_reset_reason = 0;
     }
 #endif
-    /* Disable pad latches */
-    CRG_TOP->P0_RESET_PAD_LATCH_REG = CRG_TOP_P0_PAD_LATCH_REG_P0_LATCH_EN_Msk;
-    CRG_TOP->P1_RESET_PAD_LATCH_REG = CRG_TOP_P1_PAD_LATCH_REG_P1_LATCH_EN_Msk;
-
 }
 
 void

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -96,6 +96,9 @@ void SystemInit(void)
     g_mcu_pdc_combo_idx = idx;
 
     CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_SYS_SLEEP_Msk;
+
+    /* Enable cache retainability */
+    CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_RETAIN_CACHE_Msk;
 #endif
 
     /* XXX temporarily enable PD_COM and PD_PER since we do not control them */

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -113,6 +113,10 @@ void SystemInit(void)
     da1469x_prail_dcdc_enable();
 #endif
 
+    /* Latch all pins. We will unlatch them when initialized to do something. */
+    CRG_TOP->P0_RESET_PAD_LATCH_REG = CRG_TOP_P0_PAD_LATCH_REG_P0_LATCH_EN_Msk;
+    CRG_TOP->P1_RESET_PAD_LATCH_REG = CRG_TOP_P1_PAD_LATCH_REG_P1_LATCH_EN_Msk;
+
     /* XXX temporarily enable PD_COM and PD_PER since we do not control them */
     da1469x_pd_acquire(MCU_PD_DOMAIN_COM);
     da1469x_pd_acquire(MCU_PD_DOMAIN_PER);

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -109,6 +109,9 @@ void SystemInit(void)
 
     /* Initialize and configure power rails */
     da1469x_prail_initialize();
+#if MYNEWT_VAL(MCU_DCDC_ENABLE)
+    da1469x_prail_dcdc_enable();
+#endif
 
     /* XXX temporarily enable PD_COM and PD_PER since we do not control them */
     da1469x_pd_acquire(MCU_PD_DOMAIN_COM);

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -18,20 +18,26 @@
  */
 
 #include <assert.h>
+#include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "DA1469xAB.h"
+#include "da1469x_priv.h"
 
 #define PMU_ALL_SLEEP_MASK      (CRG_TOP_PMU_CTRL_REG_TIM_SLEEP_Msk | \
                                  CRG_TOP_PMU_CTRL_REG_PERIPH_SLEEP_Msk | \
                                  CRG_TOP_PMU_CTRL_REG_COM_SLEEP_Msk | \
                                  CRG_TOP_PMU_CTRL_REG_RADIO_SLEEP_Msk)
-#define SYS_ALL_IS_UP_MASK      (CRG_TOP_SYS_STAT_REG_TIM_IS_UP_Msk | \
-                                 CRG_TOP_SYS_STAT_REG_PER_IS_UP_Msk | \
-                                 CRG_TOP_SYS_STAT_REG_COM_IS_UP_Msk | \
-                                 CRG_TOP_SYS_STAT_REG_RAD_IS_UP_Msk)
+#define SYS_ALL_IS_DOWN_MASK    (CRG_TOP_SYS_STAT_REG_TIM_IS_DOWN_Msk | \
+                                 CRG_TOP_SYS_STAT_REG_PER_IS_DOWN_Msk | \
+                                 CRG_TOP_SYS_STAT_REG_COM_IS_DOWN_Msk | \
+                                 CRG_TOP_SYS_STAT_REG_RAD_IS_DOWN_Msk)
 
 void SystemInit(void)
 {
+#if MYNEWT_VAL(OS_SCHEDULING) && MYNEWT_VAL(MCU_DEEP_SLEEP)
+    int idx;
+#endif
+
     assert(CHIP_VERSION->CHIP_ID1_REG == '2');
     assert(CHIP_VERSION->CHIP_ID2_REG == '5');
     assert(CHIP_VERSION->CHIP_ID3_REG == '2');
@@ -46,6 +52,9 @@ void SystemInit(void)
     __ISB();
 #endif
 
+    /* Initialize power domains (disable) */
+    CRG_TOP->PMU_CTRL_REG |= PMU_ALL_SLEEP_MASK;
+
     /*
      * Reset all PDC entries. Make sure PD_SYS cannot be powered down before
      * resetting as otherwise it will be powered down as soon as we clear last
@@ -57,10 +66,6 @@ void SystemInit(void)
     /* Enable Radio LDO */
     CRG_TOP->POWER_CTRL_REG |= CRG_TOP_POWER_CTRL_REG_LDO_RADIO_ENABLE_Msk;
 
-    /* Enable PD_TIM, PD_PER, PD_COM and PD_RAD */
-    CRG_TOP->PMU_CTRL_REG &= ~PMU_ALL_SLEEP_MASK;
-    while ((CRG_TOP->SYS_STAT_REG & SYS_ALL_IS_UP_MASK) != SYS_ALL_IS_UP_MASK);
-
     /* Keep CMAC in reset, we don't need it now */
     CRG_TOP->CLK_RADIO_REG = (0 << CRG_TOP_CLK_RADIO_REG_RFCU_ENABLE_Pos) |
                              (1 << CRG_TOP_CLK_RADIO_REG_CMAC_SYNCH_RESET_Pos) |
@@ -70,4 +75,30 @@ void SystemInit(void)
 
     NVIC_DisableIRQ(PDC_IRQn);
     NVIC_ClearPendingIRQ(PDC_IRQn);
+
+#if MYNEWT_VAL(OS_SCHEDULING) && MYNEWT_VAL(MCU_DEEP_SLEEP)
+    /* Make sure PD_TIM domain is always up for Timer2 to be running */
+    da1469x_pd_acquire(MCU_PD_DOMAIN_TIM);
+
+    /* Allow Timer2 (os_tick) to wake up M33 from deep sleep */
+    idx = da1469x_pdc_add(MCU_PDC_TRIGGER_TIMER2, MCU_PDC_MASTER_M33,
+                          MCU_PDC_EN_XTAL);
+    assert(idx >= 0);
+    da1469x_pdc_set(idx);
+    da1469x_pdc_ack(idx);
+
+    /* Allow to wake up M33 on JTAG */
+    idx = da1469x_pdc_add(MCU_PDC_TRIGGER_COMBO, MCU_PDC_MASTER_M33,
+                          MCU_PDC_EN_XTAL);
+    assert(idx >= 0);
+    da1469x_pdc_set(idx);
+    da1469x_pdc_ack(idx);
+    g_mcu_pdc_combo_idx = idx;
+
+    CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_SYS_SLEEP_Msk;
+#endif
+
+    /* XXX temporarily enable PD_COM and PD_PER since we do not control them */
+    da1469x_pd_acquire(MCU_PD_DOMAIN_COM);
+    da1469x_pd_acquire(MCU_PD_DOMAIN_PER);
 }

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -101,6 +101,14 @@ void SystemInit(void)
     CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_RETAIN_CACHE_Msk;
 #endif
 
+    /* Switch OTPC to deep standby (DSTBY) mode */
+    CRG_TOP->CLK_AMBA_REG |= CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+    OTPC->OTPC_MODE_REG = (OTPC->OTPC_MODE_REG &
+                           ~OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Msk) |
+                          (1 << OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Pos);
+    while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_MRDY_Msk));
+    CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
     /* XXX temporarily enable PD_COM and PD_PER since we do not control them */
     da1469x_pd_acquire(MCU_PD_DOMAIN_COM);
     da1469x_pd_acquire(MCU_PD_DOMAIN_PER);

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
+#include "mcu/da1469x_prail.h"
 #include "DA1469xAB.h"
 #include "da1469x_priv.h"
 
@@ -63,9 +64,6 @@ void SystemInit(void)
     CRG_TOP->PMU_CTRL_REG &= ~CRG_TOP_PMU_CTRL_REG_SYS_SLEEP_Msk;
     da1469x_pdc_reset();
 
-    /* Enable Radio LDO */
-    CRG_TOP->POWER_CTRL_REG |= CRG_TOP_POWER_CTRL_REG_LDO_RADIO_ENABLE_Msk;
-
     /* Keep CMAC in reset, we don't need it now */
     CRG_TOP->CLK_RADIO_REG = (0 << CRG_TOP_CLK_RADIO_REG_RFCU_ENABLE_Pos) |
                              (1 << CRG_TOP_CLK_RADIO_REG_CMAC_SYNCH_RESET_Pos) |
@@ -108,6 +106,9 @@ void SystemInit(void)
                           (1 << OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Pos);
     while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_MRDY_Msk));
     CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+    /* Initialize and configure power rails */
+    da1469x_prail_initialize();
 
     /* XXX temporarily enable PD_COM and PD_PER since we do not control them */
     da1469x_pd_acquire(MCU_PD_DOMAIN_COM);

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -37,6 +37,14 @@ syscfg.defs:
             Specifies settling time [ms] of 32K crystal oscillator.
         value: 8000
 
+    MCU_DEEP_SLEEP:
+        description: >
+            Enable deep sleep for M33 core.
+            This is an experimental feature and still under active
+            development. It is recommended to keep it disabled for
+            general usage.
+        value: 0
+
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -27,6 +27,11 @@ syscfg.defs:
             - DA14697
             - DA14699
 
+    MCU_DCDC_ENABLE:
+        description: >
+            Specifies whether or not to enable SIMO DC-DC Converter.
+        value: 0
+
     MCU_CLOCK_XTAL32M_SETTLE_TIME_US:
         description: >
             Specifies settling time [us] of 32M crystal oscillator.


### PR DESCRIPTION
This adds support for entering deep sleep on M33 core. It can decrease power consumption quite a lot, but there are still few things to be configured before we can go from miliamps to microamps. Deep sleep is disabled by default since it seems to break CMAC sometimes, working on this.

Also, it configures power rails to switch LDOs to more optimal configuration - this is not yet configurable, but will be.