### PR TITLE
da1469x LED_3

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -40,6 +40,7 @@ extern uint8_t _ram_start;
 /* LED pins */
 #define LED_1           (33)    /* P1_1 */
 #define LED_2           (43)    /* P1_11 */
+#define LED_3           (42)    /* P1_10 */
 #define LED_BLINK_PIN   LED_1
 
 /* Button pin */


### PR DESCRIPTION
Added definition for LED_3 (used by at least one ble mesh application). Assigned to unused pin on DA1469x dev board which is brought out to a header. An an external LED will be have to be wired to it as only one LED is available on the board.