### PR TITLE
[RFC] Add cryptographic HASH driver

### DIFF
--- a/apps/hash_test/pkg.yml
+++ b/apps/hash_test/pkg.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: apps/hash_test
+pkg.type: app
+pkg.description:
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/stub"
+    - "@apache-mynewt-core/crypto/mbedtls"
+    - "@apache-mynewt-core/crypto/tinycrypt"
+
+pkg.cflags: '-DMBEDTLS_USER_CONFIG_FILE="mbedtls/config_mynewt.h"'

--- a/apps/hash_test/src/main.c
+++ b/apps/hash_test/src/main.c
@@ -1,0 +1,453 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "sysinit/sysinit.h"
+#include "os/os.h"
+#include "console/console.h"
+#include "hash/hash.h"
+#include "mbedtls/sha256.h"
+#include "tinycrypt/sha256.h"
+
+struct vector_data {
+    char *in;
+    uint16_t inlen;
+    char *digest;
+};
+
+struct test_vectors {
+    char *name;
+    uint16_t algo;
+    uint8_t digestlen;
+    uint8_t len;
+    struct vector_data vectors[];
+};
+
+/*
+ * vectors from:
+ *   http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA_All.pdf
+ */
+
+static struct test_vectors sha224_vectors = {
+    .name = "SHA-224",
+    .algo = HASH_ALGO_SHA224,
+    .len = 4,
+    .digestlen = 28,
+    .vectors = {
+        {
+            .in = "abc",
+            .inlen = 3,
+            .digest = "\x23\x09\x7d\x22\x34\x05\xd8\x22"
+                      "\x86\x42\xa4\x77\xbd\xa2\x55\xb3"
+                      "\x2a\xad\xbc\xe4\xbd\xa0\xb3\xf7"
+                      "\xe3\x6c\x9d\xa7",
+        },
+        {
+            .in = "",
+            .inlen = 0,
+            .digest = "\xd1\x4a\x02\x8c\x2a\x3a\x2b\xc9"
+                      "\x47\x61\x02\xbb\x28\x82\x34\xc4"
+                      "\x15\xa2\xb0\x1f\x82\x8e\xa6\x2a"
+                      "\xc5\xb3\xe4\x2f",
+        },
+        {
+            .in = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            .inlen = 56,
+            .digest = "\x75\x38\x8b\x16\x51\x27\x76\xcc"
+                      "\x5d\xba\x5d\xa1\xfd\x89\x01\x50"
+                      "\xb0\xc6\x45\x5c\xb4\xf5\x8b\x19"
+                      "\x52\x52\x25\x25",
+        },
+        {
+            .in = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                  "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+            .inlen = 112,
+            .digest = "\xc9\x7c\xa9\xa5\x59\x85\x0c\xe9"
+                      "\x7a\x04\xa9\x6d\xef\x6d\x99\xa9"
+                      "\xe0\xe0\xe2\xab\x14\xe6\xb8\xdf"
+                      "\x26\x5f\xc0\xb3",
+        },
+    },
+};
+
+static struct test_vectors sha256_vectors = {
+    .name = "SHA-256",
+    .algo = HASH_ALGO_SHA256,
+    .len = 4,
+    .digestlen = 32,
+    .vectors = {
+        {
+            .in = "abc",
+            .inlen = 3,
+            .digest = "\xba\x78\x16\xbf\x8f\x01\xcf\xea"
+                      "\x41\x41\x40\xde\x5d\xae\x22\x23"
+                      "\xb0\x03\x61\xa3\x96\x17\x7a\x9c"
+                      "\xb4\x10\xff\x61\xf2\x00\x15\xad",
+        },
+        {
+            .in = "",
+            .inlen = 0,
+            .digest = "\xe3\xb0\xc4\x42\x98\xfc\x1c\x14"
+                      "\x9a\xfb\xf4\xc8\x99\x6f\xb9\x24"
+                      "\x27\xae\x41\xe4\x64\x9b\x93\x4c"
+                      "\xa4\x95\x99\x1b\x78\x52\xb8\x55",
+        },
+        {
+            .in = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            .inlen = 56,
+            .digest = "\x24\x8d\x6a\x61\xd2\x06\x38\xb8"
+                      "\xe5\xc0\x26\x93\x0c\x3e\x60\x39"
+                      "\xa3\x3c\xe4\x59\x64\xff\x21\x67"
+                      "\xf6\xec\xed\xd4\x19\xdb\x06\xc1",
+        },
+        {
+            .in = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+                  "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+            .inlen = 112,
+            .digest = "\xcf\x5b\x16\xa7\x78\xaf\x83\x80"
+                      "\x03\x6c\xe5\x9e\x7b\x04\x92\x37"
+                      "\x0b\x24\x9b\x11\xe8\xf0\x7a\x51"
+                      "\xaf\xac\x45\x03\x7a\xfe\xe9\xd1",
+        },
+    },
+};
+
+static struct test_vectors *all_tests[] = {
+    &sha224_vectors,
+    &sha256_vectors,
+    NULL,
+};
+
+void
+run_nist_vectors(struct hash_dev *hash, struct test_vectors *test_mode)
+{
+    uint8_t *inbuf;
+    uint16_t algo;
+    uint8_t outbuf[HASH_MAX_DIGEST_LEN];
+    struct vector_data *vectors;
+    struct vector_data *vector;
+    int i;
+    uint32_t sz;
+
+    algo = test_mode->algo;
+    vectors = test_mode->vectors;
+    sz = test_mode->digestlen;
+
+    printf("%s hash\n", test_mode->name);
+    for (i = 0; i < test_mode->len; i++) {
+        printf("\tvector %d: ", i);
+        vector = &vectors[i];
+        inbuf = (uint8_t *)vector->in;
+
+        if (!hash_has_support(hash, algo)) {
+            printf("not supported\n");
+            continue;
+        }
+
+        if (hash_custom_process(hash, algo, inbuf, vector->inlen, outbuf) != 0) {
+            printf("fail\n");
+            continue;
+        }
+
+        if (memcmp(outbuf, vector->digest, sz) == 0) {
+            printf("ok\n");
+        } else {
+            printf("invalid\n");
+        }
+    }
+}
+
+struct stream_data {
+    char *name;
+    uint16_t algo;
+    uint8_t digestlen;
+    char *digest;
+};
+
+static struct stream_data streams[] = {
+    {
+        .name = "SHA-224",
+        .algo = HASH_ALGO_SHA224,
+        .digestlen = 28,
+        .digest = "\x20\x79\x46\x55\x98\x0c\x91\xd8"
+                  "\xbb\xb4\xc1\xea\x97\x61\x8a\x4b"
+                  "\xf0\x3f\x42\x58\x19\x48\xb2\xee"
+                  "\x4e\xe7\xad\x67",
+    },
+    {
+        .name = "SHA-256",
+        .algo = HASH_ALGO_SHA256,
+        .digestlen = 32,
+        .digest = "\xcd\xc7\x6e\x5c\x99\x14\xfb\x92"
+                  "\x81\xa1\xc7\xe2\x84\xd7\x3e\x67"
+                  "\xf1\x80\x9a\x48\xa4\x97\x20\x0e"
+                  "\x04\x6d\x39\xcc\xc7\x11\x2c\xd0",
+    },
+};
+
+void
+run_stream_test(struct hash_dev *hash)
+{
+    uint8_t inbuf[HASH_MAX_BLOCK_LEN];
+    uint8_t outbuf[HASH_MAX_DIGEST_LEN];
+    struct hash_generic_context ctx;
+    struct stream_data *stream;
+    int i, d;
+    int rc;
+
+    for (d = 0; d < sizeof(streams)/sizeof(streams[0]); d++) {
+        stream = &streams[d];
+        printf("%s: ", stream->name);
+
+        if (!hash_has_support(hash, stream->algo)) {
+            printf("unsupported\n");
+            continue;
+        }
+
+        rc = hash_custom_start(hash, &ctx, stream->algo);
+        if (rc) {
+            printf("failure\n");
+            continue;
+        }
+
+        memset(inbuf, 'a', 64);
+
+        /*
+         * XXX no test needed because 1000000 is a multiple of 64
+         */
+        for (i = 0; i < 1000000; i += 64) {
+            rc = hash_custom_update(hash, &ctx, stream->algo, inbuf, 64);
+            if (rc) {
+                printf("failure\n");
+                continue;
+            }
+        }
+
+        rc = hash_custom_finish(hash, &ctx, stream->algo, outbuf);
+        if (rc) {
+            printf("failure\n");
+        }
+
+        if (memcmp(outbuf, stream->digest, stream->digestlen) == 0) {
+            printf("ok\n");
+        } else {
+            printf("invalid\n");
+        }
+    }
+}
+
+typedef void (* hash_start_func_t)(void *, void *);
+typedef void (* hash_update_func_t)(void *, const uint8_t *, uint32_t);
+typedef void (* hash_finish_func_t)(void *, uint8_t *);
+
+static void
+_hash_sha256_start(void *data, void *arg)
+{
+    (void)hash_sha256_start(data, arg);
+}
+
+static void
+_hash_sha256_update(void *data, const uint8_t *input, uint32_t inlen)
+{
+    (void)hash_sha256_update(data, input, inlen);
+}
+
+static void
+_hash_sha256_finish(void *data, uint8_t *output)
+{
+    (void)hash_sha256_finish(data, output);
+}
+
+static void
+mbed_sha256_start(void *data, void *arg)
+{
+    (void)arg;
+    (void)mbedtls_sha256_starts_ret((mbedtls_sha256_context *)data, 0);
+}
+
+static void
+mbed_sha256_update(void *data, const uint8_t *input, uint32_t inlen)
+{
+    (void)mbedtls_sha256_update_ret((mbedtls_sha256_context *)data, input,
+            (uint16_t)inlen);
+}
+
+static void
+mbed_sha256_finish(void *data, uint8_t *output)
+{
+    (void)mbedtls_sha256_finish_ret((mbedtls_sha256_context *)data, output);
+}
+
+static void
+tc_sha256_start(void *data, void *arg)
+{
+    (void)arg;
+    (void)tc_sha256_init((TCSha256State_t)data);
+}
+
+static void
+_tc_sha256_update(void *data, const uint8_t *input, uint32_t inlen)
+{
+    (void)tc_sha256_update((TCSha256State_t)data, input, inlen);
+}
+
+static void
+tc_sha256_finish(void *data, uint8_t *output)
+{
+    (void)tc_sha256_final(output, (TCSha256State_t)data);
+}
+
+static void
+run_sha256_benchmark(char *name, hash_start_func_t start_fn,
+        hash_update_func_t update_fn, hash_finish_func_t finish_fn,
+        void *ctx, void *start_arg)
+{
+    int i;
+    uint8_t output[SHA256_DIGEST_LEN];
+    uint8_t input[SHA256_BLOCK_LEN];
+    os_time_t t;
+    char *expected_digest = "\xcd\xc7\x6e\x5c\x99\x14\xfb\x92"
+                            "\x81\xa1\xc7\xe2\x84\xd7\x3e\x67"
+                            "\xf1\x80\x9a\x48\xa4\x97\x20\x0e"
+                            "\x04\x6d\x39\xcc\xc7\x11\x2c\xd0";
+
+    printf("%s - running on 1000000 input chars... ", name);
+    t = os_time_get();
+    memset(input, 'a', SHA256_BLOCK_LEN);
+    start_fn(ctx, start_arg);
+    for (i = 0; i < 1000000; i += SHA256_BLOCK_LEN) {
+        update_fn(ctx, input, SHA256_BLOCK_LEN);
+    }
+    finish_fn(ctx, output);
+    if (memcmp(output, expected_digest, SHA256_DIGEST_LEN)) {
+        printf("fail\n");
+        return;
+    }
+    printf("done in %lu ticks\n", os_time_get() - t);
+}
+
+static void
+concurrency_test_handler(void *arg)
+{
+    struct os_task *t;
+    struct hash_dev *hash = (struct hash_dev *)arg;
+    uint16_t ok, fail;
+    struct hash_sha256_context ctx;
+    uint8_t input[SHA256_BLOCK_LEN];
+    uint8_t output[HASH_MAX_BLOCK_LEN];
+    char *expected_digest = "\xcd\xc7\x6e\x5c\x99\x14\xfb\x92"
+                            "\x81\xa1\xc7\xe2\x84\xd7\x3e\x67"
+                            "\xf1\x80\x9a\x48\xa4\x97\x20\x0e"
+                            "\x04\x6d\x39\xcc\xc7\x11\x2c\xd0";
+    int i, j;
+
+    t = os_sched_get_current_task();
+    ok = fail = 0;
+    memset(input, 'a', SHA256_BLOCK_LEN);
+    for (i = 10; i > 0; i--) {
+        (void)hash_custom_start(hash, &ctx, HASH_ALGO_SHA256);
+        for (j = 0; j < 1000000; j += SHA256_BLOCK_LEN) {
+            hash_custom_update(hash, &ctx, HASH_ALGO_SHA256, input,
+                    SHA256_BLOCK_LEN);
+        }
+        (void)hash_custom_finish(hash, &ctx, HASH_ALGO_SHA256, output);
+        if (memcmp(output, expected_digest, SHA256_DIGEST_LEN)) {
+            fail++;
+        } else {
+            ok++;
+        }
+        os_time_delay(10);
+    }
+
+    printf("%s [%d fails / %d ok] done\n", t->t_name, fail, ok);
+
+    while (1) {
+        os_time_delay(OS_TICKS_PER_SEC);
+    }
+}
+
+#define TASK_AMOUNT 8
+#define STACK_SIZE 128
+static struct os_task tasks[TASK_AMOUNT];
+static char names[TASK_AMOUNT][6];
+static void
+run_concurrency_test(struct hash_dev *hash)
+{
+    os_stack_t *pstack;
+    int i;
+
+    printf("\n=== Concurrency [%d tasks] ===\n", TASK_AMOUNT);
+
+    assert(TASK_AMOUNT < 10);
+    for (i = 0; i < TASK_AMOUNT; i++) {
+        pstack = malloc(sizeof(os_stack_t) * STACK_SIZE);
+        assert(pstack);
+
+        sprintf(names[i], "task%c", i + '0');
+        os_task_init(&tasks[i], names[i], concurrency_test_handler, hash,
+                8 + i, OS_WAIT_FOREVER, pstack, STACK_SIZE);
+    }
+}
+
+int
+main(void)
+{
+    struct hash_dev *hash;
+    struct hash_sha256_context hash_sha256;
+    mbedtls_sha256_context mbed_sha256;
+    struct tc_sha256_state_struct tc_sha256;
+    int i;
+
+    sysinit();
+
+    hash = (struct hash_dev *) os_dev_open("hash", OS_TIMEOUT_NEVER, NULL);
+    assert(hash);
+
+    printf("\n=== NIST vectors ===\n");
+    for (i = 0; all_tests[i] != NULL; i++) {
+        run_nist_vectors(hash, all_tests[i]);
+    }
+
+    printf("\n=== SHA-256 of 1000000 'a' letters ===\n");
+    run_stream_test(hash);
+
+    mbedtls_sha256_init(&mbed_sha256);
+    tc_sha256_init(&tc_sha256);
+
+    for (i = 1; i <= 3; i++) {
+        printf("\n=== Benchmarks - iteration %d ===\n", i);
+        run_sha256_benchmark("HASH", _hash_sha256_start, _hash_sha256_update,
+                _hash_sha256_finish, &hash_sha256, hash);
+        run_sha256_benchmark("MBEDTLS", mbed_sha256_start, mbed_sha256_update,
+                mbed_sha256_finish, &mbed_sha256, NULL);
+        run_sha256_benchmark("TINYCRYPT", tc_sha256_start, _tc_sha256_update,
+                tc_sha256_finish, &tc_sha256, NULL);
+        os_time_delay(OS_TICKS_PER_SEC);
+    }
+
+    run_concurrency_test(hash);
+
+    while (1) {
+        os_eventq_run(os_eventq_dflt_get());
+    }
+
+    return 0;
+}

