### PR TITLE
sensors/bma253: sensor driver with the following changes

### DIFF
--- a/hw/drivers/sensors/bma253/README.md
+++ b/hw/drivers/sensors/bma253/README.md
@@ -1,0 +1,64 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+
+
+
+/*********************************************************/
+driver for bma253
+version: eee54bbf. 2019/5/14 
+/*********************************************************/
+target platform: nrf52832
+BSP: nrf52dk
+/*********************************************************/
+mynewt-core version: 0-dev
+mynewt-nimble version: 0-dev
+/*********************************************************/
+test tool: apps/sensors_test
+           bma253_shell
+
+[command for testing double tap feature]
+- option 1:
+sensor notify bma253_0 on double
+or
+- option 2:
+bma253 wait-for-tap double
+
+if using the sensor_shell (option 1), the double tap could be turned off by:
+sensor notify bma253_0 off double
+
+
+[command for sensor data read test]
+sensor read bmp253_0 1 -n 10 -i 20 -d 4000
+    for sensor read, both "polling" and "streaming" modes are supported
+    [polling mode - BMA253_READ_M_POLL]
+    the polling interval is specified by the "-i" argument to the "sensor" commmand, and
+    polling duration is specified by "-d" argument, and both are in "mill-seconds"
+
+    [streaming mode - BMA253_READ_M_STREAM]
+    In this mode, currently, the driver enters an loop until the "timeout" parameter (currently is INT_MAX requested from sensor_shell)
+    is reached and keeps reading from sensor FIFO, and events are reported to its sensor data listeners.
+
+    The way the driver is implemented may be changed in future if sensor framework split read request in to two API calls:
+    setup_read(this is where sensors are set up for subsequenet polling or interrupt based streaming), and poll()/report_data().
+
+
+Any feedback is welcome, please write to our support contact for any questions or suggestions.
+

