### PR TITLE
Shell newtmgr bridge

### DIFF
--- a/encoding/tinycbor/include/tinycbor/cbor.h
+++ b/encoding/tinycbor/include/tinycbor/cbor.h
@@ -215,6 +215,7 @@ CBOR_INLINE_API CborError cbor_encode_double(CborEncoder *encoder, double value)
 
 CBOR_API CborError cbor_encoder_create_array(CborEncoder *encoder, CborEncoder *arrayEncoder, size_t length);
 CBOR_API CborError cbor_encoder_create_map(CborEncoder *encoder, CborEncoder *mapEncoder, size_t length);
+CBOR_API CborError cbor_encoder_create_indef_text_string(CborEncoder *encoder, CborEncoder *stringEncoder);
 CBOR_API CborError cbor_encoder_create_indef_byte_string(CborEncoder *encoder, CborEncoder *stringEncoder);
 CBOR_API CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *containerEncoder);
 CBOR_API CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborEncoder *containerEncoder);

--- a/encoding/tinycbor/src/cborencoder.c
+++ b/encoding/tinycbor/src/cborencoder.c
@@ -522,6 +522,20 @@ CborError cbor_encoder_create_map(CborEncoder *encoder, CborEncoder *mapEncoder,
 }
 
 /**
+ * Creates a indefinite-length text string in the CBOR stream provided by
+ * \a encoder and initializes \a stringEncoder so that chunks of original string
+ * can be added using the CborEncoder functions. The string must be terminated by
+ * calling cbor_encoder_close_container() with the same \a encoder and
+ * \a stringEncoder parameters.
+ *
+ * \sa cbor_encoder_create_array
+ */
+CborError cbor_encoder_create_indef_text_string(CborEncoder *encoder, CborEncoder *stringEncoder)
+{
+    return create_container(encoder, stringEncoder, CborIndefiniteLength, TextStringType << MajorTypeShift);
+}
+
+/**
  * Creates a indefinite-length byte string in the CBOR stream provided by
  * \a encoder and initializes \a stringEncoder so that chunks of original string
  * can be added using the CborEncoder functions. The string must be terminated by

--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -476,12 +476,12 @@ err:
 
 static const struct shell_cmd bat_cli_commands[] =
 {
-    { "read", cmd_bat_read, HELP(bat_read_help) },
-    { "write", cmd_bat_write, HELP(bat_write_help) },
-    { "list", cmd_bat_list, HELP(bat_list_help) },
-    { "pollrate", cmd_bat_poll_rate, HELP(bat_poll_rate_help) },
-    { "monitor", cmd_bat_monitor, HELP(bat_monitor_help) },
-    { NULL, NULL, NULL }
+    SHELL_CMD("read", cmd_bat_read, &bat_read_help),
+    SHELL_CMD("write", cmd_bat_write, &bat_write_help),
+    SHELL_CMD("list", cmd_bat_list, &bat_list_help),
+    SHELL_CMD("pollrate", cmd_bat_poll_rate, &bat_poll_rate_help),
+    SHELL_CMD("monitor", cmd_bat_monitor, &bat_monitor_help),
+    { 0 },
 };
 
 /**

--- a/kernel/os/include/os/os_error.h
+++ b/kernel/os/include/os/os_error.h
@@ -45,6 +45,16 @@ enum os_error {
 
 typedef enum os_error os_error_t;
 
+/**
+ * @brief Converts an OS error code (`OS_[...]`) to an equivalent system error
+ * code (`SYS_E[...]`).
+ *
+ * @param os_error              The OS error code to convert.
+ *
+ * @return                      The equivalent system error code.
+ */
+int os_error_to_sys(os_error_t os_error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/os/src/os_error.c
+++ b/kernel/os/src/os_error.c
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "defs/error.h"
+#include "os/os_error.h"
+
+int
+os_error_to_sys(os_error_t os_error)
+{
+    switch (os_error) {
+        case OS_OK:             return SYS_EOK;
+        case OS_ENOMEM:         return SYS_ENOMEM; 
+        case OS_EINVAL:         return SYS_EINVAL; 
+        case OS_INVALID_PARM:   return SYS_EINVAL; 
+        case OS_TIMEOUT:        return SYS_ETIMEOUT; 
+        case OS_ENOENT:         return SYS_ENOENT; 
+        case OS_EBUSY:          return SYS_EBUSY; 
+        default:                return SYS_EUNKNOWN;
+    }
+}

--- a/mgmt/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/mgmt/include/mgmt/mgmt.h
@@ -58,6 +58,7 @@ extern "C" {
 #define MGMT_GROUP_ID_SPLIT     (6)
 #define MGMT_GROUP_ID_RUN       (7)
 #define MGMT_GROUP_ID_FS        (8)
+#define MGMT_GROUP_ID_SHELL     (9)
 #define MGMT_GROUP_ID_PERUSER   (64)
 
 /**

--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -63,6 +63,7 @@ void console_blocking_mode(void);
 void console_non_blocking_mode(void);
 void console_echo(int on);
 
+int console_vprintf(const char *fmt, va_list ap);
 int console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;
 

--- a/sys/console/full/src/console_fmt.c
+++ b/sys/console/full/src/console_fmt.c
@@ -24,21 +24,11 @@
 
 #define CONS_OUTPUT_MAX_LINE    128
 
-
 #if MYNEWT_VAL(BASELIBC_PRESENT)
 
-/**
- * Prints the specified format string to the console.
- *
- * @return                      The number of characters that would have been
- *                                  printed if the console buffer were
- *                                  unlimited.  This return value is analogous
- *                                  to that of snprintf.
- */
 int
-console_printf(const char *fmt, ...)
+console_vprintf(const char *fmt, va_list ap)
 {
-    va_list args;
     int num_chars;
 
     num_chars = 0;
@@ -50,28 +40,16 @@ console_printf(const char *fmt, ...)
         }
     }
 
-    va_start(args, fmt);
-    num_chars += vprintf(fmt, args);
-    va_end(args);
+    num_chars += vprintf(fmt, ap);
 
     return num_chars;
 }
 
