### PR TITLE
da1469x/hal_flash: Add support for non-quad writes

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
@@ -25,6 +25,7 @@ syscfg.vals:
     QSPI_FLASH_SECTOR_SIZE: 4096
     QSPI_FLASH_SECTOR_COUNT: 256
     QSPI_FLASH_PAGE_SIZE: 256
+    QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM: 0x32
     # Set default pins for peripherals
     UART_0_PIN_TX: 9
     UART_0_PIN_RX: 8

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -107,6 +107,20 @@ da1469x_qspi_mode_quad(const struct hal_flash *dev)
 }
 
 CODE_QSPI_INLINE static void
+da1469x_qspi_mode_dual(const struct hal_flash *dev)
+{
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_SET_DUAL_Msk;
+    QSPIC->QSPIC_CTRLMODE_REG |= QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO2_OEN_Msk |
+                                 QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO2_DAT_Msk |
+                                 QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO3_OEN_Msk |
+                                 QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO3_DAT_Msk;
+
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
+    da1469x_qspi_write8(dev, 0xff);
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
+}
+
+CODE_QSPI_INLINE static void
 da1469x_qspi_mode_manual(const struct hal_flash *dev)
 {
     QSPIC->QSPIC_CTRLMODE_REG &= ~QSPIC_QSPIC_CTRLMODE_REG_QSPIC_AUTO_MD_Msk;
@@ -173,10 +187,30 @@ da1469x_qspi_cmd_write_page(const struct hal_flash *dev, uint32_t address,
 
     QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
 
-    address = __builtin_bswap32(address) & 0xffffff00;
-    da1469x_qspi_write32(dev, address | 0x32);
-
-    da1469x_qspi_mode_quad(dev);
+    if (MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_IO_PAGE_PROGRAM) > 0) {
+        /* Only command in single mode address and data in quad mode */
+        da1469x_qspi_write8(dev, MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_IO_PAGE_PROGRAM));
+        da1469x_qspi_mode_quad(dev);
+        da1469x_qspi_write8(dev, (uint8_t)(address >> 16U));
+        da1469x_qspi_write8(dev, (uint8_t)(address >> 8U));
+        da1469x_qspi_write8(dev, (uint8_t)(address));
+    } else if (MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM) > 0) {
+        /* Command and data in single mode, data in quad mode */
+        address = __builtin_bswap32(address) & 0xffffff00;
+        da1469x_qspi_write32(dev, address |
+                                  MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM));
+        da1469x_qspi_mode_quad(dev);
+    } else  if (MYNEWT_VAL(QSPI_FLASH_CMD_DUAL_INPUT_PAGE_PROGRAM) > 0) {
+        /* Command and data in single mode, data in dual mode */
+        address = __builtin_bswap32(address) & 0xffffff00;
+        da1469x_qspi_write32(dev, address |
+                                  MYNEWT_VAL(QSPI_FLASH_CMD_DUAL_INPUT_PAGE_PROGRAM));
+        da1469x_qspi_mode_dual(dev);
+    } else {
+        /* Standard page program command in single mode */
+        address = __builtin_bswap32(address) & 0xffffff00;
+        da1469x_qspi_write32(dev, address | 0x02);
+    }
 
     while (length >= 4) {
         da1469x_qspi_write32(dev, *(uint32_t *)buf);
@@ -192,7 +226,11 @@ da1469x_qspi_cmd_write_page(const struct hal_flash *dev, uint32_t address,
 
     QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
 
-    da1469x_qspi_mode_single(dev);
+    if ((MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_IO_PAGE_PROGRAM) > 0) ||
+        (MYNEWT_VAL(QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM) > 0) ||
+        (MYNEWT_VAL(QSPI_FLASH_CMD_DUAL_INPUT_PAGE_PROGRAM) > 0)) {
+        da1469x_qspi_mode_single(dev);
+    }
 
     return written;
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -69,6 +69,18 @@ syscfg.defs:
         value: 0
 
 # QSPI definitions
+    QSPI_FLASH_CMD_QUAD_IO_PAGE_PROGRAM:
+        description: >
+            Command to send data and address to flash in quad mode (usually 38H).
+        value: -1
+    QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM:
+        description: >
+            Command to send data to flash in quad mode  (usually 32H).
+        value: -1
+    QSPI_FLASH_CMD_DUAL_INPUT_PAGE_PROGRAM:
+        description: >
+            Command to send data to flash in dual mode  (usually A2H).
+        value: -1
     QSPI_FLASH_ADDRESS_LENGTH:
         description: >
             Sector address length used by flash (only 24 bit supported now)


### PR DESCRIPTION
Currently writes to flash were hard coded to use Quad Input Page Program
command 32H.
Unlike 02H (Page Program) this command is not shared by all manufacturers.
Now BSP has to specify one of page program commands to use:
QSPI_FLASH_CMD_QUAD_IO_PAGE_PROGRAM
QSPI_FLASH_CMD_QUAD_INPUT_PAGE_PROGRAM
QSPI_FLASH_CMD_DUAL_INPUT_PAGE_PROGRAM
It none is set. Standard 02H Page Program will be used.