### PR TITLE
native; enable os_cputime for native BSP. Make task priority for

### DIFF
--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -100,4 +100,9 @@ hal_bsp_init(void)
             OS_DEV_INIT_PRIMARY, 0, simaccel_init, (void *) NULL);
     assert(rc == 0);
 #endif
+
+#if MYNEWT_VAL(OS_CPUTIME_TIMER_NUM >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
 }

--- a/hw/mcu/native/src/hal_timer.c
+++ b/hw/mcu/native/src/hal_timer.c
@@ -106,8 +106,8 @@ hal_timer_config(int num, uint32_t clock_freq)
     nt->last_ostime = os_time_get();
     if (!native_timer_task_started) {
         os_task_init(&native_timer_task_struct, "native_timer",
-          native_timer_task, NULL, OS_TASK_PRI_HIGHEST, OS_WAIT_FOREVER,
-          native_timer_stack, NATIVE_TIMER_STACK_SIZE);
+          native_timer_task, NULL, MYNEWT_VAL(MCU_TIMER_POLLER_PRIO),
+          OS_WAIT_FOREVER, native_timer_stack, NATIVE_TIMER_STACK_SIZE);
 
         /* Initialize the eventq and task */
         os_eventq_init(&native_timer_evq);

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -65,4 +65,8 @@ syscfg.defs:
     MCU_UART_POLLER_PRIO:
         description: 'Priority of native UART poller task.'
         type: task_priority
+        value: 1
+    MCU_TIMER_POLLER_PRIO:
+        description: 'Priority of native UART poller task.'
+        type: task_priority
         value: 0

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -67,6 +67,6 @@ syscfg.defs:
         type: task_priority
         value: 1
     MCU_TIMER_POLLER_PRIO:
-        description: 'Priority of native UART poller task.'
+        description: 'Priority of native HAL timer task.'
         type: task_priority
         value: 0


### PR DESCRIPTION
hal_timer configurable. This allows writing unittests for subsystems which use os_cputime.

This breaks nimble controller unittest. There's going to be a PR against that repo fixing that.
