### PR TITLE
hw: Moving software devices creation code from BSP to pkg_init.

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -30,25 +30,6 @@
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
 #include "defs/sections.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -114,32 +95,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -65,6 +59,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -30,25 +30,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "flash_map/flash_map.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -113,32 +94,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/arduino_primo_nrf52/syscfg.yml
+++ b/hw/bsp/arduino_primo_nrf52/syscfg.yml
@@ -33,12 +33,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -70,6 +64,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -31,25 +31,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -114,32 +95,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/bmd300eval/syscfg.yml
+++ b/hw/bsp/bmd300eval/syscfg.yml
@@ -25,12 +25,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -54,6 +48,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -32,25 +32,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -115,32 +96,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/dwm1001-dev/syscfg.yml
+++ b/hw/bsp/dwm1001-dev/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -68,6 +62,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -32,25 +32,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -115,32 +96,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/nina-b1/syscfg.yml
+++ b/hw/bsp/nina-b1/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -68,6 +62,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/nordic_pca10040/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10040/src/hal_bsp.c
@@ -30,27 +30,8 @@
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
 #include "defs/sections.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
 #if MYNEWT_VAL(ENC_FLASH_DEV)
 #include <ef_nrf5x/ef_nrf5x.h>
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
 #endif
 
 /*
@@ -133,32 +114,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/nordic_pca10040/syscfg.yml
+++ b/hw/bsp/nordic_pca10040/syscfg.yml
@@ -26,16 +26,9 @@ syscfg.defs:
     ENC_FLASH_DEV:
         description: 'Encrypting flash driver over interal flash for testing'
         value: 0
-
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
     RAM_RESIDENT:
         description: 'Compile app to be loaded to RAM'
         value: 0
@@ -72,6 +65,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/nordic_pca10056/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10056/src/hal_bsp.c
@@ -29,14 +29,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
 
 /*
  * What memory to include in coredump.
@@ -106,27 +98,11 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
 }
 
 #if MYNEWT_VAL(BSP_USE_HAL_SPI)

--- a/hw/bsp/nordic_pca20020/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca20020/src/hal_bsp.c
@@ -31,28 +31,9 @@
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
 #include "defs/sections.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
 #if MYNEWT_VAL(LIS2DH12_ONB)
 #include "lis2dh12/lis2dh12.h"
 static struct lis2dh12 lis2dh12;
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
 #endif
 
 #if MYNEWT_VAL(LIS2DH12_ONB)
@@ -172,34 +153,11 @@ sensor_dev_create(void)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 
     sensor_dev_create();
 }

--- a/hw/bsp/nordic_pca20020/syscfg.yml
+++ b/hw/bsp/nordic_pca20020/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
     LIS2DH12_ONB:
         description: 'NRF52 Thingy onboard lis2dh12 sensor'
@@ -73,5 +67,4 @@ syscfg.vals.BLE_CONTROLLER:
     BLE_XTAL_SETTLE_TIME: 1500
 
 syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"
     - "!LIS2DH12_ONB || I2C_0"

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -32,25 +32,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -115,32 +96,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/puckjs/syscfg.yml
+++ b/hw/bsp/puckjs/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -61,6 +55,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 0
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -31,25 +31,6 @@
 #include "hal/hal_spi.h"
 #include "hal/hal_i2c.h"
 #include "hal/hal_watchdog.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -114,32 +95,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/rb-blend2/syscfg.yml
+++ b/hw/bsp/rb-blend2/syscfg.yml
@@ -29,12 +29,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -67,6 +61,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -30,25 +30,6 @@
 #include "hal/hal_flash.h"
 #include "hal/hal_spi.h"
 #include "hal/hal_watchdog.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -113,32 +94,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/rb-nano2/syscfg.yml
+++ b/hw/bsp/rb-nano2/syscfg.yml
@@ -29,12 +29,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -74,6 +68,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/ruuvitag_rev_b/src/hal_bsp.c
+++ b/hw/bsp/ruuvitag_rev_b/src/hal_bsp.c
@@ -31,13 +31,6 @@
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
 #include "defs/sections.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
 #if MYNEWT_VAL(BME280_ONB)
 #include "bme280/bme280.h"
 static struct bme280 bme280;
@@ -45,18 +38,6 @@ static struct bme280 bme280;
 #if MYNEWT_VAL(LIS2DH12_ONB)
 #include "lis2dh12/lis2dh12.h"
 static struct lis2dh12 lis2dh12;
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
 #endif
 
 #if MYNEWT_VAL(BME280_ONB)
@@ -221,34 +202,11 @@ sensor_dev_create(void)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52832 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 
     sensor_dev_create();
 }

--- a/hw/bsp/ruuvitag_rev_b/syscfg.yml
+++ b/hw/bsp/ruuvitag_rev_b/syscfg.yml
@@ -35,12 +35,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
     BME280_ONB:
         description: 'Enable RuuviTag onboard BME280 sensor'
@@ -94,7 +88,6 @@ syscfg.vals.BLE_CONTROLLER:
     BLE_XTAL_SETTLE_TIME: 1500
 
 syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"
     - "!BME280_ONB || SPI_0_MASTER"
     - "!LIS2DH12_ONB || SPI_0_MASTER"
     - "!LIS2DH12_ONB || BSP_RUUVITAG_REV_B_NUM >= 3"

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -33,25 +33,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -117,33 +98,12 @@ void
 hal_bsp_init(void)
 {
     int rc;
-#if MYNEWT_VAL(SOFT_PWM)
-    int idx;
-    char *spwm_name;
-#endif
 
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 
     /*
      * Not sure about this, but for now we will hold the SX1276 in reset.

--- a/hw/bsp/telee02/syscfg.yml
+++ b/hw/bsp/telee02/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -65,6 +59,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -32,25 +32,6 @@
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
 #include "bsp/bsp.h"
-#if MYNEWT_VAL(SOFT_PWM)
-#include "pwm/pwm.h"
-#include "soft_pwm/soft_pwm.h"
-#endif
-#if MYNEWT_VAL(UARTBB_0)
-#include "uart_bitbang/uart_bitbang.h"
-#endif
-
-#if MYNEWT_VAL(SOFT_PWM)
-static struct pwm_dev os_bsp_spwm[MYNEWT_VAL(SOFT_PWM_DEVS)];
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
-    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
-    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
-    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
-};
-#endif
 
 /*
  * What memory to include in coredump.
@@ -115,32 +96,9 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
 void
 hal_bsp_init(void)
 {
-#if MYNEWT_VAL(SOFT_PWM)
-    int rc;
-    int idx;
-    char *spwm_name;
-#endif
-
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
-
-#if MYNEWT_VAL(SOFT_PWM)
-    for (idx = 0; idx < MYNEWT_VAL(SOFT_PWM_DEVS); idx++) {
-        asprintf(&spwm_name, "spwm%d", idx);
-        rc = os_dev_create(&os_bsp_spwm[idx].pwm_os_dev, spwm_name,
-                           OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
-                           soft_pwm_dev_init, UINT_TO_POINTER(idx));
-        assert(rc == 0);
-    }
-#endif
-
-#if MYNEWT_VAL(UARTBB_0)
-    rc = os_dev_create(&os_bsp_uartbb0.ud_dev, "uartbb0",
-                       OS_DEV_INIT_PRIMARY, 0, uart_bitbang_init,
-                       (void *)&os_bsp_uartbb0_cfg);
-    assert(rc == 0);
-#endif
 }

--- a/hw/bsp/vbluno52/syscfg.yml
+++ b/hw/bsp/vbluno52/syscfg.yml
@@ -28,12 +28,6 @@ syscfg.defs:
     UARTBB_0:
         description: 'Enable bit-banger UART 0'
         value: 0
-    UARTBB_0_PIN_TX:
-        description: 'TX pin for UARTBB0'
-        value: -1
-    UARTBB_0_PIN_RX:
-        description: 'RX pin for UARTBB0'
-        value: -1
 
 syscfg.vals:
     # Enable nRF52832 MCU
@@ -64,6 +58,3 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500
-
-syscfg.restrictions:
-    - "!UARTBB_0 || (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)"

--- a/hw/drivers/pwm/soft_pwm/include/soft_pwm/soft_pwm.h
+++ b/hw/drivers/pwm/soft_pwm/include/soft_pwm/soft_pwm.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 
 int soft_pwm_dev_init(struct os_dev *odev, void *arg);
+void soft_pwm_pkg_init();
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/pwm/soft_pwm/pkg.yml
+++ b/hw/drivers/pwm/soft_pwm/pkg.yml
@@ -25,5 +25,9 @@ pkg.keywords:
 
 pkg.apis:
     - PWM_HW_IMPL
+
 pkg.deps:
-   - "@apache-mynewt-core/hw/drivers/pwm"
+    - "@apache-mynewt-core/hw/drivers/pwm"
+
+pkg.init:
+    soft_pwm_pkg_init: 'MYNEWT_VAL(SOFT_PWM_SYSINIT_STAGE)'

--- a/hw/drivers/pwm/soft_pwm/src/soft_pwm.c
+++ b/hw/drivers/pwm/soft_pwm/src/soft_pwm.c
@@ -54,6 +54,7 @@ struct soft_pwm_dev {
 };
 
 static struct soft_pwm_dev instances[DEV_COUNT];
+static struct pwm_dev os_dev_spwm[DEV_COUNT];
 
 /**
  * Cycle start callback
@@ -505,4 +506,26 @@ soft_pwm_dev_init(struct os_dev *odev, void *arg)
     pwm_funcs->pwm_disable = soft_pwm_disable;
 
     return (0);
+}
+
+void
+soft_pwm_pkg_init()
+{
+    int rc;
+    int idx;
+    char *spwm_name;
+
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    for (idx = 0; idx < DEV_COUNT; idx++) {
+        asprintf(&spwm_name, "spwm%d", idx);
+        rc = os_dev_create(&os_dev_spwm[idx].pwm_os_dev,
+                           spwm_name,
+                           OS_DEV_INIT_KERNEL,
+                           OS_DEV_INIT_PRIO_DEFAULT,
+                           soft_pwm_dev_init,
+                           UINT_TO_POINTER(idx));
+        SYSINIT_PANIC_ASSERT(rc == 0);
+    }
 }

--- a/hw/drivers/pwm/soft_pwm/syscfg.yml
+++ b/hw/drivers/pwm/soft_pwm/syscfg.yml
@@ -17,10 +17,14 @@
 #
 
 syscfg.defs:
+    SOFT_PWM_SYSINIT_STAGE:
+        description: 'Sysinit stage for the soft PWM package'
+        value: 5
+
     SOFT_PWM_DEVS:
-        description: 'NUMBER OF SOFT PWM DEVICES'
+        description: 'Number of soft PWM devices.'
         value: 1
 
     SOFT_PWM_CHANS:
-        description: 'NUMBER OF SOFT PWM CHANNELS PER DEVICE'
+        description: 'Number of soft PWM channels per device.'
         value: 4

--- a/hw/drivers/uart/uart_bitbang/include/uart_bitbang/uart_bitbang.h
+++ b/hw/drivers/uart/uart_bitbang/include/uart_bitbang/uart_bitbang.h
@@ -32,6 +32,7 @@ struct uart_bitbang_conf {
 
 struct os_dev;
 int uart_bitbang_init(struct os_dev *, void *);
+void uart_bitbang_pkg_init();
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/uart/uart_bitbang/src/uart_bitbang.c
+++ b/hw/drivers/uart/uart_bitbang/src/uart_bitbang.c
@@ -64,6 +64,13 @@ struct uart_bitbang {
     void *ub_func_arg;
 };
 
+static struct uart_dev os_dev_uartbb0;
+static const struct uart_bitbang_conf os_bsp_uartbb0_cfg = {
+    .ubc_txpin = MYNEWT_VAL(UARTBB_0_PIN_TX),
+    .ubc_rxpin = MYNEWT_VAL(UARTBB_0_PIN_RX),
+    .ubc_cputimer_freq = MYNEWT_VAL(OS_CPUTIME_FREQ),
+};
+
 /*
  * Bytes start with START bit (0) followed by 8 data bits and then the
  * STOP bit (1). STOP bit should be configurable. Data bits are sent LSB first.
@@ -359,3 +366,19 @@ uart_bitbang_init(struct os_dev *odev, void *arg)
     return OS_OK;
 }
 
+void
+uart_bitbang_pkg_init()
+{
+    int rc;
+
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    rc = os_dev_create(&os_dev_uartbb0.ud_dev,
+                       "uartbb0",
+                       OS_DEV_INIT_PRIMARY,
+                       0,
+                       uart_bitbang_init,
+                       (void *)&os_bsp_uartbb0_cfg);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+}

--- a/hw/drivers/uart/uart_bitbang/syscfg.yml
+++ b/hw/drivers/uart/uart_bitbang/syscfg.yml
@@ -28,4 +28,5 @@ syscfg.defs:
         value: -1
 
 syscfg.restrictions:
-    - (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)
+    - UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0
+    - CONSOLE_UART_BAUD <= 19200

--- a/hw/drivers/uart/uart_bitbang/syscfg.yml
+++ b/hw/drivers/uart/uart_bitbang/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,15 +16,16 @@
 # under the License.
 #
 
-pkg.name: hw/drivers/uart/uart_bitbang
-pkg.description: Async UART port with a bitbanger.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-pkg.apis:
-pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/hw/drivers/uart"
+syscfg.defs:
+    UARTBB_SYSINIT_STAGE:
+        description: 'Sysinit stage for the UART bitbang package'
+        value: 5
+    UARTBB_0_PIN_TX:
+        description: 'TX pin for UARTBB0'
+        value: -1
+    UARTBB_0_PIN_RX:
+        description: 'RX pin for UARTBB0'
+        value: -1
 
-pkg.init:
-    uart_bitbang_pkg_init: 'MYNEWT_VAL(UARTBB_SYSINIT_STAGE)'
+syscfg.restrictions:
+    - (UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0)


### PR DESCRIPTION
Recently all peripheral device creation code was moved from hw/bsp/board/src/hal_bsp.c to hw/mcu/manuf/variant/src/mcu_periph.c. This prevents replicating code throughout BSPs.
This PR moves soft peripheral(i.e. soft pwm, uart bb) code to hw/mcu. 