### PR TITLE
Added DA1469x Pro DK to list of supported hardware platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It currently supports the following hardware platforms:
 * chipKIT Wi-FIRE (PIC32MZ microcontroller)
 * Creator Ci40 module (dual MIPS interAptiv CPU)
 * EE-02 board with Semtech Sx1276 chip from Telenor (Cortex-M4) 
+* DA1469x Pro DK from Dialog Semiconductor (Cortex-M33)
 
 Apache Mynewt uses the
 [Newt](https://www.github.com/apache/mynewt-newt) build and package


### PR DESCRIPTION
Update to reamdme file now that DA1469x supported has been added. 