### PR TITLE
[STM32F4]: Add black_vet6 board

### DIFF
--- a/hw/bsp/black_vet6/boot-stm32f4ve.ld
+++ b/hw/bsp/black_vet6/boot-stm32f4ve.ld
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 32K
+  CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/black_vet6/bsp.yml
+++ b/hw/bsp/black_vet6/bsp.yml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.arch: cortex_m4
+bsp.compiler: compiler/arm-none-eabi-m4
+bsp.linkerscript:
+    - "hw/bsp/black_vet6/stm32f4ve.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/black_vet6/boot-stm32f4ve.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
+bsp.downloadscript: "hw/bsp/black_vet6/stm32f4ve_download.sh"
+bsp.debugscript: "hw/bsp/black_vet6/stm32f4ve_debug.sh"
+bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/black_vet6/stm32f4ve_download.cmd"
+bsp.debugscript.WINDOWS.OVERWRITE: "hw/bsp/black_vet6/stm32f4ve_debug.cmd"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x08000000
+            size: 32kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x08020000
+            size: 256kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x08060000
+            size: 128kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x08008000
+            size: 32kB
+
+        FLASH_AREA_IMAGE_1:
+            device: 1
+            offset: 0x00000000
+            size: 256kB
+
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 1
+            offset: 0x00040000
+            size: 256kB
+

--- a/hw/bsp/black_vet6/include/bsp/bsp.h
+++ b/hw/bsp/black_vet6/include/bsp/bsp.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+#include <mcu/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stackos sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+#define sec_bss_nz_core __attribute__((section(".bss.core.nz")))
+
+/* More convenient section placement macros. */
+#define bssnz_t         sec_bss_nz_core
+
+extern uint8_t _ram_start;
+extern uint8_t _ccram_start;
+
+#define RAM_SIZE        (128 * 1024)
+#define CCRAM_SIZE      (64 * 1024)
+
+/* LED pins */
+#define LED_BLINK_PIN   MCU_GPIO_PORTA(6)
+
+/* UART */
+#define UART_CNT 1
+#define SPI_SS_PIN       (4)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/black_vet6/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/black_vet6/include/bsp/stm32f4xx_hal_conf.h
@@ -1,0 +1,434 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.2.4
+  * @date    06-May-2016
+  * @brief   HAL configuration file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_HAL_CONF_H
+#define __STM32F4xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#if 0
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_CAN_MODULE_ENABLED
+#define HAL_CRC_MODULE_ENABLED
+#define HAL_CRYP_MODULE_ENABLED
+#define HAL_DAC_MODULE_ENABLED
+#define HAL_DCMI_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+/* #define HAL_DMA2D_MODULE_ENABLED */
+#define HAL_ETH_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_NAND_MODULE_ENABLED
+#define HAL_NOR_MODULE_ENABLED
+#define HAL_PCCARD_MODULE_ENABLED
+#define HAL_SRAM_MODULE_ENABLED
+/* #define HAL_SDRAM_MODULE_ENABLED */
+#define HAL_HASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_LTDC_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RTC_MODULE_ENABLED
+/* #define HAL_SAI_MODULE_ENABLED */
+#define HAL_SD_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+#define HAL_IRDA_MODULE_ENABLED
+#define HAL_SMARTCARD_MODULE_ENABLED
+#define HAL_WWDG_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
+#define HAL_HCD_MODULE_ENABLED
+#else
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_ETH_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RNG_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#endif
+
+/* ########################## HSE/HSI Values adaptation ##################### */
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE  ((uint32_t)32000)
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)12288000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0x0F) /*!< tick interrupt priority */
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              0 /* The prefetch will be enabled in SystemClock_Config(), depending on the used
+                                           STM32F405/415/07/417 device: RevA (prefetch must be off) or RevZ (prefetch can be on/off) */
+#define  INSTRUCTION_CACHE_ENABLE     1
+#define  DATA_CACHE_ENABLE            1
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+/* ################## Ethernet peripheral configuration ##################### */
+
+/* Section 1 : Ethernet peripheral configuration */
+
+/* MAC ADDRESS: MAC_ADDR0:MAC_ADDR1:MAC_ADDR2:MAC_ADDR3:MAC_ADDR4:MAC_ADDR5 */
+#define MAC_ADDR0   2
+#define MAC_ADDR1   0
+#define MAC_ADDR2   0
+#define MAC_ADDR3   0
+#define MAC_ADDR4   0
+#define MAC_ADDR5   0
+
+/* Definition of the Ethernet driver buffers size and count */
+#define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
+#define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
+#define ETH_RXBUFNB                    ((uint32_t)4)       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
+#define ETH_TXBUFNB                    ((uint32_t)4)       /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+/* Section 2: PHY configuration section */
+
+/* DP83848 PHY Address*/
+#define DP83848_PHY_ADDRESS             0x01
+/* PHY Reset delay these values are based on a 1 ms Systick interrupt*/
+#define PHY_RESET_DELAY                 ((uint32_t)0x000000FF)
+/* PHY Configuration delay */
+#define PHY_CONFIG_DELAY                ((uint32_t)0x00000FFF)
+
+#define PHY_READ_TO                     ((uint32_t)0x0000FFFF)
+#define PHY_WRITE_TO                    ((uint32_t)0x0000FFFF)
+
+/* Section 3: Common PHY Registers */
+
+#define PHY_BCR                         ((uint16_t)0x00)    /*!< Transceiver Basic Control Register   */
+#define PHY_BSR                         ((uint16_t)0x01)    /*!< Transceiver Basic Status Register    */
+
+#define PHY_RESET                       ((uint16_t)0x8000)  /*!< PHY Reset */
+#define PHY_LOOPBACK                    ((uint16_t)0x4000)  /*!< Select loop-back mode */
+#define PHY_FULLDUPLEX_100M             ((uint16_t)0x2100)  /*!< Set the full-duplex mode at 100 Mb/s */
+#define PHY_HALFDUPLEX_100M             ((uint16_t)0x2000)  /*!< Set the half-duplex mode at 100 Mb/s */
+#define PHY_FULLDUPLEX_10M              ((uint16_t)0x0100)  /*!< Set the full-duplex mode at 10 Mb/s  */
+#define PHY_HALFDUPLEX_10M              ((uint16_t)0x0000)  /*!< Set the half-duplex mode at 10 Mb/s  */
+#define PHY_AUTONEGOTIATION             ((uint16_t)0x1000)  /*!< Enable auto-negotiation function     */
+#define PHY_RESTART_AUTONEGOTIATION     ((uint16_t)0x0200)  /*!< Restart auto-negotiation function    */
+#define PHY_POWERDOWN                   ((uint16_t)0x0800)  /*!< Select the power down mode           */
+#define PHY_ISOLATE                     ((uint16_t)0x0400)  /*!< Isolate PHY from MII                 */
+
+#define PHY_AUTONEGO_COMPLETE           ((uint16_t)0x0020)  /*!< Auto-Negotiation process completed   */
+#define PHY_LINKED_STATUS               ((uint16_t)0x0004)  /*!< Valid link established               */
+#define PHY_JABBER_DETECTION            ((uint16_t)0x0002)  /*!< Jabber condition detected            */
+
+/* Section 4: Extended PHY Registers */
+
+#define PHY_SR                          ((uint16_t)0x10)    /*!< PHY status register Offset                      */
+#define PHY_MICR                        ((uint16_t)0x11)    /*!< MII Interrupt Control Register                  */
+#define PHY_MISR                        ((uint16_t)0x12)    /*!< MII Interrupt Status and Misc. Control Register */
+
+#define PHY_LINK_STATUS                 ((uint16_t)0x0001)  /*!< PHY Link mask                                   */
+#define PHY_SPEED_STATUS                ((uint16_t)0x0002)  /*!< PHY Speed mask                                  */
+#define PHY_DUPLEX_STATUS               ((uint16_t)0x0004)  /*!< PHY Duplex mask                                 */
+
+#define PHY_MICR_INT_EN                 ((uint16_t)0x0002)  /*!< PHY Enable interrupts                           */
+#define PHY_MICR_INT_OE                 ((uint16_t)0x0001)  /*!< PHY Enable output interrupt events              */
+
+#define PHY_MISR_LINK_INT_EN            ((uint16_t)0x0020U)  /*!< Enable Interrupt on change of link status       */
+#define PHY_LINK_INTERRUPT              ((uint16_t)0x2000U)  /*!< PHY link status interrupt mask                  */
+
+/* ################## SPI peripheral configuration ########################## */
+
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
+
+#define USE_SPI_CRC                     0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32f4xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32f4xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32f4xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32f4xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32f4xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CAN_MODULE_ENABLED
+  #include "stm32f4xx_hal_can.h"
+#endif /* HAL_CAN_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32f4xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32f4xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DMA2D_MODULE_ENABLED
+  #include "stm32f4xx_hal_dma2d.h"
+#endif /* HAL_DMA2D_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32f4xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_DCMI_MODULE_ENABLED
+  #include "stm32f4xx_hal_dcmi.h"
+#endif /* HAL_DCMI_MODULE_ENABLED */
+
+#ifdef HAL_ETH_MODULE_ENABLED
+  #include "stm32f4xx_hal_eth.h"
+#endif /* HAL_ETH_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32f4xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_SRAM_MODULE_ENABLED
+  #include "stm32f4xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+  #include "stm32f4xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+  #include "stm32f4xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_PCCARD_MODULE_ENABLED
+  #include "stm32f4xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */
+
+#ifdef HAL_SDRAM_MODULE_ENABLED
+  #include "stm32f4xx_hal_sdram.h"
+#endif /* HAL_SDRAM_MODULE_ENABLED */
+
+#ifdef HAL_HASH_MODULE_ENABLED
+ #include "stm32f4xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32f4xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32f4xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32f4xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LTDC_MODULE_ENABLED
+ #include "stm32f4xx_hal_ltdc.h"
+#endif /* HAL_LTDC_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32f4xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32f4xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32f4xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+ #include "stm32f4xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+ #include "stm32f4xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32f4xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32f4xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32f4xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32f4xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32f4xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32f4xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32f4xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32f4xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+ #include "stm32f4xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F4xx_HAL_CONF_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/bsp/black_vet6/pkg.yml
+++ b/hw/bsp/black_vet6/pkg.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bsp/black_vet6
+pkg.type: bsp
+pkg.description: BSP definition for the STM32F4VE.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - stm32
+    - e407
+
+pkg.cflags:
+    # STM SDK files require these defines.
+    - '-DSTM32F407xx'
+
+pkg.cflags.HARDFLOAT:
+    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/hw/drivers/flash/spiflash"
+
+pkg.deps.ADC_1:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+pkg.deps.ADC_2:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+pkg.deps.ADC_3:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+
+pkg.deps.UART_0:
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+
+pkg.deps.ETH_0:
+    - "@apache-mynewt-core/hw/drivers/lwip/stm32_eth"

