### PR TITLE
sensors: Enhance helper functions

### DIFF
--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -5349,6 +5349,7 @@ bma253_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);

--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -1391,6 +1391,7 @@ bme280_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -1408,6 +1409,7 @@ bme280_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -1388,6 +1388,7 @@ bmp280_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     ((struct bmp280 *)(node))->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -1407,6 +1408,7 @@ bmp280_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     ((struct bmp280 *)(node))->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/bmp388/src/bmp388.c
+++ b/hw/drivers/sensors/bmp388/src/bmp388.c
@@ -4088,6 +4088,7 @@ bmp388_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -4108,6 +4109,7 @@ bmp388_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/dps368/src/dps368.c
+++ b/hw/drivers/sensors/dps368/src/dps368.c
@@ -1026,6 +1026,7 @@ dps368_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -1043,6 +1044,7 @@ dps368_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/kxtj3/src/kxtj3.c
+++ b/hw/drivers/sensors/kxtj3/src/kxtj3.c
@@ -1590,6 +1590,7 @@ kxtj3_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);

--- a/hw/drivers/sensors/lis2de12/src/lis2de12.c
+++ b/hw/drivers/sensors/lis2de12/src/lis2de12.c
@@ -3138,6 +3138,7 @@ lis2de12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -3158,6 +3159,7 @@ lis2de12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -3241,6 +3241,7 @@ lis2dh12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -3261,6 +3262,7 @@ lis2dh12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -3480,6 +3480,7 @@ lis2dw12_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -3500,6 +3501,7 @@ lis2dw12_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -1208,6 +1208,7 @@ lps33hw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -1228,6 +1229,7 @@ lps33hw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -1202,6 +1202,7 @@ lps33thw_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -1222,6 +1223,7 @@ lps33thw_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -2964,6 +2964,7 @@ lsm6dso_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
 
     dev->node_is_spi = false;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);
@@ -2984,6 +2985,7 @@ lsm6dso_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
 
     dev->node_is_spi = true;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_spi_node_create(name, node, spi_cfg, sensor_itf);

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -731,6 +731,7 @@ ms5837_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -720,6 +720,7 @@ ms5840_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
     };
     int rc;
 
+    sensor_itf->si_dev = &node->bnode.odev;
     bus_node_set_callbacks((struct os_dev *)node, &cbs);
 
     rc = bus_i2c_node_create(name, node, i2c_cfg, sensor_itf);


### PR DESCRIPTION
sensor_itf.si_dev has to have valid pointer to node.
It could be done in sensor_itf variable declaration, but often
this is the only filed that needs to be initialize and it is
easy to overlook.

Device creation helpers have both pointer in argument list
so now they setup si_dev to correct value.

This change dose not affect existing code.