--- a/hw/drivers/sensors/bma253/include/bma253/bma253.h
+++ b/hw/drivers/sensors/bma253/include/bma253/bma253.h
@@ -29,6 +29,9 @@
 extern "C" {
 #endif
 
+
+#define BMA253_UNUSED_VAR(v)    ((void)v)
+
 /* XXX use some better defaults. For now it is min */
 #define BMA253_LOW_G_DELAY_MS_DEFAULT       2
 #define BMA253_HIGH_G_DELAY_MS_DEFAULT      2
@@ -197,7 +200,26 @@ struct bma253_private_driver_data {
     uint8_t int_num;
     uint8_t int_route;
     uint8_t int_ref_cnt;
+
+    uint8_t fifo_buf[31 * 6];
 };
+
+typedef union bma253_feature_enable {
+    struct {
+        uint32_t any_motion :1;
+        uint32_t double_tap :1;
+        uint32_t single_tap :1;
+        uint32_t orient     :1;
+        uint32_t low_g      :1;
+        uint32_t high_g     :1;
+    } req;
+
+    uint32_t bits;
+} bma253_feature_enable_t;
+
+#ifndef MAX
+#define MAX(n, m) (((n) < (m)) ? (m) : (n))
+#endif
 
 /* The device itself */
 struct bma253 {
@@ -220,6 +242,30 @@ struct bma253 {
 
     /* Private driver data */
     struct bma253_private_driver_data pdd;
+
+    /* all the features currently enabled */
+    sensor_event_type_t     ev_enabled;
+
+    uint32_t                daq_req_new: 1;
+    /* the data acquisition is in progress */
+    uint32_t                daq_in_proc: 1;
+
+
+    /* this flag is to turn on or off bus read/write monitoring */
+    uint32_t                bus_rw_mon      :1;
+
+    /* currently configured bandwidth on hw, of type: enum bma253_filter_bandwidth */
+    uint32_t                bandwidth_curr  :3;
+
+    /* this flag tells that an important hw config change (like bandwidth, power mode) is pending */
+    uint32_t                hw_cfg_pending  :1;
+
+    /* pending power mode, of type enum bma253_power_mode */
+    uint32_t                pending_hw_cfg_pm:3;
+
+    /* pending bandwidth, of type enum bma253_filter_bandwidth */
+    uint32_t                pending_hw_cfg_bw:3;
+
 };
 
 /* Offset compensation is performed to target this given value, by axis */

--- a/hw/drivers/sensors/bma253/src/bma253_shell.c
+++ b/hw/drivers/sensors/bma253/src/bma253_shell.c
@@ -216,7 +216,7 @@ struct stream_read_context {
 };
 
 static bool
-bma253_stream_read_cb(void * arg,
+bma253_stream_read_cb_core(void * arg,
                       struct sensor_accel_data * sad)
 {
     char buffer_x[20];
@@ -239,6 +239,21 @@ bma253_stream_read_cb(void * arg,
     return ctx->count == 0;
 }
 
+static
+int bma253_stream_read_cb(
+        struct sensor   *sensor,
+        void            *read_arg,
+        void            *data,
+        sensor_type_t   type)
+{
+    BMA253_UNUSED_VAR(sensor);
+    BMA253_UNUSED_VAR(type);
+
+    bma253_stream_read_cb_core(read_arg, (struct sensor_accel_data *)data);
+
+    return 0;
+}
+
 static int
 bma253_stream_read_cmd(struct bma253 * bma253,
                        int argc,
@@ -256,10 +271,11 @@ bma253_stream_read_cmd(struct bma253 * bma253,
         return EINVAL;
     }
 
-    return bma253_stream_read(bma253,
-                              bma253_stream_read_cb,
-                              &ctx,
-                              0);
+    return bma253_stream_read(&bma253->sensor,
+            SENSOR_TYPE_ACCELEROMETER,
+            bma253_stream_read_cb,
+            &ctx,
+            0);
 }
 
 static int
@@ -431,6 +447,7 @@ bma253_wait_for_tap_cmd(struct bma253 * bma253,
     const struct tap_type * tap_type;
     uint8_t i;
     int rc;
+
 
     if (argc != 1) {
         return EINVAL;

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -32,7 +32,7 @@ syscfg.defs:
         value: 1
     BMA253_INT_CFG_OUTPUT:
         description: 'Set 0 for push-pull, 1 for open-drain'
-        value: 1
+        value: 0
     BMA253_INT_PIN_DEVICE:
         description: 'Interrupt pin number 1 or 2 on accelerometer device'
         value: 1

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -299,17 +299,16 @@ static struct sensor_itf i2c_0_itf_ms40 = {
 };
 #endif
 
-
 #if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(BMA253_OFB)
-static struct sensor_itf i2c_0_itf_lis = {
+static struct sensor_itf spi2c_0_itf_bma253 = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
     .si_addr = 0x18,
     .si_ints = {
-        { 26, MYNEWT_VAL(BMA2XX_INT_PIN_DEVICE),
-            MYNEWT_VAL(BMA2XX_INT_CFG_ACTIVE)},
-        { 25, MYNEWT_VAL(BMA2XX_INT2_PIN_DEVICE),
-            MYNEWT_VAL(BMA2XX_INT_CFG_ACTIVE)}
+        { 12, MYNEWT_VAL(BMA253_INT_PIN_DEVICE),
+            MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)},
+        { 24, MYNEWT_VAL(BMA253_INT2_PIN_DEVICE),
+            MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)}
     },
 };
 #endif
@@ -796,19 +795,22 @@ config_bma253_sensor(void)
     cfg.low_g_delay_ms = BMA253_LOW_G_DELAY_MS_DEFAULT;
     cfg.high_g_delay_ms = BMA253_HIGH_G_DELAY_MS_DEFAULT;
     cfg.g_range = BMA253_G_RANGE_2;
-    cfg.filter_bandwidth = BMA253_FILTER_BANDWIDTH_1000_HZ;
+    /* filter_bandwidth is the intended setting for data streaming */
+    cfg.filter_bandwidth = BMA253_FILTER_BANDWIDTH_31_25_HZ;
     cfg.use_unfiltered_data = false;
     cfg.tap_quiet = BMA253_TAP_QUIET_30_MS;
     cfg.tap_shock = BMA253_TAP_SHOCK_50_MS;
     cfg.d_tap_window = BMA253_D_TAP_WINDOW_250_MS;
     cfg.tap_wake_samples = BMA253_TAP_WAKE_SAMPLES_2;
-    cfg.tap_thresh_g = 1.0;
+    cfg.tap_thresh_g = 0.200f;
     cfg.offset_x_g = 0.0;
     cfg.offset_y_g = 0.0;
     cfg.offset_z_g = 0.0;
-    cfg.power_mode = BMA253_POWER_MODE_NORMAL;
-    cfg.sleep_duration = BMA253_SLEEP_DURATION_0_5_MS;
+    /* options: BMA253_POWER_MODE_SUSPEND, BMA253_POWER_MODE_NORMAL, BMA253_POWER_MODE_LPM_1, */
+    cfg.power_mode = BMA253_POWER_MODE_SUSPEND;
+    cfg.sleep_duration = BMA253_SLEEP_DURATION_10_MS;
     cfg.sensor_mask = SENSOR_TYPE_ACCELEROMETER;
+    /* options: BMA253_READ_M_STREAM, BMA253_READ_M_POLL */
     cfg.read_mode = BMA253_READ_M_POLL;
 
     rc = bma253_config((struct bma253 *)dev, &cfg);
@@ -1343,7 +1345,7 @@ sensor_dev_create(void)
 
 #if MYNEWT_VAL(BMA253_OFB)
     rc = os_dev_create((struct os_dev *)&bma253, "bma253_0",
-      OS_DEV_INIT_PRIMARY, 0, bma253_init, &i2c_0_itf_lis);
+      OS_DEV_INIT_PRIMARY, 0, bma253_init, &spi2c_0_itf_bma253);
     assert(rc == 0);
 
     rc = config_bma253_sensor();


### PR DESCRIPTION
  - sensor data read uses burst read to get all axes
  - from register read, change param last_op to 0 for i2cn_master_write
  - dump registers after DT event notification setup
  - reuse get_registers() to simplify get_register()
  - more sophiscated fifo read using fifo frame counter info
  - add a flag to control the bus read write tracing
  - added lpm support with config arbitration for interrupts and data streaming
  - refactor struct int_status to bma253_int_stat_t for optimized efficiency and size (struct from 23 bytes to 4 bytes)
  - added bma253_clear_fifo
  - fix insufficient delay issue after register_write
  - spi support was added
  - added a log level filter and fine tuned some logs
  - changed configuration parameters for data streaming and tapping interrupts
  - code clean up: remove some of the comments
  - unset ev_enabled at unset_notification() api hook
  - clear registered_mask after double tap interrupt fire, so that future notificaiton is possible
  - invalidate data and add necessary delays when needed before reading data so that data get is valid
  - add a delay needed immediately after changing power mode
  - readme about the driver added
  - make comments in code complaint with coding style, remove c++ comments
  - use struct sensor_read_ctx to replace struct sensor_data_subscriber_info