### PR TITLE
Feature: Main Task OS Sanity Check

### DIFF
--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -175,6 +175,11 @@ syscfg.defs:
         description: >
             If set, assert callback gets called inside __assert_func()
         value: 0
+    OS_MAIN_TASK_SANITY_ITVL_S:
+        description: >
+            Interval for sanity check on main task. Setting a 0 will disable
+            sanity check on main task. Value is in seconds.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1


### PR DESCRIPTION
Added ability to include `os_sanity` check with `main task`.
Developers will have to create their os_sanity check-in in their application.
