### PR TITLE
stm32/flash: Change STM32_FLASH_NUM_AREAS to match spec

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -69,7 +69,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ ARRAY_SIZE(stm32_flash_sectors)
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/black_vet6/syscfg.yml
+++ b/hw/bsp/black_vet6/syscfg.yml
@@ -22,8 +22,8 @@ syscfg.defs:
         value: 512
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 9
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 8
 
     ADC_1:
         description: "ADC_1"

--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -51,7 +51,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nucleo-f401re/syscfg.yml
+++ b/hw/bsp/nucleo-f401re/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 512
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 9
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 8
 
     UART_0:
         description: 'Whether to enable UART0'

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -60,7 +60,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/nucleo-f413zh/syscfg.yml
+++ b/hw/bsp/nucleo-f413zh/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 1536
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 17
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 16
 
     UART_0:
         description: 'UART 0'

--- a/hw/bsp/nucleo-f439zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f439zi/src/hal_bsp.c
@@ -81,7 +81,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f439zi/syscfg.yml
+++ b/hw/bsp/nucleo-f439zi/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 2048
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 25
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 24
 
     UART_0:
         description: 'UART 0'

--- a/hw/bsp/nucleo-f746zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f746zg/src/hal_bsp.c
@@ -95,7 +95,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f746zg/syscfg.yml
+++ b/hw/bsp/nucleo-f746zg/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 1024
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 9
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 8
 
     UART_0:
         description: 'Uart 0'

--- a/hw/bsp/nucleo-f767zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f767zi/src/hal_bsp.c
@@ -100,7 +100,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/nucleo-f767zi/syscfg.yml
+++ b/hw/bsp/nucleo-f767zi/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 2048
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 13
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
 
     UART_0:
         description: 'Uart 0'

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -68,7 +68,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(TRNG)

--- a/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
@@ -22,8 +22,8 @@ syscfg.defs:
         value: 1024
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 13
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
 
     ADC_1:
         description: "ADC_1"

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -68,7 +68,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/stm32f429discovery/syscfg.yml
+++ b/hw/bsp/stm32f429discovery/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 2048
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 25
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 24
 
     UART_0:
         description: 'UART 0'

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -57,7 +57,7 @@ const uint32_t stm32_flash_sectors[] = {
 };
 
 #define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
-static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) == SZ,
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
         "STM32_FLASH_NUM_AREAS does not match flash sectors");
 
 #if MYNEWT_VAL(UART_0)

--- a/hw/bsp/stm32f4discovery/syscfg.yml
+++ b/hw/bsp/stm32f4discovery/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 1024
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 13
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
 
     UART_0:
         description: 'UART 0'

--- a/hw/bsp/stm32f7discovery/syscfg.yml
+++ b/hw/bsp/stm32f7discovery/syscfg.yml
@@ -23,8 +23,8 @@ syscfg.defs:
         value: 1024
 
     STM32_FLASH_NUM_AREAS:
-        description: 'Amount of flash sectors for a non-linear STM32 MCU.'
-        value: 13
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
 
     UART_0:
         description: 'Uart 0'

--- a/hw/mcu/stm/stm32_common/src/hal_flash.c
+++ b/hw/mcu/stm/stm32_common/src/hal_flash.c
@@ -53,7 +53,7 @@ const struct hal_flash_funcs stm32_flash_funcs = {
 
 #if !FLASH_IS_LINEAR
 extern const uint32_t stm32_flash_sectors[];
-#define FLASH_NUM_AREAS (MYNEWT_VAL(STM32_FLASH_NUM_AREAS) - 1)
+#define FLASH_NUM_AREAS MYNEWT_VAL(STM32_FLASH_NUM_AREAS)
 #else
 #define FLASH_NUM_AREAS (_FLASH_SIZE / _FLASH_SECTOR_SIZE)
 #endif


### PR DESCRIPTION
syscfg values STM32_FLASH_NUM_AREAS had number of sectors increased by 1,
probably due to way it was used in asserts.

Value was misleading and did not match description field.

Now STM32_FLASH_NUM_AREAS has accurate value as described in datasheet,
and asserts are corrected.