--- a/apps/hash_test/syscfg.yml
+++ b/apps/hash_test/syscfg.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    APP_HASH_DEV:
+        description: HASH device name
+        value: '"hash"'
+
+syscfg.vals:
+    HASH: 1

--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -244,6 +244,14 @@ extern "C" {
 #undef MBEDTLS_CTR_DRBG_C
 #endif
 
+#if MYNEWT_VAL(MBEDTLS_SHA256_ALT) == 0
+#undef MBEDTLS_SHA256_ALT
+#elif !defined(MBEDTLS_SHA256_ALT)
+#define MBEDTLS_SHA256_ALT 1
+#endif
+#if MYNEWT_VAL(MBEDTLS_SHA256_C) == 0
+#undef MBEDTLS_SHA256_C
+#endif
 #if MYNEWT_VAL(MBEDTLS_MD5_C) == 0
 #undef MBEDTLS_MD5_C
 #endif

--- a/crypto/mbedtls/include/mbedtls/sha256_alt.h
+++ b/crypto/mbedtls/include/mbedtls/sha256_alt.h
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __ALT_SHA256_H__
+#define __ALT_SHA256_H__
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(HASH)
+#include "hash/sha256_alt.h"
+#endif
+
+#endif /* __ALT_SHA256_H__ */

--- a/crypto/mbedtls/selftest/syscfg.yml
+++ b/crypto/mbedtls/selftest/syscfg.yml
@@ -56,6 +56,8 @@ syscfg.vals:
   MBEDTLS_CCM_C: 1
 
   # Hash functions
+  MBEDTLS_SHA256_C: 1
+  MBEDTLS_SHA256_ALT: 0
   MBEDTLS_MD5_C: 1
   MBEDTLS_SHA1_C: 1
   MBEDTLS_SHA512_C: 1

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -94,6 +94,11 @@ syscfg.defs:
     value: 0
 
   # Hash functions
+  MBEDTLS_SHA256_ALT:
+    description: 'Set to enable HW based HASH'
+    value: 0
+  MBEDTLS_SHA256_C:
+    value: 1
   MBEDTLS_MD5_C:
     value: 0
   MBEDTLS_SHA1_C:

--- a/hw/bsp/frdm-k64f/pkg.yml
+++ b/hw/bsp/frdm-k64f/pkg.yml
@@ -71,3 +71,6 @@ pkg.deps.CRYPTO:
 
 pkg.deps.ENC_FLASH_DEV:
     - "@apache-mynewt-core/hw/drivers/flash/enc_flash/ef_crypto"
+
+pkg.deps.HASH:
+    - "@apache-mynewt-core/hw/drivers/hash/hash_k64f"

--- a/hw/bsp/frdm-k64f/src/hal_bsp.c
+++ b/hw/bsp/frdm-k64f/src/hal_bsp.c
@@ -39,6 +39,10 @@
 #if MYNEWT_VAL(ENC_FLASH_DEV)
 #include <ef_crypto/ef_crypto.h>
 #endif
+#if MYNEWT_VAL(HASH)
+#include "hash/hash.h"
+#include "hash_k64f/hash_k64f.h"
+#endif
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || \
     MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || MYNEWT_VAL(UART_5)
 #include "uart/uart.h"
@@ -78,6 +82,10 @@ static struct trng_dev os_bsp_trng;
 
 #if MYNEWT_VAL(CRYPTO)
 static struct crypto_dev os_bsp_crypto;
+#endif
+
+#if MYNEWT_VAL(HASH)
+static struct hash_dev os_bsp_hash;
 #endif
 
 /*
@@ -209,6 +217,12 @@ hal_bsp_init(void)
     rc = os_dev_create(&os_bsp_crypto.dev, "crypto",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
                        k64f_crypto_dev_init, NULL);
+    assert(rc == 0);
+#endif
+
+#if MYNEWT_VAL(HASH)
+    rc = os_dev_create(&os_bsp_hash.dev, "hash", OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT, k64f_hash_dev_init, NULL);
     assert(rc == 0);
 #endif
 

--- a/hw/bsp/nucleo-f439zi/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f439zi/include/bsp/stm32f4xx_hal_conf.h
@@ -69,7 +69,6 @@
 #define HAL_PCCARD_MODULE_ENABLED
 #define HAL_SRAM_MODULE_ENABLED
 /* #define HAL_SDRAM_MODULE_ENABLED */
-#define HAL_HASH_MODULE_ENABLED
 #define HAL_GPIO_MODULE_ENABLED
 #define HAL_I2C_MODULE_ENABLED
 #define HAL_I2S_MODULE_ENABLED
@@ -102,6 +101,7 @@
 #define HAL_RNG_MODULE_ENABLED
 #define HAL_CRYP_MODULE_ENABLED
 #define HAL_PWR_MODULE_ENABLED
+#define HAL_HASH_MODULE_ENABLED
 #endif
 
 /* ########################## HSE/HSI Values adaptation ##################### */

--- a/hw/bsp/nucleo-f439zi/pkg.yml
+++ b/hw/bsp/nucleo-f439zi/pkg.yml
@@ -46,3 +46,6 @@ pkg.deps.TRNG:
 
 pkg.deps.CRYPTO:
     - "@apache-mynewt-core/hw/drivers/crypto/crypto_stm32"
+
+pkg.deps.HASH:
+    - "@apache-mynewt-core/hw/drivers/hash/hash_stm32"

--- a/hw/bsp/nucleo-f439zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f439zi/src/hal_bsp.c
@@ -36,6 +36,11 @@
 #include "crypto_stm32/crypto_stm32.h"
 #endif
 
+#if MYNEWT_VAL(HASH)
+#include "hash/hash.h"
+#include "hash_stm32/hash_stm32.h"
+#endif
+
 #include <hal/hal_bsp.h>
 #include <hal/hal_gpio.h>
 #include <hal/hal_timer.h>
@@ -90,6 +95,10 @@ static struct trng_dev os_bsp_trng;
 
 #if MYNEWT_VAL(CRYPTO)
 static struct crypto_dev os_bsp_crypto;
+#endif
+
+#if MYNEWT_VAL(HASH)
+static struct hash_dev os_bsp_hash;
 #endif
 
 #if MYNEWT_VAL(UART_0)
@@ -195,6 +204,11 @@ hal_bsp_init(void)
     rc = os_dev_create(&os_bsp_crypto.dev, "crypto",
                        OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
                        stm32_crypto_dev_init, NULL);
+#endif
+
+#if MYNEWT_VAL(HASH)
+    rc = os_dev_create(&os_bsp_hash.dev, "hash", OS_DEV_INIT_KERNEL,
+                       OS_DEV_INIT_PRIO_DEFAULT, stm32_hash_dev_init, NULL);
     assert(rc == 0);
 #endif
 

--- a/hw/drivers/hash/hash_k64f/include/hash_context.h
+++ b/hw/drivers/hash/hash_k64f/include/hash_context.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __HASH_CONTEXT_H__
+#define __HASH_CONTEXT_H__
+
+#include "hash/hash.h"
+
+/*
+ * SHA-224 is not supported supported on K64F
+ */
+struct hash_sha224_context {
+    void *dev;
+};
+
+/*
+ * SHA-256 is implemented.
+ */
+struct hash_sha256_context {
+    /* Store device pointer */
+    void *dev;
+    /* Total length of the hashed data */
+    uint32_t len;
+    /* Current context output of the hash */
+    unsigned int output[SHA256_DIGEST_LEN >> 2];
+    /* Last block added, used to pad on finish() */
+    uint8_t pad[SHA256_BLOCK_LEN];
+    /* Amount added to pad, used on finish() */
+    uint8_t remain;
+};
+
+#endif /* __HASH_CONTEXT_H__ */

--- a/hw/drivers/hash/hash_k64f/include/hash_k64f/hash_k64f.h
+++ b/hw/drivers/hash/hash_k64f/include/hash_k64f/hash_k64f.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __HASH_K64F_H__
+#define __HASH_K64F_H__
+
+#include "hash/hash.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int k64f_hash_dev_init(struct os_dev *dev, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HASH_K64F_H__ */

--- a/hw/drivers/hash/hash_k64f/pkg.yml
+++ b/hw/drivers/hash/hash_k64f/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/hash/hash_k64f
+pkg.description: Hash driver for NXP K64F
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.apis:
+    - HASH_HW_IMPL
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/drivers/hash"

--- a/hw/drivers/hash/hash_k64f/src/hash_k64f.c
+++ b/hw/drivers/hash/hash_k64f/src/hash_k64f.c
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "mcu/cmsis_nvic.h"
+#include <os/mynewt.h>
+
+#include "hash/hash.h"
+#include "hash_k64f/hash_k64f.h"
+
+static struct os_mutex gmtx;
+static uint32_t g_algos = HASH_ALGO_SHA256;
+
+/*
+ * These routines are exported by NXP's provided CAU and mmCAU software
+ * library.
+ */
+extern int mmcau_sha256_initialize_output(const unsigned int *output);
+extern void mmcau_sha256_hash_n(const unsigned char *msg_data,
+        const int num_blks, unsigned int *sha256_state);
+extern void mmcau_sha256_update(const unsigned char *msg_data,
+        const int num_blks, unsigned int *sha256_state);
+extern void mmcau_sha256_hash (const unsigned char *msg_data,
+        unsigned int *sha256_state);
+
+/*
+ * Fallback CAU routines in C.
+ */
+extern int cau_sha256_initialize_output(const unsigned int *output);
+extern void cau_sha256_hash_n(const unsigned char *msg_data,
+        const int num_blks, unsigned int *sha256_state);
+extern void cau_sha256_update(const unsigned char *msg_data,
+        const int num_blks, unsigned int *sha256_state);
+extern void cau_sha256_hash(const unsigned char *msg_data,
+        unsigned int *sha256_state);
+
+static int
+k64f_hash_start(struct hash_dev *hash, void *ctx, uint16_t algo)
+{
+    struct hash_sha256_context *sha256ctx;
+
+    if (!(algo & g_algos)) {
+        return -1;
+    }
+
+    os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
+    sha256ctx = (struct hash_sha256_context *)ctx;
+    (void)cau_sha256_initialize_output(sha256ctx->output);
+    sha256ctx->len = 0;
+    sha256ctx->remain = 0;
+
+    return 0;
+}
+
+static int
+k64f_hash_update(struct hash_dev *hash, void *ctx, uint16_t algo,
+        const void *inbuf, uint32_t inlen)
+{
+    uint32_t i;
+    uint32_t remain;
+    struct hash_sha256_context *sha256ctx;
+    uint8_t *u8p;
+
+    sha256ctx = (struct hash_sha256_context *)ctx;
+    i = 0;
+    remain = inlen;
+    u8p = (uint8_t *)inbuf;
+
+    while (remain >= SHA256_BLOCK_LEN) {
+        cau_sha256_hash_n((const unsigned char *)&u8p[i], 1,
+                sha256ctx->output);
+        remain -= SHA256_BLOCK_LEN;
+        i += SHA256_BLOCK_LEN;
+    }
+
+    sha256ctx->len += i;
+
+    if (remain > 0) {
+        memcpy(sha256ctx->pad, &u8p[i], remain);
+        sha256ctx->remain = remain;
+    }
+
+    return 0;
+}
+
+static int
+k64f_hash_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
+        void *outbuf)
+{
+    uint32_t i;
+    uint32_t *b32p;
+    uint8_t ARRSZ = sizeof(uint64_t);
+    struct hash_sha256_context *sha256ctx;
+
+    sha256ctx = (struct hash_sha256_context *)ctx;
+    sha256ctx->pad[sha256ctx->remain] = 0x80;
+    sha256ctx->len += sha256ctx->remain;
+    sha256ctx->remain++;
+
+    i = sha256ctx->remain;
+
+    if (sha256ctx->remain >= (SHA256_BLOCK_LEN - ARRSZ)) {
+        memset(&sha256ctx->pad[i], 0, SHA256_BLOCK_LEN - i);
+        cau_sha256_hash_n((const unsigned char *)sha256ctx->pad, 1,
+                sha256ctx->output);
+        i = 0;
+    }
+
+    /*
+     * Pad remaining data of the last block and add the original message's
+     * length as big endian 64-bit
+     */
+    memset(&sha256ctx->pad[i], 0, SHA256_BLOCK_LEN - i);
+    *((uint64_t *)&sha256ctx->pad[SHA256_BLOCK_LEN - sizeof(uint64_t)]) =
+        os_bswap_64(sha256ctx->len * 8);
+    cau_sha256_hash_n((const unsigned char *)sha256ctx->pad, 1,
+            sha256ctx->output);
+
+    b32p = (uint32_t *)outbuf;
+    for (i = 0; i < 8; i++) {
+        b32p[i] = os_bswap_32(sha256ctx->output[i]);
+    }
+
+    os_mutex_release(&gmtx);
+    return 0;
+}
+
+static int
+k64f_hash_dev_open(struct os_dev *dev, uint32_t wait, void *arg)
+{
+    struct hash_dev *hash;
+
+    hash = (struct hash_dev *)dev;
+    assert(hash);
+
+    /* Not reentrant */
+    if (dev->od_flags & OS_DEV_F_STATUS_OPEN) {
+        return OS_EBUSY;
+    }
+
+    return OS_OK;
+}
+
+int
+k64f_hash_dev_init(struct os_dev *dev, void *arg)
+{
+    struct hash_dev *hash;
+
+    hash = (struct hash_dev *)dev;
+    assert(hash);
+
+    OS_DEV_SETHANDLERS(dev, k64f_hash_dev_open, NULL);
+
+    assert(os_mutex_init(&gmtx) == 0);
+
+    hash->interface.start = k64f_hash_start;
+    hash->interface.update = k64f_hash_update;
+    hash->interface.finish = k64f_hash_finish;
+    hash->interface.algomask = g_algos;
+
+    return 0;
+}