--- a/hw/bsp/black_vet6/run_from_flash.ld
+++ b/hw/bsp/black_vet6/run_from_flash.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F407 when running from flash without bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08000000, LENGTH = 512K
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* No image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/black_vet6/run_from_loader.ld
+++ b/hw/bsp/black_vet6/run_from_loader.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F407 when running from flash and using the bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08020000, LENGTH = 256K /* First image slot. */
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/black_vet6/run_from_sram.ld
+++ b/hw/bsp/black_vet6/run_from_sram.ld
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F407 when running code from SRAM */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+  CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __coredata_start__
+ *   __coredata_end__
+ *   __corebss_start__
+ *   __corebss_end__
+ *   __ecoredata
+ *   __ecorebss
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    __text = .;
+
+    .text :
+    {
+        __vector_tbl_reloc__ = .;
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > RAM
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > RAM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > RAM
+
+    __exidx_end = .;
+
+    . = ALIGN(8);
+    __etext = .;
+
+    .coredata : AT (__etext)
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(8);
+        __coredata_end__ = .;
+    } > CCM
+
+    __ecoredata = __etext + SIZEOF(.coredata);
+
+    /* This section is here so that the start of .data has the same VMA and LMA */
+    .ram_coredata (NOLOAD):
+    {
+        . = . + SIZEOF(.coredata);
+    } > RAM
+
+    .data : AT (__ecoredata)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        *(.corebss*)
+        *(.bss.core.nz)
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > CCM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    . = ALIGN(8);
+    __HeapBase = .;
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > CCM
+
+    /* Set stack top to end of CCM; stack limit is bottom of stack */
+    __StackTop = ORIGIN(CCM) + LENGTH(CCM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check for CCM overflow */
+    ASSERT(__StackLimit >= __ecorebss, "CCM overflow!")
+}
+

