### PR TITLE
hw/sensors: Reset read offset in 'read' shell cmd

### DIFF
--- a/hw/sensor/src/sensor_shell.c
+++ b/hw/sensor/src/sensor_shell.c
@@ -546,6 +546,7 @@ sensor_cmd_read(char **argv, int argc)
     g_spd.spd_sensor_type = type;
 
     /* Start 1st read immediately */
+    g_spd.spd_read_next_msecs_off = 0;
     g_spd.spd_read_start_ticks = os_cputime_get32();
     sensor_shell_read_timer_cb(NULL);
 


### PR DESCRIPTION
Next read offset is never reset to 0 so after complete 'read' sequence
next command will request 1st read operation immediately and then next
one will be scheduled after duration of complete previous sequence
because next read offset is still set to that duration.

Need to make sure read offset is reset to 0 before 1st read operation.