### PR TITLE
kernel/os/arch: Reset all handlers to os_default_irq_asm

### DIFF
--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -201,21 +201,21 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
+        /*
+         * Install default interrupt handler for all interrupts except Reset,
+         * which'll print out system state at the time of the interrupt, and
+         * few other regs which should help in trying to figure out what went
+         * wrong.
+         */
+        for (i = -NVIC_USER_IRQ_OFFSET + 2;
+             i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
+            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
+        }
+
+        /* Install our system interrupt handlers */
         NVIC_SetVector(SVC_IRQ_NUMBER, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
-
-        /*
-         * Install default interrupt handler, which'll print out system
-         * state at the time of the interrupt, and few other regs which
-         * should help in trying to figure out what went wrong.
-         */
-        NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(HardFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm); /* Hardfault */
-        for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
-            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
-        }
 
         /* Set the PendSV interrupt exception priority to the lowest priority */
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);

--- a/kernel/os/src/arch/cortex_m3/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m3/os_arch_arm.c
@@ -210,23 +210,21 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
+        /*
+         * Install default interrupt handler for all interrupts except Reset,
+         * which'll print out system state at the time of the interrupt, and
+         * few other regs which should help in trying to figure out what went
+         * wrong.
+         */
+        for (i = -NVIC_USER_IRQ_OFFSET + 2;
+             i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
+            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
+        }
+
+        /* Install our system interrupt handlers */
         NVIC_SetVector(SVC_IRQ_NUMBER, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
-
-        /*
-         * Install default interrupt handler, which'll print out system
-         * state at the time of the interrupt, and few other regs which
-         * should help in trying to figure out what went wrong.
-         */
-        NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);
-        for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
-            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
-        }
 
         /* Set the PendSV interrupt exception priority to the lowest priority */
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);

--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -214,23 +214,21 @@ os_arch_os_init(void)
             NVIC->IPR[i] = -1;
         }
 
+        /*
+         * Install default interrupt handler for all interrupts except Reset,
+         * which'll print out system state at the time of the interrupt, and
+         * few other regs which should help in trying to figure out what went
+         * wrong.
+         */
+        for (i = -NVIC_USER_IRQ_OFFSET + 2;
+             i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
+            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
+        }
+
+        /* Install our system interrupt handlers */
         NVIC_SetVector(SVCall_IRQn, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
-
-        /*
-         * Install default interrupt handler, which'll print out system
-         * state at the time of the interrupt, and few other regs which
-         * should help in trying to figure out what went wrong.
-         */
-        NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);
-        for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
-            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
-        }
 
         /* Set the PendSV interrupt exception priority to the lowest priority */
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -214,23 +214,21 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
+        /*
+         * Install default interrupt handler for all interrupts except Reset,
+         * which'll print out system state at the time of the interrupt, and
+         * few other regs which should help in trying to figure out what went
+         * wrong.
+         */
+        for (i = -NVIC_USER_IRQ_OFFSET + 2;
+             i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
+            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
+        }
+
+        /* Install our system interrupt handlers */
         NVIC_SetVector(SVCall_IRQn, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
-
-        /*
-         * Install default interrupt handler, which'll print out system
-         * state at the time of the interrupt, and few other regs which
-         * should help in trying to figure out what went wrong.
-         */
-        NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);
-        for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
-            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
-        }
 
         /* Set the PendSV interrupt exception priority to the lowest priority */
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -214,23 +214,21 @@ os_arch_os_init(void)
             NVIC->IP[i] = -1;
         }
 
+        /*
+         * Install default interrupt handler for all interrupts except Reset,
+         * which'll print out system state at the time of the interrupt, and
+         * few other regs which should help in trying to figure out what went
+         * wrong.
+         */
+        for (i = -NVIC_USER_IRQ_OFFSET + 2;
+             i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
+            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
+        }
+
+        /* Install our system interrupt handlers */
         NVIC_SetVector(SVCall_IRQn, (uint32_t)SVC_Handler);
         NVIC_SetVector(PendSV_IRQn, (uint32_t)PendSV_Handler);
         NVIC_SetVector(SysTick_IRQn, (uint32_t)SysTick_Handler);
-
-        /*
-         * Install default interrupt handler, which'll print out system
-         * state at the time of the interrupt, and few other regs which
-         * should help in trying to figure out what went wrong.
-         */
-        NVIC_SetVector(NonMaskableInt_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(-13, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(MemoryManagement_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(BusFault_IRQn, (uint32_t)os_default_irq_asm);
-        NVIC_SetVector(UsageFault_IRQn, (uint32_t)os_default_irq_asm);
-        for (i = 0; i < NVIC_NUM_VECTORS - NVIC_USER_IRQ_OFFSET; i++) {
-            NVIC_SetVector(i, (uint32_t)os_default_irq_asm);
-        }
 
         /* Set the PendSV interrupt exception priority to the lowest priority */
         NVIC_SetPriority(PendSV_IRQn, PEND_SV_PRIO);


### PR DESCRIPTION
Instead of leaving some (possibly) unused interrupt handlers set to
default values set by startup code, let's just set all of them to
our os_default_irq_asm.

This allows to avoid magic numbers like "-13" for HardFault_IRQn which
for some reason is not defined for some ST MCUs.