### PR TITLE
trng driver implemented with software backend

### DIFF
--- a/hw/bsp/native/pkg.yml
+++ b/hw/bsp/native/pkg.yml
@@ -30,5 +30,9 @@ pkg.deps:
     - "@apache-mynewt-core/hw/mcu/native"
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
     - "@apache-mynewt-core/hw/drivers/flash/enc_flash/ef_tinycrypt"
+    - "@apache-mynewt-core/hw/drivers/trng/trng_sw"
     - "@apache-mynewt-core/net/ip/native_sockets"
+
+pkg.init:
+    hal_bsp_init_trng: 2
 

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <unistd.h>
 #include <inttypes.h>
 #include "os/mynewt.h"
 #include <bsp/bsp.h>
@@ -32,6 +33,7 @@
 #include "hal/hal_i2c.h"
 #include "defs/sections.h"
 #include "ef_tinycrypt/ef_tinycrypt.h"
+#include <trng_sw/trng_sw.h>
 
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
 #include "sim/sim_accel.h"
@@ -40,7 +42,12 @@ static struct sim_accel os_bsp_accel0;
 
 static struct uart_dev os_bsp_uart0;
 static struct uart_dev os_bsp_uart1;
-
+static struct trng_sw_dev os_bsp_trng;
+static pid_t mypid;
+static struct trng_sw_dev_cfg os_bsp_trng_cfg = {
+    .tsdc_entr = &mypid,
+    .tsdc_len = sizeof(mypid)
+};
 static sec_data_secret struct eflash_tinycrypt_dev ef_dev0 = {
     .etd_dev = {
         .efd_hal = {
@@ -90,14 +97,36 @@ hal_bsp_init(void)
             OS_DEV_INIT_PRIMARY, 0, uart_hal_init, (void *) NULL);
     assert(rc == 0);
 
+    mypid = getpid();
+    rc = os_dev_create((struct os_dev *)&os_bsp_trng, "trng",
+                       OS_DEV_INIT_PRIMARY, 0, trng_sw_dev_init,
+                       &os_bsp_trng_cfg);
+    assert(rc == 0);
+
 #if MYNEWT_VAL(I2C_0)
     rc = hal_i2c_init(0, NULL);
     assert(rc == 0);
 #endif
-    
+
 #if MYNEWT_VAL(SIM_ACCEL_PRESENT)
     rc = os_dev_create((struct os_dev *) &os_bsp_accel0, "simaccel0",
             OS_DEV_INIT_PRIMARY, 0, simaccel_init, (void *) NULL);
     assert(rc == 0);
 #endif
+}
+
+void
+hal_bsp_init_trng(void)
+{
+    int i;
+    int rc;
+
+    /*
+     * Add entropy (don't do it like this if you use this for real, use
+     * something proper).
+     */
+    for (i = 0; i < 8; i++) {
+        rc = trng_sw_dev_add_entropy(&os_bsp_trng, &mypid, sizeof(mypid));
+        assert(rc == 0);
+    }
 }

--- a/hw/drivers/trng/trng_sw/include/trng_sw/trng_sw.h
+++ b/hw/drivers/trng/trng_sw/include/trng_sw/trng_sw.h
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _TRNG_SW_H_
+#define _TRNG_SW_H_
+
+#include <os/os_dev.h>
+#include <trng/trng.h>
+#include <tinycrypt/hmac_prng.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct trng_sw_dev {
+    struct trng_dev tsd_dev;
+    struct tc_hmac_prng_struct tsd_prng;
+    uint8_t tsd_entr[32]; /* min entropy to reseed */
+    uint8_t tsd_entr_len;
+};
+
+/**
+ * Initial personalization data when initializing the device.
+ */
+struct trng_sw_dev_cfg {
+    void *tsdc_entr;    /* pointer to entropy data */
+    int tsdc_len;       /* number of bytes of entropy */
+};
+
+/**
+ * Initializer routine for ther TRNG software implementation
+ *
+ * @param dev Pointer to device being initialized
+ * @param arg Pointer to struct trng_sw_dev_cfg structure.
+ *
+ * @return 0 on success. Non-zero on error.
+ */
+int trng_sw_dev_init(struct os_dev *dev, void *arg);
+
+/**
+ * Add more entropy to random number generator. Use things like
+ * interrupt/packet arrival timestamps.
+ * Note: before you can use this driver, you have to give at least
+ * 32 bytes of entropy.
+ *
+ * @param tsd Pointer to device
+ * @param entr Pointer to random data to add to entropy pool.
+ * @param entr_len Number of bytes to add.
+ *
+ * @return 0 on success. Non-zero on error.
+ */
+int trng_sw_dev_add_entropy(struct trng_sw_dev *tsd, void *entr, int entr_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/drivers/trng/trng_sw/pkg.yml
+++ b/hw/drivers/trng/trng_sw/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/trng/trng_sw
+pkg.description: TRNG driver in software.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.apis:
+    - TRNG_HW_IMPL
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/drivers/trng"

--- a/hw/drivers/trng/trng_sw/selftest/pkg.yml
+++ b/hw/drivers/trng/trng_sw/selftest/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/trng/trng_sw/selftest
+pkg.type: unittest
+pkg.description: Unit testing of TRNG SW driver API
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/drivers/trng"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"

--- a/hw/drivers/trng/trng_sw/selftest/src/test.c
+++ b/hw/drivers/trng/trng_sw/selftest/src/test.c
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#include "trng_sw_test.h"
+
+TEST_SUITE(trng_sw_test_suite)
+{
+    trng_sw_test_read();
+    trng_sw_test_add_entropy();
+}
+
+int
+main(int argc, char **argv)
+{
+    trng_sw_test_suite();
+    return tu_any_failed;
+}

--- a/hw/drivers/trng/trng_sw/selftest/src/testcases/trng_sw_test_entropy.c
+++ b/hw/drivers/trng/trng_sw/selftest/src/testcases/trng_sw_test_entropy.c
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#include <trng_sw/trng_sw.h>
+
+#include "trng_sw_test.h"
+
+TEST_CASE_SELF(trng_sw_test_add_entropy)
+{
+    struct trng_sw_dev *tsd;
+    int rc;
+    int i;
+    uint8_t somedata[64];
+
+    tsd = (struct trng_sw_dev *)os_dev_lookup("trng");
+    TEST_ASSERT_FATAL(tsd != NULL);
+
+    memset(somedata, 0xa5, sizeof(somedata));
+    for (i = 0; i < sizeof(somedata); i++) {
+        rc = trng_sw_dev_add_entropy(tsd, somedata, i);
+        TEST_ASSERT(rc == 0);
+    }
+}

--- a/hw/drivers/trng/trng_sw/selftest/src/testcases/trng_sw_test_read.c
+++ b/hw/drivers/trng/trng_sw/selftest/src/testcases/trng_sw_test_read.c
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <trng/trng.h>
+
+#include "trng_sw_test.h"
+
+TEST_CASE_SELF(trng_sw_test_read)
+{
+    struct trng_dev *dev;
+    int rc;
+    uint32_t val1, val2, val3;
+    int i;
+    uint8_t data[32];
+
+    dev = (struct trng_dev *)os_dev_lookup("trng");
+    TEST_ASSERT_FATAL(dev != NULL);
+
+    val1 = trng_get_u32(dev);
+    val2 = trng_get_u32(dev);
+    TEST_ASSERT(val1 != val2);
+
+    rc = trng_read(dev, &val3, sizeof(val3));
+    TEST_ASSERT(rc == sizeof(val3));
+    TEST_ASSERT(val1 != val2);
+    TEST_ASSERT(val1 != val3);
+    TEST_ASSERT(val2 != val3);
+
+    rc = trng_read(dev, &val2, sizeof(val2));
+    TEST_ASSERT(rc == sizeof(val2));
+    TEST_ASSERT(val3 != val2);
+
+    for (i = 1; i < sizeof(data); i++) {
+        rc = trng_read(dev, data, i);
+        TEST_ASSERT(rc == i);
+    }
+}

--- a/hw/drivers/trng/trng_sw/selftest/src/trng_sw_test.h
+++ b/hw/drivers/trng/trng_sw/selftest/src/trng_sw_test.h
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _TRNG_SW_TEST_H_
+#define _TRNG_SW_TEST_H_
+
+#include "os/mynewt.h"
+#include "testutil/testutil.h"
+
+TEST_SUITE_DECL(trng_sw_test_suite);
+TEST_CASE_DECL(trng_sw_test_read);
+TEST_CASE_DECL(trng_sw_test_add_entropy);
+
+#endif

--- a/hw/drivers/trng/trng_sw/src/trng_sw.c
+++ b/hw/drivers/trng/trng_sw/src/trng_sw.c
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include <string.h>
+
+#include <tinycrypt/constants.h>
+
+#include <trng/trng.h>
+#include <trng_sw/trng_sw.h>
+
+/*
+ * SW implementation of a TRNG driver API.
+ * Utilizes PRNG implementation from tinycrypt.
+ */
+static size_t
+trng_sw_read(struct trng_dev *dev, void *ptr, size_t size)
+{
+    struct trng_sw_dev *tsd = (struct trng_sw_dev *)dev;
+    int rc;
+
+    rc = tc_hmac_prng_generate(ptr, size, &tsd->tsd_prng);
+    assert(rc == TC_CRYPTO_SUCCESS);
+
+    return size;
+}
+
+static uint32_t
+trng_sw_get_u32(struct trng_dev *dev)
+{
+    struct trng_sw_dev *tsd = (struct trng_sw_dev *)dev;
+    uint32_t val;
+    int rc;
+
+    rc = tc_hmac_prng_generate((void *)&val, sizeof(val), &tsd->tsd_prng);
+    assert(rc == TC_CRYPTO_SUCCESS);
+
+    return val;
+}
+
+static int
+trng_sw_dev_open(struct os_dev *dev, uint32_t wait, void *arg)
+{
+    return 0;
+}
+
+int
+trng_sw_dev_add_entropy(struct trng_sw_dev *tsd, void *entr, int entr_len)
+{
+    int blen;
+    int rc;
+
+    blen = min(sizeof(tsd->tsd_entr) - tsd->tsd_entr_len, entr_len);
+    memcpy(tsd->tsd_entr + tsd->tsd_entr_len, entr, blen);
+    tsd->tsd_entr_len += blen;
+
+    if (tsd->tsd_entr_len == sizeof(tsd->tsd_entr)) {
+        rc = tc_hmac_prng_reseed(&tsd->tsd_prng, tsd->tsd_entr,
+                                 sizeof(tsd->tsd_entr), NULL, 0);
+        assert(rc == TC_CRYPTO_SUCCESS);
+        tsd->tsd_entr_len = 0;
+        if (blen != entr_len) {
+            /*
+             * If we got more entropy, don't waste it.
+             */
+            entr = (uint8_t *)entr + blen;
+            entr_len -= blen;
+            blen = min(sizeof(tsd->tsd_entr), entr_len);
+            memcpy(tsd->tsd_entr, (uint8_t *)entr, blen);
+            tsd->tsd_entr_len += blen;
+        }
+    } else {
+        rc = 0;
+    }
+    return 0;
+}
+
+int
+trng_sw_dev_init(struct os_dev *odev, void *arg)
+{
+    struct trng_sw_dev *tsd;
+    struct trng_sw_dev_cfg *tsdc;
+    int rc;
+
+    tsd = (struct trng_sw_dev *)odev;
+    tsdc = (struct trng_sw_dev_cfg *)arg;
+    assert(odev && tsdc);
+
+    OS_DEV_SETHANDLERS(odev, trng_sw_dev_open, NULL);
+
+    tsd->tsd_dev.interface.get_u32 = trng_sw_get_u32;
+    tsd->tsd_dev.interface.read = trng_sw_read;
+
+    rc = tc_hmac_prng_init(&tsd->tsd_prng, tsdc->tsdc_entr, tsdc->tsdc_len);
+    assert(rc == TC_CRYPTO_SUCCESS);
+
+    return 0;
+}


### PR DESCRIPTION
Mostly for use from unit tests, could also be utilized with BSPs which don't have access to HW RNG.