### PR TITLE
[Fix]: NRF52 Custom Frequency

### DIFF
--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -24,6 +24,7 @@
 #include "bus/bus_debug.h"
 #include "bus/bus_driver.h"
 #include "bus/drivers/i2c_common.h"
+#include "bus/drivers/i2c_nrf52_twim.h"
 #include "mcu/nrf52_hal.h"
 #include "nrfx.h"
 #if MYNEWT_VAL(I2C_NRF52_TWIM_STAT)


### PR DESCRIPTION
Included `i2c_nrf52_twim.h` to `i2c_nrf52_twim.c` as it contains the variable `TWIM_CUSTOM_FREQUENCY_FREQUENCY_K380` to build properly.