### PR TITLE
Add callbacks for __assert_func() & hal_system_reset() instead of the macros

### DIFF
--- a/hw/hal/include/hal/hal_system.h
+++ b/hw/hal/include/hal/hal_system.h
@@ -91,6 +91,11 @@ const char *hal_reset_cause_str(void);
  */
 void hal_system_clock_start(void);
 
+/**
+ * Reset callback to be called before an reset happens inside hal_system_reset()
+ */
+void hal_system_reset_cb(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -33,6 +33,10 @@ syscfg.defs:
             buffer of this size is allocated on the stack during verify
             operations.
         value: 16
+    HAL_SYSTEM_RESET_CB:
+        description: >
+            If set, hal system reset callback gets called inside hal_system_reset().
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     HAL_FLASH_VERIFY_WRITES: 1

--- a/hw/mcu/ambiq/apollo2/src/hal_system.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_system.c
@@ -32,6 +32,11 @@ hal_system_init(void)
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             /*

--- a/hw/mcu/arc/snps/src/hal_system.c
+++ b/hw/mcu/arc/snps/src/hal_system.c
@@ -38,6 +38,11 @@ hal_system_init(void)
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             /*

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -65,6 +65,11 @@ hal_system_init(void)
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             asm("bkpt");

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_system.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_system.c
@@ -23,6 +23,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     /* Unlock sequence */
     SYSKEY = 0x00000000;
     SYSKEY = 0xAA996655;

--- a/hw/mcu/microchip/pic32mz2048efg100/src/hal_system.c
+++ b/hw/mcu/microchip/pic32mz2048efg100/src/hal_system.c
@@ -24,6 +24,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     /* Unlock sequence */
     SYSKEY = 0x00000000;
     SYSKEY = 0xAA996655;

--- a/hw/mcu/mips/danube/src/hal_system.c
+++ b/hw/mcu/mips/danube/src/hal_system.c
@@ -24,6 +24,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
     }
 }

--- a/hw/mcu/native/src/hal_system.c
+++ b/hw/mcu/native/src/hal_system.c
@@ -31,6 +31,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
 #if MYNEWT_VAL(SELFTEST)
     /* Don't hang in the middle of a unit test. */
     assert(0);

--- a/hw/mcu/nordic/nrf51xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_system.c
@@ -44,6 +44,11 @@ hal_system_init(void)
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         NVIC_SystemReset();
     }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -46,6 +46,11 @@ hal_system_init(void)
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             /*

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -21,10 +21,6 @@
 #include "hal/hal_system.h"
 #include "nrf.h"
 
-#ifdef MYNEWT_VAL_MCU_PRE_BKPT_CB
-extern void MYNEWT_VAL(MCU_PRE_BKPT_CB)(void);
-#endif
-
 /**
  * Function called at startup. Called after BSS and .data initialized but
  * prior to the _start function.
@@ -56,10 +52,6 @@ hal_system_reset(void)
             /*
              * If debugger is attached, breakpoint here.
              */
-#ifdef MYNEWT_VAL_MCU_PRE_BKPT_CB
-            MYNEWT_VAL(MCU_PRE_BKPT_CB)();
-#endif
-
 #if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
             asm("bkpt");
 #endif

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -78,13 +78,6 @@ syscfg.defs:
             the breakpoint wherever it gets called, For example, reset and crash
        value: 0
 
-    MCU_PRE_BKPT_CB:
-       description: >
-            A callback which needs to get called before bkpt instruction is
-            executed, when a reset happens or when assert happens when the
-            debugger is connected.
-       value:
-
 # MCU peripherals definitions
     I2C_0:
         description: 'Enable nRF52xxx I2C (TWI) 0'

