### PR TITLE
baselibc: Update static asserts definition

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -69,7 +69,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ ARRAY_SIZE(stm32_flash_sectors)
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -51,7 +51,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -60,7 +60,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nucleo-f439zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f439zi/src/hal_bsp.c
@@ -81,7 +81,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f746zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f746zg/src/hal_bsp.c
@@ -95,7 +95,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f767zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f767zi/src/hal_bsp.c
@@ -100,7 +100,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -68,7 +68,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -68,7 +68,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -57,7 +57,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-_Static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -18,6 +18,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 
 #include "os/mynewt.h"
 #include <bsp/bsp.h>
@@ -1337,7 +1338,7 @@ spiflash_identify(struct spiflash_dev *dev)
     /* List of supported spi flash chips can be found in:
      * hw/drivers/flash/spiflash/chips/sysconfig.yml
      */
-    _Static_assert((sizeof(supported_chips) / sizeof(supported_chips[0])) > 1,
+    static_assert((sizeof(supported_chips) / sizeof(supported_chips[0])) > 1,
         "At lease one spiflash chip must be specified in sysconfig with SPIFLASH_<chipid>:1");
 
     spiflash_lock(dev);

--- a/hw/mcu/stm/stm32l0xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32l0xx/src/hal_flash.c
@@ -18,6 +18,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 #include <syscfg/syscfg.h>
 #include <mcu/stm32_hal.h>
 #include "hal/hal_flash_int.h"
@@ -38,7 +39,7 @@
  * intentionally alerts the user that this code needs to be updated
  * as well.
  */
-_Static_assert(_FLASH_SECTOR_SIZE == (_REAL_SECTOR_SIZE * _PAGES_PER_SECTOR),
+static_assert(_FLASH_SECTOR_SIZE == (_REAL_SECTOR_SIZE * _PAGES_PER_SECTOR),
     "STM32_FLASH_SECTOR_SIZE was changed; the erase function needs updating!");
 
 int

--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -41,8 +41,8 @@ STAILQ_HEAD(, os_mempool) g_os_mempool_list;
 #if MYNEWT_VAL(OS_MEMPOOL_POISON)
 static uint32_t os_mem_poison = 0xde7ec7ed;
 
-_Static_assert(sizeof(struct os_memblock) % 4 == 0, "sizeof(struct os_memblock) shall be aligned to 4");
-_Static_assert(sizeof(os_mem_poison) == 4, "sizeof(os_mem_poison) shall be 4");
+static_assert(sizeof(struct os_memblock) % 4 == 0, "sizeof(struct os_memblock) shall be aligned to 4");
+static_assert(sizeof(os_mem_poison) == 4, "sizeof(os_mem_poison) shall be 4");
 
 static void
 os_mempool_poison(const struct os_mempool *mp, void *start)
@@ -305,8 +305,8 @@ os_memblock_from(const struct os_mempool *mp, const void *block_addr)
     uint32_t baddr32;
     uint32_t end;
 
-    _Static_assert(sizeof block_addr == sizeof baddr32,
-                   "Pointer to void must be 32-bits.");
+    static_assert(sizeof block_addr == sizeof baddr32,
+                  "Pointer to void must be 32-bits.");
 
     baddr32 = (uint32_t)block_addr;
     true_block_size = OS_MEMPOOL_TRUE_BLOCK_SIZE(mp);

--- a/kernel/os/src/os_time.c
+++ b/kernel/os/src/os_time.c
@@ -333,8 +333,8 @@ os_time_ms_to_ticks(uint32_t ms, os_time_t *out_ticks)
     return 0;
 #endif
 
-    _Static_assert(OS_TICKS_PER_SEC <= UINT32_MAX,
-                   "OS_TICKS_PER_SEC must be <= UINT32_MAX");
+    static_assert(OS_TICKS_PER_SEC <= UINT32_MAX,
+                  "OS_TICKS_PER_SEC must be <= UINT32_MAX");
 
     ticks = ((uint64_t)ms * OS_TICKS_PER_SEC) / 1000;
     if (ticks > UINT32_MAX) {

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -27,6 +27,10 @@ extern "C" {
 
 #endif
 
+#if __STDC_VERSION__ >= 201112L && !defined __cplusplus
+#define static_assert _Static_assert
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/stats/full/include/stats/stats.h
+++ b/sys/stats/full/include/stats/stats.h
@@ -306,7 +306,7 @@ int stats_persist_init(struct stats_hdr *hdr, uint8_t size,
 #else /* MYNEWT_VAL(STATS_PERSIST) */
 
 #define STATS_PERSISTED_SECT_START(__name) \
-    _Static_assert(0, "You must enable STATS_PERSIST to use persistent stats");
+    static_assert(0, "You must enable STATS_PERSIST to use persistent stats");
 
 #define STATS_PERSIST_SCHED(hdrp_)
 

--- a/sys/sysdown/src/sysdown.c
+++ b/sys/sysdown/src/sysdown.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <assert.h>
 #include "os/mynewt.h"
 
 /**
@@ -44,8 +45,8 @@ sysdown(int reason)
 #define SYSDOWN_TIMEOUT_TICKS   \
     (MYNEWT_VAL(SYSDOWN_TIMEOUT_MS) * OS_TICKS_PER_SEC / 1000)
 
-_Static_assert(SYSDOWN_TIMEOUT_TICKS >= 0 && SYSDOWN_TIMEOUT_TICKS < INT32_MAX,
-               "SYSDOWN_TIMEOUT_MS value not in valid range");
+static_assert(SYSDOWN_TIMEOUT_TICKS >= 0 && SYSDOWN_TIMEOUT_TICKS < INT32_MAX,
+              "SYSDOWN_TIMEOUT_MS value not in valid range");
 
 static volatile int sysdown_num_in_progress;
 bool sysdown_active;

--- a/test/testutil/include/testutil/testutil.h
+++ b/test/testutil/include/testutil/testutil.h
@@ -259,14 +259,14 @@ TEST_SUITE_##suite_name(void);                               \
 #else
 
 #define TEST_CASE_SELF(case_name)                               \
-    _Static_assert(0, "Test `"#case_name"` is a self test.  "   \
-                      "It can only be run from `newt test`");   \
+    static_assert(0, "Test `"#case_name"` is a self test.  "    \
+                     "It can only be run from `newt test`");    \
     /* Emit case definition anyway to prevent syntax errors. */ \
     TEST_CASE_SELF_EMIT_(case_name)
 
 #define TEST_CASE_TASK(case_name)                               \
-    _Static_assert(0, "Test `"#case_name"` is a self test.  "   \
-                      "It can only be run from `newt test`");   \
+    static_assert(0, "Test `"#case_name"` is a self test.  "    \
+                     "It can only be run from `newt test`");    \
     /* Emit case definition anyway to prevent syntax errors. */ \
     TEST_CASE_TASK_EMIT_(case_name)
     


### PR DESCRIPTION
Static asserts are part of C11.
There is C language keyword _Static_assert
and convenience macro static_assert.

For C++ there is no _Static_assert while static_assert is defined.

This adds missing macro to assert.h that is defined when compiled
by C compiler.

header files are updated so they could be used by C++.

C files are updated just to make it consistent.