### PR TITLE
endian: Add le24 and be24 helpers

### DIFF
--- a/kernel/os/include/os/endian.h
+++ b/kernel/os/include/os/endian.h
@@ -204,15 +204,19 @@ extern "C" {
 #endif
 
 void put_le16(void *buf, uint16_t x);
+void put_le24(void *buf, uint32_t x);
 void put_le32(void *buf, uint32_t x);
 void put_le64(void *buf, uint64_t x);
 uint16_t get_le16(const void *buf);
+uint32_t get_le24(const void *buf);
 uint32_t get_le32(const void *buf);
 uint64_t get_le64(const void *buf);
 void put_be16(void *buf, uint16_t x);
+void put_be24(void *buf, uint32_t x);
 void put_be32(void *buf, uint32_t x);
 void put_be64(void *buf, uint64_t x);
 uint16_t get_be16(const void *buf);
+uint32_t get_be24(const void *buf);
 uint32_t get_be32(const void *buf);
 uint64_t get_be64(const void *buf);
 void swap_in_place(void *buf, int len);

--- a/kernel/os/src/endian.c
+++ b/kernel/os/src/endian.c
@@ -30,6 +30,17 @@ put_le16(void *buf, uint16_t x)
 }
 
 void
+put_le24(void *buf, uint32_t x)
+{
+    uint8_t *u8ptr;
+
+    u8ptr = buf;
+    u8ptr[0] = (uint8_t)x;
+    u8ptr[1] = (uint8_t)(x >> 8);
+    u8ptr[2] = (uint8_t)(x >> 16);
+}
+
+void
 put_le32(void *buf, uint32_t x)
 {
     uint8_t *u8ptr;
@@ -66,6 +77,20 @@ get_le16(const void *buf)
     u8ptr = buf;
     x = u8ptr[0];
     x |= (uint16_t)u8ptr[1] << 8;
+
+    return x;
+}
+
+uint32_t
+get_le24(const void *buf)
+{
+    const uint8_t *u8ptr;
+    uint32_t x;
+
+    u8ptr = buf;
+    x = u8ptr[0];
+    x |= (uint32_t)u8ptr[1] << 8;
+    x |= (uint32_t)u8ptr[2] << 16;
 
     return x;
 }
@@ -115,6 +140,17 @@ put_be16(void *buf, uint16_t x)
 }
 
 void
+put_be24(void *buf, uint32_t x)
+{
+    uint8_t *u8ptr;
+
+    u8ptr = buf;
+    u8ptr[0] = (uint8_t)(x >> 24);
+    u8ptr[1] = (uint8_t)(x >> 16);
+    u8ptr[2] = (uint8_t)(x >> 8);
+}
+
+void
 put_be32(void *buf, uint32_t x)
 {
     uint8_t *u8ptr;
@@ -151,6 +187,20 @@ get_be16(const void *buf)
     u8ptr = buf;
     x = (uint16_t)u8ptr[0] << 8;
     x |= u8ptr[1];
+
+    return x;
+}
+
+uint32_t
+get_be24(const void *buf)
+{
+    const uint8_t *u8ptr;
+    uint32_t x;
+
+    u8ptr = buf;
+    x = (uint32_t)u8ptr[0] << 24;
+    x |= (uint32_t)u8ptr[1] << 16;
+    x |= (uint32_t)u8ptr[2] << 8;
 
     return x;
 }


### PR DESCRIPTION
Those are useful for some BLE and Mesh PDU handling (and probably more).
Instead of user defining own function it should be beneficial to have
common implementation.

Not that this is useful only for flat buffers so only put and get
helpers.