### PR TITLE
[STM32]: Fix hal_debugger_connected function

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_system.c
+++ b/hw/mcu/stm/stm32_common/src/hal_system.c
@@ -43,8 +43,11 @@ hal_system_reset(void)
 int
 hal_debugger_connected(void)
 {
-    /* FIXME */
+#if (__CORTEX_M == 0)
     return 0;
+#else
+    return CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk;
+#endif
 }
 
 uint32_t


### PR DESCRIPTION
Implementation was stubbed and marked to be fixed.
Cortex standard way to detect debugger presence is used.