### PR TITLE
repository.yml: latest core dep on latest mcuboot

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -93,4 +93,5 @@ repo.deps:
         user: JuulLabs-OSS
         repo: mcuboot
         vers:
-            master: 1-latest
+            master: 0-dev
+            mynewt_1_6_0_tag: 1-latest


### PR DESCRIPTION
Before this commit, the latest version of core depended on "1-latest" of mcuboot.  I.e.,

```
    mcuboot:
        type: github
        user: JuulLabs-OSS
        repo: mcuboot
        vers:
            master: 1-latest
```

This is a problem for a user who wants to use the latest version of both repos.  If the user's project.yml specifies "0.0.0" for both repos, `newt upgrade` fails with the following error:

```
Error: Repository conflicts:
    Installation of repo "mcuboot" is blocked:
                       project.yml requires mcuboot ==0.0.0
          apache-mynewt-core,0.0.0 requires mcuboot ==1.3.0
```

The fix is to make the latest mynewt-core depend on the latest mcuboot:

```
    mcuboot:
        type: github
        user: JuulLabs-OSS
        repo: mcuboot
        vers:
            master: 0-dev
            mynewt_1_6_0_tag: 1-latest
```