### PR TITLE
sys/shell: Don't emit NLIP frames > 127 bytes

### DIFF
--- a/mgmt/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/mgmt/include/mgmt/mgmt.h
@@ -28,7 +28,13 @@ extern "C" {
 #endif
 
 /* MTU for newtmgr responses */
-#define MGMT_MAX_MTU 1024
+#define MGMT_MAX_MTU            1024
+
+/* NLIP packets sent over serial are fragmented into frames of 127 bytes or
+ * fewer. This 127-byte maximum applies to the entire frame, including header,
+ * CRC, and terminating newline.
+ */
+#define MGMT_NLIP_MAX_FRAME     127
 
 #ifndef STR
 /* Stringification of constants */

--- a/mgmt/newtmgr/transport/nmgr_uart/src/nmgr_uart.c
+++ b/mgmt/newtmgr/transport/nmgr_uart/src/nmgr_uart.c
@@ -36,7 +36,6 @@
 
 #define SHELL_NLIP_PKT          0x0609
 #define SHELL_NLIP_DATA         0x0414
-#define SHELL_NLIP_MAX_FRAME    128
 
 #define NUS_EV_TO_STATE(ptr)                                            \
     (struct nmgr_uart_state *)((uint8_t *)ptr -                         \
@@ -109,7 +108,7 @@ nmgr_uart_out(struct nmgr_transport *nt, struct os_mbuf *m)
     /*
      * Create another mbuf chain with base64 encoded data.
      */
-    n = os_msys_get(SHELL_NLIP_MAX_FRAME, 0);
+    n = os_msys_get(MGMT_NLIP_MAX_FRAME, 0);
     if (!n || OS_MBUF_TRAILINGSPACE(n) < 32) {
         goto err;
     }
@@ -323,12 +322,12 @@ nmgr_uart_rx_char(void *arg, uint8_t data)
     int rc;
 
     if (!nus->nus_rx) {
-        m = os_msys_get_pkthdr(SHELL_NLIP_MAX_FRAME, 0);
+        m = os_msys_get_pkthdr(MGMT_NLIP_MAX_FRAME, 0);
         if (!m) {
             return 0;
         }
         nus->nus_rx = OS_MBUF_PKTHDR(m);
-        if (OS_MBUF_TRAILINGSPACE(m) < SHELL_NLIP_MAX_FRAME) {
+        if (OS_MBUF_TRAILINGSPACE(m) < MGMT_NLIP_MAX_FRAME) {
             /*
              * mbuf is too small.
              */

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -28,6 +28,7 @@ pkg.deps:
     - "@apache-mynewt-core/time/datetime"
 
 pkg.deps.SHELL_NEWTMGR:
+    - "@apache-mynewt-core/mgmt/mgmt"
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/util/crc"
 


### PR DESCRIPTION
NLIP specifies a maximum frame size of 127 bytes (https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-console.md).

Prior to this commit, the shell emitted frames larger than 127 bytes. Typically, in a multi-frame response:
* last frame:   135 bytes
* other frames: 131 bytes

This commit ensures outgoing frames have a length <= 127 bytes.

The new code does not take efforts to maximize the length of each frame. In a multi-frame response, each frame typically has a length of 115 bytes.  Filling out the full 127 bytes is somewhat tricky because the frames get base64-encoded and padded (we could do it, but it didn't seem
worth the effort).