### PR TITLE
mgmt/newtmgr: Remove dead code

### DIFF
--- a/mgmt/newtmgr/pkg.yml
+++ b/mgmt/newtmgr/pkg.yml
@@ -30,9 +30,6 @@ pkg.deps:
     - "@apache-mynewt-core/mgmt/newtmgr/nmgr_os"
     - "@apache-mynewt-core/util/mem"
 
-pkg.deps.NEWTMGR_BLE_HOST:
-    - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
-
 pkg.apis:
     - newtmgr
 


### PR DESCRIPTION
NEWTMGR_BLE_HOST was removed in

cc8ead34b MYNEWT-492 - Remove unused obsolete settings.