-
 #else
 
-/**
- * Prints the specified format string to the console.
- *
- * @return                      The number of characters that would have been
- *                                  printed if the console buffer were
- *                                  unlimited.  This return value is analogous
- *                                  to that of snprintf.
- */
 int
-console_printf(const char *fmt, ...)
+console_vprintf(const char *fmt, va_list ap)
 {
-    va_list args;
     char buf[CONS_OUTPUT_MAX_LINE];
     int num_chars;
     int len;
@@ -88,15 +66,35 @@ console_printf(const char *fmt, ...)
         }
     }
 
-    va_start(args, fmt);
-    len = vsnprintf(buf, sizeof(buf), fmt, args);
+    len = vsnprintf(buf, sizeof(buf), fmt, ap);
     num_chars += len;
     if (len >= sizeof(buf)) {
         len = sizeof(buf) - 1;
     }
     console_write(buf, len);
+
+    return num_chars;
+}
+
+#endif
+
+/**
+ * Prints the specified format string to the console.
+ *
+ * @return                      The number of characters that would have been
+ *                                  printed if the console buffer were
+ *                                  unlimited.  This return value is analogous
+ *                                  to that of snprintf.
+ */
+int
+console_printf(const char *fmt, ...)
+{
+    va_list args;
+    int num_chars;
+
+    va_start(args, fmt);
+    num_chars = console_vprintf(fmt, args);
     va_end(args);
 
     return num_chars;
 }
-#endif

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -47,6 +47,12 @@ void console_blocking_mode(void);
 void console_non_blocking_mode(void);
 void console_echo(int on);
 
+static int inline
+console_vprintf(const char *fmt, va_list ap)
+{
+    return 0;
+}
+
 static int console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));;
 static int inline