--- a/hw/drivers/hash/hash_k64f/src/hash_k64f_cau.c
+++ b/hw/drivers/hash/hash_k64f/src/hash_k64f_cau.c
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include "hash_k64f/hash_k64f.h"
+
+/*
+ * CAU interface
+ */
+
+#define CAU_CMD1_SHIFT 22
+#define CAU_CMD2_SHIFT 11
+#define CAU_CMD3_SHIFT 0
+
+#define CAU_CMD1(x) (0x80000000 | (x) << CAU_CMD1_SHIFT)
+#define CAU_CMD2(x) (0x00100000 | (x) << CAU_CMD2_SHIFT)
+#define CAU_CMD3(x) (0x00000200 | (x) << CAU_CMD3_SHIFT)
+
+#define CA7    9
+#define CA8    10
+
+#define ADRA   0x50      /* CAA = CAA + CAx */
+#define MVAR   0x90      /* CAx = CAA */
+#define HASH   0x120
+#define SHS2   0x150
+
+#define HF2C   6         /* Ch */
+#define HF2M   7         /* Maj */
+#define HF2S   8         /* S0 */
+#define HF2T   9         /* S1 */
+#define HF2U   10        /* s0 */
+#define HF2V   11        /* s1 */
+
+/*
+ * First 32 bits of the fractional parts of the square roots of the
+ * first 8 primes (2..19)
+ */
+static uint32_t sha256_initial_h[SHA256_DIGEST_LEN] = {
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+};
+
+/*
+ * First 32 bits of the fractional parts of the cube roots of the
+ * first 64 primes (2..311)
+ */
+static uint32_t sha256_k[] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+int
+cau_sha256_initialize_output(const unsigned int *output)
+{
+    memcpy((unsigned int *)output, sha256_initial_h, SHA256_DIGEST_LEN);
+    return 0;
+}
+
+void
+cau_sha256_hash_n(const unsigned char *msg_data, const int num_blks,
+        unsigned int *sha256_state)
+{
+    int i;
+    uint32_t *b32p;
+    /* NOTE: avoid stack overrun when stack size is small */
+    static uint32_t w[64];
+    int blk;
+
+    b32p = (uint32_t *)msg_data;
+
+    for (i = 0; i < 8; i++) {
+        CAU->LDR_CA[i] = sha256_state[i];
+    }
+
+    blk = num_blks;
+    while (blk-- > 0) {
+        for (i = 0; i < 16; i++) {
+            CAU->LDR_CAA = w[i] = os_bswap_32(b32p[i]);
+            CAU->DIRECT[0] = CAU_CMD1(ADRA + CA7) + CAU_CMD2(HASH + HF2T) +
+                CAU_CMD3(HASH + HF2C);
+            CAU->ADR_CAA = sha256_k[i];
+            CAU->DIRECT[0] = CAU_CMD1(MVAR + CA8) + CAU_CMD2(HASH + HF2S) +
+                CAU_CMD3(HASH + HF2M);
+            CAU->DIRECT[0] = CAU_CMD1(SHS2);
+        }
+
+        for (i = 16; i < 64; i++) {
+            CAU->LDR_CAA = w[i - 16];
+            CAU->LDR_CA[8] = w[i - 15];
+            CAU->DIRECT[0] = CAU_CMD1(HASH + HF2U);
+            CAU->ADR_CAA = w[i - 7];
+            CAU->LDR_CA[8] = w[i - 2];
+            CAU->DIRECT[0] = CAU_CMD1(HASH + HF2V);
+            w[i] = CAU->STR_CAA;
+            CAU->DIRECT[0] = CAU_CMD1(ADRA + CA7) + CAU_CMD2(HASH + HF2T) +
+                CAU_CMD3(HASH + HF2C);
+            CAU->ADR_CAA = sha256_k[i];
+            CAU->DIRECT[0] = CAU_CMD1(MVAR + CA8) + CAU_CMD2(HASH + HF2S) +
+                CAU_CMD3(HASH + HF2M);
+            CAU->DIRECT[0] = CAU_CMD1(SHS2);
+        }
+
+        for (i = 0; i < 8; i++) {
+            CAU->ADR_CA[i] = sha256_state[i];
+            sha256_state[i] = CAU->STR_CA[i];
+        }
+    }
+}
+
+void
+cau_sha256_update(const unsigned char *msg_data, const int num_blks,
+        unsigned int *sha256_state)
+{
+    memcpy(sha256_state, sha256_initial_h, SHA256_DIGEST_LEN);
+    cau_sha256_hash_n(msg_data, num_blks, sha256_state);
+}
+
+void
+cau_sha256_hash(const unsigned char *msg_data, unsigned int *sha256_state)
+{
+    cau_sha256_hash_n(msg_data, 1, sha256_state);
+}

