### PR TITLE
Updated NRF51 Wake Up Reasons

### DIFF
--- a/hw/hal/include/hal/hal_system.h
+++ b/hw/hal/include/hal/hal_system.h
@@ -66,10 +66,10 @@ enum hal_reset_reason {
     HAL_RESET_SOFT = 4,
     /** Low supply voltage */
     HAL_RESET_BROWNOUT = 5,
-    /** Power on */
-    HAL_RESET_POWER_OFF = 6,
     /** Restart due to user request */
-    HAL_RESET_REQUESTED = 7,
+    HAL_RESET_REQUESTED = 6,
+    /** System Off, wakeup on external interrupt*/
+    HAL_RESET_SYS_OFF_INT = 7,
 };
 
 /**

--- a/hw/hal/include/hal/hal_system.h
+++ b/hw/hal/include/hal/hal_system.h
@@ -66,8 +66,10 @@ enum hal_reset_reason {
     HAL_RESET_SOFT = 4,
     /** Low supply voltage */
     HAL_RESET_BROWNOUT = 5,
+    /** Power on */
+    HAL_RESET_POWER_OFF = 6,
     /** Restart due to user request */
-    HAL_RESET_REQUESTED = 6,
+    HAL_RESET_REQUESTED = 7,
 };
 
 /**

--- a/hw/mcu/nordic/nrf51xxx/src/hal_reset_cause.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_reset_cause.c
@@ -37,6 +37,8 @@ hal_reset_cause(void)
         reason = HAL_RESET_SOFT;
     } else if (reg & POWER_RESETREAS_RESETPIN_Msk) {
         reason = HAL_RESET_PIN;
+    } else if (reg & POWER_RESETREAS_OFF_Msk) {
+        reason = HAL_RESET_SYS_OFF_INT;
     } else {
         reason = HAL_RESET_POR; /* could also be brownout */
     }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_reset_cause.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_reset_cause.c
@@ -37,8 +37,8 @@ hal_reset_cause(void)
         reason = HAL_RESET_SOFT;
     } else if (reg & POWER_RESETREAS_RESETPIN_Msk) {
         reason = HAL_RESET_PIN;
-    } else if(reg & POWER_RESETREAS_OFF_Msk) {
-        reason = HAL_RESET_POWER_OFF;
+    } else if (reg & POWER_RESETREAS_OFF_Msk) {
+        reason = HAL_RESET_SYS_OFF_INT;
     } else {
         reason = HAL_RESET_POR; /* could also be brownout */
     }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_reset_cause.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_reset_cause.c
@@ -37,6 +37,8 @@ hal_reset_cause(void)
         reason = HAL_RESET_SOFT;
     } else if (reg & POWER_RESETREAS_RESETPIN_Msk) {
         reason = HAL_RESET_PIN;
+    } else if(reg & POWER_RESETREAS_OFF_Msk) {
+        reason = HAL_RESET_POWER_OFF;
     } else {
         reason = HAL_RESET_POR; /* could also be brownout */
     }

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -31,8 +31,9 @@ extern "C" {
         (reason == HAL_RESET_WATCHDOG ? "WDOG" :                        \
           (reason == HAL_RESET_SOFT ? "SOFT" :                          \
             (reason == HAL_RESET_BROWNOUT ? "BROWNOUT" :                \
-              (reason == HAL_RESET_REQUESTED ? "REQUESTED" :            \
-                "UNKNOWN"))))))
+              (reason == HAL_RESET_POWER_OFF ? "WAKEUP_SYS_OFF" :       \
+                (reason == HAL_RESET_REQUESTED ? "REQUESTED" :          \
+                "UNKNOWN")))))))
 
 struct log_reboot_info {
     enum hal_reset_reason reason;

--- a/sys/reboot/include/reboot/log_reboot.h
+++ b/sys/reboot/include/reboot/log_reboot.h
@@ -31,8 +31,8 @@ extern "C" {
         (reason == HAL_RESET_WATCHDOG ? "WDOG" :                        \
           (reason == HAL_RESET_SOFT ? "SOFT" :                          \
             (reason == HAL_RESET_BROWNOUT ? "BROWNOUT" :                \
-              (reason == HAL_RESET_POWER_OFF ? "WAKEUP_SYS_OFF" :       \
-                (reason == HAL_RESET_REQUESTED ? "REQUESTED" :          \
+              (reason == HAL_RESET_REQUESTED ? "REQUESTED" :            \
+                (reason == HAL_RESET_SYS_OFF_INT ? "SYSTEM_OFF_INT" :   \
                 "UNKNOWN")))))))
 
 struct log_reboot_info {


### PR DESCRIPTION
Continuation of this [PR](https://github.com/apache/mynewt-core/pull/1743).

Adding the same reset reasons between NRF51 and NRF52.