### PR TITLE
bsp/dialog_da1469x-dk-pro: Fix download to empty flash

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -105,6 +105,12 @@ mon reset
 mon halt
 restore $FLASH_LOADER.bin binary 0x20000000
 symbol-file $FLASH_LOADER
+
+# Configure QSPI controller so it can read flash in automode (values 
+# valid for Macronix flash found on Dialog development kits)
+set *(int *)0x3800000C = 0xa8a500eb
+set *(int *)0x38000010 = 0x00000066
+
 set *(int *)0x500000BC = 4
 set \$sp=*(int *)0x20000000
 set \$pc=*(int *)0x20000004


### PR DESCRIPTION
If a valid image is present in flash then the ROM based bootloader
configures the QSPI controller using values found in the product header.
If an image is not present this configuration does not take place. This
causes problems if an application is running out of RAM and needs to
read the flash in QSPI automode. For example if the flash loader
application is loaded into RAM on a board containing a blank flash then
it is able to erase and program the flash as these operations take place
in SPI mode. However it is not able to read the flash as a memory mapped
device because the QSPI controller has not been configured with valid
read commands for use in automode. The inability to read the flash
causes the verify performed as part of the programming process to fail.
This fix resolves this issue by writing the read commands into the
relevant registers when the download script is exected.