--- a/hw/drivers/hash/hash_stm32/include/hash_context.h
+++ b/hw/drivers/hash/hash_stm32/include/hash_context.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __HASH_CONTEXT_H__
+#define __HASH_CONTEXT_H__
+
+#include "hash/hash.h"
+
+/*
+ * On STM32 the SDK already handles context...
+ */
+
+struct hash_sha224_context {
+    void *dev;
+};
+
+struct hash_sha256_context {
+    void *dev;
+};
+
+#endif /* __HASH_CONTEXT_H__ */

--- a/hw/drivers/hash/hash_stm32/include/hash_stm32/hash_stm32.h
+++ b/hw/drivers/hash/hash_stm32/include/hash_stm32/hash_stm32.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __HASH_STM32_H__
+#define __HASH_STM32_H__
+
+#include "hash/hash.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int stm32_hash_dev_init(struct os_dev *dev, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HASH_STM32_H__ */

--- a/hw/drivers/hash/hash_stm32/pkg.yml
+++ b/hw/drivers/hash/hash_stm32/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/hash/hash_stm32
+pkg.description: Crypto hash driver for STM32
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.apis:
+    - HASH_HW_IMPL
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/drivers/hash"

--- a/hw/drivers/hash/hash_stm32/src/hash_stm32.c
+++ b/hw/drivers/hash/hash_stm32/src/hash_stm32.c
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include "mcu/cmsis_nvic.h"
+#include <os/mynewt.h>
+#include "mcu/stm32_hal.h"
+#include "hash/hash.h"
+#include "hash_stm32/hash_stm32.h"
+
+static struct os_mutex gmtx;
+
+/*
+ * STM32F415xx and STM32F417xx have a HASH unit that only supports MD5/SHA1
+ */
+
+#if defined(STM32F437xx) || defined(STM32F439xx) || defined(STM32F479xx) || \
+    defined(STM32F756xx) || defined(STM32F777xx) || defined(STM32F779xx) || \
+    defined(STM32L4A6xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || \
+    defined(STM32L4S9xx)
+static uint32_t g_algos = HASH_ALGO_SHA224 | HASH_ALGO_SHA256;
+#else
+static uint32_t g_algos = 0;
+#endif
+
+static int
+stm32_hash_start(struct hash_dev *hash, void *ctx, uint16_t algo)
+{
+    uint32_t algomask;
+
+    (void)ctx;
+
+    if (!(algo & g_algos)) {
+        return -1;
+    }
+
+    os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
+
+    switch (algo) {
+    case HASH_ALGO_SHA224:
+        algomask = HASH_ALGOSELECTION_SHA224;
+        break;
+    case HASH_ALGO_SHA256:
+        algomask = HASH_ALGOSELECTION_SHA256;
+        break;
+    default:
+        assert(0);
+        return -1;
+    }
+
+    HASH->CR = algomask | HASH_CR_INIT | HASH_DATATYPE_8B;
+
+    return 0;
+}
+
+static int
+stm32_hash_update(struct hash_dev *hash, void *ctx, uint16_t algo,
+        const void *inbuf, uint32_t inlen)
+{
+    uint32_t *u32p;
+    int i;
+
+    (void)ctx;
+
+    u32p = (uint32_t *)inbuf;
+    for (i = 0; i < (inlen + 3) / 4; i++) {
+        HASH->DIN = u32p[i];
+    }
+    __HAL_HASH_SET_NBVALIDBITS(inlen);
+
+    return 0;
+}
+
+static int
+stm32_hash_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
+        void *outbuf)
+{
+    uint8_t digestsz;
+    uint32_t *u32p;
+    int i;
+
+    (void)ctx;
+
+    switch (algo) {
+    case HASH_ALGO_SHA224:
+        digestsz = SHA224_DIGEST_LEN / 4;
+        break;
+    case HASH_ALGO_SHA256:
+        digestsz = SHA256_DIGEST_LEN / 4;
+        break;
+    default:
+        assert(0);
+        return -1;
+    }
+
+    __HAL_HASH_START_DIGEST();
+
+    while (HASH->SR & HASH_FLAG_BUSY) ;
+
+    u32p = (uint32_t *)outbuf;
+    for (i = 0; i < digestsz; i++) {
+        /*
+         * XXX HASH_DIGEST is only available on devices that support
+         * SHA-2, and its first 5 words are mapped at the same address
+         * as HASH below.
+         */
+        u32p[i] = os_bswap_32(HASH_DIGEST->HR[i]);
+    }
+
+    os_mutex_release(&gmtx);
+    return 0;
+}
+
+static int
+stm32_hash_dev_open(struct os_dev *dev, uint32_t wait, void *arg)
+{
+    struct hash_dev *hash;
+
+    hash = (struct hash_dev *)dev;
+    assert(hash);
+
+    /* XXX Not reentrant? */
+    if (dev->od_flags & OS_DEV_F_STATUS_OPEN) {
+        return OS_EBUSY;
+    }
+
+    __HAL_RCC_HASH_CLK_ENABLE();
+
+    return 0;
+}
+
+int
+stm32_hash_dev_init(struct os_dev *dev, void *arg)
+{
+    struct hash_dev *hash;
+
+    hash = (struct hash_dev *)dev;
+    assert(hash);
+
+    OS_DEV_SETHANDLERS(dev, stm32_hash_dev_open, NULL);
+
+    assert(os_mutex_init(&gmtx) == 0);
+
+    hash->interface.start = stm32_hash_start;
+    hash->interface.update = stm32_hash_update;
+    hash->interface.finish = stm32_hash_finish;
+    hash->interface.algomask = g_algos;
+
+    return 0;
+}

