### PR TITLE
[STM32] SPI - fix usage of unitialized variable

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -926,6 +926,7 @@ uint16_t hal_spi_tx_val(int spi_num, uint16_t val)
     }
     __HAL_DISABLE_INTERRUPTS(sr);
     spi_stat.tx++;
+    retval = 0;
     rc = HAL_SPI_TransmitReceive(&spi->handle,(uint8_t *)&val,
                                  (uint8_t *)&retval, len,
                                  STM32_HAL_SPI_TIMEOUT);


### PR DESCRIPTION
When doing an 8-byte SPI transfer the high byte of the uint16_t return variable was never initialized and could return to the caller whatever was on the stack. This initializes the variable before doing the SPI
transfer.

This issue was first reported here: https://twitter.com/MisterTechBlog/status/1121373727193649152