### PR TITLE
apps/bus_test: Fix build after bus driver changes

### DIFF
--- a/apps/bus_test/lis2dh_node/pkg.yml
+++ b/apps/bus_test/lis2dh_node/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/bus/i2c"
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"

--- a/apps/bus_test/lis2dh_node/src/lis2dh_node.c
+++ b/apps/bus_test/lis2dh_node/src/lis2dh_node.c
@@ -20,7 +20,7 @@
 #include "os/mynewt.h"
 #include "console/console.h"
 #include "bus/bus.h"
-#include "bus/i2c.h"
+#include "bus/drivers/i2c_common.h"
 #include "lis2dh_node/lis2dh_node.h"
 
 static struct bus_i2c_node g_lis2dh_node;
@@ -88,7 +88,7 @@ lis2dh_node_i2c_create(const char *name, const struct bus_i2c_node_cfg *cfg)
     bus_node_set_callbacks((struct os_dev *)&g_lis2dh_node, &cbs);
 
     rc = bus_i2c_node_create(name, &g_lis2dh_node,
-                             (struct bus_i2c_node_cfg *)cfg);
+                             (struct bus_i2c_node_cfg *)cfg, NULL);
 
     return rc;
 }

--- a/apps/bus_test/src/main.c
+++ b/apps/bus_test/src/main.c
@@ -19,12 +19,14 @@
 
 #include "os/mynewt.h"
 #include "bus/bus.h"
-#include "bus/i2c.h"
-#include "bus/spi.h"
+#include "bus/drivers/i2c_common.h"
+#include "bus/drivers/spi_common.h"
 #include "console/console.h"
 #include "hal/hal_gpio.h"
+#if MYNEWT_VAL(APP_USE_BME280_SENSOR)
 #include "sensor/sensor.h"
 #include "sensor/temperature.h"
+#endif
 
 #if MYNEWT_VAL(APP_USE_LIS2DH_NODE)
 #include "lis2dh_node/lis2dh_node.h"
@@ -53,8 +55,8 @@ static const struct bus_spi_node_cfg g_bme280_spi_node_cfg = {
     .mode = BUS_SPI_MODE_0,
     .data_order = BUS_SPI_DATA_ORDER_MSB,
     .freq = MYNEWT_VAL(BME280_NODE_SPI_FREQUENCY),
-#endif
 };
+#endif
 
 static struct os_dev *g_bme280_node;
 #endif


### PR DESCRIPTION
Bus driver evolved leaving bus_test behind.
Dependency updated.
Includes fixed.
One minor change in the code to match api changes.
One endif in wrong place moved.