### PR TITLE
Fix some CI test failures

### DIFF
--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/util/streamer/src/streamer.c
+++ b/util/streamer/src/streamer.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <stdarg.h>
 #include "streamer/streamer.h"
 
 int


### PR DESCRIPTION
`newt test all` in a project containing the nimble repo fails with the following errors:
```
     va_start(ap, fmt);
Failed tests: [nimble/host/test]
     ^~~~~~~~
     os_start
repos/apache-mynewt-core/util/streamer/src/streamer.c:42:5: error: implicit declaration of function ‘va_end’; did you mean ‘rand’? [-Werror=implicit-function-declaration]
     va_end(ap);
     ^~~~~~
     rand
repos/apache-mynewt-core/util/streamer/src/streamer.c:40:5: error: ‘ap’ is used uninitialized in this function [-Werror=uninitialized]
     va_start(ap, fmt);
     ^~~~~~~~~~~~~~~~~
```