### PR TITLE
mgmt/imgmgr: Log image management events

### DIFF
--- a/mgmt/imgmgr/pkg.yml
+++ b/mgmt/imgmgr/pkg.yml
@@ -28,6 +28,7 @@ pkg.deps:
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/mgmt/mgmt"
     - "@apache-mynewt-core/sys/flash_map"
+    - "@apache-mynewt-core/sys/log/modlog"
 
 pkg.req_apis:
     - newtmgr

--- a/mgmt/imgmgr/src/imgmgr_log.c
+++ b/mgmt/imgmgr/src/imgmgr_log.c
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "modlog/modlog.h"
+#include "cborattr/cborattr.h"
+#include "imgmgr/imgmgr.h"
+#include "imgmgr_priv.h"
+
+/**
+ * Log event types (all events are CBOR-encoded):
+ *
+ * upstart:
+ *     When: upon receiving an upload request with an offset of 0.
+ *     Structure:
+ *     {
+ *         "ev": "upstart",
+ *         "rc": <mgmt-error-code (int)>
+ *     }
+ *
+ * updone:
+ *     When: upon receiving an upload request containing the final chunk of an
+ *           image OR a failed upload request with a non-zero offset.
+ *     Structure:
+ *     {
+ *         "ev": "updone",
+ *         "rc": <mgmt-error-code (int)>
+ *         "hs": <image-hash (byte-string)> (only present on success)
+ *     }
+ *
+ * pend:
+ *     When: upon receiving a non-permanent `set-pending` request.
+ *     Structure:
+ *     {
+ *         "ev": "pend",
+ *         "rc": <mgmt-error-code (int)>,
+ *         "hs": <image-hash (byte-string)>
+ *     }
+ *
+ * conf:
+ *     When: upon receiving a `confirm` request OR a permanent `set-pending`
+ *           request.
+ *     Structure:
+ *     {
+ *         "ev": "conf",
+ *         "rc": <mgmt-error-code (int)>,
+ *         "hs": <image-hash (byte-string)> (only present for `set-pending`)
+ *     }
+ */
+
+#define IMGMGR_LOG_EV_UPSTART   "upstart"
+#define IMGMGR_LOG_EV_UPDONE    "updone"
+#define IMGMGR_LOG_EV_PEND      "pend"
+#define IMGMGR_LOG_EV_CONF      "conf"
+
+static int
+imgmgr_log_gen(const char *ev, int status, const uint8_t *hash)
+{
+#if MYNEWT_VAL(LOG_VERSION) > 2 && \
+    LOG_MOD_LEVEL_IS_ACTIVE(MYNEWT_VAL(IMGMGR_LOG_LVL), LOG_LEVEL_INFO)
+
+    struct os_mbuf *om;
+    int rc;
+
+    const struct cbor_out_attr_t attrs[] = {
+        {
+            .attribute = "ev",
+            .val = {
+                .type = CborAttrTextStringType,
+                .string = ev,
+            },
+        },
+        {
+            .attribute = "rc",
+            .val = {
+                .type = CborAttrIntegerType,
+                .integer = status,
+            },
+        },
+        {
+            .attribute = "hs",
+            .val = {
+                .type = CborAttrByteStringType,
+                .bytestring.data = hash,
+                .bytestring.len = IMGMGR_HASH_LEN,
+            },
+            .omit = hash == NULL,    
+        },
+        { 0 }
+    };
+
+    rc = cbor_write_object_msys(attrs, &om);
+    if (rc != 0) {
+        return rc;
+    }
+
+    modlog_append_mbuf(MYNEWT_VAL(IMGMGR_LOG_MOD), LOG_LEVEL_INFO,
+                       LOG_ETYPE_CBOR, om);
+#endif
+
+    return 0;
+}
+
+int
+imgmgr_log_upload_start(int status)
+{
+    return imgmgr_log_gen(IMGMGR_LOG_EV_UPSTART, status, NULL);
+}
+
+int
+imgmgr_log_upload_done(int status, const uint8_t *hash)
+{
+    return imgmgr_log_gen(IMGMGR_LOG_EV_UPDONE, 0, hash);
+}
+
+int
+imgmgr_log_pending(int status, const uint8_t *hash)
+{
+    return imgmgr_log_gen(IMGMGR_LOG_EV_PEND, status, hash);
+}
+
+int
+imgmgr_log_confirm(int status, const uint8_t *hash)
+{
+    return imgmgr_log_gen(IMGMGR_LOG_EV_CONF, status, hash);
+}

