### PR TITLE
Changing the device closed by battery_adc_close

### DIFF
--- a/hw/battery/src/battery_adc.c
+++ b/hw/battery/src/battery_adc.c
@@ -137,7 +137,7 @@ battery_adc_close(struct os_dev *dev)
 {
     struct battery_adc *bat_adc = (struct battery_adc *)dev;
     if (bat_adc->adc_dev) {
-        os_dev_close((struct os_dev *)&bat_adc->dev);
+        os_dev_close((struct os_dev *)&bat_adc->adc_dev);
         bat_adc->adc_dev = NULL;
     }
     return 0;


### PR DESCRIPTION
This function tries to close `bat_adc->dev` when it should be closing `bat_adc->adc_dev` that corresponds to the underlying ADC device.
In my case calling this function caused a recursion loop and crashed mynewt.