--- a/hw/bsp/black_vet6/src/arch/cortex_m4/startup_STM32F40x.s
+++ b/hw/bsp/black_vet6/src/arch/cortex_m4/startup_STM32F40x.s
@@ -1,0 +1,353 @@
+/* File: startup_STM32F40x.S
+ * Purpose: startup file for Cortex-M4 devices. Should use with
+ *   GCC for ARM Embedded Processors
+ * Version: V1.4
+ * Date: 09 July 2012
+ *
+ * Copyright (c) 2011, 2012, ARM Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the ARM Limited nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ARM LIMITED BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+    .syntax unified
+    .arch armv7-m
+
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 0xc00
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long    Reset_Handler         /* Reset Handler */
+    .long    NMI_Handler           /* NMI Handler */
+    .long    HardFault_Handler     /* Hard Fault Handler */
+    .long    MemManage_Handler     /* MPU Fault Handler */
+    .long    BusFault_Handler      /* Bus Fault Handler */
+    .long    UsageFault_Handler    /* Usage Fault Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    SVC_Handler           /* SVCall Handler */
+    .long    DebugMon_Handler      /* Debug Monitor Handler */
+    .long    0                     /* Reserved */
+    .long    PendSV_Handler        /* PendSV Handler */
+    .long    SysTick_Handler       /* SysTick Handler */
+
+    /* External interrupts */
+    .long     WWDG_IRQHandler               /* Window WatchDog */
+    .long     PVD_IRQHandler                /* PVD through EXTI Line detection */
+    .long     TAMP_STAMP_IRQHandler         /* Tamper and TimeStamps through the EXTI line */
+    .long     RTC_WKUP_IRQHandler           /* RTC Wakeup through the EXTI line */
+    .long     FLASH_IRQHandler              /* FLASH */
+    .long     RCC_IRQHandler                /* RCC */
+    .long     EXTI0_IRQHandler              /* EXTI Line0 */
+    .long     EXTI1_IRQHandler              /* EXTI Line1 */
+    .long     EXTI2_IRQHandler              /* EXTI Line2 */
+    .long     EXTI3_IRQHandler              /* EXTI Line3 */
+    .long     EXTI4_IRQHandler              /* EXTI Line4 */
+    .long     DMA1_Stream0_IRQHandler       /* DMA1 Stream 0 */
+    .long     DMA1_Stream1_IRQHandler       /* DMA1 Stream 1 */
+    .long     DMA1_Stream2_IRQHandler       /* DMA1 Stream 2 */
+    .long     DMA1_Stream3_IRQHandler       /* DMA1 Stream 3 */
+    .long     DMA1_Stream4_IRQHandler       /* DMA1 Stream 4 */
+    .long     DMA1_Stream5_IRQHandler       /* DMA1 Stream 5 */
+    .long     DMA1_Stream6_IRQHandler       /* DMA1 Stream 6 */
+    .long     ADC_IRQHandler                /* ADC1, ADC2 and ADC3s */
+    .long     CAN1_TX_IRQHandler            /* CAN1 TX */
+    .long     CAN1_RX0_IRQHandler           /* CAN1 RX0 */
+    .long     CAN1_RX1_IRQHandler           /* CAN1 RX1 */
+    .long     CAN1_SCE_IRQHandler           /* CAN1 SCE */
+    .long     EXTI9_5_IRQHandler            /* External Line[9:5]s */
+    .long     TIM1_BRK_TIM9_IRQHandler      /* TIM1 Break and TIM9 */
+    .long     TIM1_UP_TIM10_IRQHandler      /* TIM1 Update and TIM10 */
+    .long     TIM1_TRG_COM_TIM11_IRQHandler /* TIM1 Trigger and Commutation and TIM11 */
+    .long     TIM1_CC_IRQHandler            /* TIM1 Capture Compare */
+    .long     TIM2_IRQHandler               /* TIM2 */
+    .long     TIM3_IRQHandler               /* TIM3 */
+    .long     TIM4_IRQHandler               /* TIM4 */
+    .long     I2C1_EV_IRQHandler            /* I2C1 Event */
+    .long     I2C1_ER_IRQHandler            /* I2C1 Error */
+    .long     I2C2_EV_IRQHandler            /* I2C2 Event */
+    .long     I2C2_ER_IRQHandler            /* I2C2 Error */
+    .long     SPI1_IRQHandler               /* SPI1 */
+    .long     SPI2_IRQHandler               /* SPI2 */
+    .long     USART1_IRQHandler             /* USART1 */
+    .long     USART2_IRQHandler             /* USART2 */
+    .long     USART3_IRQHandler             /* USART3 */
+    .long     EXTI15_10_IRQHandler          /* External Line[15:10]s */
+    .long     RTC_Alarm_IRQHandler          /* RTC Alarm (A and B) through EXTI Line */
+    .long     OTG_FS_WKUP_IRQHandler        /* USB OTG FS Wakeup through EXTI line */
+    .long     TIM8_BRK_TIM12_IRQHandler     /* TIM8 Break and TIM12 */
+    .long     TIM8_UP_TIM13_IRQHandler      /* TIM8 Update and TIM13 */
+    .long     TIM8_TRG_COM_TIM14_IRQHandler /* TIM8 Trigger and Commutation and TIM14 */
+    .long     TIM8_CC_IRQHandler            /* TIM8 Capture Compare */
+    .long     DMA1_Stream7_IRQHandler       /* DMA1 Stream7 */
+    .long     FSMC_IRQHandler               /* FSMC */
+    .long     SDIO_IRQHandler               /* SDIO */
+    .long     TIM5_IRQHandler               /* TIM5 */
+    .long     SPI3_IRQHandler               /* SPI3 */
+    .long     UART4_IRQHandler              /* UART4 */
+    .long     UART5_IRQHandler              /* UART5 */
+    .long     TIM6_DAC_IRQHandler           /* TIM6 and DAC1&2 underrun errors */
+    .long     TIM7_IRQHandler               /* TIM7 */
+    .long     DMA2_Stream0_IRQHandler       /* DMA2 Stream 0 */
+    .long     DMA2_Stream1_IRQHandler       /* DMA2 Stream 1 */
+    .long     DMA2_Stream2_IRQHandler       /* DMA2 Stream 2 */
+    .long     DMA2_Stream3_IRQHandler       /* DMA2 Stream 3 */
+    .long     DMA2_Stream4_IRQHandler       /* DMA2 Stream 4 */
+    .long     ETH_IRQHandler                /* Ethernet */
+    .long     ETH_WKUP_IRQHandler           /* Ethernet Wakeup through EXTI line */
+    .long     CAN2_TX_IRQHandler            /* CAN2 TX */
+    .long     CAN2_RX0_IRQHandler           /* CAN2 RX0 */
+    .long     CAN2_RX1_IRQHandler           /* CAN2 RX1 */
+    .long     CAN2_SCE_IRQHandler           /* CAN2 SCE */
+    .long     OTG_FS_IRQHandler             /* USB OTG FS */
+    .long     DMA2_Stream5_IRQHandler       /* DMA2 Stream 5 */
+    .long     DMA2_Stream6_IRQHandler       /* DMA2 Stream 6 */
+    .long     DMA2_Stream7_IRQHandler       /* DMA2 Stream 7 */
+    .long     USART6_IRQHandler             /* USART6 */
+    .long     I2C3_EV_IRQHandler            /* I2C3 event */
+    .long     I2C3_ER_IRQHandler            /* I2C3 error */
+    .long     OTG_HS_EP1_OUT_IRQHandler     /* USB OTG HS End Point 1 Out */
+    .long     OTG_HS_EP1_IN_IRQHandler      /* USB OTG HS End Point 1 In */
+    .long     OTG_HS_WKUP_IRQHandler        /* USB OTG HS Wakeup through EXTI */
+    .long     OTG_HS_IRQHandler             /* USB OTG HS */
+    .long     DCMI_IRQHandler               /* DCMI */
+    .long     CRYP_IRQHandler               /* CRYP crypto */
+    .long     HASH_RNG_IRQHandler           /* Hash and Rng */
+    .long     FPU_IRQHandler                /* FPU */
+
+    .size    __isr_vector, . - __isr_vector
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+/* Copy data core section from flash to RAM */
+    ldr    r1, =__etext
+    ldr    r2, =__coredata_start__
+    ldr    r3, =__coredata_end__
+
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+    ldr    r1, =__ecoredata
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+.LC1:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC1
+
+/* Set the bss core section to zero */
+    mov     r0, #0
+    ldr     r1, =__corebss_start__
+    ldr     r2, =__corebss_end__
+
+.LC2:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt    .LC2
+
+    /* Set the other bss section to zero as well*/
+    ldr     r1, =__bss_start__
+    ldr     r2, =__bss_end__
+
+.LC3:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt    .LC3
+
+/* Call system initialization and startup routines */
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx     r0
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .text
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro    def_default_handler    handler_name
+    .align 1
+    .thumb_func
+    .weak    \handler_name
+    .type    \handler_name, %function
+\handler_name :
+    b    .
+    .size    \handler_name, . - \handler_name
+    .endm
+
+    def_default_handler    NMI_Handler
+    def_default_handler    HardFault_Handler
+    def_default_handler    MemManage_Handler
+    def_default_handler    BusFault_Handler
+    def_default_handler    UsageFault_Handler
+    def_default_handler    SVC_Handler
+    def_default_handler    DebugMon_Handler
+    def_default_handler    PendSV_Handler
+    def_default_handler    SysTick_Handler
+    def_default_handler    Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+
+    def_irq_default_handler     WWDG_IRQHandler
+    def_irq_default_handler     PVD_IRQHandler
+    def_irq_default_handler     TAMP_STAMP_IRQHandler
+    def_irq_default_handler     RTC_WKUP_IRQHandler
+    def_irq_default_handler     FLASH_IRQHandler
+    def_irq_default_handler     RCC_IRQHandler
+    def_irq_default_handler     EXTI0_IRQHandler
+    def_irq_default_handler     EXTI1_IRQHandler
+    def_irq_default_handler     EXTI2_IRQHandler
+    def_irq_default_handler     EXTI3_IRQHandler
+    def_irq_default_handler     EXTI4_IRQHandler
+    def_irq_default_handler     DMA1_Stream0_IRQHandler
+    def_irq_default_handler     DMA1_Stream1_IRQHandler
+    def_irq_default_handler     DMA1_Stream2_IRQHandler
+    def_irq_default_handler     DMA1_Stream3_IRQHandler
+    def_irq_default_handler     DMA1_Stream4_IRQHandler
+    def_irq_default_handler     DMA1_Stream5_IRQHandler
+    def_irq_default_handler     DMA1_Stream6_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     CAN1_TX_IRQHandler
+    def_irq_default_handler     CAN1_RX0_IRQHandler
+    def_irq_default_handler     CAN1_RX1_IRQHandler
+    def_irq_default_handler     CAN1_SCE_IRQHandler
+    def_irq_default_handler     EXTI9_5_IRQHandler
+    def_irq_default_handler     TIM1_BRK_TIM9_IRQHandler
+    def_irq_default_handler     TIM1_UP_TIM10_IRQHandler
+    def_irq_default_handler     TIM1_TRG_COM_TIM11_IRQHandler
+    def_irq_default_handler     TIM1_CC_IRQHandler
+    def_irq_default_handler     TIM2_IRQHandler
+    def_irq_default_handler     TIM3_IRQHandler
+    def_irq_default_handler     TIM4_IRQHandler
+    def_irq_default_handler     I2C1_EV_IRQHandler
+    def_irq_default_handler     I2C1_ER_IRQHandler
+    def_irq_default_handler     I2C2_EV_IRQHandler
+    def_irq_default_handler     I2C2_ER_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     SPI2_IRQHandler
+    def_irq_default_handler     USART1_IRQHandler
+    def_irq_default_handler     USART2_IRQHandler
+    def_irq_default_handler     USART3_IRQHandler
+    def_irq_default_handler     EXTI15_10_IRQHandler
+    def_irq_default_handler     RTC_Alarm_IRQHandler
+    def_irq_default_handler     OTG_FS_WKUP_IRQHandler
+    def_irq_default_handler     TIM8_BRK_TIM12_IRQHandler
+    def_irq_default_handler     TIM8_UP_TIM13_IRQHandler
+    def_irq_default_handler     TIM8_TRG_COM_TIM14_IRQHandler
+    def_irq_default_handler     TIM8_CC_IRQHandler
+    def_irq_default_handler     DMA1_Stream7_IRQHandler
+    def_irq_default_handler     FSMC_IRQHandler
+    def_irq_default_handler     SDIO_IRQHandler
+    def_irq_default_handler     TIM5_IRQHandler
+    def_irq_default_handler     SPI3_IRQHandler
+    def_irq_default_handler     UART4_IRQHandler
+    def_irq_default_handler     UART5_IRQHandler
+    def_irq_default_handler     TIM6_DAC_IRQHandler
+    def_irq_default_handler     TIM7_IRQHandler
+    def_irq_default_handler     DMA2_Stream0_IRQHandler
+    def_irq_default_handler     DMA2_Stream1_IRQHandler
+    def_irq_default_handler     DMA2_Stream2_IRQHandler
+    def_irq_default_handler     DMA2_Stream3_IRQHandler
+    def_irq_default_handler     DMA2_Stream4_IRQHandler
+    def_irq_default_handler     ETH_IRQHandler
+    def_irq_default_handler     ETH_WKUP_IRQHandler
+    def_irq_default_handler     CAN2_TX_IRQHandler
+    def_irq_default_handler     CAN2_RX0_IRQHandler
+    def_irq_default_handler     CAN2_RX1_IRQHandler
+    def_irq_default_handler     CAN2_SCE_IRQHandler
+    def_irq_default_handler     OTG_FS_IRQHandler
+    def_irq_default_handler     DMA2_Stream5_IRQHandler
+    def_irq_default_handler     DMA2_Stream6_IRQHandler
+    def_irq_default_handler     DMA2_Stream7_IRQHandler
+    def_irq_default_handler     USART6_IRQHandler
+    def_irq_default_handler     I2C3_EV_IRQHandler
+    def_irq_default_handler     I2C3_ER_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_OUT_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_IN_IRQHandler
+    def_irq_default_handler     OTG_HS_WKUP_IRQHandler
+    def_irq_default_handler     OTG_HS_IRQHandler
+    def_irq_default_handler     DCMI_IRQHandler
+    def_irq_default_handler     CRYP_IRQHandler
+    def_irq_default_handler     HASH_RNG_IRQHandler
+    def_irq_default_handler     FPU_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
+
+    .end

