### PR TITLE
bmp280 fixes

### DIFF
--- a/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
+++ b/hw/drivers/sensors/bmp280/include/bmp280/bmp280.h
@@ -106,6 +106,7 @@ struct bmp280 {
         struct bus_i2c_node i2c_node;
         struct bus_spi_node spi_node;
     };
+    bool node_is_spi;
 #else
     struct os_dev dev;
 #endif

--- a/hw/drivers/sensors/bmp280/src/bmp280_shell.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280_shell.c
@@ -160,17 +160,43 @@ bmp280_shell_cmd_oversample(int argc, char **argv)
     uint8_t oversample;
     uint32_t type;
 
-    if (argc > 3) {
+    if (argc > 4) {
         return bmp280_shell_err_too_many_args(argv[1]);
     }
 
-    /* Display the oversample */
-    if (argc == 3) {
-        val = parse_ll_bounds(argv[2], 4, 8, &rc);
+    /* Display the oversampling */
+    if (argc == 2) {
+        rc = bmp280_get_oversample(&g_sensor_itf,
+                                   SENSOR_TYPE_AMBIENT_TEMPERATURE, &oversample);
+        if (rc == 0) {
+            if (oversample == 0) {
+                console_printf("Temperature measurement disabled\n");
+            } else {
+                console_printf("Temperature oversampling %u (x%u)\n",
+                               oversample, 1U << (oversample - 1));
+            }
+        } else {
+            console_printf("Error reading temperature oversampling %d\n", rc);
+        }
+        rc = bmp280_get_oversample(&g_sensor_itf, SENSOR_TYPE_PRESSURE,
+                                   &oversample);
+        if (rc == 0) {
+            if (oversample == 0) {
+                console_printf("Pressure measurement disabled\n");
+            } else {
+                console_printf("Pressure oversampling %u (x%u)\n",
+                               oversample, 1U << (oversample - 1));
+            }
+        } else {
+            console_printf("Error reading pressure oversampling %d\n", rc);
+        }
+    } else if (argc == 3) {
+        /* Display the oversample */
+        val = (uint8_t)parse_ll_bounds(argv[2], 5, 6, &rc);
         if (rc) {
             return bmp280_shell_err_invalid_arg(argv[2]);
         }
-        rc = bmp280_get_oversample(&g_sensor_itf, val, &oversample);
+        rc = bmp280_get_oversample(&g_sensor_itf, 1U << val, &oversample);
         if (rc) {
             goto err;
         }
@@ -179,12 +205,12 @@ bmp280_shell_cmd_oversample(int argc, char **argv)
 
     /* Update the oversampling  */
     if (argc == 4) {
-        val = parse_ll_bounds(argv[2], 4, 8, &rc);
+        val = (uint8_t)parse_ll_bounds(argv[2], 5, 6, &rc);
         if (rc) {
             return bmp280_shell_err_invalid_arg(argv[2]);
         }
 
-        type = val;
+        type = 1U << val;
 
         val = parse_ll_bounds(argv[3], 0, 5, &rc);
         if (rc) {

--- a/hw/drivers/sensors/bmp280/src/bmp280_shell.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280_shell.c
@@ -303,63 +303,53 @@ err:
     return rc;
 }
 
+static void
+bmp280_shell_dump_reg(const char *name, uint8_t addr)
+{
+    uint8_t val = 0;
+    int rc;
+
+    rc = bmp280_readlen(&g_sensor_itf, addr, &val, 1);
+    if (rc == 0) {
+        console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
+    } else {
+        console_printf("0x%02X (%s): failed (%d)\n", addr, name, rc);
+    }
+}
+
+#define DUMP_REG(name) bmp280_shell_dump_reg(#name, BMP280_REG_ADDR_ ## name)
+
 static int
 bmp280_shell_cmd_dump(int argc, char **argv)
 {
-  uint8_t val;
-
   if (argc > 3) {
       return bmp280_shell_err_too_many_args(argv[1]);
   }
 
   /* Dump all the register values for debug purposes */
-  val = 0;
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_T1, &val, 1));
-  console_printf("0x%02X (DIG_T1): 0x%02X\n", BMP280_REG_ADDR_DIG_T1, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_T2, &val, 1));
-  console_printf("0x%02X (DIG_T2):  0x%02X\n", BMP280_REG_ADDR_DIG_T2, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_T3, &val, 1));
-  console_printf("0x%02X (DIG_T3):   0x%02X\n", BMP280_REG_ADDR_DIG_T3, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P1, &val, 1));
-  console_printf("0x%02X (DIG_P1): 0x%02X\n", BMP280_REG_ADDR_DIG_P1, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P2, &val, 1));
-  console_printf("0x%02X (DIG_P2):  0x%02X\n", BMP280_REG_ADDR_DIG_P2, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P3, &val, 1));
-  console_printf("0x%02X (DIG_P3):   0x%02X\n", BMP280_REG_ADDR_DIG_P3, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P4, &val, 1));
-  console_printf("0x%02X (DIG_P4): 0x%02X\n", BMP280_REG_ADDR_DIG_P4, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P5, &val, 1));
-  console_printf("0x%02X (DIG_P5):  0x%02X\n", BMP280_REG_ADDR_DIG_P5, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P6, &val, 1));
-  console_printf("0x%02X (DIG_P6):   0x%02X\n", BMP280_REG_ADDR_DIG_P6, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P7, &val, 1));
-  console_printf("0x%02X (DIG_P7): 0x%02X\n", BMP280_REG_ADDR_DIG_P7, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P8, &val, 1));
-  console_printf("0x%02X (DIG_P8):  0x%02X\n", BMP280_REG_ADDR_DIG_P8, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_DIG_P9, &val, 1));
-  console_printf("0x%02X (DIG_P9):   0x%02X\n", BMP280_REG_ADDR_DIG_P9, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_CHIPID, &val, 1));
-  console_printf("0x%02X (CHIPID):   0x%02X\n", BMP280_REG_ADDR_CHIPID, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_VERSION, &val, 1));
-  console_printf("0x%02X (VER):   0x%02X\n", BMP280_REG_ADDR_VERSION, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_STATUS, &val, 1));
-  console_printf("0x%02X (STATUS):   0x%02X\n", BMP280_REG_ADDR_STATUS, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_CTRL_MEAS, &val, 1));
-  console_printf("0x%02X (CTRL_MEAS):   0x%02X\n", BMP280_REG_ADDR_CTRL_MEAS, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_CONFIG, &val, 1));
-  console_printf("0x%02X (CONFIG):   0x%02X\n", BMP280_REG_ADDR_CONFIG, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_PRESS_MSB, &val, 1));
-  console_printf("0x%02X (PRESS MSB):   0x%02X\n", BMP280_REG_ADDR_PRESS_MSB, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_PRESS_LSB, &val, 1));
-  console_printf("0x%02X (PRESS LSB):   0x%02X\n", BMP280_REG_ADDR_PRESS_LSB, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_PRESS_XLSB, &val, 1));
-  console_printf("0x%02X (PRESS XLSB):   0x%02X\n", BMP280_REG_ADDR_PRESS_XLSB, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_TEMP_XLSB, &val, 1));
-  console_printf("0x%02X (TEMP MSB):   0x%02X\n", BMP280_REG_ADDR_TEMP_MSB, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_TEMP_LSB, &val, 1));
-  console_printf("0x%02X (TEMP LSB):   0x%02X\n", BMP280_REG_ADDR_TEMP_LSB, val);
-  assert(0 == bmp280_readlen(&g_sensor_itf, BMP280_REG_ADDR_TEMP_XLSB, &val, 1));
-  console_printf("0x%02X (TEMP XLSB):   0x%02X\n", BMP280_REG_ADDR_TEMP_XLSB, val);
+  DUMP_REG(DIG_T1);
+  DUMP_REG(DIG_T2);
+  DUMP_REG(DIG_T3);
+  DUMP_REG(DIG_P1);
+  DUMP_REG(DIG_P2);
+  DUMP_REG(DIG_P3);
+  DUMP_REG(DIG_P4);
+  DUMP_REG(DIG_P5);
+  DUMP_REG(DIG_P6);
+  DUMP_REG(DIG_P7);
+  DUMP_REG(DIG_P8);
+  DUMP_REG(DIG_P9);
+  DUMP_REG(CHIPID);
+  DUMP_REG(VERSION);
+  DUMP_REG(STATUS);
+  DUMP_REG(CTRL_MEAS);
+  DUMP_REG(CONFIG);
+  DUMP_REG(PRESS_MSB);
+  DUMP_REG(PRESS_LSB);
+  DUMP_REG(PRESS_XLSB);
+  DUMP_REG(TEMP_XLSB);
+  DUMP_REG(TEMP_LSB);
+  DUMP_REG(TEMP_XLSB);
 
   return 0;
 }

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -27,6 +27,9 @@ syscfg.defs:
     BMP280_SHELL_ITF_TYPE:
         description: 'Shell interface type for the BMP280'
         value: 1
