### PR TITLE
sensor_shell: Fix infinite read

### DIFF
--- a/hw/sensor/src/sensor_shell.c
+++ b/hw/sensor/src/sensor_shell.c
@@ -489,6 +489,10 @@ sensor_cmd_read(char **argv, int argc)
         goto usage;
     }
 
+    g_spd.spd_nsamples = 0;
+    g_spd.spd_poll_itvl = 0;
+    g_spd.spd_poll_duration = 0;
+
     sensor_name = argv[0];
     type = strtol(argv[1], NULL, 0);
 


### PR DESCRIPTION
sensor read without count/interval/duration is supposed to read just
one value (set of values).
If read was executed before with interval specified next execution
without arguments ends up in infinite reading loop due to complex
condition.

Now count/interval/duration are reset before parsing arguments so
code is more deterministic.