### PR TITLE
Fix build errors (missing includes)

### DIFF
--- a/hw/mcu/ambiq/apollo2/src/hal_system.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_system.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdint.h>
+#include "os/mynewt.h"
 #include "mcu/cortex_m4.h"
 #include "hal/hal_system.h"
 #include "am_mcu_apollo.h"

--- a/hw/mcu/nxp/MK64F12/src/hal_system.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_system.c
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-#include <mcu/cortex_m4.h>
+#include "os/mynewt.h"
+#include "mcu/cortex_m4.h"
 #include "hal/hal_system.h"
 
 int hal_debugger_connected(void)

--- a/hw/mcu/nxp/mkw41z/src/hal_system.c
+++ b/hw/mcu/nxp/mkw41z/src/hal_system.c
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-#include <mcu/cortex_m0.h>
+#include "os/mynewt.h"
+#include "mcu/cortex_m0.h"
 #include "hal/hal_system.h"
 
 void


### PR DESCRIPTION
It seems a recent PR broke a few targets.  This PR gets CI passing again.