### PR TITLE
Fix wrong type in log reader's uint32_t decoder

### DIFF
--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -74,7 +74,7 @@ static uint32_t
 log_shell_cbor_reader_get32(struct cbor_decoder_reader *d, int offset)
 {
     struct log_shell_cbor_reader *cbr = (struct log_shell_cbor_reader *)d;
-    uint8_t val = 0;
+    uint32_t val = 0;
 
     (void)log_read_body(cbr->log, cbr->dptr, &val, offset, sizeof(val));
 
@@ -331,5 +331,3 @@ shell_log_storage_cmd(int argc, char **argv)
 #endif
 
 #endif
-
-


### PR DESCRIPTION
I noticed timestamps in the `log` CLI output were all the same, with only the upper 8 bits of the value set. The actual log entry data is correct and the issue is with the log reader's cbor decoder for uint32_t types, where a uint8_t was used by mistake. Logs are decoding correctly now with this fix.