### PR TITLE
mcu/fe310: add tickles sleep

### DIFF
--- a/hw/mcu/sifive/fe310/include/mcu/fe310.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1024)
+#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/sifive/fe310/src/hal_os_tick.c
+++ b/hw/mcu/sifive/fe310/src/hal_os_tick.c
@@ -48,12 +48,16 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
 void
 timer_interrupt_handler(void)
 {
+    int delta;
+    int ticks;
     uint64_t time = get_timer_value();
-    int delta = (int)(time - last_tick_time);
-    last_tick_time = time;
 
-    int ticks = delta / ticks_per_ostick;
-    set_mtimecmp(time + ticks_per_ostick);
+    delta = (int)(time - last_tick_time);
+    ticks = (int)(delta / ticks_per_ostick);
+
+    last_tick_time += ticks * ticks_per_ostick;
+
+    set_mtimecmp(last_tick_time + ticks_per_ostick);
 
     os_time_advance(ticks);
 }

--- a/hw/mcu/sifive/fe310/src/hal_os_tick.c
+++ b/hw/mcu/sifive/fe310/src/hal_os_tick.c
@@ -28,11 +28,19 @@ static uint32_t ticks_per_ostick;
 #define RTC_FREQ        32768
 
 uint64_t get_timer_value(void);
+void timer_interrupt_handler(void);
 void set_mtimecmp(uint64_t time);
 
 void
 os_tick_idle(os_time_t ticks)
 {
+    if (MYNEWT_VAL(OS_TICKLESS_SLEEP) && ticks > 1) {
+        set_mtimecmp(last_tick_time + ticks_per_ostick * ticks);
+    }
+    __asm volatile ("wfi");
+    if (MYNEWT_VAL(OS_TICKLESS_SLEEP) && ticks > 1) {
+        timer_interrupt_handler();
+    }
 }
 
 void

--- a/hw/mcu/sifive/fe310/src/hal_system.c
+++ b/hw/mcu/sifive/fe310/src/hal_system.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 
 void

--- a/hw/mcu/sifive/fe310/syscfg.yml
+++ b/hw/mcu/sifive/fe310/syscfg.yml
@@ -70,3 +70,10 @@ syscfg.defs:
     TIMER_2:
         description: 'Whether to use PWM0 8 bit timer as system timer'
         value:  0
+    OS_TICKS_PER_SEC:
+        description: 'Desired ticks frequency in Hz'
+        value: 128
+        range: 128,256,512,1024
+    OS_TICKLESS_SLEEP:
+        description: 'Enable tickless sleep'
+        value: 1


### PR DESCRIPTION
- WFI if present on FE310 now it is used for idle time
- calculation of next tick time is more accurate
- build error fixed