### PR TITLE
drivers/*da1469x; don't depend on MCU specific header file directly.

### DIFF
--- a/hw/drivers/adc/gpadc_da1469x/pkg.yml
+++ b/hw/drivers/adc/gpadc_da1469x/pkg.yml
@@ -31,4 +31,3 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"
-    - hw/mcu/dialog/da1469x

--- a/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
+++ b/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
@@ -23,7 +23,6 @@
 
 #include <adc/adc.h>
 
-#include <DA1469xAB.h>
 #include <mcu/mcu.h>
 #include <mcu/da1469x_pd.h>
 

--- a/hw/drivers/adc/sdadc_da1469x/pkg.yml
+++ b/hw/drivers/adc/sdadc_da1469x/pkg.yml
@@ -31,4 +31,3 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"
-    - hw/mcu/dialog/da1469x

--- a/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
+++ b/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
@@ -21,7 +21,6 @@
 
 #include <adc/adc.h>
 
-#include <DA1469xAB.h>
 #include <mcu/mcu.h>
 #include <mcu/da1469x_pd.h>
 

--- a/hw/drivers/trng/trng_da1469x/src/trng_da1469x.c
+++ b/hw/drivers/trng/trng_da1469x/src/trng_da1469x.c
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 #include <trng/trng.h>
-#include <DA1469xAB.h>
+#include <mcu/mcu.h>
 
 #define DA1469X_TRNG_FIFO_SIZE  (32 * sizeof(uint32_t))
 #define DA1469X_TRNG_FIFO_ADDR  (0x30050000UL)

--- a/hw/mcu/dialog/da1469x/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#include "DA1469xAB.h"
+
 #define sec_text_ram_core   __attribute__((section(".text_ram"))) __attribute__((noinline))
 
 #define MCU_SYSVIEW_INTERRUPTS \


### PR DESCRIPTION
This allows use of the driver on different MCU with same type of
peripheral. Direct them to find the proper definition via mcu/mcu.h.