### PR TITLE
[Feature]: Main Task OS Sanity Check

### DIFF
--- a/kernel/os/src/os.c
+++ b/kernel/os/src/os.c
@@ -235,8 +235,7 @@ os_init(int (*main_fn)(int argc, char **arg))
     if (main_fn) {
         err = os_task_init(&g_os_main_task, "main", os_main, main_fn,
                    OS_MAIN_TASK_PRIO,
-                   (OS_MAIN_TASK_TIMER_TICKS == 0) ? \
-                        OS_WAIT_FOREVER : OS_MAIN_TASK_TIMER_TICKS,
+                   (OS_MAIN_TASK_TIMER_TICKS == 0) ? OS_WAIT_FOREVER : OS_MAIN_TASK_TIMER_TICKS,
                    g_os_main_stack, OS_STACK_ALIGN(OS_MAIN_STACK_SIZE));
         assert(err == 0);
     }

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -175,6 +175,11 @@ syscfg.defs:
         description: >
             If set, assert callback gets called inside __assert_func()
         value: 0
+    OS_MAIN_TASK_SANITY_ITVL_MS:
+        description: >
+            Interval for sanity check on main task. Setting a 0 will disable
+            sanity check on main task. Value is in milliseconds.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1


### PR DESCRIPTION
Added ability to include `os_sanity` check with `main task`.
Developers will have to create their os_sanity check-in in their application.