--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -86,6 +86,12 @@ console_echo(int on)
 {
 }
 
+static int inline
+console_vprintf(const char *fmt, va_list ap)
+{
+    return 0;
+}
+
 static int inline console_printf(const char *fmt, ...)
     __attribute__ ((format (printf, 1, 2)));
 

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -26,6 +26,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/time/datetime"
+    - "@apache-mynewt-core/util/streamer"
 
 pkg.deps.SHELL_NEWTMGR:
     - "@apache-mynewt-core/mgmt/mgmt"

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -33,6 +33,9 @@ pkg.deps.SHELL_NEWTMGR:
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/util/crc"
 
+pkg.deps.SHELL_BRIDGE:
+    - "@apache-mynewt-core/encoding/tinycbor"
+
 pkg.req_apis:
     - console
 

--- a/sys/shell/src/shell_bridge.c
+++ b/sys/shell/src/shell_bridge.c
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(SHELL_BRIDGE)
+
+#include "mgmt/mgmt.h"
+#include "cborattr/cborattr.h"
+#include "streamer/streamer.h"
+#include "tinycbor/cbor_mbuf_writer.h"
+#include "shell_priv.h"
+
+static struct mgmt_group shell_bridge_group;
+
+static int shell_bridge_exec(struct mgmt_cbuf *cb);
+
+static struct mgmt_handler shell_bridge_group_handlers[] = {
+    [SHELL_NMGR_OP_EXEC] = { NULL, shell_bridge_exec },
+};
+
+/**
+ * Handler for the `shell exec` newtmgr command.
+ */
+static int
+shell_bridge_exec(struct mgmt_cbuf *cb)
+{
+    char line[MYNEWT_VAL(SHELL_BRIDGE_MAX_IN_LEN)];
+    char *argv[MYNEWT_VAL(SHELL_CMD_ARGC_MAX)];
+    struct shell_bridge_streamer sbs;
+    CborEncoder str_encoder;
+    CborError err;
+    int argc;
+    int rc;
+
+    const struct cbor_attr_t attrs[] = {
+        {
+            .attribute = "argv",
+            .type = CborAttrArrayType,
+            .addr.array = {
+                .element_type = CborAttrTextStringType,
+                .arr.strings.ptrs = argv,
+                .arr.strings.store = line,
+                .arr.strings.storelen = sizeof line,
+                .count = &argc,
+                .maxlen = sizeof argv / sizeof argv[0],
+            },
+        },
+        { 0 },
+    };
+
+    err = cbor_read_object(&cb->it, attrs);
+    if (err != 0) {
+        return MGMT_ERR_EINVAL;
+    }
+
+    /* Key="o"; value=<command-output> */
+    err |= cbor_encode_text_stringz(&cb->encoder, "o");
+    err |= cbor_encoder_create_indef_text_string(&cb->encoder, &str_encoder);
+
+    shell_bridge_streamer_new(&sbs, &str_encoder);
+    rc = shell_exec(argc, argv, &sbs.streamer);
+
+    err |= cbor_encoder_close_container(&cb->encoder, &str_encoder);
+
+    /* Key="rc"; value=<status> */
+    err |= cbor_encode_text_stringz(&cb->encoder, "rc");
+    err |= cbor_encode_int(&cb->encoder, rc);
+
+    if (err != 0) {
+        return MGMT_ERR_ENOMEM;
+    }
+
+    return 0;
+}
+
+int
+shell_bridge_init(void)
+{
+    int rc;
+
+    MGMT_GROUP_SET_HANDLERS(&shell_bridge_group, shell_bridge_group_handlers);
+    shell_bridge_group.mg_group_id = MGMT_GROUP_ID_SHELL;
+
+    rc = mgmt_group_register(&shell_bridge_group);
+    if (rc) {
+        return rc;
+    }
+
+    return 0;
+}
+
+#endif