--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -1,0 +1,510 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include "os/mynewt.h"
+#include "bsp/bsp.h"
+#include "stm32f407xx.h"
+#include "stm32f4xx_hal_gpio_ex.h"
+#include "stm32f4xx_hal_dma.h"
+#include "stm32f4xx_hal_adc.h"
+#include "flash_map/flash_map.h"
+#if MYNEWT_VAL(TRNG)
+#include "trng/trng.h"
+#include "trng_stm32/trng_stm32.h"
+#endif
+#if MYNEWT_VAL(UART_0)
+#include "uart/uart.h"
+#include "uart_hal/uart_hal.h"
+#endif
+#if MYNEWT_VAL(ADC_1) || MYNEWT_VAL(ADC_2) || MYNEWT_VAL(ADC_3)
+#include "adc_stm32f4/adc_stm32f4.h"
+#endif
+#include "hal/hal_i2c.h"
+#include "hal/hal_timer.h"
+#include "hal/hal_bsp.h"
+#include "hal/hal_gpio.h"
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+#include "hal/hal_spi.h"
+#endif
+#if MYNEWT_VAL(ETH_0)
+#include "stm32_eth/stm32_eth.h"
+#include "stm32_eth/stm32_eth_cfg.h"
+#endif
+#include "mcu/stm32_hal.h"
+#include "mcu/stm32f4_bsp.h"
+#include "mcu/stm32f4xx_mynewt_hal.h"
+
+#if MYNEWT_VAL(SPIFLASH)
+#include <spiflash/spiflash.h>
+#endif
+
+
+const uint32_t stm32_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* End of flash */
+};
+
+#define SZ ARRAY_SIZE(stm32_flash_sectors)
+_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+        "STM32_FLASH_NUM_AREAS does not match flash sectors");
+
+#if MYNEWT_VAL(TRNG)
+static struct trng_dev os_bsp_trng;
+#endif
+
+#if MYNEWT_VAL(UART_0)
+struct uart_dev hal_uart0;
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE) || \
+    MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_1_SLAVE)
+#include <hal/hal_spi.h>
+#endif
+
+#if MYNEWT_VAL(ADC_1)
+struct adc_dev my_dev_adc1;
+#endif
+#if MYNEWT_VAL(ADC_2)
+struct adc_dev my_dev_adc2;
+#endif
+#if MYNEWT_VAL(ADC_3)
+struct adc_dev my_dev_adc3;
+#endif
+
+#if MYNEWT_VAL(ADC_1)
+/*
+ * adc_handle is defined earlier because the DMA handle's
+ * parent needs to be pointing to the adc_handle
+ */
+extern ADC_HandleTypeDef adc1_handle;
+
+#define STM32F4_DEFAULT_DMA00_HANDLE {\
+    .Instance = DMA2_Stream0,\
+    .Init.Channel = DMA_CHANNEL_0,\
+    .Init.Direction = DMA_PERIPH_TO_MEMORY,\
+    .Init.PeriphInc = DMA_PINC_DISABLE,\
+    .Init.MemInc = DMA_MINC_ENABLE,\
+    .Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD,\
+    .Init.MemDataAlignment = DMA_MDATAALIGN_WORD,\
+    .Init.Mode = DMA_CIRCULAR,\
+    .Init.Priority = DMA_PRIORITY_HIGH,\
+    .Init.FIFOMode = DMA_FIFOMODE_DISABLE,\
+    .Init.FIFOThreshold = DMA_FIFO_THRESHOLD_HALFFULL,\
+    .Init.MemBurst = DMA_MBURST_SINGLE,\
+    .Init.PeriphBurst = DMA_PBURST_SINGLE,\
+    .Parent = &adc1_handle,\
+}
+
+DMA_HandleTypeDef adc1_dma00_handle = STM32F4_DEFAULT_DMA00_HANDLE;
+#endif
+
+#if MYNEWT_VAL(ADC_2)
+
+extern ADC_HandleTypeDef adc2_handle;
+
+#define STM32F4_DEFAULT_DMA21_HANDLE {\
+    .Instance = DMA2_Stream2,\
+    .Init.Channel = DMA_CHANNEL_1,\
+    .Init.Direction = DMA_PERIPH_TO_MEMORY,\
+    .Init.PeriphInc = DMA_PINC_DISABLE,\
+    .Init.MemInc = DMA_MINC_ENABLE,\
+    .Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD,\
+    .Init.MemDataAlignment = DMA_MDATAALIGN_WORD,\
+    .Init.Mode = DMA_CIRCULAR,\
+    .Init.Priority = DMA_PRIORITY_HIGH,\
+    .Init.FIFOMode = DMA_FIFOMODE_DISABLE,\
+    .Init.FIFOThreshold = DMA_FIFO_THRESHOLD_HALFFULL,\
+    .Init.MemBurst = DMA_MBURST_SINGLE,\
+    .Init.PeriphBurst = DMA_PBURST_SINGLE,\
+    .Parent = &adc2_handle,\
+}
+
+DMA_HandleTypeDef adc2_dma21_handle = STM32F4_DEFAULT_DMA21_HANDLE;
+#endif
+
+
+#if MYNEWT_VAL(ADC_3)
+
+extern ADC_HandleTypeDef adc3_handle;
+
+#define STM32F4_DEFAULT_DMA12_HANDLE {\
+    .Instance = DMA2_Stream1,\
+    .Init.Channel = DMA_CHANNEL_2,\
+    .Init.Direction = DMA_PERIPH_TO_MEMORY,\
+    .Init.PeriphInc = DMA_PINC_DISABLE,\
+    .Init.MemInc = DMA_MINC_ENABLE,\
+    .Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD,\
+    .Init.MemDataAlignment = DMA_MDATAALIGN_WORD,\
+    .Init.Mode = DMA_CIRCULAR,\
+    .Init.Priority = DMA_PRIORITY_HIGH,\
+    .Init.FIFOMode = DMA_FIFOMODE_DISABLE,\
+    .Init.FIFOThreshold = DMA_FIFO_THRESHOLD_HALFFULL,\
+    .Init.MemBurst = DMA_MBURST_SINGLE,\
+    .Init.PeriphBurst = DMA_PBURST_SINGLE,\
+    .Parent = &adc3_handle,\
+}
+
+DMA_HandleTypeDef adc3_dma12_handle = STM32F4_DEFAULT_DMA12_HANDLE;
+#endif
+
+#define STM32F4_ADC_DEFAULT_INIT_TD {\
+    .ClockPrescaler = ADC_CLOCKPRESCALER_PCLK_DIV2,\
+    .Resolution = ADC_RESOLUTION12b,\
+    .DataAlign = ADC_DATAALIGN_RIGHT,\
+    .ScanConvMode = DISABLE,\
+    .EOCSelection = DISABLE,\
+    .ContinuousConvMode = ENABLE,\
+    .NbrOfConversion = 1,\
+    .DiscontinuousConvMode = DISABLE,\
+    .NbrOfDiscConversion = 0,\
+    .ExternalTrigConv = ADC_SOFTWARE_START,\
+    .ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE,\
+    .DMAContinuousRequests = ENABLE\
+}
+
+#if MYNEWT_VAL(ADC_1)
+
+/*****************ADC1 Config ***************/
+#define STM32F4_DEFAULT_ADC1_HANDLE {\
+    .Init = STM32F4_ADC_DEFAULT_INIT_TD,\
+    .Instance = ADC1,\
+    .NbrOfCurrentConversionRank = 0,\
+    .DMA_Handle = &adc1_dma00_handle,\
+    .Lock = HAL_UNLOCKED,\
+    .State = 0,\
+    .ErrorCode = 0\
+}
+
+ADC_HandleTypeDef adc1_handle = STM32F4_DEFAULT_ADC1_HANDLE;
+
+#define STM32F4_ADC1_DEFAULT_SAC {\
+    .c_refmv = 3300,\
+    .c_res   = 12,\
+    .c_configured = 1,\
+    .c_cnum = ADC_CHANNEL_10\
+}
+
+struct adc_chan_config adc1_chan10_config = STM32F4_ADC1_DEFAULT_SAC;
+
+#define STM32F4_ADC1_DEFAULT_CONFIG {\
+    .sac_chan_count = 16,\
+    .sac_chans = (struct adc_chan_config [16]){{0},{0},{0},{0},{0},{0},{0},{0},{0},{0},STM32F4_ADC1_DEFAULT_SAC},\
+    .sac_adc_handle = &adc1_handle,\
+}
+
+struct stm32f4_adc_dev_cfg adc1_config = STM32F4_ADC1_DEFAULT_CONFIG;
+/*********************************************/
+#endif
+
+#if MYNEWT_VAL(ADC_2)
+
+/*****************ADC2 Config ***************/
+#define STM32F4_DEFAULT_ADC2_HANDLE {\
+    .Init = STM32F4_ADC_DEFAULT_INIT_TD,\
+    .Instance = ADC2,\
+    .NbrOfCurrentConversionRank = 0,\
+    .DMA_Handle = &adc2_dma21_handle,\
+    .Lock = HAL_UNLOCKED,\
+    .State = 0,\
+    .ErrorCode = 0\
+}
+
+ADC_HandleTypeDef adc2_handle = STM32F4_DEFAULT_ADC2_HANDLE;
+
+#define STM32F4_ADC2_DEFAULT_SAC {\
+    .c_refmv = 3300,\
+    .c_res   = 12,\
+    .c_configured = 1,\
+    .c_cnum = ADC_CHANNEL_1\
+}
+
+struct adc_chan_config adc2_chan1_config = STM32F4_ADC2_DEFAULT_SAC;
+
+#define STM32F4_ADC2_DEFAULT_CONFIG {\
+    .sac_chan_count = 16,\
+    .sac_chans = (struct adc_chan_config [16]){{0},STM32F4_ADC1_DEFAULT_SAC}\
+    .sac_adc_handle = &adc2_handle,\
+}
+
+struct stm32f4_adc_dev_cfg adc2_config = STM32F4_ADC2_DEFAULT_CONFIG;
+/*********************************************/
+#endif
+
+#if MYNEWT_VAL(ADC_3)
+
+#define STM32F4_DEFAULT_ADC3_HANDLE {\
+    .Init = STM32F4_ADC_DEFAULT_INIT_TD,\
+    .Instance = ADC3,\
+    .NbrOfCurrentConversionRank = 0,\
+    .DMA_Handle = &adc3_dma12_handle,\
+    .Lock = HAL_UNLOCKED,\
+    .State = 0,\
+    .ErrorCode = 0\
+}
+
+ADC_HandleTypeDef adc3_handle = STM32F4_DEFAULT_ADC3_HANDLE;
+
+#define STM32F4_ADC3_DEFAULT_SAC {\
+    .c_refmv = 3300,\
+    .c_res   = 12,\
+    .c_configured = 1,\
+    .c_cnum = ADC_CHANNEL_4\
+}
+
+struct adc_chan_config adc3_chan4_config = STM32F4_ADC3_DEFAULT_SAC;
+
+#define STM32F4_ADC3_DEFAULT_CONFIG {\
+    .sac_chan_count = 16,\
+    .sac_chans = (struct adc_chan_config [16]){{0},{0},{0},{0},STM32F4_ADC3_DEFAULT_SAC},\
+    .sac_adc_handle = &adc3_handle,\
+}
+
+struct stm32f4_adc_dev_cfg adc3_config = STM32F4_ADC3_DEFAULT_CONFIG;
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+static struct stm32_hal_i2c_cfg i2c_cfg0 = {
+    .hic_i2c = I2C1,
+    .hic_rcc_reg = &RCC->APB1ENR,
+    .hic_rcc_dev = RCC_APB1ENR_I2C1EN,
+    .hic_pin_sda = MCU_GPIO_PORTB(9),
+    .hic_pin_scl = MCU_GPIO_PORTB(8),
+    .hic_pin_af = GPIO_AF4_I2C1,
+    .hic_10bit = 0,
+    .hic_speed = 100000				/* 100kHz */
+};
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+struct stm32_hal_spi_cfg spi0_cfg = {
+    .ss_pin = -1,
+    .sck_pin  = MYNEWT_VAL(SPI_0_SCK),
+    .miso_pin = MYNEWT_VAL(SPI_0_MISO),
+    .mosi_pin = MYNEWT_VAL(SPI_0_MOSI),
+    .irq_prio = 2
+};
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_1_SLAVE)
+struct stm32_hal_spi_cfg spi0_cfg = {
+    .ss_pin = -1,
+    .sck_pin  = MYNEWT_VAL(SPI_1_SCK),
+    .miso_pin = MYNEWT_VAL(SPI_1_MISO),
+    .mosi_pin = MYNEWT_VAL(SPI_1_MOSI),
+    .irq_prio = 2
+};
+#endif
+
+#if MYNEWT_VAL(UART_0)
+static const struct stm32_uart_cfg uart_cfg0 = {
+    .suc_uart = USART1,
+    .suc_rcc_reg = &RCC->APB2ENR,
+    .suc_rcc_dev = RCC_APB2ENR_USART1EN,
+    .suc_pin_tx = MYNEWT_VAL(UART_0_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_CTS),
+    .suc_pin_af = GPIO_AF7_USART1,
+    .suc_irqn = USART1_IRQn
+};
+#endif
+#if MYNEWT_VAL(ETH_0)
+static const struct stm32_eth_cfg eth_cfg = {
+    /*
+     * PORTA
+     *   PA1 - ETH_RMII_REF_CLK
+     *   PA2 - ETH_RMII_MDIO
+     *   PA3 - ETH_RMII_MDINT  (GPIO irq?)
+     *   PA7 - ETH_RMII_CRS_DV
+     */
+    .sec_port_mask[0] = (1 << 1) | (1 << 2) | (1 << 7),
+
+    /*
+     * PORTC
+     *   PC1 - ETH_RMII_MDC
+     *   PC4 - ETH_RMII_RXD0
+     *   PC5 - ETH_RMII_RXD1
+     */
+    .sec_port_mask[2] = (1 << 1) | (1 << 4) | (1 << 5),
+
+    /*
+     * PORTG
+     *   PG11 - ETH_RMII_TXEN
+     *   PG13 - ETH_RMII_TXD0
+     *   PG14 - ETH_RMII_TXD1
+     */
+    .sec_port_mask[6] = (1 << 11) | (1 << 13) | (1 << 14),
+    .sec_phy_type = SMSC_8710_RMII,
+    .sec_phy_irq = MCU_GPIO_PORTA(3)
+};
+#endif
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE
+    },
+    [1] = {
+        .hbmd_start = &_ccram_start,
+        .hbmd_size = CCRAM_SIZE
+    }
+};
+
+extern const struct hal_flash stm32_flash_dev;
+
+#if MYNEWT_VAL(SPIFLASH)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+struct bus_spi_node_cfg flash_spi_cfg = {
+    .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
+    .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
+    .mode = BUS_SPI_MODE_3,
+    .data_order = HAL_SPI_MSB_FIRST,
+    .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
+};
+#endif
+#endif
+
+static const struct hal_flash *flash_devs[] = {
+    [0] = &stm32_flash_dev,
+#if MYNEWT_VAL(SPIFLASH)
+    [1] = &spiflash_dev.hal,
+#endif
+};
+
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    if (id >= ARRAY_SIZE(flash_devs)) {
+        return NULL;
+    }
+
+    return flash_devs[id];
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = ARRAY_SIZE(dump_cfg);
+    return dump_cfg;
+}
+
+int
+hal_bsp_power_state(int state)
+{
+    return (0);
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    /* Add any interrupt priorities configured by the bsp here */
+    return pri;
+}
+
+void
+hal_bsp_init(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(TRNG)
+    rc = os_dev_create(&os_bsp_trng.dev, "trng", OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT, stm32_trng_dev_init, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = hal_spi_init(0, &spi0_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(SPI_0_SLAVE)
+    rc = hal_spi_init(0, &spi0_cfg, HAL_SPI_TYPE_SLAVE);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(UART_0)
+    rc = os_dev_create((struct os_dev *) &hal_uart0, "uart0",
+      OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *)&uart_cfg0);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(ADC_1)
+    rc = os_dev_create((struct os_dev *) &my_dev_adc1, "adc1",
+            OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+            stm32f4_adc_dev_init, &adc1_config);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(ADC_2)
+    rc = os_dev_create((struct os_dev *) &my_dev_adc2, "adc2",
+            OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+            stm32f4_adc_dev_init, &adc2_config);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(ADC_3)
+    rc = os_dev_create((struct os_dev *) &my_dev_adc3, "adc3",
+            OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+            stm32f4_adc_dev_init, &adc3_config);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+    rc = hal_i2c_init(0, &i2c_cfg0);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(TIMER_0)
+    hal_timer_init(0, TIM2);
+#endif
+
+#if MYNEWT_VAL(TIMER_1)
+    hal_timer_init(1, TIM3);
+#endif
+
+#if MYNEWT_VAL(TIMER_2)
+    hal_timer_init(2, TIM4);
+#endif
+
+#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(ETH_0)
+    rc = stm32_eth_init(&eth_cfg);
+    assert(rc == 0);
+#endif
+}

--- a/hw/bsp/black_vet6/src/system_stm32f4xx.c
+++ b/hw/bsp/black_vet6/src/system_stm32f4xx.c
@@ -1,0 +1,355 @@
+/**
+  ******************************************************************************
+  * @file    system_stm32f4xx.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    01-July-2015
+  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File.
+  *
+  *   This file provides two functions and one global variable to be called from
+  *   user application:
+  *      - SystemInit(): This function is called at startup just after reset and
+  *                      before branch to main program. This call is made inside
+  *                      the "startup_stm32f4xx.s" file.
+  *
+  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
+  *                                  by the user application to setup the SysTick
+  *                                  timer or configure other parameters.
+  *
+  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+  *                                 be called whenever the core clock is changed
+  *                                 during program execution.
+  *
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f4xx_system
+  * @{
+  */
+
+/** @addtogroup STM32F4xx_System_Private_Includes
+  * @{
+  */
+
+#include "bsp/stm32f4xx_hal_conf.h"
+#include "stm32f4xx.h"
+#include "mcu/cmsis_nvic.h"
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_Defines
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+uint32_t SystemCoreClock = 168000000;
+
+const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+const uint8_t APBPrescTable[8] = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_FunctionPrototypes
+  * @{
+  */
+
+static void SystemClock_Config(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32F4xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system
+  *         Initialize the FPU setting, vector table location and External memory
+  *         configuration.
+  * @param  None
+  * @retval None
+  */
+void SystemInit(void)
+{
+    /* FPU settings ----------------------------------------------------------*/
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    /* set CP10 and CP11 Full Access */
+    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));
+#endif
+    /* Reset the RCC clock configuration to the default reset state ----------*/
+    /* Set HSION bit */
+    RCC->CR |= (uint32_t)0x00000001;
+
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000;
+
+    /* Reset HSEON, CSSON and PLLON bits */
+    RCC->CR &= (uint32_t)0xFEF6FFFF;
+
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x24003010;
+
+    /* Reset HSEBYP bit */
+    RCC->CR &= (uint32_t)0xFFFBFFFF;
+
+    /* Disable all interrupts */
+    RCC->CIR = 0x00000000;
+
+    /* Configure System Clock */
+    SystemClock_Config();
+
+    /* Relocate the vector table */
+    NVIC_Relocate();
+}
+
+/**
+   * @brief  Update SystemCoreClock variable according to Clock Register Values.
+  *         The SystemCoreClock variable contains the core clock (HCLK), it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *
+  * @note   Each time the core clock (HCLK) changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.
+  *
+  * @note   - The system frequency computed by this function is not the real
+  *           frequency in the chip. It is calculated based on the predefined
+  *           constant and the selected clock source:
+  *
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(*)
+  *
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(**)
+  *
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**)
+  *             or HSI_VALUE(*) multiplied/divided by the PLL factors.
+  *
+  *         (*) HSI_VALUE is a constant defined in stm32f4xx_hal_conf.h file (default value
+  *             16 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.
+  *
+  *         (**) HSE_VALUE is a constant defined in stm32f4xx_hal_conf.h file (its value
+  *              depends on the application requirements), user has to ensure that HSE_VALUE
+  *              is same as the real frequency of the crystal used. Otherwise, this function
+  *              may have wrong result.
+  *
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  *
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate(void)
+{
+    uint32_t tmp;
+    uint32_t pllvco;
+    uint32_t pllp;
+    uint32_t pllsource;
+    uint32_t pllm;
+
+    /* Get SYSCLK source -----------------------------------------------------*/
+    tmp = RCC->CFGR & RCC_CFGR_SWS;
+
+    switch (tmp)
+    {
+    case 0x00:  /* HSI used as system clock source */
+        SystemCoreClock = HSI_VALUE;
+        break;
+    case 0x04:  /* HSE used as system clock source */
+        SystemCoreClock = HSE_VALUE;
+        break;
+    case 0x08:  /* PLL used as system clock source */
+
+        /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLL_M) * PLL_N
+         SYSCLK = PLL_VCO / PLL_P
+         */
+        pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) >> 22;
+        pllm = RCC->PLLCFGR & RCC_PLLCFGR_PLLM;
+
+        if (pllsource != 0) {
+            /* HSE used as PLL clock source */
+            pllvco = (HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 6);
+        } else {
+            /* HSI used as PLL clock source */
+            pllvco = (HSI_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 6);
+        }
+
+        pllp = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLP) >>16) + 1 ) * 2;
+        SystemCoreClock = pllvco / pllp;
+        break;
+    default:
+      SystemCoreClock = HSI_VALUE;
+      break;
+  }
+    /* Compute HCLK frequency ------------------------------------------------*/
+    /* Get HCLK prescaler */
+    tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
+    /* HCLK frequency */
+    SystemCoreClock >>= tmp;
+}
+
+/**
+  * @brief  System Clock Configuration
+  *         The system Clock is configured as follow :
+  *            System Clock source            = PLL (HSE)
+  *            SYSCLK(Hz)                     = 168000000
+  *            HCLK(Hz)                       = 168000000
+  *            AHB Prescaler                  = 1
+  *            APB1 Prescaler                 = 4
+  *            APB2 Prescaler                 = 2
+  *            HSE Frequency(Hz)              = 8000000
+  *            PLL_M                          = 8
+  *            PLL_N                          = 336
+  *            PLL_P                          = 2
+  *            PLL_Q                          = 7
+  *            VDD(V)                         = 3.3
+  *            Main regulator output voltage  = Scale1 mode
+  *            Flash Latency(WS)              = 5
+  * @param  None
+  * @retval None
+  */
+static void SystemClock_Config(void)
+{
+  /* Configure Flash prefetch, Instruction cache, Data cache */
+#if (INSTRUCTION_CACHE_ENABLE != 0)
+    __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
+#endif /* INSTRUCTION_CACHE_ENABLE */
+
+#if (DATA_CACHE_ENABLE != 0)
+    __HAL_FLASH_DATA_CACHE_ENABLE();
+#endif /* DATA_CACHE_ENABLE */
+
+#if (PREFETCH_ENABLE != 0)
+    __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+#endif /* PREFETCH_ENABLE */
+
+    /* Enable Power Control clock */
+    __HAL_RCC_PWR_CLK_ENABLE();
+
+    /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+    /* Enable HSE and wait till HSE is ready */
+    RCC->CR |= ((uint32_t)RCC_CR_HSEON);
+    while (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET) {
+        /* XXX: some error should occur here */
+    }
+
+    /* HCLK Configuration */
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_SYSCLK_DIV1);
+
+    /* PCLK1 Configuration */
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE1, RCC_HCLK_DIV4);
+
+    /* PCLK2 Configuration */
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, (RCC_HCLK_DIV2 << 3));
+
+    /* Configure the main PLL clock source, multiplication and division factors. */
+    WRITE_REG(RCC->PLLCFGR, (RCC_PLLSOURCE_HSE  | \
+                             8                  | \
+                             (336 << POSITION_VAL(RCC_PLLCFGR_PLLN))  | \
+                             (((RCC_PLLP_DIV2 >> 1) -1) << POSITION_VAL(RCC_PLLCFGR_PLLP)) | \
+                             (7 << POSITION_VAL(RCC_PLLCFGR_PLLQ))));
+
+    /* Enable the main PLL. */
+    __HAL_RCC_PLL_ENABLE();
+
+    /* Wait till PLL is ready */
+    while (__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET) {
+        /* XXX: handle this */
+    }
+
+    /* Enable the Flash prefetch */
+    __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+
+    /* Set flash wait states */
+    __HAL_FLASH_SET_LATENCY(FLASH_LATENCY_5);
+
+    /* Start PLL */
+    __HAL_RCC_SYSCLK_CONFIG(RCC_SYSCLKSOURCE_PLLCLK);
+
+    while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK) {
+        /* XXX: deal with this*/
+    }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/bsp/black_vet6/stm32f4ve.ld
+++ b/hw/bsp/black_vet6/stm32f4ve.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F407 when running from flash and using the bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08020000, LENGTH = 256K /* First image slot. */
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/black_vet6/stm32f4ve_debug.cmd
+++ b/hw/bsp/black_vet6/stm32f4ve_debug.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/black_vet6/stm32f4ve_debug.sh
+++ b/hw/bsp/black_vet6/stm32f4ve_debug.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+
+. $CORE_PATH/hw/scripts/stlink.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+
+stlink_debug

