### PR TITLE
Change DPS368 sensor driver output units from hPa to Pa

### DIFF
--- a/hw/drivers/sensors/dps368/src/dps368.c
+++ b/hw/drivers/sensors/dps368/src/dps368.c
@@ -545,15 +545,15 @@ dps368_validate_sample_accuracy(struct dps368 *dps368)
 }
 
 /**
- * Gets compensated pressure in hecto Pascal
+ * Gets compensated pressure in Pascals
  *
  * @param Instance of sensor specific driver state
- * @param ptr computed and temperature compensated pressure in hPa
+ * @param ptr computed and temperature compensated pressure in Pa
  *
  * @return 0 on success, and non-zero error code on failure
  */
 static int
-dps368_get_pressure_hPa(struct dps368 *dps368,float *pressurehPa)
+dps368_get_pressure_Pa(struct dps368 *dps368,float *pressurePa)
 {
     int rc;
     uint8_t read_buffer[IFX_DPS368_PSR_TMP_READ_LEN] = {0};
@@ -606,9 +606,7 @@ dps368_get_pressure_hPa(struct dps368 *dps368,float *pressurehPa)
                     temp_scaled * dps368->calib_coeffs.C01 +temp_scaled * press_scaled *
                     ( dps368->calib_coeffs.C11 + press_scaled * dps368->calib_coeffs.C21 );
 
-    press_final = press_final * 0.01f;  //to convert it into mBar // hPa
-
-    *pressurehPa  = press_final;  //press_final;
+    *pressurePa  = press_final;  //press_final;
 
     return 0;
 }
@@ -924,7 +922,7 @@ dps368_sensor_read(struct sensor *sensor, sensor_type_t type,
 
     if (type & SENSOR_TYPE_PRESSURE) {
         struct sensor_press_data spd;
-        rc = dps368_get_pressure_hPa(dps368, &spd.spd_press);
+        rc = dps368_get_pressure_Pa(dps368, &spd.spd_press);
         if (rc) {
             return rc;
         }

--- a/hw/drivers/sensors/dps368/src/dps368.c
+++ b/hw/drivers/sensors/dps368/src/dps368.c
@@ -747,7 +747,9 @@ int dps368_init(struct os_dev *dev, void *arg)
 
     dps368->cfg.config_opt = DPS3xx_CONF_WITH_INIT_SEQUENCE;
 
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
     dps368_stats_int(dev);
+#endif
 
     rc = sensor_init(sensor, dev);
 
@@ -1022,5 +1024,3 @@ dps368_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
     return rc;
 }
 #endif
-
-

--- a/hw/drivers/sensors/dps368/src/dps368_comm_interface.c
+++ b/hw/drivers/sensors/dps368/src/dps368_comm_interface.c
@@ -21,6 +21,7 @@
 #include "dps368_priv.h"
 
 
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
 /* Define the stats section and records */
 STATS_SECT_START(dps368_stat_section)
     STATS_SECT_ENTRY(read_errors)
@@ -37,8 +38,9 @@ STATS_NAME_END(dps368_stat_section)
 
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(dps368_stat_section) g_dps368_stats;
+#endif
 
-
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
 /**
  * sensor stats init
  *
@@ -60,7 +62,7 @@ dps368_stats_int(struct os_dev *dev)
     rc = stats_register(dev->od_name, STATS_HDR(g_dps368_stats));
     SYSINIT_PANIC_ASSERT(rc == 0);
 }
-
+#endif
 
 /*DPS368 bus W/R handling */
 #if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
@@ -92,7 +94,9 @@ dps368_i2c_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
         DPS368_LOG(ERROR,
                 "Could not write to 0x%02X:0x%02X with value 0x%02X\n",
                 itf->si_addr, reg, value);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
         STATS_INC(g_dps368_stats, read_errors);
+#endif
     }
 
     return rc;
@@ -122,7 +126,9 @@ dps368_spi_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
         rc = SYS_EINVAL;
         DPS368_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
                 itf->si_num, reg);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
         STATS_INC(g_dps368_stats, write_errors);
+#endif
         goto err;
     }
 
@@ -132,7 +138,9 @@ dps368_spi_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
         rc = SYS_EINVAL;
         DPS368_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n", itf->si_num,
                 reg);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
         STATS_INC(g_dps368_stats, write_errors);
+#endif
         goto err;
     }
 
@@ -180,7 +188,9 @@ dps368_i2c_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     if (rc) {
         DPS368_LOG(ERROR, "I2C access failed at address 0x%02X\n",
                 itf->si_addr);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
         STATS_INC(g_dps368_stats, read_errors);
+#endif
         return rc;
     }
 
@@ -217,7 +227,9 @@ dps368_spi_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
         rc = SYS_EINVAL;
         DPS368_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
                 itf->si_num, reg);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
         STATS_INC(g_dps368_stats, read_errors);
+#endif
         goto err;
     }
 
@@ -228,7 +240,9 @@ dps368_spi_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
             rc = SYS_EINVAL;
             DPS368_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n", itf->si_num,
                     reg);
+#if MYNEWT_VAL(DPS368_ENABLE_STATS)
             STATS_INC(g_dps368_stats, read_errors);
+#endif
             goto err;
         }
         buffer[i] = retval;
@@ -319,5 +333,3 @@ int dps368_read_regs(struct sensor_itf *itf, uint8_t addr, uint8_t *buff, uint8_
 
     return rc;
 }
-
-

--- a/hw/drivers/sensors/dps368/syscfg.yml
+++ b/hw/drivers/sensors/dps368/syscfg.yml
@@ -64,3 +64,6 @@ syscfg.defs:
     DPS368_DFLT_CONF_MODE:
         description: 'Default Mode for sensor: Valid values are 0, 1,2,5,6,7. Refere enum in driver package'
         value: 7 #Background for both P and T
+    DPS368_ENABLE_STATS:
+        description: 'Enable statistics for the driver'
+        value: 0

--- a/sys/stats/full/src/stats.c
+++ b/sys/stats/full/src/stats.c
@@ -115,7 +115,7 @@ stats_register_internal(const char *name, struct stats_hdr *shdr)
      * is already registered.
      */
     STAILQ_FOREACH(cur, &g_stats_registry, s_next) {
-        if (!strcmp(cur->s_name, name)) {
+        if (!strcmp(cur->s_name, name) || cur == shdr) {
             rc = -1;
             goto err;
         }


### PR DESCRIPTION
Change pressure units from hecto Pascals (hPa) to Pascals to match units used by other pressure sensor drivers (e.g. lps33th/thw, ms5840, etc).
