### PR TITLE
mcu/nordic/nrf52xx: Remove unused backwards compatibility setting.

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -451,10 +451,6 @@ syscfg.defs:
             - "!XTAL_RC"
         deprecated: 1
 
-syscfg.vals.MCU_NRF52810:
-    MCU_TARGET: nRF52810
-syscfg.vals.MCU_NRF52811:
-    MCU_TARGET: nRF52811
 syscfg.vals.MCU_NRF52832:
     MCU_TARGET: nRF52832
 syscfg.vals.MCU_NRF52840:


### PR DESCRIPTION
Removed backwards compatibility unused settings introduced with nrf5281x support.