### PR TITLE
travis: upgrade to go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ _addons: &addon_conf
       - linux-libc-dev:i386
 
 go:
-  - "1.11"
+  - "1.12"
 
 git:
   depth: false


### PR DESCRIPTION
Travis builds are currently failing due to an incompatible version of go.  The latest newt requires go 1.12+.

```
+go get mynewt.apache.org/newt/newt
../../../mynewt.apache.org/newt/newt/downloader/downloader.go:509:14: ee.ExitCode undefined (type *exec.ExitError has no field or method ExitCode)
```

This PR upgrades from 1.11 to 1.12.