### PR TITLE
repository.yml: 1.6.0 should not depend on mcuboot 

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -94,4 +94,3 @@ repo.deps:
         repo: mcuboot
         vers:
             master: 0-dev
-            mynewt_1_6_0_tag: 1-latest


### PR DESCRIPTION
repository.yml: 1.6.0 should not depend on mcuboot 