### PR TITLE
Check for existing stats instance before inserting in the global stats registry

### DIFF
--- a/sys/stats/full/src/stats.c
+++ b/sys/stats/full/src/stats.c
@@ -115,7 +115,7 @@ stats_register_internal(const char *name, struct stats_hdr *shdr)
      * is already registered.
      */
     STAILQ_FOREACH(cur, &g_stats_registry, s_next) {
-        if (!strcmp(cur->s_name, name)) {
+        if (!strcmp(cur->s_name, name) || cur == shdr) {
             rc = -1;
             goto err;
         }


### PR DESCRIPTION
Adds a check for a statistics instance in `g_stats_registry` with the same address as the one being added (previously duplicates were being rejected only if the name is the same). 

Multiple sensors may use the same driver but some drivers only implement one instance of statistics. This can lead to a loop in the `g_stats_registry` linked list, because currently `stats_register_internal()` assumes that statistics with different names will use unique statistics. 

The problem arises when a statistics instance is registered twice under different names. The actual instance is the same, so the second time it is registered the linked list insertion will cause `s_next` of the entry to point to itself. 
