### PR TITLE
hw/mcu/dialog: Enable DCDC only when VBAT is OK

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -122,20 +122,33 @@ da1469x_prail_dcdc_enable(void)
     DCDC->DCDC_V14_REG |= DCDC_DCDC_VDD_REG_DCDC_VDD_ENABLE_HV_Msk;
     DCDC->DCDC_V14_REG |= DCDC_DCDC_VDD_REG_DCDC_VDD_ENABLE_LV_Msk;
 
-    DCDC->DCDC_CTRL1_REG |= DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
-
     da1469x_retreg_init(g_mcu_dcdc_config, ARRAY_SIZE(g_mcu_dcdc_config));
     da1469x_retreg_assign(&g_mcu_dcdc_config[0], &DCDC->DCDC_V18_REG);
     da1469x_retreg_assign(&g_mcu_dcdc_config[1], &DCDC->DCDC_V18P_REG);
     da1469x_retreg_assign(&g_mcu_dcdc_config[2], &DCDC->DCDC_VDD_REG);
     da1469x_retreg_assign(&g_mcu_dcdc_config[3], &DCDC->DCDC_V14_REG);
     da1469x_retreg_assign(&g_mcu_dcdc_config[4], &DCDC->DCDC_CTRL1_REG);
+
+    /*
+     * Enabling DCDC while VBAT is below 2.5 V renders system unstable even
+     * if VBUS is available. Enable DCDC only if VBAT is above minimal value.
+     */
+    if (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_COMP_VBAT_HIGH_Msk) {
+        DCDC->DCDC_CTRL1_REG |= DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
+    }
 }
 
 void
 da1469x_prail_dcdc_restore(void)
 {
-    da1469x_retreg_restore(g_mcu_dcdc_config, ARRAY_SIZE(g_mcu_dcdc_config));
+    /*
+     * Enabling DCDC while VBAT is below 2.5 V renders system unstable even
+     * if VBUS is available. Enable DCDC only if VBAT is above minimal value.
+     */
+    if (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_COMP_VBAT_HIGH_Msk) {
+        da1469x_retreg_restore(g_mcu_dcdc_config, ARRAY_SIZE(g_mcu_dcdc_config));
+        DCDC->DCDC_CTRL1_REG |= DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
+    }
 }
 #endif
 


### PR DESCRIPTION
Enabling DCDC converter when battery level is low results
in instant reboot even when VBUS is present.
This would make it impossible to charge battery if it drops
below critical level.