--- a/sys/shell/src/shell_bridge_streamer.c
+++ b/sys/shell/src/shell_bridge_streamer.c
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(SHELL_BRIDGE)
+
+#include "tinycbor/cbor.h"
+#include "shell_priv.h"
+
+static int
+shell_bridge_streamer_write(struct streamer *streamer,
+                            const void *src, size_t len)
+{
+    struct shell_bridge_streamer *sbs;
+    int err;
+
+    sbs = (struct shell_bridge_streamer *)streamer;
+
+    /* Encode the data as a CBOR text string. */
+    err = cbor_encode_text_string(sbs->str_encoder, src, len);
+    if (err != 0) {
+        return SYS_ENOMEM;
+    }
+
+    return 0;
+}
+
+static int
+shell_bridge_streamer_vprintf(struct streamer *streamer,
+                              const char *fmt, va_list ap)
+{
+    char buf[MYNEWT_VAL(SHELL_BRIDGE_PRINTF_LEN)];
+    int num_chars;
+    int rc;
+
+    num_chars = vsnprintf(buf, sizeof buf, fmt, ap);
+    if (num_chars > sizeof buf - 1) {
+        num_chars = sizeof buf - 1;
+    }
+
+    rc = shell_bridge_streamer_write(streamer, buf, num_chars);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return num_chars;
+}
+
+static const struct streamer_cfg shell_bridge_streamer_cfg = {
+    .write_cb = shell_bridge_streamer_write,
+    .vprintf_cb = shell_bridge_streamer_vprintf,
+};
+
+void
+shell_bridge_streamer_new(struct shell_bridge_streamer *sbs,
+                          struct CborEncoder *str_encoder)
+{
+    *sbs = (struct shell_bridge_streamer) {
+        .streamer.cfg = &shell_bridge_streamer_cfg,
+        .str_encoder = str_encoder,
+    };
+}
+
+#endif

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -26,13 +26,15 @@
 
 #include "hal/hal_system.h"
 #include "hal/hal_nvreg.h"
+#include "streamer/streamer.h"
 #include "shell/shell.h"
 #include "shell_priv.h"
 
 #define SHELL_OS "os"
 
-int
-shell_os_tasks_display_cmd(int argc, char **argv)
+static int
+shell_os_tasks_display_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                           struct streamer *streamer)
 {
     struct os_task *prev_task;
     struct os_task_info oti;
@@ -46,9 +48,9 @@ shell_os_tasks_display_cmd(int argc, char **argv)
         name = argv[1];
     }
 
-    console_printf("Tasks: \n");
+    streamer_printf(streamer, "Tasks: \n");
     prev_task = NULL;
-    console_printf("%8s %3s %3s %8s %8s %8s %8s %8s %8s %3s\n",
+    streamer_printf(streamer, "%8s %3s %3s %8s %8s %8s %8s %8s %8s %3s\n",
       "task", "pri", "tid", "runtime", "csw", "stksz", "stkuse",
       "lcheck", "ncheck", "flg");
     while (1) {
@@ -65,7 +67,7 @@ shell_os_tasks_display_cmd(int argc, char **argv)
             }
         }
 
-        console_printf("%8s %3u %3u %8lu %8lu %8u %8u %8lu %8lu\n",
+        streamer_printf(streamer, "%8s %3u %3u %8lu %8lu %8u %8u %8lu %8lu\n",
                 oti.oti_name, oti.oti_prio, oti.oti_taskid,
                 (unsigned long)oti.oti_runtime, (unsigned long)oti.oti_cswcnt,
                 oti.oti_stksize, oti.oti_stkusage,
@@ -75,14 +77,15 @@ shell_os_tasks_display_cmd(int argc, char **argv)
     }
 
     if (name && !found) {
-        console_printf("Couldn't find task with name %s\n", name);
+        streamer_printf(streamer, "Couldn't find task with name %s\n", name);
     }
 
     return 0;
 }
 
 int