--- a/hw/drivers/hash/include/hash/hash.h
+++ b/hw/drivers/hash/include/hash/hash.h
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __HASH_H__
+#define __HASH_H__
+
+#include <inttypes.h>
+#include <stddef.h>
+#include "os/mynewt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * HASH definitions
+ */
+#define SHA224_DIGEST_LEN              28
+#define SHA256_DIGEST_LEN              32
+#define HASH_MAX_DIGEST_LEN            SHA256_DIGEST_LEN
+
+#define SHA256_BLOCK_LEN               64  /* 512 bits */
+#define HASH_MAX_BLOCK_LEN             SHA256_BLOCK_LEN
+
+/*
+ * MCU specific context structs
+ */
+#include "hash_context.h"
+
+struct hash_generic_context {
+    union {
+        struct hash_sha224_context sha224ctx;
+        struct hash_sha256_context sha256ctx;
+    };
+};
+
+/*
+ * Driver capabilities
+ */
+#define HASH_ALGO_SHA224               0x0001
+#define HASH_ALGO_SHA256               0x0002
+#define HASH_ALGO_SHA512               0x0004
+
+struct hash_dev;
+
+typedef int (* hash_start_op_func_t)(struct hash_dev *hash, void *ctx,
+        uint16_t algo);
+typedef int (* hash_update_op_func_t)(struct hash_dev *hash, void *ctx,
+        uint16_t algo, const void *inbuf, uint32_t inlen);
+typedef int (* hash_finish_op_func_t)(struct hash_dev *hash, void *ctx,
+        uint16_t algo, void *outbuf);
+
+/**
+ * @struct hash_interface
+ * @brief Provides the interface into a HW hash driver
+ *
+ * @var hash_interface::start
+ * start is a hash_start_op_func_t pointer to the hashing routine used
+ * to start a new stream operation
+ *
+ * @var hash_interface::update
+ * update is a hash_update_op_func_t pointer to the hashing routine used
+ * to update the current stream operation with new data
+ *
+ * @var hash_interface::finish
+ * finish is a hash_finish_op_func_t pointer to the hashing routine used
+ * to finish the current stream operation and return a digest
+ *
+ * @var hash_interface::algomask
+ * algomask stores a bitmask of algorithms supported by this hash driver
+ */
+struct hash_interface {
+    hash_start_op_func_t start;
+    hash_update_op_func_t update;
+    hash_finish_op_func_t finish;
+    uint32_t algomask;
+};
+
+struct hash_dev {
+    struct os_dev dev;
+    struct hash_interface interface;
+};
+
+/**
+ * Hash a buffer using custom parameters; this should be used when
+ * all data to be hashed is already available, since it does all
+ * hashing in a single call.
+ *
+ * NOTE: if the hash needs to be constantly update with new data use
+ * _start(), _update(), _finish().
+ *
+ * @param hash     OS device
+ * @param algo     Algorithm to use (see HASH_ALGO_*)
+ * @param inbuf    The input data to be encrypted
+ * @param inlen    Length of the input buffer
+ * @param outbuf   Digest result
+ *
+ * @return 0 if succesfull; -1 otherwise
+ */
+int hash_custom_process(struct hash_dev *hash, uint16_t algo,
+        const void *inbuf, uint32_t inlen, void *outbuf);
+
+/**
+ * Start a stream hash operation with custom parameters
+ *
+ * NOTE: call _update() with contents and _finish() to capture the
+ * final digest.
+ *
+ * @param hash     OS device
+ * @param ctx      A context struct for the chosen algo
+ * @param algo     Algorithm to use (see HASH_ALGO_*)
+ *
+ * @return 0 if succesfull; -1 otherwise
+ */
+int hash_custom_start(struct hash_dev *hash, void *ctx, uint16_t algo);
+
+/**
+ * Update the current hash operation with new data.
+ *
+ * NOTE: _start() must have been called previously.
+ *
+ * @param hash     OS device
+ * @param ctx      A context struct for the chosen algo
+ * @param algo     Algorithm to use (see HASH_ALGO_*)
+ * @param inbuf    The input data to be encrypted
+ * @param inlen    Length of the input buffer
+ *
+ * @return 0 if succesfull; -1 otherwise
+ */
+int hash_custom_update(struct hash_dev *hash, void *ctx, uint16_t algo,
+        const void *inbuf, uint32_t inlen);
+
+/**
+ * Finish a stream hash operation and return the final digest.
+ *
+ * @param hash     OS device
+ * @param ctx      A context struct for the chosen algo
+ * @param algo     Algorithm to use (see HASH_ALGO_*)
+ * @param outbuf   Digest result
+ *
+ * @return 0 if succesfull; -1 otherwise
+ */
+int hash_custom_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
+        void *outbuf);
+
+/*
+ * Query Hash HW capabilities
+ *
+ * @param hash     OS device
+ * @param algo     Hash algorithm to check for (HASH_ALGO_*)
+ *
+ * @return true if the device has support, false otherwise.
+ */
+bool hash_has_support(struct hash_dev *hash, uint16_t algo);
+
+/*
+ * Helpers
+ */
+
+/**
+ * Generate SHA256 digest of input data buffer; this should be used
+ * when all data to be hashed is already available, since it does all
+ * hashing in a single call.
+ *
+ * @param hash     OS device
+ * @param inbuf    Input buffer
+ * @param inlen    Length of the input buffer
+ * @param outbuf   Output digest
+ *
+ * @return 0 if successfull, -1 on error
+ */
+int hash_sha256_process(struct hash_dev *hash, const void *inbuf,
+        uint32_t inlen, void *outbuf);
+
+/*
+ * Start a stream sha256 operation.
+ *
+ * @param hash     OS device
+ * @param ctx      A hash_sha256_context struct
+ * @param algo     Algorithm to use (see HASH_ALGO_*)
+ *
+ * @return 0 if successfull, -1 on error
+ */
+int hash_sha256_start(struct hash_sha256_context *ctx, struct hash_dev *hash);
+
+/*
+ * Update the sha256 operation with new data.
+ *
+ * @param ctx      A hash_sha256_context struct
+ * @param inbuf    The input data to be encrypted
+ * @param inlen    Length of the input buffer
+ *
+ * @return 0 if successfull, -1 on error
+ */
+int hash_sha256_update(struct hash_sha256_context *ctx, const void *inbuf,
+        uint32_t inlen);
+
+/*
+ * Finish the sha256 operation and return the final digest.
+ *
+ * @param ctx      A hash_sha256_context struct
+ * @param outbuf   Resulting digest of the sha256
+ *
+ * @return 0 if successfull, -1 on error
+ */
+int hash_sha256_finish(struct hash_sha256_context *ctx, void *outbuf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HASH_H__ */

--- a/hw/drivers/hash/include/hash/sha256_alt.h
+++ b/hw/drivers/hash/include/hash/sha256_alt.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SHA256_ALT_H__
+#define __SHA256_ALT_H__
+
+#include <os/mynewt.h>
+
+#if MYNEWT_VAL(MBEDTLS_SHA256_ALT)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <hash/hash.h>
+
+typedef struct mbedtls_sha256_context {
+    struct hash_dev *hash;
+    struct hash_sha256_context sha256ctx;
+} mbedtls_sha256_context;
+
+void mbedtls_sha256_init(mbedtls_sha256_context *ctx);
+void mbedtls_sha256_free(mbedtls_sha256_context *ctx);
+void mbedtls_sha256_clone(mbedtls_sha256_context *dst,
+        const mbedtls_sha256_context *src);
+int mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224);
+int mbedtls_sha256_update_ret(mbedtls_sha256_context *ctx,
+        const unsigned char *input, size_t ilen);
+int mbedtls_sha256_finish_ret(mbedtls_sha256_context *ctx,
+        unsigned char output[32]);
+
+/*
+ * XXX deprecated functions
+ */
+void mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224);
+void mbedtls_sha256_update(mbedtls_sha256_context *ctx,
+        const unsigned char *input, size_t ilen);
+void mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
+        unsigned char output[32]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MYNEWT_VAL(MBEDTLS_SHA256_ALT) */
+
+#endif /* __SHA256_ALT_H__ */