--- a/mgmt/imgmgr/src/imgmgr_priv.h
+++ b/mgmt/imgmgr/src/imgmgr_priv.h
@@ -95,6 +95,10 @@ int imgmgr_state_write(struct mgmt_cbuf *njb);
 int imgr_find_by_ver(struct image_version *find, uint8_t *hash);
 int imgr_find_by_hash(uint8_t *find, struct image_version *ver);
 int imgr_cli_register(void);
+int imgmgr_log_upload_start(int status);
+int imgmgr_log_upload_done(int status, const uint8_t *hash);
+int imgmgr_log_pending(int status, const uint8_t *hash);
+int imgmgr_log_confirm(int status, const uint8_t *hash);
 
 #ifdef __cplusplus
 }

--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -43,3 +43,15 @@ syscfg.defs:
         description: >
             Sysinit stage for image management functionality.
         value: 500
+
+    IMGMGR_LOG_MOD:
+        description: 'Module ID for the image manager structured log.'
+        value: 176
+    IMGMGR_LOG_LVL:
+        description: 'Minimum level for the image manager structured log.'
+        value: 15  # Log disabled by default.
+
+syscfg.logs:
+    IMGMGR_LOG:
+        module: MYNEWT_VAL(IMGMGR_LOG_MOD)
+        level: MYNEWT_VAL(IMGMGR_LOG_LVL)

--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -88,6 +88,22 @@ struct log;
 #define LOG_SYSLEVEL    ((uint8_t)MYNEWT_VAL_LOG_LEVEL)
 #endif
 
+/**
+ * @brief Determines if a log module will accept an entry with a given level.
+ *
+ * A log entry is only accepted if its level is less than or equal to both:
+ *    o Global log level setting (LOG_LEVEL), and
+ *    o The specified module log level
+ *
+ * @param mod_level             The module's minimum log level.
+ * @param entry_level           The level of the entry to be logged.
+ *
+ * @return                      true if the entry would be logged;
+ *                              false otherwise.
+ */
+#define LOG_MOD_LEVEL_IS_ACTIVE(mod_level, entry_level) \
+    (LOG_LEVEL <= (entry_level) && (mod_level) <= (entry_level))
+
 /* Newtmgr Log opcodes */
 #define LOGS_NMGR_OP_READ               (0)
 #define LOGS_NMGR_OP_CLEAR              (1)


### PR DESCRIPTION
This PR adds logging for four image management events.

It will be a nuisance to change the format of these log entries in the future, so we should try to get them right the first time.  Please don't hold back in critiquing the log entry formats!

All events are CBOR-encoded:
```
upstart:
    When: upon receiving an upload request with an offset of 0.
    Structure:
    {
        "ev": "upstart",
        "rc": <mgmt-error-code (int)>
    }

updone:
    When: upon receiving an upload request containing the final chunk
          of an image OR a failed upload request with a non-zero offset.
    Structure:
    {
        "ev": "updone",
        "rc": <mgmt-error-code (int)>
        "hs": <image-hash (byte-string)> (only present on success)
    }

pend:
    When: upon receiving a non-permanent `set-pending` request.
    Structure:
    {
        "ev": "pend",
        "rc": <mgmt-error-code (int)>,
        "hs": <image-hash (byte-string)>
    }

conf:
    When: upon receiving a `confirm` request OR a permanent
          `set-pending` request.
    Structure:
    {
        "ev": "conf",
        "rc": <mgmt-error-code (int)>,
        "hs": <image-hash (byte-string)> (only present for `set-pending`)
    }
```

Here is a log snippet after an upload-test-reset-confirm cycle:
```
     44518     1559419790601524us |     CUSTOM (176)         INFO (1)   cbor {"ev":"upstart","rc":0}
     46008     1559419842390600us |     CUSTOM (176)         INFO (1)   cbor {"ev":"updone","hs":"ZEiw0Ttss5oSc/FUldJB1mFiw/wed+Tt1MBr8uo9aK8=","rc":0}
     46085     1559419899070308us |     CUSTOM (176)         INFO (1)   cbor {"ev":"pend","hs":"ZEiw0Ttss5oSc/FUldJB1mFiw/wed+Tt1MBr8uo9aK8=","rc":0}
     46109     1559419964396732us |     CUSTOM (176)         INFO (1)   cbor {"ev":"conf","rc":0}
```

Image management logging is disabled by default.  To enable it:

1. Override `IMGMGR_LOG_LVL` with a value <= 1 (`LOG_LEVEL_INFO`)
2. Map the `IMGMGR_LOG_MOD` module to a log, e.g.,
```
    rc = modlog_register(MYNEWT_VAL(IMGMGR_LOG_MOD), &my_log,
                         LOG_LEVEL_INFO, NULL);
    assert(rc == 0);
```