--- a/hw/bsp/black_vet6/stm32f4ve_download.cmd
+++ b/hw/bsp/black_vet6/stm32f4ve_download.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/black_vet6/stm32f4ve_download.sh
+++ b/hw/bsp/black_vet6/stm32f4ve_download.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/stlink.sh
+
+if [ "$MFG_IMAGE" ]; then
+    FLASH_OFFSET=0x08000000
+fi
+
+common_file_to_load
+stlink_load

--- a/hw/bsp/black_vet6/syscfg.yml
+++ b/hw/bsp/black_vet6/syscfg.yml
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB.'
+        value: 512
+
+    STM32_FLASH_NUM_AREAS:
+        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
+        value: 9
+
+    ADC_1:
+        description: "ADC_1"
+        value:  0
+    ADC_2:
+        description: "ADC_2"
+        value:  0
+    ADC_3:
+        description: "ADC_3"
+        value:  0
+
+    UART_0:
+        description: 'Whether to enable UART0'
+        value:  1
+    UART_0_TX:
+        description: 'UART 0 TX pin. TX from J6 connector'
+        value:  'MCU_GPIO_PORTA(9)'
+    UART_0_RX:
+        description: 'UART 0 RX pin. RX from J6 connector'
+        value:  'MCU_GPIO_PORTA(10)'
+    UART_0_RTS:
+        description: 'UART 0 RTS pin.'
+        value:  -1
+    UART_0_CTS:
+        description: 'UART 0 CTS pin.'
+        value:  -1
+
+    SPI_0_SCK:
+        description: 'SPI_0 clock pin'
+        value: 'MCU_GPIO_PORTB(3)'
+    SPI_0_MISO:
+        description: 'SPI_0 MISO pin'
+        value: 'MCU_GPIO_PORTB(4)'
+    SPI_0_MOSI:
+        description: 'SPI_0 MOSI pin'
+        value: 'MCU_GPIO_PORTB(5)'
+
+    SPI_1_SCK:
+        description: 'SPI_1 clock pin'
+        value: 'MCU_GPIO_PORTB(13)'
+    SPI_1_MISO:
+        description: 'SPI_1 MISO pin'
+        value: 'MCU_GPIO_PORTB(14)'
+    SPI_1_MOSI:
+        description: 'SPI_1 MOSI pin'
+        value: 'MCU_GPIO_PORTB(15)'
+
+    TIMER_0:
+        description: 'Enable TIMER_0, (TIM2 up to 84MHz, 32 bits)'
+        value: 1
+    TIMER_1:
+        description: 'Enable TIMER_1, (TIM3 up to 84MHz, 16 bits)'
+        value: 0
+    TIMER_2:
+        description: 'Enable TIMER_2, (TIM4 up to 84MHz, 16 bits)'
+        value: 0
+
+    ETH_0:
+        description: 'Ethernet driver for LwIP'
+        value: 0
+
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    HARDFLOAT: 1
+
+    SPI_0_MASTER: 1
+    # On board SPIFLASH configuraiont for W25Q16VBS
+    SPIFLASH: 1
+    SPIFLASH_SPI_NUM: 0
+    SPIFLASH_SPI_CS_PIN: 'MCU_GPIO_PORTB(0)'
+    SPIFLASH_BAUDRATE: 42000
+    SPIFLASH_MANUFACTURER: 0xEF
+    SPIFLASH_MEMORY_TYPE: 0x40
+    SPIFLASH_MEMORY_CAPACITY: 0x15
+    SPIFLASH_SECTOR_COUNT: 512
+    SPIFLASH_SECTOR_SIZE: 4094
+    SPIFLASH_PAGE_SIZE: 256
+
+    SPIFLASH_TBP1_TYPICAL: 20
+    SPIFLASH_TBP1_MAXIMUM: 50
+    SPIFLASH_TPP_TYPICAL: 700
+    SPIFLASH_TPP_MAXIMUM: 3000
+    SPIFLASH_TSE_TYPICAL: 30000
+    SPIFLASH_TSE_MAXIMUM: 400000
+    SPIFLASH_TBE1_TYPICAL: 120000
+    SPIFLASH_TBE1_MAXIMUM: 800000
+    SPIFLASH_TBE2_TYPICAL: 150000
+    SPIFLASH_TBE2_MAXIMUM: 1000000
+    SPIFLASH_TCE_TYPICAL: 3000000
+    SPIFLASH_TCE_MAXIMUM: 10000000
+
+    BSP_FLASH_SPI_BUS: '"spi0"'


### PR DESCRIPTION
Support for cheap board with STM32F407VE (168MHz, 192KB Ram and 512 KBFlash)
and external 2MB of spiflash.