-shell_os_mpool_display_cmd(int argc, char **argv)
+shell_os_mpool_display_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                           struct streamer *streamer)
 {
     struct os_mempool *mp;
     struct os_mempool_info omi;
@@ -96,10 +99,10 @@ shell_os_mpool_display_cmd(int argc, char **argv)
         name = argv[1];
     }
 
-    console_printf("Mempools: \n");
+    streamer_printf(streamer, "Mempools: \n");
     mp = NULL;
-    console_printf("%32s %5s %4s %4s %4s\n", "name", "blksz", "cnt", "free",
-                   "min");
+    streamer_printf(streamer, "%32s %5s %4s %4s %4s\n",
+                    "name", "blksz", "cnt", "free", "min");
     while (1) {
         mp = os_mempool_info_get_next(mp, &omi);
         if (mp == NULL) {
@@ -114,13 +117,13 @@ shell_os_mpool_display_cmd(int argc, char **argv)
             }
         }
 
-        console_printf("%32s %5d %4d %4d %4d\n", omi.omi_name,
+        streamer_printf(streamer, "%32s %5d %4d %4d %4d\n", omi.omi_name,
                        omi.omi_block_size, omi.omi_num_blocks,
                        omi.omi_num_free, omi.omi_min_free);
     }
 
     if (name && !found) {
-        console_printf("Couldn't find a memory pool with name %s\n",
+        streamer_printf(streamer, "Couldn't find a memory pool with name %s\n",
                 name);
     }
 
@@ -128,7 +131,8 @@ shell_os_mpool_display_cmd(int argc, char **argv)
 }
 
 int
-shell_os_date_cmd(int argc, char **argv)
+shell_os_date_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                  struct streamer *streamer)
 {
     int rc;
 #if MYNEWT_VAL(SHELL_OS_DATETIME_CMD)
@@ -146,7 +150,7 @@ shell_os_date_cmd(int argc, char **argv)
         assert(rc == 0);
         rc = datetime_format(&tv, &tz, buf, sizeof(buf));
         assert(rc == 0);
-        console_printf("%s\n", buf);
+        streamer_printf(streamer, "%s\n", buf);
 #endif
     } else if (argc == 1) {
 #if (MYNEWT_VAL(SHELL_OS_DATETIME_CMD) & 2) == 2
@@ -155,7 +159,7 @@ shell_os_date_cmd(int argc, char **argv)
         if (rc == 0) {
             rc = os_settimeofday(&tv, &tz);
         } else {
-            console_printf("Invalid datetime\n");
+            streamer_printf(streamer, "Invalid datetime\n");
         }
 #endif
     } else {
@@ -166,13 +170,14 @@ shell_os_date_cmd(int argc, char **argv)
 }
 
 int
-shell_os_reset_cmd(int argc, char **argv)
+shell_os_reset_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                   struct streamer *streamer)
 {
 #if MYNEWT_VAL(SHELL_OS_SERIAL_BOOT_NVREG)
     if (argc == 2 && !strcmp(argv[1], "serial_boot")) {
         hal_nvreg_write(MYNEWT_VAL(BOOT_SERIAL_NVREG_INDEX),
                         MYNEWT_VAL(BOOT_SERIAL_NVREG_MAGIC));
-        console_printf("serial_boot mode\n");
+        streamer_printf(streamer, "serial_boot mode\n");
     }
 #endif
     os_time_delay(OS_TICKS_PER_SEC / 10);
@@ -183,16 +188,20 @@ shell_os_reset_cmd(int argc, char **argv)
 static int
 shell_os_ls_dev(struct os_dev *dev, void *arg)
 {
-    console_printf("%4d %3x %s\n",
-                   dev->od_open_ref, dev->od_flags, dev->od_name);
+    struct streamer *streamer;
+
+    streamer = arg;
+    streamer_printf(streamer, "%4d %3x %s\n",
+                    dev->od_open_ref, dev->od_flags, dev->od_name);
     return 0;
 }
 
 int
-shell_os_ls_dev_cmd(int argc, char **argv)
+shell_os_ls_dev_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                    struct streamer *streamer)
 {
-    console_printf("%4s %3s %s\n", "ref", "flg", "name");
-    os_dev_walk(shell_os_ls_dev, NULL);
+    streamer_printf(streamer, "%4s %3s %s\n", "ref", "flg", "name");
+    os_dev_walk(shell_os_ls_dev, streamer);
     return 0;
 }
 
