### PR TITLE
[console] fix race condition in rtt_console_write_ch

### DIFF
--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -78,7 +78,7 @@ rtt_console_write_ch(char c)
             break;
         }
 
-        if (!rtt_console_retries_left) {
+        if (rtt_console_retries_left <= 0) {
             break;
         }
 


### PR DESCRIPTION
- if multiple tasks write to rtt console when it is not present,
rtt_console_retries_left can be decremented below zero, leading to
near-infinite retry.  This blocks the calling task for a few years.