### PR TITLE
Software breakpoints and asserts

### DIFF
--- a/hw/bsp/hifive1/hifive1_debug.sh
+++ b/hw/bsp/hifive1/hifive1_debug.sh
@@ -32,5 +32,6 @@
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f $CORE_PATH/hw/bsp/hifive1/riscv_openocd.cfg"
 GDB=riscv64-unknown-elf-gdb
-
+# Magic value that is checked inside hal_debugger_connected()
+EXTRA_GDB_CMDS="set *0x100000BC=0x5151A2BC"
 openocd_debug

--- a/hw/hal/include/hal/hal_debug.h
+++ b/hw/hal/include/hal/hal_debug.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * @addtogroup HAL
+ * @{
+ *   @defgroup HALDebug HAL Debug
+ *   @{
+ */
+
+#ifndef H_HAL_DEBUG_
+#define H_HAL_DEBUG_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <syscfg/syscfg.h>
+
+#if MYNEWT_VAL(HAL_BREAK_HOOK)
+/* User defined function to be called before code is stopped in debugger */
+void hal_break_hook(void);
+#else
+static inline void hal_break_hook() {}
+#endif
+
+#ifndef HAL_DEBUG_BREAK
+#define HAL_DEBUG_BREAK()                                      \
+        (void)(MYNEWT_VAL(HAL_ENABLE_SOFTWARE_BREAKPOINTS) &&  \
+               hal_debugger_connected() &&                     \
+               (hal_break_hook(), 1) &&                        \
+               (hal_debug_break(), 1))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_HAL_DEBUG_ */
+
+/**
+ *   @} HALDebug
+ * @} HAL
+ */

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -37,6 +37,11 @@ syscfg.defs:
         description: >
             If set, hal system reset callback gets called inside hal_system_reset().
         value: 0
+    HAL_ENABLE_SOFTWARE_BREAKPOINTS:
+        description: >
+            If set to 0 software breakpoints placed with HAL_DEBUG_BREAK macro will not
+            be executed.
+        value: 1
 
 syscfg.vals.OS_DEBUG_MODE:
     HAL_FLASH_VERIFY_WRITES: 1

--- a/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
+++ b/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (128)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/ambiq/apollo2/src/hal_system.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_system.c
@@ -39,12 +39,7 @@ hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            /*
-             * If debugger is attached, breakpoint here.
-             */
-            asm("bkpt");
-        }
+        HAL_DEBUG_BREAK();
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/arc/snps/include/mcu/mcu_arc.h
+++ b/hw/mcu/arc/snps/include/mcu/mcu_arc.h
@@ -20,13 +20,17 @@
 #ifndef __MCU_ARC_H__
 #define __MCU_ARC_H__
 
-#include "os/mynewt.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define OS_TICKS_PER_SEC    (100)
+
+static inline void
+hal_debug_break(void)
+{
+    asm("BRK_S");
+}
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/arc/snps/src/hal_system.c
+++ b/hw/mcu/arc/snps/src/hal_system.c
@@ -44,12 +44,7 @@ hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            /*
-             * If debugger is attached, breakpoint here.
-             */
-            asm("BRK_S");
-        }
+        HAL_DEBUG_BREAK();
 /* TODO: Reset system! */
         //NVIC_SystemReset();
     }

--- a/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
@@ -21,12 +21,19 @@
 #define __MCU_CORTEX_M33_H_
 
 #include "mcu/mcu.h"
+#include "core_cm33.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define OS_TICKS_PER_SEC    (128)
+
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -72,9 +72,7 @@ hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            asm("bkpt");
-        }
+        HAL_DEBUG_BREAK();
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/mips/danube/include/mcu/mips.h
+++ b/hw/mcu/mips/danube/include/mcu/mips.h
@@ -22,4 +22,10 @@
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __asm ("break");
+}
+
 #endif /* __MCU_MIPS_H__ */

--- a/hw/mcu/native/include/mcu/mcu_sim.h
+++ b/hw/mcu/native/include/mcu/mcu_sim.h
@@ -31,6 +31,8 @@ extern const char *native_uart_dev_strs[];
 
 void mcu_sim_parse_args(int argc, char **argv);
 
+void static inline hal_debug_break(void) {}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
@@ -21,6 +21,7 @@
 #define __MCU_CORTEX_M0_H__
 
 #include "nrf51.h"
+#include "core_cm0.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +33,12 @@ extern "C" {
  * cleanly into 32768 to avoid a systemic bias in the actual tick frequency.
  */
 #define OS_TICKS_PER_SEC    (128)