@@ -253,42 +262,12 @@ static const struct shell_cmd_help ls_dev_help = {
 #endif
 
 static const struct shell_cmd os_commands[] = {
-    {
-        .sc_cmd = "tasks",
-        .sc_cmd_func = shell_os_tasks_display_cmd,
-#if MYNEWT_VAL(SHELL_CMD_HELP)
-        .help = &tasks_help,
-#endif
-    },
-    {
-        .sc_cmd = "mpool",
-        .sc_cmd_func = shell_os_mpool_display_cmd,
-#if MYNEWT_VAL(SHELL_CMD_HELP)
-        .help = &mpool_help,
-#endif
-    },
-    {
-        .sc_cmd = "date",
-        .sc_cmd_func = shell_os_date_cmd,
-#if MYNEWT_VAL(SHELL_CMD_HELP)
-        .help = &date_help,
-#endif
-    },
-    {
-        .sc_cmd = "reset",
-        .sc_cmd_func = shell_os_reset_cmd,
-#if MYNEWT_VAL(SHELL_CMD_HELP)
-        .help = &reset_help,
-#endif
-    },
-    {
-        .sc_cmd = "lsdev",
-        .sc_cmd_func = shell_os_ls_dev_cmd,
-#if MYNEWT_VAL(SHELL_CMD_HELP)
-        .help = &ls_dev_help,
-#endif
-    },
-    { NULL, NULL, NULL },
+    SHELL_CMD_EXT("tasks", shell_os_tasks_display_cmd, &tasks_help),
+    SHELL_CMD_EXT("mpool", shell_os_mpool_display_cmd, &mpool_help),
+    SHELL_CMD_EXT("date", shell_os_date_cmd, &date_help),
+    SHELL_CMD_EXT("reset", shell_os_reset_cmd, &reset_help),
+    SHELL_CMD_EXT("lsdev", shell_os_ls_dev_cmd, &ls_dev_help),
+    { 0 },
 };
 
 void

--- a/sys/shell/src/shell_priv.h
+++ b/sys/shell/src/shell_priv.h
@@ -24,7 +24,19 @@
 extern "C" {
 #endif
 
+#include "streamer/streamer.h"
 #include "shell/shell.h"
+struct CborEncoder;
+ 
+#if MYNEWT_VAL(SHELL_BRIDGE)
+/**
+ * Streams CBOR text strings to its encoder.
+ */
+struct shell_bridge_streamer {
+    struct streamer streamer;
+    struct CborEncoder *str_encoder;
+};
+#endif
 
 #if MYNEWT_VAL(SHELL_NEWTMGR)
 #define SHELL_NLIP_PKT_START1 (6)
@@ -39,6 +51,12 @@ void shell_nlip_clear_pkt(void);
 
 void shell_os_register(void);
 void shell_prompt_register(void);
+
+#if MYNEWT_VAL(SHELL_BRIDGE)
+void shell_bridge_streamer_new(struct shell_bridge_streamer *sbs,
+                               struct CborEncoder *str_encoder);
+int shell_bridge_init(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/shell/src/shell_prompt.c
+++ b/sys/shell/src/shell_prompt.c
@@ -73,7 +73,7 @@ static const struct shell_cmd prompt_commands[] = {
         .help = &ticks_help,
 #endif
     },
-    { NULL, NULL, NULL },
+    { 0 },
 };
 
 

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -74,6 +74,22 @@ syscfg.defs:
             write 2, read/write 3 (default)
         value: 3 
 
+    SHELL_BRIDGE:
+        description: >
+            Enables the `shell exec` newtmgr command; executes shell commands
+            via newtmgr.
+        value: 0
+    SHELL_BRIDGE_MAX_IN_LEN:
+        description: >
+            Maximum combined length of arguments passed to the `shell exec`
+            newtmgr command.
+        value: 128
+    SHELL_BRIDGE_PRINTF_LEN:
+        description: >
+            Maximum number of characters that can be streamed by a single
+            printf call during processing of the `shell exec` newtmgr command.
+        value: 128
+
 ## duplicated from boot/boot_serial
     BOOT_SERIAL_NVREG_MAGIC:
         description: >

--- a/util/streamer/include/streamer/streamer.h
+++ b/util/streamer/include/streamer/streamer.h
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_STREAMER_
+#define H_STREAMER_
+
+#include "os/mynewt.h"
+
+struct streamer;
+
+typedef int streamer_write_fn(struct streamer *streamer,
+                              const void *src, size_t len);
+
+typedef int streamer_vprintf_fn(struct streamer *streamer,
+                                const char *fmt, va_list ap); 
+
+struct streamer_cfg {
+    streamer_write_fn *write_cb;
+    streamer_vprintf_fn *vprintf_cb;
+};
+
+/**
+ * @brief Provides a generic data streaming interface.
+ */
+struct streamer {
+    const struct streamer_cfg *cfg;
+};
+
+/**
+ * @brief Streams data to an mbuf chain.
+ */
+struct streamer_mbuf {
+    struct streamer streamer; /* Must be first member. */
+    struct os_mbuf *om;
+};
+
+/**
+ * @brief Writes the given flat buffer to a streamer.
+ *
+ * @param streamer              The streamer to write to.
+ * @param src                   The flat buffer to write.
+ * @param len                   The number of bytes to write.
+ *
+ * @return                      0 on success; SYS_E[...] on failure.
+ */
+int streamer_write(struct streamer *streamer, const void *src, size_t len);
+
+/**
+ * @brief Writes printf-formatted text to a streamer.
+ *
+ * A null-terminator does *not* get written.
+ *
+ * @param streamer              The streamer to write to.
+ * @param src                   The flat buffer to write.
+ * @param len                   The number of bytes to write.
+ *
+ * @return                      Number of bytes written on success;
+ *                              SYS_E[...] on failure.
+ */
+int streamer_vprintf(struct streamer *streamer, const char *fmt, va_list ap);
+
+/**
+ * @brief Writes printf-formatted text to a streamer.
+ */
+int streamer_printf(struct streamer *streamer, const char *fmt, ...);
+
+/**
+ * @brief Acquires the singleton console streamer.
+ */
+struct streamer *streamer_console_get(void);
+
+/**
+ * Constructs an mbuf streamer.
+ *
+ * @param sm                    The mbuf streamer object to populate.
+ * @param om                    The mbuf chain to write to.  This may already
+ *                                  contain data.
+ *
+ * @return                      0 on success; SYS_E[...] on failure.
+ */
+int streamer_mbuf_new(struct streamer_mbuf *sm, struct os_mbuf *om);
+
+/**
+ * Constructs an mbuf streamer that uses mbufs acquired from msys.
+ *
+ * @param sm                    The mbuf streamer object to populate.
+ *
+ * @return                      0 on success; SYS_E[...] on failure.
+ */
+int streamer_msys_new(struct streamer_mbuf *sm);
+
+#endif

--- a/util/streamer/pkg.yml
+++ b/util/streamer/pkg.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+pkg.name: util/streamer
+pkg.description: "Generic streaming utility"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps: 
+    - "@apache-mynewt-core/kernel/os"
+
+pkg.req_apis:
+    - console

--- a/util/streamer/src/streamer.c
+++ b/util/streamer/src/streamer.c
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "streamer/streamer.h"
+
+int
+streamer_write(struct streamer *streamer, const void *src, size_t len)
+{
+    return streamer->cfg->write_cb(streamer, src, len);
+}
+
+int
+streamer_vprintf(struct streamer *streamer, const char *fmt, va_list ap)
+{
+    return streamer->cfg->vprintf_cb(streamer, fmt, ap);
+}
+
+int
+streamer_printf(struct streamer *streamer, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start(ap, fmt);
+    rc = streamer_vprintf(streamer, fmt, ap);
+    va_end(ap);
+
+    return rc;
+}

--- a/util/streamer/src/streamer_console.c
+++ b/util/streamer/src/streamer_console.c
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "console/console.h"
+#include "streamer/streamer.h"
+
+static int
+streamer_console_write(struct streamer *streamer, const void *src, size_t len)
+{
+    console_write(src, len);
+    return 0;
+}
+
+static int
+streamer_console_vprintf(struct streamer *streamer,
+                         const char *fmt, va_list ap)
+{
+    return console_vprintf(fmt, ap);
+}
+
+static const struct streamer_cfg streamer_cfg_console = {
+    .write_cb = streamer_console_write,
+    .vprintf_cb = streamer_console_vprintf,
+};
+
+static struct streamer streamer_console = {
+    .cfg = &streamer_cfg_console,
+};
+
+struct streamer *
+streamer_console_get(void)
+{
+    return &streamer_console;
+}

--- a/util/streamer/src/streamer_mbuf.c
+++ b/util/streamer/src/streamer_mbuf.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "streamer/streamer.h"
+
+static int
+streamer_mbuf_write(struct streamer *streamer, const void *src, size_t len)
+{
+    struct streamer_mbuf *sm;
+    int rc;
+
+    if (len > UINT16_MAX) {
+        return SYS_EINVAL;
+    }
+
+    sm = (struct streamer_mbuf *)streamer;
+    rc = os_mbuf_append(sm->om, src, len);
+    if (rc != 0) {
+        return os_error_to_sys(rc);
+    }
+
+    return 0;
+}
+
+static int
+streamer_mbuf_vprintf(struct streamer *streamer, const char *fmt, va_list ap)
+{
+    char buf[MYNEWT_VAL(STREAMER_MBUF_PRINTF_MAX)];
+    int num_chars;
+    int rc;
+
+    num_chars = vsnprintf(buf, sizeof buf, fmt, ap);
+    if (num_chars > sizeof buf - 1) {
+        num_chars = sizeof buf - 1;
+    }
+
+    rc = streamer_mbuf_write(streamer, buf, num_chars);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return num_chars;
+}
+
+static const struct streamer_cfg streamer_cfg_mbuf = {
+    .write_cb = streamer_mbuf_write,
+    .vprintf_cb = streamer_mbuf_vprintf,
+};
+
+int
+streamer_mbuf_new(struct streamer_mbuf *sm, struct os_mbuf *om)
+{
+    if (sm == NULL || om == NULL) {
+        return SYS_EINVAL;
+    }
+
+    *sm = (struct streamer_mbuf) {
+        .streamer.cfg = &streamer_cfg_mbuf,
+        .om = om,
+    };
+
+    return 0;
+}
+
+int
+streamer_msys_new(struct streamer_mbuf *sm)
+{
+    struct os_mbuf *om;
+    int rc;
+
+    om = os_msys_get_pkthdr(0, 0);
+    if (om == NULL) {
+        return SYS_ENOMEM;
+    }
+
+    rc = streamer_mbuf_new(sm, om);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}

--- a/util/streamer/syscfg.yml
+++ b/util/streamer/syscfg.yml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+syscfg.defs:
+    STREAMER_MBUF_PRINTF_MAX:
+        description: >
+            Maximum number of characters that can be streamed to an mbuf in a
+            single printf call.
+        value: 128


### PR DESCRIPTION
Implement a new newtmgr command: `shell exec`.  This command allows shell commands to be executed via newtmgr.

This PR requires a sibling change to the newtmgr tool: https://github.com/apache/mynewt-newtmgr/pull/126