### PR TITLE
Add bsp.yml metadata with board info

### DIFF
--- a/hw/bsp/ada_feather_nrf52/bsp.yml
+++ b/hw/bsp/ada_feather_nrf52/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Adafruit Feather"
+bsp.url: https://www.adafruit.com/product/3574
+bsp.maker: "Adafruit Industries"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/apollo2_evb/bsp.yml
+++ b/hw/bsp/apollo2_evb/bsp.yml
@@ -19,6 +19,9 @@
 
 # Flash sector size: 8 kB.
 
+bsp.name: "Apollo EVB"
+bsp.url: https://www.ambiqmicro.com/mcu/
+bsp.maker: "Ambiq micro"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4 
 bsp.linkerscript:

--- a/hw/bsp/b-l072z-lrwan1/bsp.yml
+++ b/hw/bsp/b-l072z-lrwan1/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "B-L072Z-LRWAN1"
+bsp.url: https://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/b-l475e-iot01a/bsp.yml
+++ b/hw/bsp/b-l475e-iot01a/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "B-L475E-IOT01A"
+bsp.url: https://www.st.com/en/evaluation-tools/b-l475e-iot01a.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/bbc_microbit/bsp.yml
+++ b/hw/bsp/bbc_microbit/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "micro:bit"
+bsp.url: https://microbit.org/guide/hardware/
+bsp.maker: "BBC (with Nordic nRF51822)"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/black_vet6/bsp.yml
+++ b/hw/bsp/black_vet6/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Black VET6"
+bsp.url: "http://wiki.stm32duino.com/index.php?title=STM32F4xx_boards#Black_VET6_-_STM32F407VET6_.28512KB_Flash.2C_192K_RAM.2C_100_pin.29"
+bsp.maker: "STM32Duino"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/bmd300eval/bsp.yml
+++ b/hw/bsp/bmd300eval/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "BMD-300: Bluetooth 5"
+bsp.url: https://www.rigado.com/products/modules/bmd-300/
+bsp.maker: "RIGADO"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/ci40/bsp.yml
+++ b/hw/bsp/ci40/bsp.yml
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+bsp.name: "Creator Ci40 IoT Kit"
+bsp.url: https://creatordev.io/ci40-iot-dev-kit.html
+bsp.maker: "Imagination Technologies"
+
 bsp.arch: mips
 bsp.compiler: compiler/mips
 bsp.linkerscript: "hw/bsp/ci40/uhi32.ld"

--- a/hw/bsp/frdm-k64f/bsp.yml
+++ b/hw/bsp/frdm-k64f/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "FRDM-K64F: Freedom Development Platform"
+bsp.url: https://www.nxp.com/support/developer-resources/evaluation-and-development-boards/freedom-development-boards/mcu-boards/freedom-development-platform-for-kinetis-k64-k63-and-k24-mcus:FRDM-K64F
+bsp.maker: "NXP"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript: "hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld"

--- a/hw/bsp/hifive1/bsp.yml
+++ b/hw/bsp/hifive1/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "HiFive1"
+bsp.url: https://www.sifive.com/boards/hifive1
+bsp.maker: "SiFive"
 bsp.arch: rv32imac
 bsp.compiler: compiler/riscv64
 bsp.linkerscript:

--- a/hw/bsp/nina-b1/bsp.yml
+++ b/hw/bsp/nina-b1/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NINA-B1 series"
+bsp.url: https://www.u-blox.com/en/product/nina-b1-series
+bsp.maker: "u-blox"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nordic_pca10028-16k/bsp.yml
+++ b/hw/bsp/nordic_pca10028-16k/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "nRF51 DK (16KB)"
+bsp.url: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
+bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nordic_pca10028/bsp.yml
+++ b/hw/bsp/nordic_pca10028/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "nRF51 DK"
+bsp.url: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
+bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nordic_pca10040/bsp.yml
+++ b/hw/bsp/nordic_pca10040/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "nRF52 DK"
+bsp.url: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK
+bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nordic_pca10056/bsp.yml
+++ b/hw/bsp/nordic_pca10056/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "nRF52840 DK"
+bsp.url: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
+bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nordic_pca20020/bsp.yml
+++ b/hw/bsp/nordic_pca20020/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Nordic Thingy:52"
+bsp.url: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/Nordic-Thingy-52
+bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f030r8/bsp.yml
+++ b/hw/bsp/nucleo-f030r8/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F030R8"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f030r8.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f072rb/bsp.yml
+++ b/hw/bsp/nucleo-f072rb/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F072RB"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f072rb.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f103rb/bsp.yml
+++ b/hw/bsp/nucleo-f103rb/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F103RB"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f103rb.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m3
 bsp.compiler: compiler/arm-none-eabi-m3
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f303k8/bsp.yml
+++ b/hw/bsp/nucleo-f303k8/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F303K8"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f303k8.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f303re/bsp.yml
+++ b/hw/bsp/nucleo-f303re/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F303RE"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f303re.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f401re/bsp.yml
+++ b/hw/bsp/nucleo-f401re/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F401RE"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f401re.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f413zh/bsp.yml
+++ b/hw/bsp/nucleo-f413zh/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F413ZH"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f413zh.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f439zi/bsp.yml
+++ b/hw/bsp/nucleo-f439zi/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F439ZI"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f439zi.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f746zg/bsp.yml
+++ b/hw/bsp/nucleo-f746zg/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F746ZG"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f746zg.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:

