### PR TITLE
kernel/os: Assert that eventq is valid before put

### DIFF
--- a/kernel/os/src/os_eventq.c
+++ b/kernel/os/src/os_eventq.c
@@ -46,6 +46,8 @@ os_eventq_put(struct os_eventq *evq, struct os_event *ev)
     int resched;
     os_sr_t sr;
 
+    assert(evq != NULL && os_eventq_inited(evq));
+
     os_trace_api_u32x2(OS_TRACE_ID_EVENTQ_PUT, (uint32_t)evq, (uint32_t)ev);
 
     OS_ENTER_CRITICAL(sr);

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -28,14 +28,16 @@
 
 struct conf_handler_head conf_handlers;
 
-static os_event_fn conf_ev_fn_load;
-
 static struct os_mutex conf_mtx;
+
+#if MYNEWT_VAL(OS_SCHEDULING)
+static os_event_fn conf_ev_fn_load;
 
 /* OS event - causes persisted config values to be loaded at startup. */
 static struct os_event conf_ev_load = {
     .ev_cb = conf_ev_fn_load,
 };
+#endif
 
 void
 conf_init(void)
@@ -62,7 +64,9 @@ conf_init(void)
      * processed.  This gives main() a chance to configure the underlying
      * storage first.
      */
+#if MYNEWT_VAL(OS_SCHEDULING)
     os_eventq_put(os_eventq_dflt_get(), &conf_ev_load);
+#endif
 }
 
 void
@@ -86,11 +90,13 @@ conf_register(struct conf_handler *handler)
     return 0;
 }
 
+#if MYNEWT_VAL(OS_SCHEDULING)
 static void
 conf_ev_fn_load(struct os_event *ev)
 {
     conf_ensure_loaded();
 }
+#endif
 
 /*
  * Find conf_handler based on name.


### PR DESCRIPTION
Trigger a crash if the application attempts to put an event on a null or uninitialized event queue.  Without the assert, both of these conditions can put the system in a strange state: the event "thinks" it is enqueued, but it is not actually present in the eventq's list.  As a consequence, the event never gets processed, and it is impossible to queue the event again because it thinks it is already enqueued.

There is a second change in this PR: `sys/config: Only use the dflt evq if it exists`.  This fixes a bug uncovered by the added assert.  During sysinit, `sys/config` enqueues the conf_load event to the default event queue.  If the app is a boot loader (or other app that doesn't use the scheduler), the default event queue never gets initialized, so this is a bug.  I feel like `sys/config` should not be enqeueing anything to the default event queue, but this is something I added myself, so... I guess it is what it is? :)