+    BMP280_SHELL_ITF_BUS:
+        description: 'Shell interface bus for the BMP280 when bus driver is used'
+        value: '"i2c0"'
     BMP280_SHELL_CSPIN:
         description: 'CS pin for BMP280'
         value : -1

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -67,6 +67,37 @@ syscfg.defs:
     BMP280_OFB:
         description: 'BMP280 is present'
         value : 0
+    BMP280_OFB_BUS:
+        description: 'I2C or SPI interface used for BMP280'
+        value: '"i2c0"'
+    BMP280_OFB_I2C_NUM:
+        description: 'I2C interface used for BMP280'
+        value: -1
+        restrictions:
+         - '(BMP280_OFB == 0) ||
+            ((BMP280_OFB_I2C_NUM == 0) && (I2C_0 == 1)) ||
+            ((BMP280_OFB_I2C_NUM == 1) && (I2C_1 == 1)) ||
+            ((BMP280_OFB_I2C_NUM == 2) && (I2C_2 == 1)) ||
+            ((BMP280_OFB_I2C_NUM == -1))'
+    BMP280_OFB_SPI_NUM:
+        description: 'SPI interface used for ADXL345'
+        value: -1
+        restrictions:
+         - '(BMP280_OFB == 0) ||
+            ((BMP280_OFB_SPI_NUM == 0) && (SPI_0_MASTER == 1)) ||
+            ((BMP280_OFB_SPI_NUM == 1) && (SPI_1_MASTER == 1)) ||
+            ((BMP280_OFB_SPI_NUM == 2) && (SPI_2_MASTER == 1)) ||
+            ((BMP280_OFB_SPI_NUM == -1))'
+    BMP280_OFB_BAUDRATE:
+        description: 'BMP280 SPI speed'
+        value: 4000
+    BMP280_OFB_I2C_ADDR:
+        description: 'I2C address of BMP280 0x76 or 0x77'
+        value: 0x77
+        range: 0x76,0x77
+    BMP280_OFB_CS:
+        description: 'SPI CS pin for BMP280'
+        value:
     TCS34725_OFB:
         description: 'TCS34725 is present'
         value : 0


### PR DESCRIPTION
There were couple of problems with BMP280

- bus driver implementation was not correctly working with SPI interface
- all bit fields in registers 'config' and 'meas_ctrl' were incorrectly handled
- dump command had too much asserts
- oversample CLI command was not working as designed
- sensor creator did not have bus driver support for this sensor