### PR TITLE
Fix copying CI targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,7 @@ before_script:
       gcc --version
       if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
       cp -R $HOME/ci/mynewt-core-project.yml project.yml
+      mkdir -p targets
       cp -R $HOME/ci/mynewt-core-targets targets
       newt install
       # pass in the number of target sets


### PR DESCRIPTION
CI currently expects target tree inside targets directory and uses a hardcoded path. The targets directory might not exist on some of the repos tested, so create it first here. CI will be updated to use the repo slug to determine which repo's targets it should build.