--- a/hw/mcu/nxp/MK64F12/src/hal_system.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_system.c
@@ -27,6 +27,11 @@ int hal_debugger_connected(void)
 
 void hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             /*

--- a/hw/mcu/nxp/mkw41z/src/hal_system.c
+++ b/hw/mcu/nxp/mkw41z/src/hal_system.c
@@ -23,6 +23,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         NVIC_SystemReset();
     }

--- a/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.c
+++ b/hw/mcu/nxp/src/ext/sdk-2.0-frdm-k64f_b160321/devices/MK64F12/drivers/fsl_common.c
@@ -45,6 +45,10 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     for (;;)
     {
         __asm("bkpt #0");

--- a/hw/mcu/sifive/fe310/src/hal_system.c
+++ b/hw/mcu/sifive/fe310/src/hal_system.c
@@ -22,6 +22,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while(1) {
         if (hal_debugger_connected()) {
             asm ("ebreak");

--- a/hw/mcu/stm/stm32_common/src/hal_system.c
+++ b/hw/mcu/stm/stm32_common/src/hal_system.c
@@ -24,6 +24,11 @@
 void
 hal_system_reset(void)
 {
+
+#if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
+    hal_system_reset_cb();
+#endif
+
     while (1) {
         if (hal_debugger_connected()) {
             /*

--- a/kernel/os/include/os/arch/common.h
+++ b/kernel/os/include/os/arch/common.h
@@ -70,6 +70,7 @@ os_error_t os_arch_os_start(void);
 void os_set_env(os_stack_t *);
 void os_arch_init_task_stack(os_stack_t *sf);
 void os_default_irq_asm(void);
+void os_assert_cb(void);
 
 #ifdef __cplusplus
 }

--- a/kernel/os/src/arch/arc/os_fault.c
+++ b/kernel/os/src/arch/arc/os_fault.c
@@ -133,6 +133,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     (void)sr;
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -117,6 +117,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
 
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -130,6 +130,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
 
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -147,6 +147,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     log_reboot(&lri);
 #endif
 
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -151,6 +151,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     log_reboot(&lri);
 #endif
 
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
+
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -25,10 +25,6 @@
 #include "hal/hal_system.h"
 #include "os_priv.h"
 
-#ifdef MYNEWT_VAL_MCU_PRE_BKPT_CB
-extern void MYNEWT_VAL(MCU_PRE_BKPT_CB)(void);
-#endif
-
 #if MYNEWT_VAL(OS_COREDUMP)
 #include "coredump/coredump.h"
 #endif
@@ -159,10 +155,6 @@ __assert_func(const char *file, int line, const char *func, const char *e)
        /*
         * If debugger is attached, breakpoint before the trap.
         */
-#ifdef MYNEWT_VAL_MCU_PRE_BKPT_CB
-       MYNEWT_VAL(MCU_PRE_BKPT_CB)();
-#endif
-
 #if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
        asm("bkpt");
 #endif

--- a/kernel/os/src/arch/cortex_m7/os_fault.c
+++ b/kernel/os/src/arch/cortex_m7/os_fault.c
@@ -130,6 +130,10 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
 
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
+
     if (hal_debugger_connected()) {
        /*
         * If debugger is attached, breakpoint before the trap.

--- a/kernel/os/src/arch/mips/os_fault.c
+++ b/kernel/os/src/arch/mips/os_fault.c
@@ -31,5 +31,9 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
 
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
+
     hal_system_reset();
 }

--- a/kernel/os/src/arch/pic32/os_fault.c
+++ b/kernel/os/src/arch/pic32/os_fault.c
@@ -31,5 +31,9 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     (void)sr;
     console_blocking_mode();
     OS_PRINT_ASSERT(file, line, func, e);
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     hal_system_reset();
 }

--- a/kernel/os/src/arch/rv32imac/os_fault.c
+++ b/kernel/os/src/arch/rv32imac/os_fault.c
@@ -28,7 +28,11 @@
 void
 __assert_func(const char *file, int line, const char *func, const char *e)
 {
+
     OS_PRINT_ASSERT(file, line, func, e);
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     _exit(1);
 }
 

--- a/kernel/os/src/arch/sim-armv7/os_arch.c
+++ b/kernel/os/src/arch/sim-armv7/os_arch.c
@@ -90,6 +90,10 @@ os_tick_idle(os_time_t ticks)
 void
 __assert_func(const char *file, int line, const char *func, const char *e)
 {
+
     OS_PRINT_ASSERT_SIM(file, line, func, e);
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     _Exit(1);
 }

--- a/kernel/os/src/arch/sim-mips/os_arch.c
+++ b/kernel/os/src/arch/sim-mips/os_arch.c
@@ -90,6 +90,10 @@ os_tick_idle(os_time_t ticks)
 void
 __assert_func(const char *file, int line, const char *func, const char *e)
 {
+
     OS_PRINT_ASSERT_SIM(file, line, func, e);
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     _Exit(1);
 }

--- a/kernel/os/src/arch/sim/os_arch.c
+++ b/kernel/os/src/arch/sim/os_arch.c
@@ -90,6 +90,10 @@ os_tick_idle(os_time_t ticks)
 void
 __assert_func(const char *file, int line, const char *func, const char *e)
 {
+
     OS_PRINT_ASSERT_SIM(file, line, func, e);
+#if MYNEWT_VAL(OS_ASSERT_CB)
+    os_assert_cb();
+#endif
     _Exit(1);
 }

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -171,6 +171,10 @@ syscfg.defs:
         description: >
             Sysinit stage for the Mynewt kernel.
         value: 0
+    OS_ASSERT_CB:
+        description: >
+            If set, assert callback gets called inside __assert_func()
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1


### PR DESCRIPTION
- These are non-runtime callbacks and hence do not have registration
APIs
- They are controlled by HAL_SYSTEM_RESET_CB and OS_ASSERT_CB
- The name of teh callabcks that should be defined in the BSP that needs
to utilize it are hal_system_reset_cb() and os_assert_cb()
- Removing MCU_PRE_BKPT_CB() macro