### PR TITLE
sensors/bmp280: Fix bit filed access

### DIFF
--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -1075,7 +1075,7 @@ bmp280_get_iir(struct sensor_itf *itf, uint8_t *iir)
         goto err;
     }
 
-    *iir = ((tmp & BMP280_REG_CONFIG_FILTER) >> 5);
+    *iir = (tmp & BMP280_REG_CONFIG_FILTER) >> 2;
 
     return 0;
 err:
@@ -1100,7 +1100,8 @@ bmp280_set_iir(struct sensor_itf *itf, uint8_t iir)
         goto err;
     }
 
-    iir = cfg | ((iir << 5) & BMP280_REG_CONFIG_FILTER);
+    iir = (cfg & ~BMP280_REG_CONFIG_FILTER) |
+          ((iir << 2) & BMP280_REG_CONFIG_FILTER);
 
     rc = bmp280_writelen(itf, BMP280_REG_ADDR_CONFIG, &iir, 1);
     if (rc) {
@@ -1155,7 +1156,8 @@ bmp280_set_mode(struct sensor_itf *itf, uint8_t mode)
         goto err;
     }
 
-    cfg = cfg | (mode & BMP280_REG_CTRL_MEAS_MODE);
+    cfg = (cfg & ~BMP280_REG_CTRL_MEAS_MODE) |
+          (mode & BMP280_REG_CTRL_MEAS_MODE);
 
     rc = bmp280_writelen(itf, BMP280_REG_ADDR_CTRL_MEAS, &cfg, 1);
     if (rc) {
@@ -1216,24 +1218,29 @@ bmp280_set_oversample(struct sensor_itf *itf, sensor_type_t type,
     int rc;
     uint8_t cfg;
 
-    if (type & SENSOR_TYPE_AMBIENT_TEMPERATURE || type & SENSOR_TYPE_PRESSURE) {
+    if (type & (SENSOR_TYPE_AMBIENT_TEMPERATURE | SENSOR_TYPE_PRESSURE)) {
         rc = bmp280_readlen(itf, BMP280_REG_ADDR_CTRL_MEAS, &cfg, 1);
         if (rc) {
             goto err;
         }
 
         if (type & SENSOR_TYPE_AMBIENT_TEMPERATURE) {
-            cfg = cfg | ((oversample << 5) & BMP280_REG_CTRL_MEAS_TOVER);
+            cfg = (cfg & ~BMP280_REG_CTRL_MEAS_TOVER) |
+                  ((oversample << 5) & BMP280_REG_CTRL_MEAS_TOVER);
         }
 
         if (type & SENSOR_TYPE_PRESSURE) {
-            cfg = cfg | ((oversample << 2) & BMP280_REG_CTRL_MEAS_POVER);
+            cfg = (cfg & ~BMP280_REG_CTRL_MEAS_POVER) |
+                  ((oversample << 2) & BMP280_REG_CTRL_MEAS_POVER);
         }
 
         rc = bmp280_writelen(itf, BMP280_REG_ADDR_CTRL_MEAS, &cfg, 1);
         if (rc) {
             goto err;
         }
+    } else {
+        rc = EINVAL;
+        goto err;
     }
 
     return 0;
@@ -1285,7 +1292,8 @@ bmp280_set_sby_duration(struct sensor_itf *itf, uint8_t dur)
         goto err;
     }
 
-    cfg = cfg | ((dur << 5) & BMP280_REG_CONFIG_STANDBY);
+    cfg = (cfg & ~BMP280_REG_CONFIG_STANDBY) |
+          ((dur << 5) & BMP280_REG_CONFIG_STANDBY);
 
     rc = bmp280_writelen(itf, BMP280_REG_ADDR_CONFIG, &cfg, 1);
     if (rc) {


### PR DESCRIPTION
All writes to bit fields in config and ctrl_meas registers
did not set bit correctly.
Bits were only added and never cleared that could lead
to unpredictable results.

Filter bit field was incorrectly shifted for read and write.