--- a/hw/drivers/hash/pkg.yml
+++ b/hw/drivers/hash/pkg.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/hash
+pkg.description: Crypto hashing driver interfaces
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+pkg.req_apis:
+    - HASH_HW_IMPL

--- a/hw/drivers/hash/src/hash.c
+++ b/hw/drivers/hash/src/hash.c
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "hash/hash.h"
+
+int
+hash_custom_process(struct hash_dev *hash, uint16_t algo, const void *inbuf,
+        uint32_t inlen, void *outbuf)
+{
+    int rc;
+    struct hash_generic_context ctx;
+
+    if ((hash->interface.algomask & algo) == 0) {
+        return -1;
+    }
+
+    rc = hash->interface.start(hash, &ctx, algo);
+    if (rc) {
+        return -1;
+    }
+
+    rc = hash->interface.update(hash, &ctx, algo, inbuf, inlen);
+    if (rc) {
+        return -1;
+    }
+
+    rc = hash->interface.finish(hash, &ctx, algo, outbuf);
+    return rc;
+}
+
+int
+hash_custom_start(struct hash_dev *hash, void *ctx, uint16_t algo)
+{
+    if ((hash->interface.algomask & algo) == 0) {
+        return -1;
+    }
+
+    return hash->interface.start(hash, ctx, algo);
+}
+
+int
+hash_custom_update(struct hash_dev *hash, void *ctx, uint16_t algo,
+        const void *inbuf, uint32_t inlen)
+{
+    return hash->interface.update(hash, ctx, algo, inbuf, inlen);
+}
+
+int
+hash_custom_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
+        void *outbuf)
+{
+    return hash->interface.finish(hash, ctx, algo, outbuf);
+}
+
+/*
+ * Helpers
+ */
+
+int
+hash_sha256_process(struct hash_dev *hash, const void *inbuf, uint32_t inlen,
+        void *outbuf)
+{
+    return hash_custom_process(hash, HASH_ALGO_SHA256, inbuf, inlen, outbuf);
+}
+
+int
+hash_sha256_start(struct hash_sha256_context *ctx, struct hash_dev *hash)
+{
+    ctx->dev = hash;
+    return hash_custom_start(hash, ctx, HASH_ALGO_SHA256);
+}
+
+int
+hash_sha256_update(struct hash_sha256_context *ctx, const void *inbuf,
+        uint32_t inlen)
+{
+    assert(ctx->dev);
+    return hash_custom_update(ctx->dev, ctx, HASH_ALGO_SHA256, inbuf, inlen);
+}
+
+int
+hash_sha256_finish(struct hash_sha256_context *ctx, void *outbuf)
+{
+    int rc;
+
+    assert(ctx->dev);
+
+    rc = hash_custom_finish(ctx->dev, ctx, HASH_ALGO_SHA256, outbuf);
+    ctx->dev = NULL;
+
+    return rc;
+}
+
+/*
+ * Interface
+ */
+
+bool
+hash_has_support(struct hash_dev *hash, uint16_t algo)
+{
+    return ((hash->interface.algomask & algo) != 0);
+}