--- a/hw/bsp/nucleo-f767zi/bsp.yml
+++ b/hw/bsp/nucleo-f767zi/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-F767ZI"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-f767zi.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:

--- a/hw/bsp/nucleo-l476rg/bsp.yml
+++ b/hw/bsp/nucleo-l476rg/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "NUCLEO-L476RG"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-l476rg.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/olimex-p103/bsp.yml
+++ b/hw/bsp/olimex-p103/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "STM32-P103"
+bsp.url: https://www.olimex.com/Products/ARM/ST/STM32-P103/
+bsp.maker: "Olimex"
 bsp.arch: cortex_m3
 bsp.compiler: compiler/arm-none-eabi-m3
 bsp.linkerscript:

--- a/hw/bsp/olimex_stm32-e407_devboard/bsp.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "STM32-E407"
+bsp.url: https://www.olimex.com/Products/ARM/ST/STM32-E407
+bsp.maker: "Olimex"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/pic32mx470_6lp_clicker/bsp.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/bsp.yml
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+bsp.name: "6LoWPAN Clicker"
+bsp.url: https://www.mikroe.com/clicker-6lowpan
+bsp.maker: "Mikrow"
+
 bsp.arch: pic32
 bsp.compiler: compiler/xc32
 

--- a/hw/bsp/pic32mz2048_wi-fire/bsp.yml
+++ b/hw/bsp/pic32mz2048_wi-fire/bsp.yml
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+bsp.name: "Wi-FIRE"
+bsp.url: https://store.digilentinc.com/wi-fire-wifi-enabled-pic32mz-microcontroller-board/
+bsp.maker: "Digilent Inc."
+
 bsp.arch: pic32
 bsp.compiler: compiler/xc32
 

--- a/hw/bsp/rb-blend2/bsp.yml
+++ b/hw/bsp/rb-blend2/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Blend 2"
+bsp.url: https://redbear.cc/product/retired/blend-2.html
+bsp.maker: "RedBear"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/rb-nano2/bsp.yml
+++ b/hw/bsp/rb-nano2/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Nano 2"
+bsp.url: https://redbear.cc/product/ble/ble-nano-2-soldered.html
+bsp.maker: "RedBear"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/ruuvitag_rev_b/bsp.yml
+++ b/hw/bsp/ruuvitag_rev_b/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "RuuviTag"
+bsp.url: https://ruuvi.com/ruuvitag-specs/
+bsp.maker: "Ruuvi"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/stm32f3discovery/bsp.yml
+++ b/hw/bsp/stm32f3discovery/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "STM32F3DISCOVERY"
+bsp.url: https://www.st.com/en/evaluation-tools/stm32f3discovery.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/stm32f429discovery/bsp.yml
+++ b/hw/bsp/stm32f429discovery/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "32F429IDISCOVERY"
+bsp.url: https://www.st.com/en/evaluation-tools/32f429idiscovery.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/stm32f4discovery/bsp.yml
+++ b/hw/bsp/stm32f4discovery/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "STM32F4DISCOVERY"
+bsp.url: https://www.st.com/en/evaluation-tools/stm32f4discovery.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/stm32f7discovery/bsp.yml
+++ b/hw/bsp/stm32f7discovery/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "32F746GDISCOVERY"
+bsp.url: https://www.st.com/en/evaluation-tools/32f746gdiscovery.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m7
 bsp.compiler: compiler/arm-none-eabi-m7
 bsp.linkerscript:

--- a/hw/bsp/stm32l152discovery/bsp.yml
+++ b/hw/bsp/stm32l152discovery/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "32L152CDISCOVERY"
+bsp.url: https://www.st.com/en/evaluation-tools/32l152cdiscovery.html
+bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m3
 bsp.compiler: compiler/arm-none-eabi-m3
 bsp.linkerscript:


### PR DESCRIPTION
The added data, board name, url and maker (aka manufacturer) is used by the automated web site build script to generate the online list of supported boards.

This will be used after https://github.com/apache/mynewt-site/pull/523 is merged.