### PR TITLE
sys/log: Add setting for maximum log entry size when writing.

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -180,6 +180,7 @@ STATS_SECT_START(logs)
     STATS_SECT_ENTRY(drops)
     STATS_SECT_ENTRY(errs)
     STATS_SECT_ENTRY(lost)
+    STATS_SECT_ENTRY(too_long)
 STATS_SECT_END
 
 #define LOG_STATS_INC(log, name)        STATS_INC(log->l_stats, name)
@@ -196,6 +197,7 @@ struct log {
     STAILQ_ENTRY(log) l_next;
     log_append_cb *l_append_cb;
     uint8_t l_level;
+    uint16_t l_max_entry_len;   /* Log body length; if 0 disables check. */
 #if MYNEWT_VAL(LOG_STATS)
     STATS_SECT_DECL(logs) l_stats;
 #endif
@@ -625,6 +627,17 @@ void log_set_level(struct log *log, uint8_t level);
  * @return                      current value of log level.
  */
 uint8_t log_get_level(const struct log *log);
+
+/**
+ * @brief Set maximum length of an entry in the log. If set to
+ *        0, no check will be made for maximum write length.
+ *        Note that this is maximum log body length; the log
+ *        entry header is not included in the check.
+ *
+ * @param log                   Log to set max entry length
+ * @param level                 New max entry length
+ */
+void log_set_max_entry_len(struct log *log, uint16_t max_entry_len);
 
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 /**

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -609,7 +609,7 @@ log_append_mbuf_typed_no_free(struct log *log, uint8_t module, uint8_t level,
     len = os_mbuf_len(om);
     if (len > LOG_ENTRY_HDR_SIZE) {
         rc = log_chk_max_entry_len(log, len - LOG_ENTRY_HDR_SIZE);
-        if (rc) {
+        if (rc != OS_OK) {
             goto drop;
         }
     }
@@ -675,7 +675,7 @@ log_append_mbuf_body_no_free(struct log *log, uint8_t module, uint8_t level,
 
     len = os_mbuf_len(om);
     rc = log_chk_max_entry_len(log, len);
-    if (rc) {
+    if (rc != OS_OK) {
         goto drop;
     }
 

--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -109,6 +109,21 @@ static inline uint8_t log_get_level(const struct log *log)
     return 0;
 }
 
+/**
+ * @brief Set maximum length of an entry in the log. If set to
+ *        0, no check will be made for maximum write length.
+ *        Note that this is maximum log body length; the log
+ *        entry header is not included in the check.
+ *
+ * @param log                   Log to set max entry length
+ * @param level                 New max entry length
+ */
+static inline void
+log_set_max_entry_len(struct log *log, uint16_t max_entry_len)
+{
+    return;
+}
+
 #define log_printf(...)
 
 /*


### PR DESCRIPTION
This commit adds the ability to set a maximum log entry for a given log. By default, the log maximum entry length is set to 0. A value of 0 for this field means that no check should be made for maximum log entry length. If set to a non-zero value, the log write routine(s) will check the log body length (does nt include the size of the log entry header) and if it exceeds the maximum, OS_ENOMEM will be returned and the too_long log stat will be incremented. A new API was added named log_set_max_entry_len() which allows the user to set the maximum entry length.