### PR TITLE
hw/mcu/dialog: Add PD_COM control to hal_gpio

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -20,6 +20,7 @@
 #ifndef __MCU_DA1469X_HAL_H_
 #define __MCU_DA1469X_HAL_H_
 
+#include <assert.h>
 #include "hal/hal_flash.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
This adds some logic to control PD_COM inside hal_gpio so power domain
can be disabled if not needed and we can save some power.