### PR TITLE
Logging Header Image Hash

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -116,10 +116,8 @@ struct log_handler {
     lh_registered_func_t log_registered;
 };
 
-typedef enum {
-    LOG_FLAGS_LOG_IMG_HASH_e = 1,
-    LOG_FLAGS_MAX_e,
-}log_flags_e;
+/* Flags used to indicate type of data in reserved payload*/
+#define LOG_FLAGS_LOG_IMG_HASH (1 << 0)
 
 #if MYNEWT_VAL(LOG_VERSION) == 2
 struct log_entry_hdr {

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -132,17 +132,8 @@ struct log_entry_hdr {
     uint32_t ue_index;
     uint8_t ue_module;
     uint8_t ue_level;
-    uint8_t ue_etype;
-}__attribute__((__packed__));
-#elif MYNEWT_VAL(LOG_VERSION) == 4
-struct log_entry_hdr {
-    int64_t ue_ts;
-    uint32_t ue_index;
-    uint8_t ue_module;
-    uint8_t ue_level;
     uint8_t ue_etype:4;
-    uint8_t ue_flags:4;
-    uint8_t ue_rsvd[4];
+    uint8_t ue_flag:4;
 }__attribute__((__packed__));
 #else
 #error "Unsupported log version"

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -116,6 +116,11 @@ struct log_handler {
     lh_registered_func_t log_registered;
 };
 
+typedef enum {
+    LOG_FLAGS_LOG_IMG_HASH_e = 1,
+    LOG_FLAGS_MAX_e,
+}log_flags_e;
+
 #if MYNEWT_VAL(LOG_VERSION) == 2
 struct log_entry_hdr {
     int64_t ue_ts;

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -117,7 +117,7 @@ struct log_handler {
 };
 
 /* Flags used to indicate type of data in reserved payload*/
-#define LOG_FLAGS_LOG_IMG_HASH (1 << 0)
+#define FLAGS_LOG_IMG_HASH (1 << 0)
 
 #if MYNEWT_VAL(LOG_VERSION) == 2
 struct log_entry_hdr {

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -117,7 +117,7 @@ struct log_handler {
 };
 
 /* Flags used to indicate type of data in reserved payload*/
-#define FLAGS_LOG_IMG_HASH (1 << 0)
+#define LOG_FLAGS_IMG_HASH (1 << 0)
 
 #if MYNEWT_VAL(LOG_VERSION) == 2
 struct log_entry_hdr {

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -131,6 +131,16 @@ struct log_entry_hdr {
     uint8_t ue_level;
     uint8_t ue_etype;
 }__attribute__((__packed__));
+#elif MYNEWT_VAL(LOG_VERSION) == 4
+struct log_entry_hdr {
+    int64_t ue_ts;
+    uint32_t ue_index;
+    uint8_t ue_module;
+    uint8_t ue_level;
+    uint8_t ue_etype:4;
+    uint8_t ue_flags:4;
+    uint8_t ue_rsvd[4];
+}__attribute__((__packed__));
 #else
 #error "Unsupported log version"
 #endif

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -33,6 +33,8 @@
 #include "shell/shell.h"
 #endif
 
+#include "imgmgr/imgmgr.h"
+
 struct log_info g_log_info;
 
 static STAILQ_HEAD(, log) g_log_list = STAILQ_HEAD_INITIALIZER(g_log_list);
@@ -492,6 +494,15 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 #else
     assert(etype == LOG_ETYPE_STRING);
 #endif
+#if MYNEWT_VAL(LOG_VERSION) > 3
+
+#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+    uint8_t hash[IMGMGR_HASH_LEN];
+    imgr_read_info(0, NULL, hash, NULL);
+    memcpy(ue->ue_rsvd, hash, 4);
+#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+
+#endif // MYNEWT_VAL(LOG_VERSION) > 3
 
 err:
     return (rc);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -499,7 +499,7 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 #if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
     uint8_t hash[IMGMGR_HASH_LEN];
 
-    ue->ue_flags = LOG_FLAGS_LOG_IMG_HASH_e;
+    ue->ue_flags &= LOG_FLAGS_LOG_IMG_HASH;
 
     imgr_read_info(0, NULL, hash, NULL);
     memcpy(ue->ue_rsvd, hash, 4);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -498,6 +498,9 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 
 #if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
     uint8_t hash[IMGMGR_HASH_LEN];
+
+    ue->ue_flags = LOG_FLAGS_LOG_IMG_HASH_e;
+
     imgr_read_info(0, NULL, hash, NULL);
     memcpy(ue->ue_rsvd, hash, 4);
 #endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -491,20 +491,11 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     ue->ue_index = idx;
 #if MYNEWT_VAL(LOG_VERSION) > 2
     ue->ue_etype = etype;
+#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+    ue->ue_flag &= LOG_FLAGS_LOG_IMG_HASH;
+#endif
 #else
     assert(etype == LOG_ETYPE_STRING);
-#endif
-#if MYNEWT_VAL(LOG_VERSION) > 3
-
-#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
-    uint8_t hash[IMGMGR_HASH_LEN];
-
-    ue->ue_flags &= LOG_FLAGS_LOG_IMG_HASH;
-
-    imgr_read_info(0, NULL, hash, NULL);
-    memcpy(ue->ue_rsvd, hash, 4);
-#endif
-
 #endif
 
 err:

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -503,9 +503,9 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 
     imgr_read_info(0, NULL, hash, NULL);
     memcpy(ue->ue_rsvd, hash, 4);
-#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+#endif
 
-#endif // MYNEWT_VAL(LOG_VERSION) > 3
+#endif
 
 err:
     return (rc);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -33,7 +33,6 @@
 #include "shell/shell.h"
 #endif
 
-
 struct log_info g_log_info;
 
 static STAILQ_HEAD(, log) g_log_list = STAILQ_HEAD_INITIALIZER(g_log_list);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -489,8 +489,10 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     ue->ue_index = idx;
 #if MYNEWT_VAL(LOG_VERSION) > 2
     ue->ue_etype = etype;
+    /* Clear flags before assigning */
+    ue->ue_flag = 0;
 #if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
-    ue->ue_flag &= LOG_FLAGS_LOG_IMG_HASH;
+    ue->ue_flag |= FLAGS_LOG_IMG_HASH;
 #endif
 #else
     assert(etype == LOG_ETYPE_STRING);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -491,8 +491,8 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     ue->ue_etype = etype;
     /* Clear flags before assigning */
     ue->ue_flag = 0;
-#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
-    ue->ue_flag |= FLAGS_LOG_IMG_HASH;
+#if MYNEWT_VAL(LOG_FLAGS_IMAGE_HASH)
+    ue->ue_flag |= LOG_FLAGS_IMG_HASH;
 #endif
 #else
     assert(etype == LOG_ETYPE_STRING);

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -33,7 +33,6 @@
 #include "shell/shell.h"
 #endif
 
-#include "imgmgr/imgmgr.h"
 
 struct log_info g_log_info;
 

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -203,7 +203,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         off += rc;
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
-
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
     g_err |= cbor_encode_text_stringz(&rsp, (char *)data);
@@ -296,7 +295,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         }
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
-
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
     if (too_long) {

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -184,7 +184,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
                 }
                 g_err |= cbor_encode_byte_string(&str_encoder, data, rc);
                 off += rc;
-                continue;
             }
         } else {
             /* Continue subsequent reads after inserting image hash after the first 

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -171,7 +171,7 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     for (off = 0; off < len && !g_err; ) {
         /* Entering first log entry. Check flag. */
         if (off == 0) {
-            if (ueh->ue_flag & FLAGS_LOG_IMG_HASH) {
+            if (ueh->ue_flag & LOG_FLAGS_IMG_HASH) {
                 /* Read entire image hash */
                 imgr_read_info(0, NULL, hash, NULL);
                 /* Store the first four bytes of the image hash */

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -179,7 +179,7 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
     g_err |= cbor_encode_text_stringz(&rsp, "res");
     g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif // MYNEWT_VAL(LOG_VERSION) > 3
+#endif
 
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
@@ -279,7 +279,7 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
     g_err |= cbor_encode_text_stringz(&rsp, "res");
     g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif // MYNEWT_VAL(LOG_VERSION) > 3
+#endif
 
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -174,13 +174,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
 
-#if MYNEWT_VAL(LOG_VERSION) > 3
-    g_err |= cbor_encode_text_stringz(&rsp, "flag");
-    g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
-    g_err |= cbor_encode_text_stringz(&rsp, "res");
-    g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif
-
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
     g_err |= cbor_encode_text_stringz(&rsp, (char *)data);
@@ -273,13 +266,6 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         }
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
-
-#if MYNEWT_VAL(LOG_VERSION) > 3
-    g_err |= cbor_encode_text_stringz(&rsp, "flag");
-    g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
-    g_err |= cbor_encode_text_stringz(&rsp, "res");
-    g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif
 
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -169,16 +169,19 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
      */
     g_err |= cbor_encoder_create_indef_byte_string(&rsp, &str_encoder);
     for (off = 0; off < len && !g_err; ) {
-        /* Entering first log entry. Check flag.*/
+        /* Entering first log entry. Check flag. */
         if (off == 0) {
             switch(ueh->ue_flag) {
             case LOG_FLAGS_LOG_IMG_HASH:
+                /* Read entire image hash */
                 imgr_read_info(0, NULL, hash, NULL);
+                /* Store the first four bytes of the image hash */
                 memcpy(data, hash, 4);
                 break;
             default:
                 break;
             }
+            /* Offset 4 bytes to account for the image hash */
             rc = log_read_body(log, dptr, data + 4, off, sizeof(data) - 4);
             if (rc < 0) {
                 g_err |= 1;
@@ -189,6 +192,8 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
             continue;
         }
 
+        /* Continue subsequent reads after inserting image hash after the first 
+           read. */
         rc = log_read_body(log, dptr, data, off, sizeof(data));
         if (rc < 0) {
             g_err |= 1;

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -175,10 +175,10 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
 
 #if MYNEWT_VAL(LOG_VERSION) > 3
-#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
-    g_err |= cbor_encode_text_stringz(&rsp, "vr");
+    g_err |= cbor_encode_text_stringz(&rsp, "flag");
+    g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
+    g_err |= cbor_encode_text_stringz(&rsp, "res");
     g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
 #endif // MYNEWT_VAL(LOG_VERSION) > 3
 
 #else
@@ -275,10 +275,10 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
 
 #if MYNEWT_VAL(LOG_VERSION) > 3
-#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
-    g_err |= cbor_encode_text_stringz(&rsp, "vr");
+    g_err |= cbor_encode_text_stringz(&rsp, "flag");
+    g_err |= cbor_encode_uint(&rsp, ueh->ue_flags);
+    g_err |= cbor_encode_text_stringz(&rsp, "res");
     g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
-#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
 #endif // MYNEWT_VAL(LOG_VERSION) > 3
 
 #else

--- a/sys/log/full/src/log_nmgr.c
+++ b/sys/log/full/src/log_nmgr.c
@@ -173,6 +173,14 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         off += rc;
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
+
+#if MYNEWT_VAL(LOG_VERSION) > 3
+#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+    g_err |= cbor_encode_text_stringz(&rsp, "vr");
+    g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
+#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+#endif // MYNEWT_VAL(LOG_VERSION) > 3
+
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
     g_err |= cbor_encode_text_stringz(&rsp, (char *)data);
@@ -265,6 +273,14 @@ log_nmgr_encode_entry(struct log *log, struct log_offset *log_offset,
         }
     }
     g_err |= cbor_encoder_close_container(&rsp, &str_encoder);
+
+#if MYNEWT_VAL(LOG_VERSION) > 3
+#if MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+    g_err |= cbor_encode_text_stringz(&rsp, "vr");
+    g_err |= cbor_encode_byte_string(&rsp, ueh->ue_rsvd, 4);
+#endif // MYNEWT_VAL(LOG_FLAGS_LOG_IMG_HASH)
+#endif // MYNEWT_VAL(LOG_VERSION) > 3
+
 #else
     g_err |= cbor_encode_text_stringz(&rsp, "msg");
     if (too_long) {

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -32,6 +32,12 @@ syscfg.defs:
         description: 'Limits what level log messages are compiled in.'
         value: 0
 
+    LOG_FLAGS_LOG_IMG_HASH:
+        description: >
+            Enable logging of the first 4 bytes of the image hash. 0 - disable; 
+            1 - enable.
+        value: 0
+
     LOG_FCB:
         description: 'Support logging to FCB.'
         value: 0

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -26,7 +26,7 @@ syscfg.defs:
 
     LOG_VERSION:
         description: 'Log entry header version used.'
-        value: 2
+        value: 4
 
     LOG_LEVEL:
         description: 'Limits what level log messages are compiled in.'
@@ -36,7 +36,7 @@ syscfg.defs:
         description: >
             Enable logging of the first 4 bytes of the image hash. 0 - disable; 
             1 - enable.
-        value: 0
+        value: 1
 
     LOG_FCB:
         description: 'Support logging to FCB.'

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -26,7 +26,7 @@ syscfg.defs:
 
     LOG_VERSION:
         description: 'Log entry header version used.'
-        value: 4
+        value: 3
 
     LOG_LEVEL:
         description: 'Limits what level log messages are compiled in.'

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -36,7 +36,7 @@ syscfg.defs:
         description: >
             Enable logging of the first 4 bytes of the image hash. 0 - disable; 
             1 - enable.
-        value: 1
+        value: 0
 
     LOG_FCB:
         description: 'Support logging to FCB.'

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -32,7 +32,7 @@ syscfg.defs:
         description: 'Limits what level log messages are compiled in.'
         value: 0
 
-    LOG_FLAGS_LOG_IMG_HASH:
+    LOG_FLAGS_IMAGE_HASH:
         description: >
             Enable logging of the first 4 bytes of the image hash. 0 - disable; 
             1 - enable.


### PR DESCRIPTION
LOG_VERSION 3:
- Carry arbitrary data up to 4 bytes long per log.
- Flag to indicate what data is being stored in the reserve field.
- First 4 bytes of the payload will contain the image hash.

Currently only setup for the first four bytes of the image hash.