### PR TITLE
lps33hw/lps33thw: Fix sensor usage of non-default event queue

### DIFF
--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -938,7 +938,7 @@ lps33hw_init(struct os_dev *dev, void *arg)
 
     lps = (struct lps33hw *) dev;
 #if MYNEWT_VAL(LPS33HW_ONE_SHOT_MODE)
-    os_callout_init(&lps->lps33hw_one_shot_read, os_eventq_dflt_get(), lps33hw_one_shot_read_cb, dev);
+    os_callout_init(&lps->lps33hw_one_shot_read, sensor_mgr_evq_get(), lps33hw_one_shot_read_cb, dev);
 #endif
 
     sensor = &lps->sensor;

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -542,7 +542,7 @@ int
 lps33thw_reset(struct sensor *sensor)
 {
     struct sensor_itf *itf;
-     
+
     itf = SENSOR_GET_ITF(sensor);
 
     return lps33thw_set_reg(itf, LPS33THW_CTRL_REG2, 0x04);
@@ -937,7 +937,7 @@ lps33thw_init(struct os_dev *dev, void *arg)
 
     lps = (struct lps33thw *) dev;
 #if MYNEWT_VAL(LPS33THW_ONE_SHOT_MODE)
-    os_callout_init(&lps->lps33thw_one_shot_read, os_eventq_dflt_get(), lps33thw_one_shot_read_cb, dev);
+    os_callout_init(&lps->lps33thw_one_shot_read, sensor_mgr_evq_get(), lps33thw_one_shot_read_cb, dev);
 #endif
 
     sensor = &lps->sensor;

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -35,6 +35,11 @@
 #include "sensor/gyro.h"
 #include "console/console.h"
 
+#ifdef MYNEWT_VAL_SENSOR_MGR_EVQ
+extern struct os_eventq MYNEWT_VAL(SENSOR_MGR_EVQ);
+#endif
+
+
 #if MYNEWT_VAL(SENSOR_POLL_TEST_LOG)
 uint32_t test_log_idx;
 uint32_t smgr_wakeup_idx;
@@ -646,7 +651,7 @@ sensor_mgr_init(void)
     int rc;
 
 #ifdef MYNEWT_VAL_SENSOR_MGR_EVQ
-    sensor_mgr_evq_set(MYNEWT_VAL(SENSOR_MGR_EVQ));
+    sensor_mgr_evq_set(&MYNEWT_VAL(SENSOR_MGR_EVQ));
 #else
     sensor_mgr_evq_set(os_eventq_dflt_get());
 #endif


### PR DESCRIPTION
1. Fixes two issues in sensor.c when an event queue other than the default queue is configured to be used:
 - Adds an `extern` needed to resolve the name of the outside queue.
 - Adds `&` to get the queue address without requiring the ampersand as part of the name in the syscfg value.  

2.  The lps33hw and lps33thw now use whatever queue the sensor layer is configured to use. 
