### PR TITLE
Added null device check in os_dev_close

### DIFF
--- a/kernel/os/src/os_dev.c
+++ b/kernel/os/src/os_dev.c
@@ -238,6 +238,11 @@ os_dev_close(struct os_dev *dev)
     int rc;
     os_sr_t sr;
 
+    if (dev == NULL) {
+        rc = OS_EINVAL;
+        goto err;
+    }
+
     if (dev->od_handlers.od_close) {
         rc = dev->od_handlers.od_close(dev);
         if (rc != 0) {


### PR DESCRIPTION
A null check on the device has been added before the close happens.

Without this check, the callback pointer will be undefined, and executing it will crash the system.