+
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -21,12 +21,22 @@
 #define __MCU_CORTEX_M4_H__
 
 #include "nrf.h"
+#include "core_cm4.h"
+#include <syscfg/syscfg.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define OS_TICKS_PER_SEC    (128)
+
+static inline void
+hal_debug_break(void)
+{
+#if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
+    __BKPT(1);
+#endif
+}
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -18,7 +18,9 @@
  */
 
 #include "syscfg/syscfg.h"
+#include "mcu/cortex_m4.h"
 #include "hal/hal_system.h"
+#include "hal/hal_debug.h"
 #include "nrf.h"
 
 /**
@@ -48,14 +50,7 @@ hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            /*
-             * If debugger is attached, breakpoint here.
-             */
-#if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
-            asm("bkpt");
-#endif
-        }
+        HAL_DEBUG_BREAK();
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
+++ b/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
@@ -32,6 +32,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC	(1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/nxp/MK64F12/src/hal_system.c
+++ b/hw/mcu/nxp/MK64F12/src/hal_system.c
@@ -34,12 +34,7 @@ void hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            /*
-             * If debugger is attached, breakpoint here.
-             */
-            asm("bkpt");
-        }
+        HAL_DEBUG_BREAK();
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/nxp/mkw41z/include/mcu/cortex_m0.h
+++ b/hw/mcu/nxp/mkw41z/include/mcu/cortex_m0.h
@@ -34,6 +34,12 @@ extern "C" {
  */
 #define OS_TICKS_PER_SEC	(1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/sifive/fe310/include/mcu/fe310.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310.h
@@ -32,6 +32,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
 
+static inline void
+hal_debug_break(void)
+{
+    __asm ("ebreak");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/sifive/fe310/src/hal_system.c
+++ b/hw/mcu/sifive/fe310/src/hal_system.c
@@ -19,6 +19,7 @@
 
 #include "os/mynewt.h"
 #include "hal/hal_system.h"
+#include <platform.h>
 
 void
 hal_system_reset(void)
@@ -38,5 +39,9 @@ hal_system_reset(void)
 int
 hal_debugger_connected(void)
 {
-    return 0;
+    /*
+     * This always on domain register is now used to detect debugger
+     * connection. openocd scripts sets magic value 0x5151A2BC when connected.
+     */
+    return AON_REG(AON_BACKUP15) == 0x5151A2BC;
 }

--- a/hw/mcu/sifive/fe310/src/hal_system.c
+++ b/hw/mcu/sifive/fe310/src/hal_system.c
@@ -29,10 +29,8 @@ hal_system_reset(void)
     hal_system_reset_cb();
 #endif
 
-    while(1) {
-        if (hal_debugger_connected()) {
-            asm ("ebreak");
-        }
+    while (1) {
+        HAL_DEBUG_BREAK();
     }
 }
 

--- a/hw/mcu/stm/stm32_common/src/hal_system.c
+++ b/hw/mcu/stm/stm32_common/src/hal_system.c
@@ -30,12 +30,7 @@ hal_system_reset(void)
 #endif
 
     while (1) {
-        if (hal_debugger_connected()) {
-            /*
-             * If debugger is attached, breakpoint here.
-             */
-            asm("bkpt");
-        }
+        HAL_DEBUG_BREAK();
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/stm/stm32f0xx/include/mcu/cortex_m0.h
+++ b/hw/mcu/stm/stm32f0xx/include/mcu/cortex_m0.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f3xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/cortex_m4.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f7xx/include/mcu/cortex_m7.h
+++ b/hw/mcu/stm/stm32f7xx/include/mcu/cortex_m7.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32l0xx/include/mcu/cortex_m0.h
+++ b/hw/mcu/stm/stm32l0xx/include/mcu/cortex_m0.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32l1xx/include/mcu/cortex_m3.h
+++ b/hw/mcu/stm/stm32l1xx/include/mcu/cortex_m3.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32l4xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32l4xx/include/mcu/cortex_m4.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32wbxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32wbxx/include/mcu/cortex_m4.h
@@ -28,6 +28,12 @@ extern "C" {
 
 #define OS_TICKS_PER_SEC    (1000)
 
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/util/break_hook_example/pkg.yml
+++ b/hw/util/break_hook_example/pkg.yml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/util/break_hook_example
+pkg.description: >
+    Break hook example.
+    This package defines HAL_BREAK_HOOK syscfg value which informs HAL_DEBUG_BREAK to
+    use user provided callback before execution stops.
+    Example prints some log. Production code hook should not do any printing it should
+    do minimum to leave platform in safe state before CPU stops.
+
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - break_hook
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/hal"
+
+pkg.req_apis:
+    - console

--- a/hw/util/break_hook_example/src/break_hook_example.c
+++ b/hw/util/break_hook_example/src/break_hook_example.c
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <console/console.h>
+
+void
+hal_break_hook(void)
+{
+    console_printf("hal_break_hook called\n");
+}

--- a/hw/util/break_hook_example/syscfg.yml
+++ b/hw/util/break_hook_example/syscfg.yml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    HAL_BREAK_HOOK:
+        description: >
+            Informs hal that hal_break_hook exists and should be used.
+        value: 1

--- a/kernel/os/include/os/os_fault.h
+++ b/kernel/os/include/os/os_fault.h
@@ -21,6 +21,9 @@
 #define _OS_FAULT_H
 
 #include "syscfg/syscfg.h"
+#include "os/os_arch.h"
+#include "hal/hal_system.h"
+#include "hal/hal_debug.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,9 +33,9 @@ void __assert_func(const char *file, int line, const char *func, const char *e)
     __attribute((noreturn));
 
 #if MYNEWT_VAL(OS_CRASH_FILE_LINE)
-#define OS_CRASH() __assert_func(__FILE__, __LINE__, NULL, NULL)
+#define OS_CRASH() (HAL_DEBUG_BREAK(), __assert_func(__FILE__, __LINE__, NULL, NULL))
 #else
-#define OS_CRASH() __assert_func(NULL, 0, NULL, NULL)
+#define OS_CRASH() (HAL_DEBUG_BREAK(), __assert_func(NULL, 0, NULL, NULL))
 #endif
 
 #ifdef __cplusplus

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -121,12 +121,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 #if MYNEWT_VAL(OS_ASSERT_CB)
     os_assert_cb();
 #endif
-    if (hal_debugger_connected()) {
-       /*
-        * If debugger is attached, breakpoint before the trap.
-        */
-       asm("bkpt");
-    }
+
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;
     /* Exception happens right away. Next line not executed. */
     hal_system_reset();

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -134,12 +134,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 #if MYNEWT_VAL(OS_ASSERT_CB)
     os_assert_cb();
 #endif
-    if (hal_debugger_connected()) {
-       /*
-        * If debugger is attached, breakpoint before the trap.
-        */
-       asm("bkpt");
-    }
+
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;
     asm("isb");
     hal_system_reset();

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -144,12 +144,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 #if MYNEWT_VAL(OS_ASSERT_CB)
     os_assert_cb();
 #endif
-    if (hal_debugger_connected()) {
-       /*
-        * If debugger is attached, breakpoint before the trap.
-        */
-       asm("bkpt");
-    }
+
     SCB->ICSR = SCB_ICSR_PENDNMISET_Msk;
     asm("isb");
     hal_system_reset();

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -151,14 +151,6 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     os_assert_cb();
 #endif
 
-    if (hal_debugger_connected()) {
-       /*
-        * If debugger is attached, breakpoint before the trap.
-        */
-#if !MYNEWT_VAL(MCU_DEBUG_IGNORE_BKPT)
-       asm("bkpt");
-#endif
-    }
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;
     asm("isb");
     hal_system_reset();

--- a/kernel/os/src/arch/cortex_m7/os_fault.c
+++ b/kernel/os/src/arch/cortex_m7/os_fault.c
@@ -134,12 +134,6 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     os_assert_cb();
 #endif
 
-    if (hal_debugger_connected()) {
-       /*
-        * If debugger is attached, breakpoint before the trap.
-        */
-       asm("bkpt");
-    }
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;
     asm("isb");
     hal_system_reset();

--- a/sys/sysinit/include/sysinit/sysinit.h
+++ b/sys/sysinit/include/sysinit/sysinit.h
@@ -67,6 +67,7 @@ void sysinit_panic_set(sysinit_panic_fn *panic_fn);
 #define SYSINIT_PANIC_ASSERT_MSG(rc, msg) do \
 {                                            \
     if (!(rc)) {                             \
+        HAL_DEBUG_BREAK();                   \
         SYSINIT_PANIC_MSG(msg);              \
     }                                        \
 } while (0)


### PR DESCRIPTION
Motivation behind this PR

- When assert fails debugger stops inside __assert_func (not at assert() call) which may
  seem like little problem but when system crashes inside __assert_func finding out
  what happened can be time consuming.
- os_assert_cb() is meant to be called before debugger stops code, in some cases
  __assert_func never reaches that point since if OS_PRINT_ASSERT or log_reboot can stack.
  If os_assert_cb() is meant to be used to prevent time critical hardware protection it should
  be called before.
- Once there is hal_debug_break() definition os_fault could be standard.