### PR TITLE
libc/baselibc: Build right memset version for Cortex-m4

### DIFF
--- a/libc/baselibc/src/memset.c
+++ b/libc/baselibc/src/memset.c
@@ -5,6 +5,10 @@
 #include <string.h>
 #include <stdint.h>
 
+#if defined(__arm__)
+#include <mcu/cmsis_nvic.h>
+#endif
+
 void *memset(void *dst, int c, size_t n)
 {
 	char *q = dst;


### PR DESCRIPTION
Coretex-M0 version was build for all arm CPUs due to __CORTEX_M not
being defined.