### PR TITLE
da1469x pwm header file

### DIFF
--- a/hw/drivers/pwm/pwm_da1469x/include/pwm_da1469x/pwm_da1469x.h
+++ b/hw/drivers/pwm/pwm_da1469x/include/pwm_da1469x/pwm_da1469x.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __PWM_DA1469x_H__
+#define __PWM_DA1469x_H__
+
+#include <pwm/pwm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Device initialization routine called by OS.
+ *
+ * @param dev Pointer to device being initialized.
+ * @param arg NA
+ *
+ * @return 0 on success, non-zero when fail.
+ */
+int da1469x_pwm_init(struct os_dev *, void *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PWM_DA1469x_H__ */

--- a/hw/mcu/dialog/da1469x/src/da1469x_periph.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_periph.c
@@ -44,7 +44,7 @@
 #endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include "pwm/pwm.h"
-#include "pwm_da1469x.h"
+#include "pwm_da1469x/pwm_da1469x.h"
 #endif
 
 #if MYNEWT_VAL(TRNG)


### PR DESCRIPTION
Added header file for da1469x pwm driver (pwm_da1469x.h) as it was missing. Also corrected include path in da1469x_periph so it points to this added header file.