### PR TITLE
hal/mcu: Fix definitions of hal_system_start

### DIFF
--- a/hw/mcu/ambiq/apollo2/src/hal_system_start.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_system_start.c
@@ -30,11 +30,9 @@
 void
 hal_system_start(void *img_start)
 {
-    typedef void jump_fn(void);
-
     uint32_t base0entry;
     uint32_t jump_addr;
-    jump_fn *fn;
+    __attribute__((noreturn)) void (*fn)(void);
 
     /* First word contains initial MSP value. */
     __set_MSP(*(uint32_t *)img_start);
@@ -42,7 +40,7 @@ hal_system_start(void *img_start)
     /* Second word contains address of entry point (Reset_Handler). */
     base0entry = *(uint32_t *)(img_start + 4);
     jump_addr = base0entry;
-    fn = (jump_fn *)jump_addr;
+    fn = (void *)jump_addr;
 
     /* Jump to image. */
     fn();

--- a/hw/mcu/sifive/fe310/src/hal_system_start.c
+++ b/hw/mcu/sifive/fe310/src/hal_system_start.c
@@ -27,9 +27,7 @@
 void
 hal_system_start(void *img_start)
 {
-    typedef void jump_fn(void);
-
-    jump_fn *fn = (jump_fn *)img_start;
+    __attribute__((noreturn)) void (*fn)(void) = img_start;
 
     /* Jump to image. */
     fn();

--- a/hw/mcu/stm/stm32_common/src/hal_system_start.c
+++ b/hw/mcu/stm/stm32_common/src/hal_system_start.c
@@ -31,11 +31,9 @@
 void
 hal_system_start(void *img_start)
 {
-    typedef void jump_fn(void);
-
     uint32_t base0entry;
     uint32_t jump_addr;
-    jump_fn *fn;
+    __attribute__((noreturn)) void (*fn)(void);
 
     /* First word contains initial MSP value. */
     __set_MSP(*(uint32_t *)img_start);
@@ -43,7 +41,7 @@ hal_system_start(void *img_start)
     /* Second word contains address of entry point (Reset_Handler). */
     base0entry = *(uint32_t *)(img_start + 4);
     jump_addr = base0entry;
-    fn = (jump_fn *)jump_addr;
+    fn = (void *)jump_addr;
 
     STM32_HAL_FLASH_REMAP();
 


### PR DESCRIPTION
Declaration of hal_system_start() has attribute noreturn.

For some MCU definition of hal_system_start() gcc can generate warning
if hal_system_start.c includes hal_system.h.

hal_system_start.c:35:1: error: 'noreturn' function does return [-Werror]

This changes convince gcc that function called by pointer will not
return.