--- a/hw/drivers/hash/src/mbedtls_sha256_alt.c
+++ b/hw/drivers/hash/src/mbedtls_sha256_alt.c
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#if MYNEWT_VAL(MBEDTLS_SHA256_ALT)
+
+#include "hash/hash.h"
+#include "hash/sha256_alt.h"
+
+void
+mbedtls_sha256_init(mbedtls_sha256_context *ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->hash = (struct hash_dev *) os_dev_open("hash", OS_TIMEOUT_NEVER,
+            NULL);
+    assert(ctx->hash);
+}
+
+void
+mbedtls_sha256_free(mbedtls_sha256_context *ctx)
+{
+    os_dev_close((struct os_dev *)ctx->hash);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+void
+mbedtls_sha256_clone(mbedtls_sha256_context *dst,
+        const mbedtls_sha256_context *src)
+{
+    memcpy(dst, src, sizeof(*dst));
+}
+
+int
+mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224)
+{
+    /* SHA-224 not supported */
+    if (is224) {
+        return -1;
+    }
+    return hash_sha256_start(&ctx->sha256ctx, ctx->hash);
+}
+
+int mbedtls_sha256_update_ret(mbedtls_sha256_context *ctx,
+        const unsigned char *input, size_t ilen)
+{
+    return hash_sha256_update(&ctx->sha256ctx, input, ilen);
+}
+
+int mbedtls_sha256_finish_ret(mbedtls_sha256_context *ctx,
+        unsigned char output[32])
+{
+    return hash_sha256_finish(&ctx->sha256ctx, output);
+}
+
+/*
+ * XXX deprecated mbedTLS functions
+ */
+
+void
+mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224)
+{
+    /* SHA-224 not supported */
+    if (is224) {
+        return;
+    }
+    (void)hash_sha256_start(&ctx->sha256ctx, ctx->hash);
+}
+
+void mbedtls_sha256_update(mbedtls_sha256_context *ctx,
+        const unsigned char *input, size_t ilen)
+{
+    (void)hash_sha256_update(&ctx->sha256ctx, input, ilen);
+}
+
+void mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
+        unsigned char output[32])
+{
+    (void)hash_sha256_finish(&ctx->sha256ctx, output);
+}
+
+#endif /* MYNEWT_VAL(MBEDTLS_SHA256_ALT) */

--- a/hw/drivers/hash/syscfg.yml
+++ b/hw/drivers/hash/syscfg.yml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    HASH_HAS_SYSCFG:
+        description: >
+            Placeholder only for now...
+        value: 0

--- a/hw/mcu/nxp/MK64F12/syscfg.yml
+++ b/hw/mcu/nxp/MK64F12/syscfg.yml
@@ -30,3 +30,7 @@ syscfg.defs:
     CRYPTO:
         description: 'Enable cryptograpy accelerator (CAU)'
         value: 0
+
+    HASH:
+        description: 'Enable hash accelerator (CAU)'
+        value: 0

--- a/hw/mcu/stm/stm32f4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f4xx/syscfg.yml
@@ -145,3 +145,7 @@ syscfg.defs:
     CRYPTO:
         description: 'Enable HW Cryptography module (CRYP)'
         value: 0
+
+    HASH:
+        description: 'Enable HW hash module (HASH)'
+        value: 0


### PR DESCRIPTION
This adds initial support for the HASH HW in K64F and STM32.