### PR TITLE
stm32/bsp: Fix build for sensorhub

### DIFF
--- a/hw/bsp/sensorhub/src/hal_bsp.c
+++ b/hw/bsp/sensorhub/src/hal_bsp.c
@@ -31,6 +31,26 @@
 #include <mcu/stm32f4_bsp.h>
 #include "bsp/bsp.h"
 
+const uint32_t stm32_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* End of flash */
+};
+
+#define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
+        "STM32_FLASH_NUM_AREAS does not match flash sectors");
+
 #if MYNEWT_VAL(UART_0)
 static struct uart_dev hal_uart0;
 
@@ -60,6 +80,7 @@ static const struct hal_bsp_mem_dump dump_cfg[] = {
     }
 };
 
+extern const struct hal_flash stm32_flash_dev;
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
 {
@@ -69,7 +90,7 @@ hal_bsp_flash_dev(uint8_t id)
     if (id != 0) {
         return NULL;
     }
-    return &stm32f4_flash_dev;
+    return &stm32_flash_dev;
 }
 
 const struct hal_bsp_mem_dump *

--- a/hw/bsp/sensorhub/src/system_stm32f4xx.c
+++ b/hw/bsp/sensorhub/src/system_stm32f4xx.c
@@ -123,7 +123,8 @@
                variable is updated automatically.
   */
   uint32_t SystemCoreClock = 16000000;
-  __I uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+  const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+  const uint8_t APBPrescTable[8] = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
 
 /**
   * @}

--- a/hw/bsp/sensorhub/syscfg.yml
+++ b/hw/bsp/sensorhub/syscfg.yml
@@ -18,6 +18,13 @@
 #
 
 syscfg.defs:
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB.'
+        value: 1024
+    STM32_FLASH_NUM_AREAS:
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
+
     UART_0:
         description: 'UART 0'
         value:  1


### PR DESCRIPTION
- AHBPrescTable had different type then in includes.
- APBPrescTable was missing.
- Flash sector defintion was not updated as other BSP were moved to
  have common code base.