### PR TITLE
drivers/adc: Remove ADC_HW_IMPL

### DIFF
--- a/hw/drivers/adc/adc_nrf51/pkg.yml
+++ b/hw/drivers/adc/adc_nrf51/pkg.yml
@@ -22,8 +22,6 @@ pkg.description: ADC driver for the NRF51
 pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-pkg.apis:
-    - ADC_HW_IMPL
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"
     - "@apache-mynewt-core/hw/mcu/nordic"

--- a/hw/drivers/adc/adc_nrf52/pkg.yml
+++ b/hw/drivers/adc/adc_nrf52/pkg.yml
@@ -22,8 +22,6 @@ pkg.description: ADC driver for the NRF52
 pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-pkg.apis:
-    - ADC_HW_IMPL
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"
     - "@apache-mynewt-core/hw/mcu/nordic"

--- a/hw/drivers/adc/adc_stm32f4/pkg.yml
+++ b/hw/drivers/adc/adc_stm32f4/pkg.yml
@@ -24,8 +24,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.features:
     - ADC_STM32F4
-pkg.apis:
-    - ADC_HW_IMPL
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"
 pkg.deps.TEST:

--- a/hw/drivers/adc/gpadc_da1469x/pkg.yml
+++ b/hw/drivers/adc/gpadc_da1469x/pkg.yml
@@ -26,8 +26,5 @@ pkg.keywords:
     - da1469x
     - adc
 
-pkg.apis:
-    - ADC_HW_IMPL
-
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"

--- a/hw/drivers/adc/pkg.yml
+++ b/hw/drivers/adc/pkg.yml
@@ -22,5 +22,3 @@ pkg.description: ADC driver interfaces
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-pkg.req_apis:
-    - ADC_HW_IMPL

--- a/hw/drivers/adc/sdadc_da1469x/pkg.yml
+++ b/hw/drivers/adc/sdadc_da1469x/pkg.yml
@@ -26,8 +26,5 @@ pkg.keywords:
     - da1469x
     - adc
 
-pkg.apis:
-    - ADC_HW_IMPL
-
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/adc"


### PR DESCRIPTION
- ADC_HW_IMPL was not being used for pkg.apis recommended purpose
  It is mainly used to differentiate APIs defined with same names