### PR TITLE
Reduce LOG_LEVEL_MAX to 15 (was: 255)

### DIFF
--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -43,7 +43,7 @@ struct log;
 #define LOG_LEVEL_ERROR    (3)
 #define LOG_LEVEL_CRITICAL (4)
 /* Up to 7 custom log levels. */
-#define LOG_LEVEL_MAX      (UINT8_MAX)
+#define LOG_LEVEL_MAX      (15)
 
 #define LOG_LEVEL_STR(level) \
     (LOG_LEVEL_DEBUG    == level ? "DEBUG"    :\
@@ -83,7 +83,7 @@ struct log;
 #define LOG_NAME_MAX_LEN    (64)
 
 #ifndef MYNEWT_VAL_LOG_LEVEL
-#define LOG_SYSLEVEL    ((uint8_t)0xff)
+#define LOG_SYSLEVEL    ((uint8_t)LOG_LEVEL_MAX)
 #else
 #define LOG_SYSLEVEL    ((uint8_t)MYNEWT_VAL_LOG_LEVEL)
 #endif

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_level.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_level.c
@@ -60,9 +60,10 @@ TEST_CASE_SELF(log_test_case_level)
         TEST_ASSERT(log_level_get(i) == 0);
     }
 
-    /* Level too great. */
-    rc = log_level_set(100, 16);
-    TEST_ASSERT(rc == SYS_EINVAL);
+    /* Level too great.  Ensure saturation at LOG_LEVEL_MAX. */
+    rc = log_level_set(100, LOG_LEVEL_MAX + 1);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(log_level_get(100) == LOG_LEVEL_MAX);
 
     /* Ensure all modules can be configured. */
     for (i = 0; i < 256; i++) {

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -341,6 +341,10 @@ log_register(char *name, struct log *log, const struct log_handler *lh,
 
     assert(!log_written);
 
+    if (level > LOG_LEVEL_MAX) {
+        level = LOG_LEVEL_MAX;
+    }
+
     log->l_name = name;
     log->l_log = lh;
     log->l_arg = arg;
@@ -442,6 +446,10 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     if (log->l_name == NULL || log->l_log == NULL) {
         rc = -1;
         goto err;
+    }
+
+    if (level > LOG_LEVEL_MAX) {
+        level = LOG_LEVEL_MAX;
     }
 
     if (log->l_log->log_type == LOG_TYPE_STORAGE) {

--- a/sys/log/full/src/log_level.c
+++ b/sys/log/full/src/log_level.c
@@ -47,8 +47,8 @@ log_level_set(uint8_t module, uint8_t level)
 {
     uint8_t *byte;
 
-    if (level > 0x0f) {
-        return SYS_EINVAL;
+    if (level > LOG_LEVEL_MAX) {
+        level = LOG_LEVEL_MAX;
     }
 
     byte = &log_level_map[module / 2];


### PR DESCRIPTION
This change patches an inconsistency in the log API.  Most of the log API allowed a log level up to 255.  However, the `log_level_get()` and `log_level_set()` functions limited the max level to 15.  These latter function imposed this limit to save RAM (fit 256 levels in 128 bytes; one per nibble).

I think 16 log levels is plenty.  Currently we use five:
```
#define LOG_LEVEL_DEBUG    (0)
#define LOG_LEVEL_INFO     (1)
#define LOG_LEVEL_WARN     (2)
#define LOG_LEVEL_ERROR    (3)
#define LOG_LEVEL_CRITICAL (4)
```

With the maximum log level reduced, log level arguments saturate at 15.  I.e., if you pass 255 to a log function, it gets converted to 15.  This is done to maintain backwards compatibility.
