### PR TITLE
kernel/os/arch: Fix HardFault_IRQn usage

### DIFF
--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -212,7 +212,6 @@ os_arch_os_init(void)
          */
         NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm); /* Hardfault */
         for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
             NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
         }

--- a/kernel/os/src/arch/cortex_m3/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m3/os_arch_arm.c
@@ -220,7 +220,7 @@ os_arch_os_init(void)
          * should help in trying to figure out what went wrong.
          */
         NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
+        NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);

--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -224,7 +224,7 @@ os_arch_os_init(void)
          * should help in trying to figure out what went wrong.
          */
         NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
+        NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -224,7 +224,7 @@ os_arch_os_init(void)
          * should help in trying to figure out what went wrong.
          */
         NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
+        NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -224,7 +224,7 @@ os_arch_os_init(void)
          * should help in trying to figure out what went wrong.
          */
         NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
+        NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
         NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);


### PR DESCRIPTION
Seems like hardcoded -13 for HardFault_IRQn are just some leftovers in
Cortex-M code, we should use proper symbol here.