### PR TITLE
Fix warning on pointer to packed struct member

### DIFF
--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -50,4 +50,3 @@ syscfg.defs:
     LPS33HW_ONE_SHOT_MODE:
         description: 'Enables one shot mode on the sensor'
         value: 0
- 


### PR DESCRIPTION
When passing a pointer to a packed struct member, gcc-9 warns about its inability to do proper alignment. This fixes the issue by using pointer to variables and copying to the struct members.

See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51628