### PR TITLE
Define logs in packages' syscfg files

### DIFF
--- a/apps/bleprph_oic/src/gatt_svr.c
+++ b/apps/bleprph_oic/src/gatt_svr.c
@@ -31,13 +31,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
+        DFLT_LOG_DEBUG("registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -45,7 +45,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/bleprph_oic/src/main.c
+++ b/apps/bleprph_oic/src/main.c
@@ -47,19 +47,19 @@ static int bleprph_gap_event(struct ble_gap_event *event, void *arg);
 static void
 bleprph_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                 "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -128,7 +128,7 @@ bleprph_advertise(void)
 #endif
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -139,7 +139,7 @@ bleprph_advertise(void)
     rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
                            &adv_params, bleprph_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -168,7 +168,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -176,7 +176,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
             assert(rc == 0);
             bleprph_print_conn_desc(&desc);
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -187,9 +187,9 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         bleprph_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         oc_ble_coap_conn_del(event->disconnect.conn.conn_handle);
 
@@ -199,32 +199,32 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bleprph_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        MODLOG_DFLT(INFO, "advertise complete; reason=%d\n",
+        DFLT_LOG_INFO("advertise complete; reason=%d\n",
                     event->adv_complete.reason);
         bleprph_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bleprph_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -236,7 +236,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -265,7 +265,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
 static void
 bleprph_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/bleprph_oic/src/misc.c
+++ b/apps/bleprph_oic/src/misc.c
@@ -28,7 +28,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_INFO("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -38,6 +38,6 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
              u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }

--- a/apps/blesplit/src/main.c
+++ b/apps/blesplit/src/main.c
@@ -46,19 +46,19 @@ static int blesplit_gap_event(struct ble_gap_event *event, void *arg);
 static void
 blesplit_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                  "encrypted=%d authenticated=%d bonded=%d\n",
                  desc->conn_itvl, desc->conn_latency,
                  desc->supervision_timeout,
@@ -84,7 +84,7 @@ blesplit_advertise(void)
     /* Figure out address to use while advertising (no privacy for now) */
     rc = ble_hs_id_infer_auto(0, &own_addr_type);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error determining address type; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error determining address type; rc=%d\n", rc);
         return;
     }
 
@@ -125,7 +125,7 @@ blesplit_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -136,7 +136,7 @@ blesplit_advertise(void)
     rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
                            &adv_params, blesplit_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -165,7 +165,7 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -173,7 +173,7 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
             assert(rc == 0);
             blesplit_print_conn_desc(&desc);
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -182,9 +182,9 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         blesplit_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Connection terminated; resume advertising. */
         blesplit_advertise();
@@ -192,33 +192,33 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         blesplit_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        MODLOG_DFLT(INFO, "advertise complete; reason=%d\n",
+        DFLT_LOG_INFO("advertise complete; reason=%d\n",
                     event->adv_complete.reason);
         blesplit_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         blesplit_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -230,7 +230,7 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -259,7 +259,7 @@ blesplit_gap_event(struct ble_gap_event *event, void *arg)
 static void
 blesplit_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/blesplit/src/misc.c
+++ b/apps/blesplit/src/misc.c
@@ -28,7 +28,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_INFO("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -38,6 +38,6 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
              u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }

--- a/apps/bsncent/src/main.c
+++ b/apps/bsncent/src/main.c
@@ -93,7 +93,7 @@ bsncent_on_subscribe(uint16_t conn_handle,
                      struct ble_gatt_attr *attr,
                      void *arg)
 {
-    MODLOG_DFLT(INFO, "Subscribe complete; status=%d conn_handle=%d "
+    DFLT_LOG_INFO("Subscribe complete; status=%d conn_handle=%d "
                       "attr_handle=%d\n",
                 error->status, conn_handle, attr->handle);
 
@@ -129,7 +129,7 @@ bsncent_subscribe(const struct peer *peer)
         &bsncent_chr_gendata_uuid.u,
         BLE_UUID16_DECLARE(BLE_GATT_DSC_CLT_CFG_UUID16));
     if (dsc == NULL) {
-        MODLOG_DFLT(ERROR, "Error: Peer lacks a CCCD for the generic data "
+        DFLT_LOG_ERROR("Error: Peer lacks a CCCD for the generic data "
                            "characteristic\n");
         goto err;
     }
@@ -139,7 +139,7 @@ bsncent_subscribe(const struct peer *peer)
     rc = ble_gattc_write_flat(peer->conn_handle, dsc->dsc.handle,
                               value, sizeof value, bsncent_on_subscribe, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "Error: Failed to subscribe to characteristic; "
+        DFLT_LOG_ERROR("Error: Failed to subscribe to characteristic; "
                            "rc=%d\n", rc);
         goto err;
     }
@@ -160,7 +160,7 @@ bsncent_on_disc_complete(const struct peer *peer, int status, void *arg)
 
     if (status != 0) {
         /* Service discovery failed.  Terminate the connection. */
-        MODLOG_DFLT(ERROR, "Error: Service discovery failed; status=%d "
+        DFLT_LOG_ERROR("Error: Service discovery failed; status=%d "
                            "conn_handle=%d\n", status, peer->conn_handle);
         ble_gap_terminate(peer->conn_handle, BLE_ERR_REM_USER_CONN_TERM);
         return;
@@ -170,7 +170,7 @@ bsncent_on_disc_complete(const struct peer *peer, int status, void *arg)
      * list of services, characteristics, and descriptors that the peer
      * supports.
      */
-    MODLOG_DFLT(ERROR, "Service discovery complete; status=%d "
+    DFLT_LOG_ERROR("Service discovery complete; status=%d "
                        "conn_handle=%d\n", status, peer->conn_handle);
 
     /* Now subscribe to the gendata characterustic. */
@@ -186,7 +186,7 @@ bsncent_on_mtu_exchanged(uint16_t conn_handle,
     int rc;
 
     if (error->status != 0) {
-        MODLOG_DFLT(ERROR, "MTU exchange failed; rc=%d\n", error->status);
+        DFLT_LOG_ERROR("MTU exchange failed; rc=%d\n", error->status);
         ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
         return 0;
     }
@@ -194,7 +194,7 @@ bsncent_on_mtu_exchanged(uint16_t conn_handle,
     /* Perform service discovery. */
     rc = peer_disc_all(conn_handle, bsncent_on_disc_complete, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "Failed to discover services; rc=%d\n", rc);
+        DFLT_LOG_ERROR("Failed to discover services; rc=%d\n", rc);
         ble_gap_terminate(conn_handle, BLE_ERR_REM_USER_CONN_TERM);
         return 0;
     }
@@ -210,7 +210,7 @@ bsncent_connect(void)
     rc = ble_gap_connect(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
                          &ble_gap_conn_params_bsn, bsncent_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "Error connecting; rc=%d\n", rc);
+        DFLT_LOG_ERROR("Error connecting; rc=%d\n", rc);
         if (!((rc == BLE_HS_EALREADY) || (rc == BLE_HS_EBUSY))) {
             /* Only assert if we are not already trying */
             assert(0);
@@ -225,7 +225,7 @@ bsncent_fill_wl(void)
 
     rc = ble_gap_wl_set(bsncent_peer_addrs, bsncent_num_peer_addrs);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "Error setting white list; rc=%d\n", rc);
+        DFLT_LOG_ERROR("Error setting white list; rc=%d\n", rc);
         assert(0);
     }
 }
@@ -302,17 +302,17 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
         /* A new connection was established or a connection attempt failed. */
         if (event->connect.status == 0) {
             /* Connection successfully established. */
-            MODLOG_DFLT(INFO, "Connection established ");
+            DFLT_LOG_INFO("Connection established ");
 
             rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
             assert(rc == 0);
             print_conn_desc(&desc);
-            MODLOG_DFLT(INFO, "\n");
+            DFLT_LOG_INFO("\n");
 
             /* Remember peer. */
             rc = peer_add(event->connect.conn_handle);
             if (rc != 0) {
-                MODLOG_DFLT(ERROR, "Failed to add peer; rc=%d\n", rc);
+                DFLT_LOG_ERROR("Failed to add peer; rc=%d\n", rc);
                 assert(0);
             }
 
@@ -325,12 +325,12 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
             rc = ble_gattc_exchange_mtu(event->connect.conn_handle,
                                         bsncent_on_mtu_exchanged, NULL);
             if (rc != 0) {
-                MODLOG_DFLT(ERROR, "Failed to exchange MTU; rc=%d\n", rc);
+                DFLT_LOG_ERROR("Failed to exchange MTU; rc=%d\n", rc);
                 return 0;
             }
         } else {
             /* Connection attempt failed; resume connecting. */
-            MODLOG_DFLT(ERROR, "Error: Connection failed; status=%d\n",
+            DFLT_LOG_ERROR("Error: Connection failed; status=%d\n",
                         event->connect.status);
             bsncent_connect();
         }
@@ -339,9 +339,9 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_DISCONNECT:
         /* Connection terminated. */
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Forget about peer. */
         peer_delete(event->disconnect.conn.conn_handle);
@@ -352,7 +352,7 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
         assert(rc == 0);
@@ -361,7 +361,7 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_NOTIFY_RX:
         /* Peer sent us a notification or indication. */
-        MODLOG_DFLT(DEBUG, "received %s; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_DEBUG("received %s; conn_handle=%d attr_handle=%d "
                            "attr_len=%d\n",
                     event->notify_rx.indication ?
                         "indication" :
@@ -377,7 +377,7 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -391,7 +391,7 @@ bsncent_gap_event(struct ble_gap_event *event, void *arg)
 static void
 bsncent_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/bsncent/src/misc.c
+++ b/apps/bsncent/src/misc.c
@@ -33,7 +33,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(DEBUG, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_DEBUG("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -45,7 +45,7 @@ print_mbuf(const struct os_mbuf *om)
     colon = 0;
     while (om != NULL) {
         if (colon) {
-            MODLOG_DFLT(DEBUG, ":");
+            DFLT_LOG_DEBUG(":");
         } else {
             colon = 1;
         }
@@ -72,7 +72,7 @@ print_uuid(const ble_uuid_t *uuid)
 {
     char buf[BLE_UUID_STR_LEN];
 
-    MODLOG_DFLT(DEBUG, "%s", ble_uuid_to_str(uuid, buf));
+    DFLT_LOG_DEBUG("%s", ble_uuid_to_str(uuid, buf));
 }
 
 /**
@@ -81,16 +81,16 @@ print_uuid(const ble_uuid_t *uuid)
 void
 print_conn_desc(const struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(DEBUG, "handle=%d our_ota_addr_type=%d our_ota_addr=%s ",
+    DFLT_LOG_DEBUG("handle=%d our_ota_addr_type=%d our_ota_addr=%s ",
                 desc->conn_handle, desc->our_ota_addr.type,
                 addr_str(desc->our_ota_addr.val));
-    MODLOG_DFLT(DEBUG, "our_id_addr_type=%d our_id_addr=%s ",
+    DFLT_LOG_DEBUG("our_id_addr_type=%d our_id_addr=%s ",
                 desc->our_id_addr.type, addr_str(desc->our_id_addr.val));
-    MODLOG_DFLT(DEBUG, "peer_ota_addr_type=%d peer_ota_addr=%s ",
+    DFLT_LOG_DEBUG("peer_ota_addr_type=%d peer_ota_addr=%s ",
                 desc->peer_ota_addr.type, addr_str(desc->peer_ota_addr.val));
-    MODLOG_DFLT(DEBUG, "peer_id_addr_type=%d peer_id_addr=%s ",
+    DFLT_LOG_DEBUG("peer_id_addr_type=%d peer_id_addr=%s ",
                 desc->peer_id_addr.type, addr_str(desc->peer_id_addr.val));
-    MODLOG_DFLT(DEBUG, "conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_DEBUG("conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                 "encrypted=%d authenticated=%d bonded=%d",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -108,102 +108,102 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
     int i;
 
     if (fields->flags != 0) {
-        MODLOG_DFLT(DEBUG, "    flags=0x%02x\n", fields->flags);
+        DFLT_LOG_DEBUG("    flags=0x%02x\n", fields->flags);
     }
 
     if (fields->uuids16 != NULL) {
-        MODLOG_DFLT(DEBUG, "    uuids16(%scomplete)=",
+        DFLT_LOG_DEBUG("    uuids16(%scomplete)=",
                     fields->uuids16_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids16; i++) {
             print_uuid(&fields->uuids16[i].u);
-            MODLOG_DFLT(DEBUG, " ");
+            DFLT_LOG_DEBUG(" ");
         }
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->uuids32 != NULL) {
-        MODLOG_DFLT(DEBUG, "    uuids32(%scomplete)=",
+        DFLT_LOG_DEBUG("    uuids32(%scomplete)=",
                     fields->uuids32_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids32; i++) {
             print_uuid(&fields->uuids32[i].u);
-            MODLOG_DFLT(DEBUG, " ");
+            DFLT_LOG_DEBUG(" ");
         }
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->uuids128 != NULL) {
-        MODLOG_DFLT(DEBUG, "    uuids128(%scomplete)=",
+        DFLT_LOG_DEBUG("    uuids128(%scomplete)=",
                     fields->uuids128_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids128; i++) {
             print_uuid(&fields->uuids128[i].u);
-            MODLOG_DFLT(DEBUG, " ");
+            DFLT_LOG_DEBUG(" ");
         }
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->name != NULL) {
         assert(fields->name_len < sizeof s - 1);
         memcpy(s, fields->name, fields->name_len);
         s[fields->name_len] = '\0';
-        MODLOG_DFLT(DEBUG, "    name(%scomplete)=%s\n",
+        DFLT_LOG_DEBUG("    name(%scomplete)=%s\n",
                     fields->name_is_complete ? "" : "in", s);
     }
 
     if (fields->tx_pwr_lvl_is_present) {
-        MODLOG_DFLT(DEBUG, "    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
+        DFLT_LOG_DEBUG("    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
     }
 
     if (fields->slave_itvl_range != NULL) {
-        MODLOG_DFLT(DEBUG, "    slave_itvl_range=");
+        DFLT_LOG_DEBUG("    slave_itvl_range=");
         print_bytes(fields->slave_itvl_range, BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->svc_data_uuid16 != NULL) {
-        MODLOG_DFLT(DEBUG, "    svc_data_uuid16=");
+        DFLT_LOG_DEBUG("    svc_data_uuid16=");
         print_bytes(fields->svc_data_uuid16, fields->svc_data_uuid16_len);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->public_tgt_addr != NULL) {
-        MODLOG_DFLT(DEBUG, "    public_tgt_addr=");
+        DFLT_LOG_DEBUG("    public_tgt_addr=");
         u8p = fields->public_tgt_addr;
         for (i = 0; i < fields->num_public_tgt_addrs; i++) {
-            MODLOG_DFLT(DEBUG, "public_tgt_addr=%s ", addr_str(u8p));
+            DFLT_LOG_DEBUG("public_tgt_addr=%s ", addr_str(u8p));
             u8p += BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN;
         }
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->appearance_is_present) {
-        MODLOG_DFLT(DEBUG, "    appearance=0x%04x\n", fields->appearance);
+        DFLT_LOG_DEBUG("    appearance=0x%04x\n", fields->appearance);
     }
 
     if (fields->adv_itvl_is_present) {
-        MODLOG_DFLT(DEBUG, "    adv_itvl=0x%04x\n", fields->adv_itvl);
+        DFLT_LOG_DEBUG("    adv_itvl=0x%04x\n", fields->adv_itvl);
     }
 
     if (fields->svc_data_uuid32 != NULL) {
-        MODLOG_DFLT(DEBUG, "    svc_data_uuid32=");
+        DFLT_LOG_DEBUG("    svc_data_uuid32=");
         print_bytes(fields->svc_data_uuid32, fields->svc_data_uuid32_len);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->svc_data_uuid128 != NULL) {
-        MODLOG_DFLT(DEBUG, "    svc_data_uuid128=");
+        DFLT_LOG_DEBUG("    svc_data_uuid128=");
         print_bytes(fields->svc_data_uuid128, fields->svc_data_uuid128_len);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->uri != NULL) {
-        MODLOG_DFLT(DEBUG, "    uri=");
+        DFLT_LOG_DEBUG("    uri=");
         print_bytes(fields->uri, fields->uri_len);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 
     if (fields->mfg_data != NULL) {
-        MODLOG_DFLT(DEBUG, "    mfg_data=");
+        DFLT_LOG_DEBUG("    mfg_data=");
         print_bytes(fields->mfg_data, fields->mfg_data_len);
-        MODLOG_DFLT(DEBUG, "\n");
+        DFLT_LOG_DEBUG("\n");
     }
 }

--- a/apps/bsnprph/src/gatt_svr.c
+++ b/apps/bsnprph/src/gatt_svr.c
@@ -87,13 +87,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
+        DFLT_LOG_DEBUG("registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -101,7 +101,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/bsnprph/src/main.c
+++ b/apps/bsnprph/src/main.c
@@ -63,19 +63,19 @@ static int bsnprph_gap_event(struct ble_gap_event *event, void *arg);
 static void
 bsnprph_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                 "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -134,7 +134,7 @@ bsnprph_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -147,7 +147,7 @@ bsnprph_advertise(void)
                            BLE_HS_FOREVER, &adv_params,
                            bsnprph_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -214,7 +214,7 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -224,7 +224,7 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
 
             bsnprph_conn_handle = event->connect.conn_handle;
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -235,9 +235,9 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
     case BLE_GAP_EVENT_DISCONNECT:
         os_callout_stop(&bsnprph_tx_timer);
 
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         bsnprph_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Connection terminated; resume advertising. */
         bsnprph_advertise();
@@ -245,32 +245,32 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
         os_callout_stop(&bsnprph_tx_timer);
-        MODLOG_DFLT(INFO, "adv complete\n");
+        DFLT_LOG_INFO("adv complete\n");
         bsnprph_advertise();
         return 0;
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bsnprph_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bsnprph_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -286,7 +286,7 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -299,7 +299,7 @@ bsnprph_gap_event(struct ble_gap_event *event, void *arg)
 static void
 bsnprph_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/bsnprph/src/misc.c
+++ b/apps/bsnprph/src/misc.c
@@ -28,7 +28,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_INFO("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -38,6 +38,6 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
              u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }

--- a/apps/ocf_sample/src/ocf_ble.c
+++ b/apps/ocf_sample/src/ocf_ble.c
@@ -44,7 +44,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_INFO("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -54,7 +54,7 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
                 u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }
 
@@ -64,19 +64,19 @@ print_addr(const void *addr)
 static void
 ocf_ble_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                       "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -128,7 +128,7 @@ ocf_ble_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -139,7 +139,7 @@ ocf_ble_advertise(void)
     rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
                            &adv_params, ocf_ble_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -175,7 +175,7 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -183,7 +183,7 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
             assert(rc == 0);
             ocf_ble_print_conn_desc(&desc);
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -192,9 +192,9 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         ocf_ble_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Connection terminated; resume advertising. */
         ocf_ble_advertise();
@@ -202,32 +202,32 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         ocf_ble_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        MODLOG_DFLT(INFO, "advertise complete; reason=%d\n",
+        DFLT_LOG_INFO("advertise complete; reason=%d\n",
                     event->adv_complete.reason);
         ocf_ble_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         ocf_ble_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -239,7 +239,7 @@ ocf_ble_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);

--- a/apps/sensors_test/src/gatt_svr.c
+++ b/apps/sensors_test/src/gatt_svr.c
@@ -35,13 +35,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
+        DFLT_LOG_DEBUG("registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -49,7 +49,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
+        DFLT_LOG_DEBUG("registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -130,19 +130,19 @@ static int g_led_pin;
 static void
 sensor_oic_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                       "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -203,7 +203,7 @@ sensor_oic_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -214,7 +214,7 @@ sensor_oic_advertise(void)
     rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
                            &adv_params, sensor_oic_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -223,7 +223,7 @@ sensor_oic_advertise(void)
 static void
 sensor_oic_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void
@@ -257,7 +257,7 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -265,7 +265,7 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
             assert(rc == 0);
             sensor_oic_print_conn_desc(&desc);
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -276,9 +276,9 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         sensor_oic_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         oc_ble_coap_conn_del(event->disconnect.conn.conn_handle);
 
@@ -288,38 +288,38 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         sensor_oic_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
 
     case BLE_GAP_EVENT_DISC_COMPLETE:
-        MODLOG_DFLT(INFO, "discovery complete; reason=%d\n",
+        DFLT_LOG_INFO("discovery complete; reason=%d\n",
                     event->disc_complete.reason);
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        MODLOG_DFLT(INFO, "advertise complete; reason=%d\n",
+        DFLT_LOG_INFO("advertise complete; reason=%d\n",
                     event->adv_complete.reason);
         sensor_oic_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         sensor_oic_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -331,7 +331,7 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);

--- a/apps/sensors_test/src/misc.c
+++ b/apps/sensors_test/src/misc.c
@@ -28,7 +28,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        DFLT_LOG_INFO("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -38,6 +38,6 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
              u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }

--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -173,7 +173,7 @@ task1_handler(void *arg)
         /* Toggle the LED */
         prev_pin_state = hal_gpio_read(g_led_pin);
         curr_pin_state = hal_gpio_toggle(g_led_pin);
-        MODLOG_DFLT(INFO, "GPIO toggle from %u to %u",
+        DFLT_LOG_INFO("GPIO toggle from %u to %u",
                     prev_pin_state, curr_pin_state);
         STATS_INC(g_stats_gpio_toggle, toggles);
 

--- a/apps/slinky_oic/src/main.c
+++ b/apps/slinky_oic/src/main.c
@@ -168,7 +168,7 @@ task1_handler(void *arg)
         /* Toggle the LED */
         prev_pin_state = hal_gpio_read(g_led_pin);
         curr_pin_state = hal_gpio_toggle(g_led_pin);
-        MODLOG_DFLT(INFO, "GPIO toggle from %u to %u",
+        DFLT_LOG_INFO("GPIO toggle from %u to %u",
                     prev_pin_state, curr_pin_state);
         STATS_INC(g_stats_gpio_toggle, toggles);
 

--- a/apps/splitty/src/main.c
+++ b/apps/splitty/src/main.c
@@ -107,7 +107,7 @@ task1_handler(void *arg)
         /* Toggle the LED */
         prev_pin_state = hal_gpio_read(g_led_pin);
         curr_pin_state = hal_gpio_toggle(g_led_pin);
-        MODLOG_INFO(LOG_MODULE_DEFAULT, "GPIO toggle from %u to %u",
+        DFLT_LOG_INFO("GPIO toggle from %u to %u",
                     prev_pin_state, curr_pin_state);
         STATS_INC(g_stats_gpio_toggle, toggles);
 

--- a/apps/testbench/src/tbb.c
+++ b/apps/testbench/src/tbb.c
@@ -56,7 +56,7 @@ tbb_print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    DFLT_LOG_INFO("%02x:%02x:%02x:%02x:%02x:%02x",
                 u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }
 
@@ -66,19 +66,19 @@ tbb_print_addr(const void *addr)
 static void
 tbb_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    DFLT_LOG_INFO("handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     tbb_print_addr(desc->our_ota_addr.val);
-    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
+    DFLT_LOG_INFO(" our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     tbb_print_addr(desc->our_id_addr.val);
-    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    DFLT_LOG_INFO(" peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     tbb_print_addr(desc->peer_ota_addr.val);
-    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    DFLT_LOG_INFO(" peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     tbb_print_addr(desc->peer_id_addr.val);
-    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    DFLT_LOG_INFO(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                       "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -137,7 +137,7 @@ tbb_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -148,7 +148,7 @@ tbb_advertise(void)
     rc = ble_gap_adv_start(tbb_own_addr_type, NULL, BLE_HS_FOREVER,
                            &adv_params, tbb_gap_event, NULL);
     if (rc != 0) {
-        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        DFLT_LOG_ERROR("error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -177,7 +177,7 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+        DFLT_LOG_INFO("connection %s; status=%d ",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
         if (event->connect.status == 0) {
@@ -185,7 +185,7 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
             assert(rc == 0);
             tbb_print_conn_desc(&desc);
         }
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Try to advertise again. */
         tbb_advertise();
@@ -193,9 +193,9 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        DFLT_LOG_INFO("disconnect; reason=%d ", event->disconnect.reason);
         tbb_print_conn_desc(&event->disconnect.conn);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
 
         /* Connection terminated; resume advertising. */
         tbb_advertise();
@@ -203,32 +203,32 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        MODLOG_DFLT(INFO, "connection updated; status=%d ",
+        DFLT_LOG_INFO("connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         tbb_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        MODLOG_DFLT(INFO, "advertise complete; reason=%d\n",
+        DFLT_LOG_INFO("advertise complete; reason=%d\n",
                     event->adv_complete.reason);
         tbb_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
+        DFLT_LOG_INFO("encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         tbb_print_conn_desc(&desc);
-        MODLOG_DFLT(INFO, "\n");
+        DFLT_LOG_INFO("\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        DFLT_LOG_INFO("subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -240,7 +240,7 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        DFLT_LOG_INFO("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -253,7 +253,7 @@ tbb_gap_event(struct ble_gap_event *event, void *arg)
 static void
 tbb_on_reset(int reason)
 {
-    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
+    DFLT_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/testbench/src/testbench.c
+++ b/apps/testbench/src/testbench.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
                  TESTTASK_PRIO, OS_WAIT_FOREVER, teststack,
                  TESTTASK_STACK_SIZE);
 
-    MODLOG_INFO(LOG_MODULE_TEST, "testbench app initialized");
+    TEST_LOG_INFO("testbench app initialized");
 
     while (1) {
         os_eventq_run(os_eventq_dflt_get());

--- a/fs/nffs/src/nffs_cache.c
+++ b/fs/nffs/src/nffs_cache.c
@@ -311,7 +311,7 @@ static void
 nffs_cache_log_block(struct nffs_cache_inode *cache_inode,
                      struct nffs_cache_block *cache_block)
 {
-    NFFS_LOG(DEBUG, "id=%u inode=%u flash_off=0x%08x "
+    NFFS_LOG_DEBUG("id=%u inode=%u flash_off=0x%08x "
                     "file_off=%u len=%d (entry=%p)\n",
              (unsigned int)cache_block->ncb_block.nb_hash_entry->nhe_id,
              (unsigned int)cache_inode->nci_inode.ni_inode_entry->nie_hash_entry.nhe_id,
@@ -326,7 +326,7 @@ nffs_cache_log_insert_block(struct nffs_cache_inode *cache_inode,
                             struct nffs_cache_block *cache_block,
                             int tail)
 {
-    NFFS_LOG(DEBUG, "caching block (%s): ", tail ? "tail" : "head");
+    NFFS_LOG_DEBUG("caching block (%s): ", tail ? "tail" : "head");
     nffs_cache_log_block(cache_inode, cache_block);
 }
 

--- a/fs/nffs/src/nffs_inode.c
+++ b/fs/nffs/src/nffs_inode.c
@@ -481,7 +481,7 @@ nffs_inode_delete_from_disk(struct nffs_inode *inode)
     nffs_crc_disk_inode_fill(&disk_inode, "");
 
     rc = nffs_inode_write_disk(&disk_inode, "", area_idx, offset);
-    NFFS_LOG(DEBUG, "inode_del_disk: wrote unlinked ino %x to disk ref %d\n",
+    NFFS_LOG_DEBUG("inode_del_disk: wrote unlinked ino %x to disk ref %d\n",
                (unsigned int)disk_inode.ndi_id,
                inode->ni_inode_entry->nie_refcnt);
 
@@ -492,7 +492,7 @@ nffs_inode_delete_from_disk(struct nffs_inode *inode)
      */
     if (nffs_hash_id_is_file(inode->ni_inode_entry->nie_hash_entry.nhe_id)) {
         nffs_inode_setflags(inode->ni_inode_entry, NFFS_INODE_FLAG_DELETED);
-        NFFS_LOG(DEBUG, "inode_delete_from_disk: ino %x flag DELETE\n",
+        NFFS_LOG_DEBUG("inode_delete_from_disk: ino %x flag DELETE\n",
                    (unsigned int)inode->ni_inode_entry->nie_hash_entry.nhe_id);
 
     }
@@ -691,7 +691,7 @@ nffs_inode_update(struct nffs_inode_entry *inode_entry)
 
     nffs_crc_disk_inode_fill(&disk_inode, filename);
 
-    NFFS_LOG(DEBUG, "nffs_inode_update writing inode %x last block %x\n",
+    NFFS_LOG_DEBUG("nffs_inode_update writing inode %x last block %x\n",
              (unsigned int)disk_inode.ndi_id,
              (unsigned int)disk_inode.ndi_lastblock_id);
 

--- a/fs/nffs/src/nffs_priv.h
+++ b/fs/nffs/src/nffs_priv.h
@@ -510,9 +510,6 @@ int nffs_write_to_file(struct nffs_file *file, const void *data, int len);
 
 #define NFFS_FLASH_LOC_NONE  nffs_flash_loc(NFFS_AREA_ID_NONE, 0)
 
-#define NFFS_LOG(lvl, ...) \
-    MODLOG_ ## lvl(LOG_MODULE_NFFS, __VA_ARGS__)
-
 #ifdef __cplusplus
 }
 #endif

--- a/fs/nffs/src/nffs_restore.c
+++ b/fs/nffs/src/nffs_restore.c
@@ -416,7 +416,7 @@ nffs_restore_inode_gets_replaced(struct nffs_inode_entry *old_inode_entry,
 
 
     if (nffs_inode_is_dummy(old_inode_entry)) {
-        NFFS_LOG(DEBUG, "inode_gets_replaced dummy!\n");
+        NFFS_LOG_DEBUG("inode_gets_replaced dummy!\n");
         *out_should_replace = 1;
         return 0;
     }
@@ -425,7 +425,7 @@ nffs_restore_inode_gets_replaced(struct nffs_inode_entry *old_inode_entry,
      * inode is known to be obsolete and needs to be replaced no matter what
      */
     if (nffs_inode_getflags(old_inode_entry, NFFS_INODE_FLAG_OBSOLETE)) {
-        NFFS_LOG(DEBUG, "inode_gets_replaced obsolete\n");
+        NFFS_LOG_DEBUG("inode_gets_replaced obsolete\n");
         *out_should_replace = 2;
         return 0;
     }
@@ -437,7 +437,7 @@ nffs_restore_inode_gets_replaced(struct nffs_inode_entry *old_inode_entry,
     }
 
     if (old_inode.ni_seq < disk_inode->ndi_seq) {
-        NFFS_LOG(DEBUG, "inode_gets_replaced seq\n");
+        NFFS_LOG_DEBUG("inode_gets_replaced seq\n");
         *out_should_replace = 3;
         return 0;
     }
@@ -497,7 +497,7 @@ nffs_restore_inode(const struct nffs_disk_inode *disk_inode, uint8_t area_idx,
              * Restore this inode even though deleted on disk
              * so the additional restored blocks have a place to go
              */
-            NFFS_LOG(DEBUG, "restoring deleted inode %x\n",
+            NFFS_LOG_DEBUG("restoring deleted inode %x\n",
                      (unsigned int)disk_inode->ndi_id);
             nffs_inode_setflags(inode_entry, NFFS_INODE_FLAG_DELETED);
         }
@@ -623,7 +623,7 @@ nffs_restore_inode(const struct nffs_disk_inode *disk_inode, uint8_t area_idx,
              * Restore this inode even though deleted on disk
              * so the additional restored blocks have a place to go
              */
-            NFFS_LOG(DEBUG, "restoring deleted inode %x\n",
+            NFFS_LOG_DEBUG("restoring deleted inode %x\n",
                      (unsigned int)disk_inode->ndi_id);
             nffs_inode_setflags(inode_entry, NFFS_INODE_FLAG_DELETED);
         }
@@ -705,13 +705,13 @@ nffs_restore_inode(const struct nffs_disk_inode *disk_inode, uint8_t area_idx,
     }
 
     if (nffs_hash_id_is_file(inode_entry->nie_hash_entry.nhe_id)) {
-        NFFS_LOG(DEBUG, "restoring file; id=0x%08x\n",
+        NFFS_LOG_DEBUG("restoring file; id=0x%08x\n",
                  (unsigned int)inode_entry->nie_hash_entry.nhe_id);
         if (inode_entry->nie_hash_entry.nhe_id >= nffs_hash_next_file_id) {
             nffs_hash_next_file_id = inode_entry->nie_hash_entry.nhe_id + 1;
         }
     } else {
-        NFFS_LOG(DEBUG, "restoring dir; id=0x%08x\n",
+        NFFS_LOG_DEBUG("restoring dir; id=0x%08x\n",
                  (unsigned int)inode_entry->nie_hash_entry.nhe_id);
         if (inode_entry->nie_hash_entry.nhe_id >= nffs_hash_next_dir_id) {
             nffs_hash_next_dir_id = inode_entry->nie_hash_entry.nhe_id + 1;
@@ -880,7 +880,7 @@ nffs_restore_block(const struct nffs_disk_block *disk_block, uint8_t area_idx,
         nffs_restore_largest_block_data_len = disk_block->ndb_data_len;
     }
 
-    NFFS_LOG(DEBUG, "restoring block; id=0x%08x seq=%u inode_id=%u prev_id=%u "
+    NFFS_LOG_DEBUG("restoring block; id=0x%08x seq=%u inode_id=%u prev_id=%u "
              "data_len=%u\n",
              (unsigned int)disk_block->ndb_id,
              (unsigned int)disk_block->ndb_seq,
@@ -1219,33 +1219,33 @@ nffs_log_contents(void)
         if (nffs_hash_id_is_block(entry->nhe_id)) {
             rc = nffs_block_from_hash_entry(&block, entry);
             assert(rc == 0 || rc == FS_ENOENT);
-            NFFS_LOG(DEBUG, "block; id=%u inode_id=",
+            NFFS_LOG_DEBUG("block; id=%u inode_id=",
                      (unsigned int)entry->nhe_id);
             if (block.nb_inode_entry == NULL) {
-                NFFS_LOG(DEBUG, "null ");
+                NFFS_LOG_DEBUG("null ");
             } else {
-                NFFS_LOG(DEBUG, "%u ",
+                NFFS_LOG_DEBUG("%u ",
                      (unsigned int)block.nb_inode_entry->nie_hash_entry.nhe_id);
             }
 
-            NFFS_LOG(DEBUG, "prev_id=");
+            NFFS_LOG_DEBUG("prev_id=");
             if (block.nb_prev == NULL) {
-                NFFS_LOG(DEBUG, "null ");
+                NFFS_LOG_DEBUG("null ");
             } else {
-                NFFS_LOG(DEBUG, "%u ", (unsigned int)block.nb_prev->nhe_id);
+                NFFS_LOG_DEBUG("%u ", (unsigned int)block.nb_prev->nhe_id);
             }
 
-            NFFS_LOG(DEBUG, "data_len=%u\n", block.nb_data_len);
+            NFFS_LOG_DEBUG("data_len=%u\n", block.nb_data_len);
         } else {
             inode_entry = (void *)entry;
             rc = nffs_inode_from_entry(&inode, inode_entry);
             if (rc == FS_ENOENT) {
-                NFFS_LOG(DEBUG, "DUMMY file; id=%x ref=%d block_id=",
+                NFFS_LOG_DEBUG("DUMMY file; id=%x ref=%d block_id=",
                          (unsigned int)entry->nhe_id, inode_entry->nie_refcnt);
                 if (inode_entry->nie_last_block_entry == NULL) {
-                    NFFS_LOG(DEBUG, "null");
+                    NFFS_LOG_DEBUG("null");
                 } else {
-                    NFFS_LOG(DEBUG, "%x",
+                    NFFS_LOG_DEBUG("%x",
                      (unsigned int)inode_entry->nie_last_block_entry->nhe_id);
                 }
             } else if (rc != 0) {
@@ -1254,18 +1254,18 @@ nffs_log_contents(void)
             /*assert(rc == 0);*/
 
             if (nffs_hash_id_is_file(entry->nhe_id)) {
-                NFFS_LOG(DEBUG, "file; id=%u name=%.3s block_id=",
+                NFFS_LOG_DEBUG("file; id=%u name=%.3s block_id=",
                          (unsigned int)entry->nhe_id, inode.ni_filename);
                 if (inode_entry->nie_last_block_entry == NULL) {
-                    NFFS_LOG(DEBUG, "null");
+                    NFFS_LOG_DEBUG("null");
                 } else {
-                    NFFS_LOG(DEBUG, "%u",
+                    NFFS_LOG_DEBUG("%u",
                      (unsigned int)inode_entry->nie_last_block_entry->nhe_id);
                 }
-                NFFS_LOG(DEBUG, "\n");
+                NFFS_LOG_DEBUG("\n");
             } else {
                 inode_entry = (void *)entry;
-                NFFS_LOG(DEBUG, "dir; id=%u name=%.3s\n",
+                NFFS_LOG_DEBUG("dir; id=%u name=%.3s\n",
                          (unsigned int)entry->nhe_id, inode.ni_filename);
 
             }
@@ -1408,7 +1408,7 @@ nffs_restore_full(const struct nffs_area_desc *area_descs)
         goto err;
     }
 
-    NFFS_LOG(DEBUG, "CONTENTS\n");
+    NFFS_LOG_DEBUG("CONTENTS\n");
     nffs_log_contents();
 
     return 0;

--- a/fs/nffs/syscfg.yml
+++ b/fs/nffs/syscfg.yml
@@ -37,3 +37,17 @@ syscfg.defs:
         description: >
             Sysinit stage for NFFS functionality.
         value: 200
+
+    ### Log settings.
+
+    NFFS_LOG_MOD:
+        description: 'Numeric module ID to use for NFFS log messages.'
+        value: 5
+    NFFS_LOG_LVL:
+        description: 'Minimum level for the NFFS log.'
+        value: 1
+
+syscfg.logs:
+    NFFS_LOG:
+        module: MYNEWT_VAL(NFFS_LOG_MOD)
+        level: MYNEWT_VAL(NFFS_LOG_LVL)

--- a/hw/drivers/bq27z561/src/bq27z561.c
+++ b/hw/drivers/bq27z561/src/bq27z561.c
@@ -32,17 +32,7 @@
 
 #include "battery/battery_prop.h"
 
-#if MYNEWT_VAL(BQ27Z561_LOG)
 #include "modlog/modlog.h"
-#endif
-
-#if MYNEWT_VAL(BQ27Z561_LOG)
-
-#define BQ27Z561_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BQ27Z561_LOG_MODULE), __VA_ARGS__)
-#else
-#define BQ27Z561_LOG(lvl_, ...)
-#endif
 
 static uint8_t
 bq27z561_calc_chksum(uint8_t *tmpbuf, uint8_t len)
@@ -143,7 +133,7 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         goto err;
     }
 
@@ -152,7 +142,7 @@ bq27z561_rd_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t *val)
     rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
         goto err;
     }
 
@@ -185,7 +175,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", reg);
         goto err;
     }
 
@@ -194,7 +184,7 @@ bq27z561_rd_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t *val)
     rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg read (rd) failed 0x%02X\n", reg);
         goto err;
     }
 
@@ -233,7 +223,7 @@ bq27z561_wr_std_reg_byte(struct bq27z561 *dev, uint8_t reg, uint8_t val)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg write 0x%02X failed\n", reg);
     }
 
     bq27z561_itf_unlock(&dev->bq27_itf);
@@ -269,7 +259,7 @@ bq27z561_wr_std_reg_word(struct bq27z561 *dev, uint8_t reg, uint16_t val)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg write 0x%02X failed\n", reg);
+        BQ27Z561_LOG_ERROR("I2C reg write 0x%02X failed\n", reg);
         goto err;
     }
 
@@ -322,7 +312,7 @@ bq27x561_wr_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *buf,
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         rc = BQ27Z561_ERR_I2C_ERR;
     }
 
@@ -384,7 +374,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -408,7 +398,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -419,7 +409,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -432,7 +422,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     cmd_read = tmpbuf[0];
     cmd_read |= ((uint16_t)tmpbuf[1]) << 8;
     if (cmd_read != cmd) {
-        BQ27Z561_LOG(ERROR, "cmd mismatch (cmd=%x cmd_ret=%x\n", cmd, cmd_read);
+        BQ27Z561_LOG_ERROR("cmd mismatch (cmd=%x cmd_ret=%x\n", cmd, cmd_read);
         ret = BQ27Z561_ERR_CMD_MISMATCH;
         goto err;
     }
@@ -452,7 +442,7 @@ bq27x561_rd_alt_mfg_cmd(struct bq27z561 *dev, uint16_t cmd, uint8_t *val,
     len -= 2;
     chksum = bq27z561_calc_chksum(tmpbuf, len);
     if (chksum != tmpbuf[34]) {
-        BQ27Z561_LOG(ERROR, "chksum failure for cmd %u (calc=%u read=%u)", cmd,
+        BQ27Z561_LOG_ERROR("chksum failure for cmd %u (calc=%u read=%u)", cmd,
                        chksum, tmpbuf[34]);
         ret = BQ27Z561_ERR_CHKSUM_FAIL;
     }
@@ -523,7 +513,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -548,7 +538,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -559,7 +549,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     rc = i2cn_master_read(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (rd) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         bq27z561_itf_unlock(&dev->bq27_itf);
         goto err;
@@ -572,7 +562,7 @@ bq27x561_rd_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     addr_read = tmpbuf[0];
     addr_read |= ((uint16_t)tmpbuf[1]) << 8;
     if (addr_read != addr) {
-        BQ27Z561_LOG(ERROR, "addr mismatch (addr_read=%x addr_ret=%x\n", addr_read,
+        BQ27Z561_LOG_ERROR("addr mismatch (addr_read=%x addr_ret=%x\n", addr_read,
                         addr);
         ret = BQ27Z561_ERR_FLASH_ADDR_MISMATCH;
         goto err;
@@ -640,7 +630,7 @@ bq27z561_wr_flash(struct bq27z561 *dev, uint16_t addr, uint8_t *buf, int buflen)
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
         goto err;
     }
@@ -673,7 +663,7 @@ err:
     rc = i2cn_master_write(dev->bq27_itf.itf_num, &i2c, MYNEWT_VAL(BQ27Z561_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(BQ27Z561_I2C_RETRIES));
     if (rc != 0) {
-        BQ27Z561_LOG(ERROR, "I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
+        BQ27Z561_LOG_ERROR("I2C reg read (wr) failed 0x%02X\n", tmpbuf[0]);
         ret = BQ27Z561_ERR_I2C_ERR;
     }
 

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -24,12 +24,6 @@ syscfg.defs:
     BQ27Z561_INT_ENABLE:
         description: 'Enable interrupt support, necessary for events'
         value: 0
-    BQ27Z561_LOG:
-        description: 'Enable BQ27Z561 logging'
-        value: 1
-    BQ27Z561_LOG_MODULE:
-        description: 'Numeric module ID to use for BQ27Z561 log messages'
-        value: 111
     BQ27Z561_SHELL_DEV_NAME:
         description: 'BQ27Z561 Shell device name'
         value: "\"bq27z561_0\""
@@ -49,3 +43,17 @@ syscfg.defs:
         description: >
             Sysinit stage for the BQ27Z561 driver.
         value: 500
+
+    ### Log settings.
+
+    BQ27Z561_LOG_MODULE:
+        description: 'Numeric module ID to use for BQ27Z561 log messages.'
+        value: 111
+    BQ27Z561_LOG_LVL:
+        description: 'Minimum level for the BQ27Z561 log.'
+        value: 15 # Disable logging by default.
+
+syscfg.logs:
+    BQ27Z561_LOG:
+        module: MYNEWT_VAL(BQ27Z561_LOG_MODULE)
+        level: MYNEWT_VAL(BQ27Z561_LOG_LVL)

--- a/hw/drivers/display/cfb/src/cfb.c
+++ b/hw/drivers/display/cfb/src/cfb.c
@@ -124,7 +124,7 @@ int cfb_print(struct os_dev *dev, char *str, uint16_t x, uint16_t y)
 	}
 
 	if (fptr->height % 8) {
-		MODLOG_DFLT(ERROR, "Wrong font size");
+		DFLT_LOG_ERROR("Wrong font size");
 		return -1;
 	}
 
@@ -139,14 +139,14 @@ int cfb_print(struct os_dev *dev, char *str, uint16_t x, uint16_t y)
 		return 0;
 	}
 
-	MODLOG_DFLT(ERROR, "Unsupported framebuffer configuration");
+	DFLT_LOG_ERROR("Unsupported framebuffer configuration");
 	return -1;
 }
 
 static int cfb_reverse_bytes(const struct char_framebuffer *fb)
 {
 	if (!(fb->screen_info & SCREEN_INFO_MONO_VTILED)) {
-		MODLOG_DFLT(ERROR, "Unsupported framebuffer configuration");
+		DFLT_LOG_ERROR("Unsupported framebuffer configuration");
 		return -1;
 	}
 
@@ -305,7 +305,7 @@ int cfb_framebuffer_init(struct os_dev *dev)
 
 
 	fb->numof_fonts = (sizeof(font_array) / sizeof((font_array)[0]));
-	MODLOG_DFLT(DEBUG, "number of fonts %d", fb->numof_fonts);
+	DFLT_LOG_DEBUG("number of fonts %d", fb->numof_fonts);
 	if (!fb->numof_fonts) {
 		return -1;
 	}

--- a/hw/drivers/display/ssd1673/src/ssd1673.c
+++ b/hw/drivers/display/ssd1673/src/ssd1673.c
@@ -255,22 +255,22 @@ static int ssd1673_write(const struct os_dev *dev, const uint16_t x,
 	bool update = true;
 
 	if (desc->pitch < desc->width) {
-		MODLOG_DFLT(ERROR, "Pitch is smaller then width");
+		DFLT_LOG_ERROR("Pitch is smaller then width");
 		return -1;
 	}
 
 	if (buf == NULL || desc->buf_size == 0) {
-		MODLOG_DFLT(ERROR, "Display buffer is not available");
+		DFLT_LOG_ERROR("Display buffer is not available");
 		return -1;
 	}
 
 	if (desc->pitch > desc->width) {
-		MODLOG_DFLT(ERROR, "Unsupported mode");
+		DFLT_LOG_ERROR("Unsupported mode");
 		return -1;
 	}
 
 	if (x != 0 && y != 0) {
-		MODLOG_DFLT(ERROR, "Unsupported origin");
+		DFLT_LOG_ERROR("Unsupported origin");
 		return -1;
 	}
 
@@ -371,20 +371,20 @@ static int ssd1673_read(const struct os_dev *dev, const uint16_t x,
 			const struct display_buffer_descriptor *desc,
 			void *buf)
 {
-	MODLOG_DFLT(ERROR, "not supported");
+	DFLT_LOG_ERROR("not supported");
 	return -1;
 }
 
 static void *ssd1673_get_framebuffer(const struct os_dev *dev)
 {
-	MODLOG_DFLT(ERROR, "not supported");
+	DFLT_LOG_ERROR("not supported");
 	return NULL;
 }
 
 static int ssd1673_set_brightness(const struct os_dev *dev,
 				  const uint8_t brightness)
 {
-	MODLOG_DFLT(WARN, "not supported");
+	DFLT_LOG_WARN("not supported");
 	return -1;
 }
 
@@ -413,7 +413,7 @@ static void ssd1673_get_capabilities(const struct os_dev *dev,
 static int ssd1673_set_pixel_format(const struct os_dev *dev,
 				    const enum display_pixel_format pf)
 {
-	MODLOG_DFLT(ERROR, "not supported");
+	DFLT_LOG_ERROR("not supported");
 	return -1;
 }
 
@@ -422,7 +422,7 @@ static int ssd1673_controller_init(struct os_dev *dev)
 	struct ssd1673_data *driver = dev->od_init_arg;
 	uint8_t tmp[3];
 
-	MODLOG_DFLT(DEBUG, "");
+	DFLT_LOG_DEBUG("");
 
 	hal_gpio_write(CONFIG_SSD1673_RESET_PIN, 0);
 	os_time_delay(SSD1673_RESET_DELAY_TICKS);
@@ -480,7 +480,7 @@ static int ssd1673_init(struct os_dev *dev, void *arg)
 	struct ssd1673_data *driver = dev->od_init_arg;
 	int rc;
 
-	MODLOG_DFLT(DEBUG, "");
+	DFLT_LOG_DEBUG("");
 
 	driver->spi_config.baudrate = CONFIG_SSD1673_SPI_FREQ;
 	driver->spi_config.data_mode = HAL_SPI_MODE0;

--- a/hw/drivers/drv2605/src/drv2605.c
+++ b/hw/drivers/drv2605/src/drv2605.c
@@ -29,9 +29,7 @@
 #include "drv2605_priv.h"
 #include <syscfg/syscfg.h>
 
-#if MYNEWT_VAL(DRV2605_LOG)
 #include "modlog/modlog.h"
-#endif
 
 #if MYNEWT_VAL(DRV2605_STATS)
 #include "stats/stats.h"
@@ -50,13 +48,6 @@ STATS_NAME_END(drv2605_stat_section)
 
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(drv2605_stat_section) g_drv2605stats;
-#endif
-
-#if MYNEWT_VAL(DRV2605_LOG)
-#define DRV2605_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(DRV2605_LOG_MODULE), __VA_ARGS__)
-#else
-#define DRV2605_LOG(lvl_, ...)
 #endif
 
 /**
@@ -88,7 +79,7 @@ drv2605_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC, 1,
                            MYNEWT_VAL(DRV2605_I2C_RETRIES));
     if (rc) {
-        DRV2605_LOG(ERROR,
+        DRV2605_LOG_ERROR(
                     "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
                     data_struct.address, reg, value);
 #if MYNEWT_VAL(DRV2605_STATS)
@@ -140,7 +131,7 @@ drv2605_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(DRV2605_I2C_RETRIES));
     if (rc) {
-        DRV2605_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        DRV2605_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     data_struct.address);
 #if MYNEWT_VAL(DRV2605_STATS)
         STATS_INC(g_drv2605stats, errors);
@@ -185,7 +176,7 @@ drv2605_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
                            MYNEWT_VAL(DRV2605_I2C_RETRIES));
     if (rc) {
-        DRV2605_LOG(ERROR,
+        DRV2605_LOG_ERROR(
                     "I2C register write failed at address 0x%02X:0x%02X\n",
                     data_struct.address, reg);
 #if MYNEWT_VAL(DRV2605_STATS)
@@ -200,7 +191,7 @@ drv2605_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(DRV2605_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        DRV2605_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        DRV2605_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     data_struct.address, reg);
 #if MYNEWT_VAL(DRV2605_STATS)
         STATS_INC(g_drv2605stats, errors);
@@ -250,7 +241,7 @@ drv2605_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
                            MYNEWT_VAL(DRV2605_I2C_RETRIES));
     if (rc) {
-        DRV2605_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        DRV2605_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     data_struct.address);
 #if MYNEWT_VAL(DRV2605_STATS)
         STATS_INC(g_drv2605stats, errors);
@@ -264,7 +255,7 @@ drv2605_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                           MYNEWT_VAL(DRV2605_I2C_RETRIES));
     if (rc) {
-        DRV2605_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        DRV2605_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     data_struct.address, reg);
 #if MYNEWT_VAL(DRV2605_STATS)
         STATS_INC(g_drv2605stats, errors);
@@ -346,7 +337,7 @@ drv2605_init(struct os_dev *dev, void *arg)
     /* Check if we can read the chip address */
     rc = drv2605_get_chip_id(arg, &id);
     if (rc) {
-        DRV2605_LOG(ERROR, "unable to get chip id [1]: %d\n", rc);
+        DRV2605_LOG_ERROR("unable to get chip id [1]: %d\n", rc);
         goto err;
     }
 
@@ -355,13 +346,13 @@ drv2605_init(struct os_dev *dev, void *arg)
 
         rc = drv2605_get_chip_id(arg, &id);
         if (rc) {
-            DRV2605_LOG(ERROR, "unable to get chip id [2]: %d\n", rc);
+            DRV2605_LOG_ERROR("unable to get chip id [2]: %d\n", rc);
             goto err;
         }
 
         if (id != DRV2605_STATUS_DEVICE_ID_2605 && id != DRV2605_STATUS_DEVICE_ID_2605L) {
             rc = SYS_EINVAL;
-            DRV2605_LOG(ERROR,
+            DRV2605_LOG_ERROR(
                         "id not as expected: got: %d, expected %d or %d\n", id,
                         DRV2605_STATUS_DEVICE_ID_2605,
                         DRV2605_STATUS_DEVICE_ID_2605L);
@@ -371,7 +362,7 @@ drv2605_init(struct os_dev *dev, void *arg)
 
     return (0);
 err:
-    DRV2605_LOG(ERROR, "Error initializing DRV2605: %d\n", rc);
+    DRV2605_LOG_ERROR("Error initializing DRV2605: %d\n", rc);
     return (rc);
 }
 

--- a/hw/drivers/drv2605/syscfg.yml
+++ b/hw/drivers/drv2605/syscfg.yml
@@ -21,12 +21,6 @@ syscfg.defs:
     DRV2605_CLI:
         description: 'Enable shell support for the DRV2605'
         value: 0
-    DRV2605_LOG:
-        description: 'Enable DRV2605 logging'
-        value: 0
-    DRV2605_LOG_MODULE:
-        description: 'Numeric module ID to use for DRV2605 log messages'
-        value: 205
     DRV2605_STATS:
         description: 'Enable DRV2605 statistics'
         value: 0
@@ -76,3 +70,17 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the DRV2605 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    DRV2605_LOG_MODULE:
+        description: 'Numeric module ID to use for DRV2605 log messages.'
+        value: 205
+    DRV2605_LOG_LVL:
+        description: 'Minimum level for the DRV2605 log.'
+        value: 15 # Disable logging by default.
+
+syscfg.logs:
+    DRV2605_LOG:
+        module: MYNEWT_VAL(DRV2605_LOG_MODULE)
+        level: MYNEWT_VAL(DRV2605_LOG_LVL)

--- a/hw/drivers/led/lp5523/src/lp5523.c
+++ b/hw/drivers/led/lp5523/src/lp5523.c
@@ -47,9 +47,6 @@ STATS_NAME_END(lp5523_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lp5523_stat_section) g_lp5523stats;
 
-#define LP5523_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LP5523_LOG_MODULE), __VA_ARGS__)
-
 int
 lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
     uint8_t value)
@@ -75,7 +72,7 @@ lp5523_set_reg(struct led_itf *itf, enum lp5523_registers addr,
                            MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-        LP5523_LOG(ERROR,
+        LP5523_LOG_ERROR(
                    "Failed to write to 0x%02X:0x%02X with value 0x%02X "
                    "(rc=%d)\n",
                    itf->li_addr, addr, value, rc);
@@ -113,7 +110,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
                            MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-        LP5523_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LP5523_LOG_ERROR("I2C access failed at address 0x%02X\n",
                    itf->li_addr);
         STATS_INC(g_lp5523stats, write_errors);
         goto err;
@@ -125,7 +122,7 @@ lp5523_get_reg(struct led_itf *itf, enum lp5523_registers addr,
                           MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-         LP5523_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+         LP5523_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     itf->li_addr, addr);
          STATS_INC(g_lp5523stats, read_errors);
     }
@@ -169,7 +166,7 @@ lp5523_set_n_regs(struct led_itf *itf, enum lp5523_registers addr,
                            1, MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-        LP5523_LOG(ERROR, "Failed to write to 0x%02X:0x%02X\n", itf->li_addr,
+        LP5523_LOG_ERROR("Failed to write to 0x%02X:0x%02X\n", itf->li_addr,
                    addr);
         STATS_INC(g_lp5523stats, read_errors);
     }
@@ -206,7 +203,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
                            0, MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-        LP5523_LOG(ERROR, "Failed to write to 0x%02X:0x%02X\n", itf->li_addr,
+        LP5523_LOG_ERROR("Failed to write to 0x%02X:0x%02X\n", itf->li_addr,
                    addr_b);
         STATS_INC(g_lp5523stats, read_errors);
         goto err;
@@ -218,7 +215,7 @@ lp5523_get_n_regs(struct led_itf *itf, enum lp5523_registers addr,
                           MYNEWT_VAL(LP5523_I2C_RETRIES));
 
     if (rc) {
-         LP5523_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n", itf->li_addr,
+         LP5523_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n", itf->li_addr,
                     addr_b);
          STATS_INC(g_lp5523stats, read_errors);
     }

--- a/hw/drivers/led/lp5523/syscfg.yml
+++ b/hw/drivers/led/lp5523/syscfg.yml
@@ -36,9 +36,6 @@ syscfg.defs:
     LP5523_ITF_LOCK_TMO:
         description: 'LP5523 interface lock timeout in milliseconds'
         value: 1000
-    LP5523_LOG_MODULE:
-        description: 'Numeric module ID to use for LP5523 log messages'
-        value: 105
     LP5523_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -53,3 +50,17 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    LP5523_LOG_MODULE:
+        description: 'Numeric module ID to use for LP5523 log messages.'
+        value: 105
+    LP5523_LOG_LVL:
+        description: 'Minimum level for the LP5523 log.'
+        value: 1
+
+syscfg.logs:
+    LP5523_LOG:
+        module: MYNEWT_VAL(LP5523_LOG_MODULE)
+        level: MYNEWT_VAL(LP5523_LOG_LVL)

--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -59,9 +59,6 @@ STATS_NAME_END(adxl345_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(adxl345_stat_section) g_adxl345stats;
 
-#define ADXL345_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(ADXL345_LOG_MODULE), __VA_ARGS__)
-
 #define ADXL345_NOTIFY_MASK  0x01
 #define ADXL345_READ_MASK    0x02
 
@@ -134,7 +131,7 @@ adxl345_i2c_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
                            MYNEWT_VAL(ADXL345_I2C_RETRIES));
 
     if (rc) {
-        ADXL345_LOG(ERROR,
+        ADXL345_LOG_ERROR(
                     "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
                     itf->si_addr, reg, value);
         STATS_INC(g_adxl345stats, read_errors);
@@ -174,7 +171,7 @@ adxl345_i2c_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(ADXL345_I2C_RETRIES));
     if (rc) {
-        ADXL345_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        ADXL345_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     itf->si_addr);
                     
         STATS_INC(g_adxl345stats, write_errors);
@@ -187,7 +184,7 @@ adxl345_i2c_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(ADXL345_I2C_RETRIES));
 
     if (rc) {
-        ADXL345_LOG(ERROR, "Failed to read from 0x%02X:0x%02X - %02X\n",
+        ADXL345_LOG_ERROR("Failed to read from 0x%02X:0x%02X - %02X\n",
                     itf->si_addr, reg, rc);
         STATS_INC(g_adxl345stats, read_errors);
     }
@@ -227,7 +224,7 @@ adxl345_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(ADXL345_I2C_RETRIES));
     if (rc) {
-        ADXL345_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        ADXL345_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     itf->si_addr);
         STATS_INC(g_adxl345stats, write_errors);
         return rc;
@@ -240,7 +237,7 @@ adxl345_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_
                           MYNEWT_VAL(ADXL345_I2C_RETRIES));
 
     if (rc) {
-        ADXL345_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        ADXL345_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     itf->si_addr, reg);
         STATS_INC(g_adxl345stats, read_errors);
     }
@@ -277,7 +274,7 @@ adxl345_spi_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, reg & ~ADXL345_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        ADXL345_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_adxl345stats, write_errors);
         goto err;
@@ -287,7 +284,7 @@ adxl345_spi_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+        ADXL345_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_adxl345stats, write_errors);
         goto err;
@@ -335,7 +332,7 @@ adxl345_spi_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        ADXL345_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_adxl345stats, read_errors);
         goto err;
@@ -345,7 +342,7 @@ adxl345_spi_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     retval = hal_spi_tx_val(itf->si_num, 0);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+        ADXL345_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                      itf->si_num, reg);
         STATS_INC(g_adxl345stats, read_errors);
         goto err;
@@ -395,7 +392,7 @@ adxl345_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        ADXL345_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        ADXL345_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_adxl345stats, read_errors);
         goto err;
@@ -406,7 +403,7 @@ adxl345_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            ADXL345_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            ADXL345_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                         itf->si_num, reg);
             STATS_INC(g_adxl345stats, read_errors);
             goto err;
@@ -947,7 +944,7 @@ adxl345_set_act_inact_enables(struct sensor_itf *itf, struct adxl345_act_inact_e
     reg |= cfg.act_x       ? (1 << 6) : 0;
     reg |= cfg.act_ac_dc   ? (1 << 7) : 0;
 
-    ADXL345_LOG(ERROR, "act_inact = 0x%x\n", reg);
+    ADXL345_LOG_ERROR("act_inact = 0x%x\n", reg);
     
     return adxl345_write8(itf, ADXL345_ACT_INACT_CTL, reg);
     
@@ -1467,7 +1464,7 @@ init_intpin(struct adxl345 * adxl345, hal_gpio_irq_handler_t handler,
     }
 
     if (pin < 0) {
-        ADXL345_LOG(ERROR, "Interrupt pin not configured\n");
+        ADXL345_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
@@ -1483,7 +1480,7 @@ init_intpin(struct adxl345 * adxl345, hal_gpio_irq_handler_t handler,
     } else if (adxl345->sensor.s_itf.si_ints[pdd->int_num].device_pin == 2) {
         pdd->int_route = 0xFF;
     } else {
-        ADXL345_LOG(ERROR, "Route not configured\n");
+        ADXL345_LOG_ERROR("Route not configured\n");
         return SYS_EINVAL;
     }
 
@@ -1493,7 +1490,7 @@ init_intpin(struct adxl345 * adxl345, hal_gpio_irq_handler_t handler,
                            trig,
                            HAL_GPIO_PULL_NONE);
     if (rc != 0) {
-        ADXL345_LOG(ERROR, "Failed to initialise interrupt pin %d\n", pin);
+        ADXL345_LOG_ERROR("Failed to initialise interrupt pin %d\n", pin);
         return rc;
     } 
     
@@ -1596,7 +1593,7 @@ adxl345_sensor_handle_interrupt(struct sensor * sensor)
 
     rc = adxl345_clear_interrupts(itf, &int_status);
     if (rc != 0) {
-        ADXL345_LOG(ERROR, "Cound not read int status err=0x%02x\n", rc);
+        ADXL345_LOG_ERROR("Cound not read int status err=0x%02x\n", rc);
         return rc;
     }
 
@@ -1613,7 +1610,7 @@ adxl345_sensor_handle_interrupt(struct sensor * sensor)
     if ((pdd->registered_mask & ADXL345_READ_MASK) &&
         ((int_status & ADXL345_INT_ACTIVITY_BIT) ||
          (int_status & ADXL345_INT_INACTIVITY_BIT))) {
-        ADXL345_LOG(ERROR, "READ EVT 0x%02x\n", int_status);
+        ADXL345_LOG_ERROR("READ EVT 0x%02x\n", int_status);
         sensor_mgr_put_read_evt(&pdd->read_ctx);
     }
 
@@ -1825,7 +1822,7 @@ adxl345_sensor_set_notification(struct sensor * sensor,
     struct adxl345_private_driver_data *pdd;
     int rc;
 
-    ADXL345_LOG(ERROR, "Enabling notifications\n");
+    ADXL345_LOG_ERROR("Enabling notifications\n");
     
     if ((sensor_event_type & ~(SENSOR_EVENT_TYPE_DOUBLE_TAP |
                                SENSOR_EVENT_TYPE_SINGLE_TAP)) != 0) {
@@ -1861,7 +1858,7 @@ adxl345_sensor_set_notification(struct sensor * sensor,
     pdd->notify_ctx.snec_evtype |= sensor_event_type;
     pdd->registered_mask |= ADXL345_NOTIFY_MASK;
 
-    ADXL345_LOG(ERROR, "Enabled notifications\n");
+    ADXL345_LOG_ERROR("Enabled notifications\n");
     
     return 0;
 #else

--- a/hw/drivers/sensors/adxl345/syscfg.yml
+++ b/hw/drivers/sensors/adxl345/syscfg.yml
@@ -50,9 +50,6 @@ syscfg.defs:
     ADXL345_ITF_LOCK_TMO:
         description: 'ADXL345 interface lock timeout in milliseconds'
         value: 1000
-    ADXL345_LOG_MODULE:
-        description: 'Numeric module ID to use for ADXL345 log messages'
-        value: 75
     ADXL345_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -61,3 +58,18 @@ syscfg.defs:
     ADXL345_ITF_ADDR:
         description: 'Slave address for ADXL345 (0x1D or 0x53)'
         value : 0x1D
+
+    ### Log settings.
+
+    ADXL345_LOG_MODULE:
+        description: 'Numeric module ID to use for ADXL345 log messages.'
+        value: 75
+    ADXL345_LOG_LVL:
+        description: 'Minimum level for the ADXL345 log.'
+        value: 1
+
+syscfg.logs:
+    ADXL345_LOG:
+        module: MYNEWT_VAL(ADXL345_LOG_MODULE)
+        level: MYNEWT_VAL(ADXL345_LOG_LVL)
+

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -45,12 +45,6 @@ syscfg.defs:
     BMA253_INT2_PIN_HOST:
         description: 'Interrupt pin number on host device connected to INT2 on device'
         value: -1
-    BMA253_LOG:
-        description: 'Enable BMA253 logging'
-        value: 0
-    BMA253_LOG_MODULE:
-        description: 'Numeric module ID to use for BMA253 log messages'
-        value: 253
     BMA253_SHELL_DEV_NAME:
         description: 'BMA253 Shell device name'
         value: "\"bma253_0\""
@@ -65,3 +59,18 @@ syscfg.defs:
     BMA253_NOTIF_STATS:
         description: 'Enable BMA253 notification stats'
         value: 0
+
+    ### Log settings.
+
+    BMA253_LOG_MODULE:
+        description: 'Numeric module ID to use for BMA253 log messages.'
+        value: 253
+    BMA253_LOG_LVL:
+        description: 'Minimum level for the BMA253 log.'
+        value: 15 # Logging disabled by default.
+
+syscfg.logs:
+    BMA253_LOG:
+        module: MYNEWT_VAL(BMA253_LOG_MODULE)
+        level: MYNEWT_VAL(BMA253_LOG_LVL)
+

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -30,16 +30,7 @@
 #include "hal/hal_i2c.h"
 #include "hal/hal_spi.h"
 #include "i2cn/i2cn.h"
-
-#if MYNEWT_VAL(BMA2XX_LOG)
 #include "modlog/modlog.h"
-#endif
-
-#define BMA2XX_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BMA2XX_LOG_MODULE), __VA_ARGS__)
-#else
-#define BMA2XX_LOG(lvl_, ...)
-#endif
 
 #define BMA2XX_NOTIFY_MASK  0x01
 #define BMA2XX_READ_MASK    0x02
@@ -179,7 +170,7 @@ spi_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
     retval = hal_spi_tx_val(itf->si_num, addr | BMA2XX_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        BMA2XX_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BMA2XX_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         goto err;
     }
@@ -189,7 +180,7 @@ spi_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMA2XX_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            BMA2XX_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                        itf->si_num, addr);
             goto err;
         }
@@ -228,7 +219,7 @@ spi_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        BMA2XX_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BMA2XX_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         goto err;
     }
@@ -238,7 +229,7 @@ spi_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t payload,
         rc = hal_spi_tx_val(itf->si_num, payload);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMA2XX_LOG(ERROR, "SPI_%u write failed addr:0x%02X:0x%02X\n",
+            BMA2XX_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
                        itf->si_num, addr);
             goto err;
         }
@@ -270,7 +261,7 @@ i2c_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
     rc = i2cn_master_write(itf->si_num, &oper, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(BMA2XX_I2C_RETRIES));
     if (rc != 0) {
-        BMA2XX_LOG(ERROR, "I2C access failed at address 0x%02X\n", addr);
+        BMA2XX_LOG_ERROR("I2C access failed at address 0x%02X\n", addr);
         return rc;
     }
 
@@ -281,7 +272,7 @@ i2c_readlen(struct sensor_itf * itf, uint8_t addr, uint8_t *payload,
     rc = i2cn_master_read(itf->si_num, &oper, OS_TICKS_PER_SEC / 10, 1,
                           MYNEWT_VAL(BMA2XX_I2C_RETRIES));
     if (rc != 0) {
-        BMA2XX_LOG(ERROR, "I2C read failed at address 0x%02X length %u\n",
+        BMA2XX_LOG_ERROR("I2C read failed at address 0x%02X length %u\n",
                    addr, len);
         return rc;
     }
@@ -306,7 +297,7 @@ i2c_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t data)
     rc = i2cn_master_write(itf->si_num, &oper, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(BMA2XX_I2C_RETRIES));
     if (rc != 0) {
-        BMA2XX_LOG(ERROR, "I2C write failed at address 0x%02X single byte\n",
+        BMA2XX_LOG_ERROR("I2C write failed at address 0x%02X single byte\n",
                    addr);
         return rc;
     }
@@ -567,7 +558,7 @@ quad_to_axis_trigger(struct axis_trigger * axis_trigger,
     axis_trigger->sign = (quad_bits >> 3) & 0x01;
     switch (quad_bits & 0x07) {
     default:
-        BMA2XX_LOG(ERROR, "unknown %s quad bits 0x%02X\n",
+        BMA2XX_LOG_ERROR("unknown %s quad bits 0x%02X\n",
                    name_bits, quad_bits);
     case 0x00:
         axis_trigger->axis = -1;
@@ -658,7 +649,7 @@ bma2xx_get_g_range(struct bma2xx *bma2xx,
 
     switch (data & 0x0F) {
     default:
-        BMA2XX_LOG(ERROR, "unknown PMU_RANGE reg value 0x%02X\n", data);
+        BMA2XX_LOG_ERROR("unknown PMU_RANGE reg value 0x%02X\n", data);
         *g_range = BMA2XX_G_RANGE_16;
         break;
     case 0x03:
@@ -818,7 +809,7 @@ bma2xx_get_power_settings(struct bma2xx *bma2xx,
 
     switch ((data[0] >> 5) & 0x07) {
     default:
-        BMA2XX_LOG(ERROR, "unknown PMU_LPW reg value 0x%02X\n", data[0]);
+        BMA2XX_LOG_ERROR("unknown PMU_LPW reg value 0x%02X\n", data[0]);
         power_settings->power_mode = BMA2XX_POWER_MODE_NORMAL;
         break;
     case 0x00:
@@ -2830,7 +2821,7 @@ bma2xx_get_fifo_cfg(struct bma2xx *bma2xx,
 
     switch ((data >> 6) & 0x03) {
     case 0x03:
-        BMA2XX_LOG(ERROR, "unknown FIFO_CONFIG_1 reg value 0x%02X\n", data);
+        BMA2XX_LOG_ERROR("unknown FIFO_CONFIG_1 reg value 0x%02X\n", data);
     case 0x00:
         fifo_cfg->fifo_mode = FIFO_MODE_BYPASS;
         break;
@@ -3266,7 +3257,7 @@ init_intpin(struct bma2xx *bma2xx,
     }
 
     if (pin < 0) {
-        BMA2XX_LOG(ERROR, "Interrupt pin not configured\n");
+        BMA2XX_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
@@ -3282,7 +3273,7 @@ init_intpin(struct bma2xx *bma2xx,
     } else if (bma2xx->sensor.s_itf.si_ints[pdd->int_num].device_pin == 2) {
         pdd->int_route = INT_ROUTE_PIN_2;
     } else {
-        BMA2XX_LOG(ERROR, "Route not configured\n");
+        BMA2XX_LOG_ERROR("Route not configured\n");
         return SYS_EINVAL;
     }
 
@@ -3566,7 +3557,7 @@ axis_offset_compensation(struct bma2xx *bma2xx,
     }
 
     if (!ready) {
-        BMA2XX_LOG(ERROR, "offset compensation already in progress\n");
+        BMA2XX_LOG_ERROR("offset compensation already in progress\n");
         return SYS_ETIMEOUT;
     }
 
@@ -3591,7 +3582,7 @@ axis_offset_compensation(struct bma2xx *bma2xx,
     }
 
     if (count == 0) {
-        BMA2XX_LOG(ERROR, "offset compensation did not complete\n");
+        BMA2XX_LOG_ERROR("offset compensation did not complete\n");
         return SYS_ETIMEOUT;
     }
 
@@ -3710,15 +3701,15 @@ bma2xx_query_offsets(struct bma2xx *bma2xx,
 
     mismatch = false;
     if (cfg->offset_x_g != val_offset_x_g) {
-        BMA2XX_LOG(ERROR, "X compensation offset value mismatch\n");
+        BMA2XX_LOG_ERROR("X compensation offset value mismatch\n");
         mismatch = true;
     }
     if (cfg->offset_y_g != val_offset_y_g) {
-        BMA2XX_LOG(ERROR, "Y compensation offset value mismatch\n");
+        BMA2XX_LOG_ERROR("Y compensation offset value mismatch\n");
         mismatch = true;
     }
     if (cfg->offset_z_g != val_offset_z_g) {
-        BMA2XX_LOG(ERROR, "Z compensation offset value mismatch\n");
+        BMA2XX_LOG_ERROR("Z compensation offset value mismatch\n");
         mismatch = true;
     }
 
@@ -4024,7 +4015,7 @@ bma2xx_wait_for_orient(struct bma2xx *bma2xx,
     pdd = &bma2xx->pdd;
 
     if (pdd->interrupt) {
-        BMA2XX_LOG(ERROR, "Interrupt used\n");
+        BMA2XX_LOG_ERROR("Interrupt used\n");
         return SYS_EINVAL;
     }
 
@@ -4101,7 +4092,7 @@ bma2xx_wait_for_high_g(struct bma2xx *bma2xx)
     pdd = &bma2xx->pdd;
 
     if (pdd->interrupt) {
-        BMA2XX_LOG(ERROR, "Interrupt used\n");
+        BMA2XX_LOG_ERROR("Interrupt used\n");
         return SYS_EINVAL;
     }
 
@@ -4173,7 +4164,7 @@ bma2xx_wait_for_low_g(struct bma2xx *bma2xx)
     pdd = &bma2xx->pdd;
 
     if (pdd->interrupt) {
-        BMA2XX_LOG(ERROR, "Interrupt used\n");
+        BMA2XX_LOG_ERROR("Interrupt used\n");
         return SYS_EINVAL;
     }
 
@@ -4276,7 +4267,7 @@ bma2xx_wait_for_tap(struct bma2xx *bma2xx,
     }
 
     if (pdd->interrupt) {
-        BMA2XX_LOG(ERROR, "Interrupt used\n");
+        BMA2XX_LOG_ERROR("Interrupt used\n");
         return SYS_EINVAL;
     }
 
@@ -4786,7 +4777,7 @@ sensor_driver_handle_interrupt(struct sensor * sensor)
 
     rc = bma2xx_get_int_status(bma2xx, &int_status);
     if (rc != 0) {
-        BMA2XX_LOG(ERROR, "Cound not read int status err=0x%02x\n", rc);
+        BMA2XX_LOG_ERROR("Cound not read int status err=0x%02x\n", rc);
         return rc;
     }
 
@@ -4848,7 +4839,7 @@ bma2xx_config(struct bma2xx *bma2xx, struct bma2xx_cfg *cfg)
     }
 
     if (chip_id != model_chip_id) {
-        BMA2XX_LOG(ERROR, "received incorrect chip ID 0x%02X\n", chip_id);
+        BMA2XX_LOG_ERROR("received incorrect chip ID 0x%02X\n", chip_id);
         return SYS_EINVAL;
     }
 

--- a/hw/drivers/sensors/bma2xx/syscfg.yml
+++ b/hw/drivers/sensors/bma2xx/syscfg.yml
@@ -42,9 +42,6 @@ syscfg.defs:
     BMA2XX_LOG:
         description: 'Enable BMA2XX logging'
         value: 0
-    BMA2XX_LOG_MODULE:
-        description: 'Numeric module ID to use for BMA2XX log messages'
-        value: 200
     BMA2XX_SHELL_DEV_NAME:
         description: 'BMA2XX Shell device name'
         value: "\"bma2xx_0\""
@@ -56,3 +53,17 @@ syscfg.defs:
             Number of retries to use for failed I2C communication.  A retry is
             used when the BMA2XX sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    BMA2XX_LOG_MODULE:
+        description: 'Numeric module ID to use for BMA2XX log messages.'
+        value: 200
+    BMA2XX_LOG_LVL:
+        description: 'Minimum level for the BMA2XX log.'
+        value: 1
+
+syscfg.logs:
+    BMA2XX_LOG:
+        module: MYNEWT_VAL(BMA2XX_LOG_MODULE)
+        level: MYNEWT_VAL(BMA2XX_LOG_LVL)

--- a/hw/drivers/sensors/bme280/src/bme280.c
+++ b/hw/drivers/sensors/bme280/src/bme280.c
@@ -64,9 +64,6 @@ STATS_NAME_END(bme280_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(bme280_stat_section) g_bme280stats;
 
-#define BME280_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BME280_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int bme280_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -200,7 +197,7 @@ bme280_compensate_temperature(int32_t rawtemp, struct bme280_pdd *pdd)
     double var1, var2, comptemp;
 
     if (rawtemp == 0x80000) {
-        BME280_LOG(ERROR, "Invalid temp data\n");
+        BME280_LOG_ERROR("Invalid temp data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -235,7 +232,7 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int32_t temp;
 
     if (rawpress == 0x80000) {
-        BME280_LOG(ERROR, "Invalid press data\n");
+        BME280_LOG_ERROR("Invalid press data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -286,7 +283,7 @@ bme280_compensate_humidity(struct sensor_itf *itf, int32_t rawhumid,
     int32_t temp;
 
     if (rawhumid == 0x8000) {
-        BME280_LOG(ERROR, "Invalid humidity data\n");
+        BME280_LOG_ERROR("Invalid humidity data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -330,7 +327,7 @@ bme280_compensate_temperature(int32_t rawtemp, struct bme280_pdd *pdd)
     int32_t var1, var2, comptemp;
 
     if (rawtemp == 0x800000) {
-        BME280_LOG(ERROR, "Invalid temp data\n");
+        BME280_LOG_ERROR("Invalid temp data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -365,7 +362,7 @@ bme280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int32_t temp;
 
     if (rawpress == 0x80000) {
-        BME280_LOG(ERROR, "Invalid pressure data\n");
+        BME280_LOG_ERROR("Invalid pressure data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -416,7 +413,7 @@ bme280_compensate_humidity(struct sensor_itf *itf, uint32_t rawhumid,
     int32_t tmp32;
 
     if (rawhumid == 0x8000) {
-        BME280_LOG(ERROR, "Invalid humidity data\n");
+        BME280_LOG_ERROR("Invalid humidity data\n");
         STATS_INC(g_bme280stats, invalid_data_errors);
         return NAN;
     }
@@ -852,7 +849,7 @@ bme280_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     retval = hal_spi_tx_val(itf->si_num, addr | BME280_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        BME280_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BME280_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         STATS_INC(g_bme280stats, read_errors);
         goto err;
@@ -863,7 +860,7 @@ bme280_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            BME280_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            BME280_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                        itf->si_num, addr);
             STATS_INC(g_bme280stats, read_errors);
             goto err;
@@ -925,7 +922,7 @@ done:
     rc = hal_spi_tx_val(itf->si_num, addr & ~BME280_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        BME280_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BME280_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         STATS_INC(g_bme280stats, write_errors);
         goto err;
@@ -936,7 +933,7 @@ done:
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            BME280_LOG(ERROR, "SPI_%u write failed addr:0x%02X:0x%02X\n",
+            BME280_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
                        itf->si_num, addr);
             STATS_INC(g_bme280stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -38,6 +38,18 @@ syscfg.defs:
             When set to 1 compensation functions use double precission floating point arithmetic recomended by specification.
             When set to 0 compensation functions use integer arithmetic.
         value : 1
+
+    ### Log settings.
+
     BME280_LOG_MODULE:
-        description: 'Numeric module ID to use for BME280 log messages'
+        description: 'Numeric module ID to use for BME280 log messages.'
         value: 208
+    BME280_LOG_LVL:
+        description: 'Minimum level for the BME280 log.'
+        value: 1
+
+syscfg.logs:
+    BME280_LOG:
+        module: MYNEWT_VAL(BME280_LOG_MODULE)
+        level: MYNEWT_VAL(BME280_LOG_LVL)
+

--- a/hw/drivers/sensors/bmp280/src/bmp280.c
+++ b/hw/drivers/sensors/bmp280/src/bmp280.c
@@ -71,9 +71,6 @@ STATS_NAME_END(bmp280_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(bmp280_stat_section) g_bmp280stats;
 
-#define BMP280_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BMP280_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int bmp280_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -216,7 +213,7 @@ bmp280_compensate_temperature(int32_t rawtemp, struct bmp280_pdd *pdd)
     double var1, var2, comptemp;
 
     if (rawtemp == 0x80000) {
-        BMP280_LOG(ERROR, "Invalid temp data\n");
+        BMP280_LOG_ERROR("Invalid temp data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
     }
@@ -251,7 +248,7 @@ bmp280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int32_t temp;
 
     if (rawpress == 0x80000) {
-        BMP280_LOG(ERROR, "Invalid press data\n");
+        BMP280_LOG_ERROR("Invalid press data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
     }
@@ -302,7 +299,7 @@ bmp280_compensate_temperature(int32_t rawtemp, struct bmp280_pdd *pdd)
     int32_t var1, var2, comptemp;
 
     if (rawtemp == 0x80000) {
-        BMP280_LOG(ERROR, "Invalid temp data\n");
+        BMP280_LOG_ERROR("Invalid temp data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
     }
@@ -338,7 +335,7 @@ bmp280_compensate_pressure(struct sensor_itf *itf, int32_t rawpress,
     int32_t temp;
 
     if (rawpress == 0x80000) {
-        BMP280_LOG(ERROR, "Invalid pressure data\n");
+        BMP280_LOG_ERROR("Invalid pressure data\n");
         STATS_INC(g_bmp280stats, invalid_data_errors);
         return NAN;
     }
@@ -725,7 +722,7 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 0,
                            MYNEWT_VAL(BMP280_I2C_RETRIES));
     if (rc) {
-        BMP280_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        BMP280_LOG_ERROR("I2C access failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_bmp280stats, write_errors);
         goto err;
@@ -737,7 +734,7 @@ bmp280_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(BMP280_I2C_RETRIES));
     if (rc) {
-        BMP280_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        BMP280_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    data_struct.address, addr);
         STATS_INC(g_bmp280stats, read_errors);
         goto err;
@@ -777,7 +774,7 @@ bmp280_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     retval = hal_spi_tx_val(itf->si_num, addr | BMP280_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        BMP280_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BMP280_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         STATS_INC(g_bmp280stats, read_errors);
         goto err;
@@ -788,7 +785,7 @@ bmp280_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMP280_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            BMP280_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                        itf->si_num, addr);
             STATS_INC(g_bmp280stats, read_errors);
             goto err;
@@ -840,7 +837,7 @@ bmp280_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
                                MYNEWT_VAL(BMP280_I2C_TIMEOUT_TICKS), 1,
                                MYNEWT_VAL(BMP280_I2C_RETRIES));
         if (rc) {
-            BMP280_LOG(ERROR, "Failed to write 0x%02X:0x%02X\n",
+            BMP280_LOG_ERROR("Failed to write 0x%02X:0x%02X\n",
                        data_struct.address, addr);
             STATS_INC(g_bmp280stats, write_errors);
             goto err;
@@ -877,7 +874,7 @@ bmp280_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr & ~BMP280_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        BMP280_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BMP280_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                    itf->si_num, addr);
         STATS_INC(g_bmp280stats, write_errors);
         goto err;
@@ -888,7 +885,7 @@ bmp280_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMP280_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+            BMP280_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                        itf->si_num, addr);
             STATS_INC(g_bmp280stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/bmp280/syscfg.yml
+++ b/hw/drivers/sensors/bmp280/syscfg.yml
@@ -47,9 +47,6 @@ syscfg.defs:
     BMP280_ITF_LOCK_TMO:
         description: 'BMP280 interface lock timeout in milliseconds'
         value: 1000
-    BMP280_LOG_MODULE:
-        description: 'Numeric module ID to use for BMP280 log messages'
-        value: 209
     BMP280_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -59,3 +56,18 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    BMP280_LOG_MODULE:
+        description: 'Numeric module ID to use for BMP280 log messages.'
+        value: 209
+    BMP280_LOG_LVL:
+        description: 'Minimum level for the BMP280 log.'
+        value: 1
+
+syscfg.logs:
+    BMP280_LOG:
+        module: MYNEWT_VAL(BMP280_LOG_MODULE)
+        level: MYNEWT_VAL(BMP280_LOG_LVL)
+

--- a/hw/drivers/sensors/bmp388/src/bmp388.c
+++ b/hw/drivers/sensors/bmp388/src/bmp388.c
@@ -113,10 +113,6 @@ STATS_NAME_END(bmp388_stat_section)
 
 struct bmp3_dev g_bmp388_dev;
 
-
-#define BMP388_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BMP388_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int bmp388_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -221,8 +217,8 @@ bmp388_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(BMP388_I2C_TIMEOUT_TICKS), 1,
                         MYNEWT_VAL(BMP388_I2C_RETRIES));
     if (rc) {
-        BMP388_LOG(ERROR, "I2C access failed at address 0x%02X\n",
-                   data_struct.address);
+        BMP388_LOG_ERROR("I2C access failed at address 0x%02X\n",
+                         data_struct.address);
         goto err;
     }
 
@@ -256,7 +252,7 @@ bmp388_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = BMP3_E_WRITE;
-        BMP388_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        BMP388_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, addr);
         goto err;
     }
@@ -266,7 +262,7 @@ bmp388_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = BMP3_E_WRITE;
-            BMP388_LOG(ERROR, "SPI_%u write failed addr:0x%02X:0x%02X\n",
+            BMP388_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
                         itf->si_num, addr);
             goto err;
         }
@@ -358,8 +354,8 @@ bmp388_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(BMP388_I2C_TIMEOUT_TICKS), 1,
                         MYNEWT_VAL(BMP388_I2C_RETRIES));
     if (rc) {
-        BMP388_LOG(ERROR, "I2C access failed at address 0x%02X\n",
-                    itf->si_addr);
+        BMP388_LOG_ERROR("I2C access failed at address 0x%02X\n",
+                         itf->si_addr);
         rc = BMP3_E_WRITE;
         return rc;
     }
@@ -371,8 +367,8 @@ bmp388_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
                         MYNEWT_VAL(BMP388_I2C_RETRIES));
 
     if (rc) {
-        BMP388_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
-                    itf->si_addr, reg);
+        BMP388_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
+                         itf->si_addr, reg);
         rc = BMP3_E_READ;
     }
 
@@ -404,8 +400,8 @@ bmp388_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     retval = hal_spi_tx_val(itf->si_num, reg | BMP388_SPI_READ_CMD_BIT);
 
     if (retval == 0xFFFF) {
-        BMP388_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
-                    itf->si_num, reg);
+        BMP388_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
+                         itf->si_num, reg);
         rc = BMP3_E_READ;
         goto err;
     }
@@ -414,8 +410,8 @@ bmp388_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
         /* Read data */
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
-            BMP388_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
-                        itf->si_num, reg);
+            BMP388_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
+                             itf->si_num, reg);
             rc = BMP3_E_READ;
             goto err;
         }
@@ -1252,50 +1248,50 @@ static int64_t compensate_temperature(const struct bmp3_uncomp_data *uncomp_data
     int64_t partial_data6;
     int64_t comp_temp;
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****uncomp_data->temperature = 0x%x calib_data->reg_calib_data.par_t1 = 0x%x\n", uncomp_data->temperature, calib_data->reg_calib_data.par_t1);
+    BMP388_LOG_ERROR("*****uncomp_data->temperature = 0x%x calib_data->reg_calib_data.par_t1 = 0x%x\n", uncomp_data->temperature, calib_data->reg_calib_data.par_t1);
 #endif
     partial_data1 = (uint64_t)(uncomp_data->temperature) - (256 * (uint64_t)(calib_data->reg_calib_data.par_t1));
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
-    BMP388_LOG(ERROR, "*****calib_data->reg_calib_data.par_t2 = 0x%x\n", calib_data->reg_calib_data.par_t2);
+    BMP388_LOG_ERROR("*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
+    BMP388_LOG_ERROR("*****calib_data->reg_calib_data.par_t2 = 0x%x\n", calib_data->reg_calib_data.par_t2);
 #endif
 
     partial_data2 = ((uint64_t)(calib_data->reg_calib_data.par_t2)) * partial_data1;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)((partial_data2&0xffffffff)));
+    BMP388_LOG_ERROR("*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)((partial_data2&0xffffffff)));
 #endif
     partial_data3 = partial_data1 * partial_data1;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)((partial_data3&0xffffffff)));
-    BMP388_LOG(ERROR, "*****calib_data->reg_calib_data.par_t3 = 0x%x\n", calib_data->reg_calib_data.par_t3);
+    BMP388_LOG_ERROR("*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)((partial_data3&0xffffffff)));
+    BMP388_LOG_ERROR("*****calib_data->reg_calib_data.par_t3 = 0x%x\n", calib_data->reg_calib_data.par_t3);
 #endif
 
     partial_data4 = (int64_t)partial_data3 * calib_data->reg_calib_data.par_t3;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)((partial_data4&0xffffffff)));
+    BMP388_LOG_ERROR("*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)((partial_data4&0xffffffff)));
 #endif
 
     partial_data5 = ((int64_t)(partial_data2 * 262144) + partial_data4);
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
 #endif
 
     partial_data6 = partial_data5 / 4294967296;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
 #endif
     /* Store t_lin in dev. structure for pressure calculation */
     calib_data->reg_calib_data.t_lin = partial_data6;
     comp_temp = (int64_t)((partial_data6 * 25)  / 16384);
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****comp_temp high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((comp_temp)>>32),(uint32_t)(comp_temp&0xffffffff));
+    BMP388_LOG_ERROR("*****comp_temp high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((comp_temp)>>32),(uint32_t)(comp_temp&0xffffffff));
 #endif
 
     return comp_temp;
@@ -1319,146 +1315,146 @@ static uint64_t compensate_pressure(const struct bmp3_uncomp_data *uncomp_data,
     int64_t sensitivity;
     uint64_t comp_press;
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****reg_calib_data->t_lin high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((reg_calib_data->t_lin)>>32),(uint32_t)(reg_calib_data->t_lin&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->t_lin high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((reg_calib_data->t_lin)>>32),(uint32_t)(reg_calib_data->t_lin&0xffffffff));
 #endif
 
     partial_data1 = reg_calib_data->t_lin * reg_calib_data->t_lin;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
 #endif
 
     partial_data2 = partial_data1 / 64;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)(partial_data2>>32),(uint32_t)(partial_data2&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)(partial_data2>>32),(uint32_t)(partial_data2&0xffffffff));
 #endif
 
     partial_data3 = (partial_data2 * reg_calib_data->t_lin) / 256;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p8 = %d\n", reg_calib_data->par_p8);
+    BMP388_LOG_ERROR("*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p8 = %d\n", reg_calib_data->par_p8);
 #endif
 
     partial_data4 = (reg_calib_data->par_p8 * partial_data3) / 32;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p7 = %d\n", reg_calib_data->par_p7);
+    BMP388_LOG_ERROR("*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p7 = %d\n", reg_calib_data->par_p7);
 #endif
 
     partial_data5 = (reg_calib_data->par_p7 * partial_data1) * 16;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p6 = %d\n", reg_calib_data->par_p6);
+    BMP388_LOG_ERROR("*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p6 = %d\n", reg_calib_data->par_p6);
 #endif
 
     partial_data6 = (reg_calib_data->par_p6 * reg_calib_data->t_lin) * 4194304;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p5 = %d\n", reg_calib_data->par_p5);
+    BMP388_LOG_ERROR("*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p5 = %d\n", reg_calib_data->par_p5);
 #endif
 
     offset = (reg_calib_data->par_p5 * 140737488355328) + partial_data4 + partial_data5 + partial_data6;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****offset high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((offset)>>32),(uint32_t)(offset&0xffffffff));
+    BMP388_LOG_ERROR("*****offset high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((offset)>>32),(uint32_t)(offset&0xffffffff));
 
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p4 = %d\n", reg_calib_data->par_p4);
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p4 = %d\n", reg_calib_data->par_p4);
 #endif
 
     partial_data2 = (reg_calib_data->par_p4 * partial_data3) / 32;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p3 = %d\n", reg_calib_data->par_p3);
+    BMP388_LOG_ERROR("*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p3 = %d\n", reg_calib_data->par_p3);
 #endif
 
     partial_data4 = (reg_calib_data->par_p3 * partial_data1) * 4;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p2 = %d\n", reg_calib_data->par_p2);
+    BMP388_LOG_ERROR("*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p2 = %d\n", reg_calib_data->par_p2);
 #endif
 
     partial_data5 = (reg_calib_data->par_p2 - 16384) * reg_calib_data->t_lin * 2097152;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p1 = %d\n", reg_calib_data->par_p1);
+    BMP388_LOG_ERROR("*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p1 = %d\n", reg_calib_data->par_p1);
 #endif
 
     sensitivity = ((reg_calib_data->par_p1 - 16384) * 70368744177664) + partial_data2 + partial_data4
             + partial_data5;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****sensitivity high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((sensitivity)>>32),(uint32_t)(sensitivity&0xffffffff));
+    BMP388_LOG_ERROR("*****sensitivity high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((sensitivity)>>32),(uint32_t)(sensitivity&0xffffffff));
 #endif
 
     partial_data1 = (sensitivity / 16777216) * uncomp_data->pressure;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p10 = %d\n", reg_calib_data->par_p10);
+    BMP388_LOG_ERROR("*****partial_data1 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data1)>>32),(uint32_t)(partial_data1&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p10 = %d\n", reg_calib_data->par_p10);
 #endif
 
     partial_data2 = reg_calib_data->par_p10 * reg_calib_data->t_lin;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p9 = %d\n", reg_calib_data->par_p9);
+    BMP388_LOG_ERROR("*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p9 = %d\n", reg_calib_data->par_p9);
 #endif
 
     partial_data3 = partial_data2 + (65536 * reg_calib_data->par_p9);
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
 #endif
 
     partial_data4 = (partial_data3 * uncomp_data->pressure) / 8192;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
 #endif
 
     partial_data5 = (partial_data4 * uncomp_data->pressure) / 512;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data5 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data5)>>32),(uint32_t)(partial_data5&0xffffffff));
 #endif
 
     partial_data6 = (int64_t)((uint64_t)uncomp_data->pressure * (uint64_t)uncomp_data->pressure);
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
-    BMP388_LOG(ERROR, "*****reg_calib_data->par_p11 = %d\n", reg_calib_data->par_p11);
+    BMP388_LOG_ERROR("*****partial_data6 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data6)>>32),(uint32_t)(partial_data6&0xffffffff));
+    BMP388_LOG_ERROR("*****reg_calib_data->par_p11 = %d\n", reg_calib_data->par_p11);
 #endif
 
     partial_data2 = (reg_calib_data->par_p11 * partial_data6) / 65536;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data2 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data2)>>32),(uint32_t)(partial_data2&0xffffffff));
 #endif
 
     partial_data3 = (partial_data2 * uncomp_data->pressure) / 128;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data3 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data3)>>32),(uint32_t)(partial_data3&0xffffffff));
 #endif
 
     partial_data4 = (offset / 4) + partial_data1 + partial_data5 + partial_data3;
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
+    BMP388_LOG_ERROR("*****partial_data4 high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((partial_data4)>>32),(uint32_t)(partial_data4&0xffffffff));
 #endif
 
     comp_press = (((uint64_t)partial_data4 * 25) / (uint64_t)1099511627776);
 
 #if COMPENSTATE_DEBUG
-    BMP388_LOG(ERROR, "*****comp_press high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((comp_press)>>32),(uint32_t)(comp_press&0xffffffff));
+    BMP388_LOG_ERROR("*****comp_press high32bit = 0x%x low32bit = 0x%x\n", (uint32_t)((comp_press)>>32),(uint32_t)(comp_press&0xffffffff));
 #endif
 
     return comp_press;
@@ -1514,7 +1510,7 @@ int8_t bmp3_get_sensor_data(struct sensor_itf *itf, uint8_t sensor_comp, struct 
             /* Parse the read data from the sensor */
             parse_sensor_data(reg_data, &uncomp_data);
 #if COMPENSTATE_DEBUG
-            BMP388_LOG(ERROR, "*****uncomp_data Temperature = %d Pressure = %d\n", uncomp_data.temperature, uncomp_data.pressure);
+            BMP388_LOG_ERROR("*****uncomp_data Temperature = %d Pressure = %d\n", uncomp_data.temperature, uncomp_data.pressure);
 #endif
             /* Compensate the pressure/temperature/both data read
             from the sensor */
@@ -1714,17 +1710,17 @@ int8_t bmp3_init(struct sensor_itf *itf, struct bmp3_dev *dev)
                     /* Read the calibration data */
                     rslt = get_calib_data(itf, dev);
                 } else {
-                    BMP388_LOG(ERROR, "******bmp3_init bmp3_soft_reset failed %d\n", rslt);
+                    BMP388_LOG_ERROR("******bmp3_init bmp3_soft_reset failed %d\n", rslt);
                 }
             } else {
-                BMP388_LOG(ERROR, "******bmp3_init get wrong chip ID\n");
+                BMP388_LOG_ERROR("******bmp3_init get wrong chip ID\n");
                 rslt = BMP3_E_DEV_NOT_FOUND;
             }
 #if BMP388_DEBUG
-            BMP388_LOG(ERROR, "******bmp3_init chip ID  0x%x\n", chip_id);
+            BMP388_LOG_ERROR("******bmp3_init chip ID  0x%x\n", chip_id);
 #endif
         } else {
-            BMP388_LOG(ERROR, "******bmp3_init get chip ID failed %d\n", rslt);
+            BMP388_LOG_ERROR("******bmp3_init get chip ID failed %d\n", rslt);
         }
     }
 
@@ -1764,10 +1760,10 @@ int bmp388_dump(struct sensor_itf *itf)
         val = 0;
         rc = bmp3_get_regs(itf, index, &val, 1, &g_bmp388_dev);
         if (rc) {
-            BMP388_LOG(ERROR, "read register 0x%02X failed %d\n", index, rc);
+            BMP388_LOG_ERROR("read register 0x%02X failed %d\n", index, rc);
             goto err;
         }
-        BMP388_LOG(ERROR, "register 0x%02X : 0x%02X\n", index, val);
+        BMP388_LOG_ERROR("register 0x%02X : 0x%02X\n", index, val);
     }
 
 err:
@@ -1969,7 +1965,7 @@ int8_t bmp388_configure_fifo_with_watermark(struct sensor_itf *itf, struct bmp3_
     /* Set the selected settings in fifo */
     rslt = bmp3_set_fifo_settings(itf, settings_sel, dev);
     if (rslt != 0) {
-    BMP388_LOG(ERROR, "bmp3_set_fifo_settings failed %d\n", rslt);
+    BMP388_LOG_ERROR("bmp3_set_fifo_settings failed %d\n", rslt);
     goto ERR;
     }
     /* Set the number of frames to be read so as to set the watermark length in the sensor */
@@ -1977,7 +1973,7 @@ int8_t bmp388_configure_fifo_with_watermark(struct sensor_itf *itf, struct bmp3_
     dev->fifo->data.req_frames = g_bmp388_dev.fifo_watermark_level;
     rslt = bmp3_set_fifo_watermark(itf, dev);
     if (rslt != 0) {
-    BMP388_LOG(ERROR, "bmp3_set_fifo_watermark failed %d\n", rslt);
+    BMP388_LOG_ERROR("bmp3_set_fifo_watermark failed %d\n", rslt);
     goto ERR;
     }
 ERR:
@@ -2013,7 +2009,7 @@ int8_t bmp388_configure_fifo_with_fifofull(struct sensor_itf *itf, struct bmp3_d
     /* Set the selected settings in fifo */
     rslt = bmp3_set_fifo_settings(itf, settings_sel, dev);
     if (rslt != 0) {
-    BMP388_LOG(ERROR, "bmp3_set_fifo_settings failed %d\n", rslt);
+    BMP388_LOG_ERROR("bmp3_set_fifo_settings failed %d\n", rslt);
     goto ERR;
     }
 ERR:
@@ -2047,7 +2043,7 @@ int8_t bmp388_enable_fifo(struct sensor_itf *itf, struct bmp3_dev *dev, uint8_t 
     /* Set the selected settings in fifo */
     rslt = bmp3_set_fifo_settings(itf, settings_sel, dev);
     if (rslt != 0) {
-    BMP388_LOG(ERROR, "bmp3_set_fifo_settings failed %d\n", rslt);
+    BMP388_LOG_ERROR("bmp3_set_fifo_settings failed %d\n", rslt);
     goto ERR;
     }
 ERR:
@@ -2403,54 +2399,54 @@ int bmp388_set_int_enable(struct sensor_itf *itf, uint8_t enabled, uint8_t int_t
     {
     case BMP388_DRDY_INT:
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "*****bmp388_set_int_enable start to set data ready interrupt\n");
+        BMP388_LOG_ERROR("*****bmp388_set_int_enable start to set data ready interrupt\n");
 #endif
         rc = bmp388_set_drdy_int(itf, enabled);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_set_drdy_int failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_set_drdy_int failed %d\n", rc);
             goto ERR;
         }
 
         rc = bmp388_set_normal_mode(itf, &g_bmp388_dev);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_set_normal_mode failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_set_normal_mode failed %d\n", rc);
             goto ERR;
         }
         break;
     case BMP388_FIFO_WTMK_INT:
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "*****bmp388_set_int_enable start to set fifo water mark\n");
+        BMP388_LOG_ERROR("*****bmp388_set_int_enable start to set fifo water mark\n");
 #endif
         rc = bmp388_configure_fifo_with_watermark(itf, &g_bmp388_dev, enabled);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_configure_fifo_with_watermark failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_configure_fifo_with_watermark failed %d\n", rc);
             goto ERR;
         }
 
         rc = bmp388_set_normal_mode(itf, &g_bmp388_dev);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_set_normal_mode failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_set_normal_mode failed %d\n", rc);
             goto ERR;
         }
         break;
     case BMP388_FIFO_FULL_INT:
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "*****bmp388_set_int_enable start to set fifo full\n");
+        BMP388_LOG_ERROR("*****bmp388_set_int_enable start to set fifo full\n");
 #endif
         rc = bmp388_configure_fifo_with_fifofull(itf, &g_bmp388_dev, enabled);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_configure_fifo_with_fifofull failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_configure_fifo_with_fifofull failed %d\n", rc);
             goto ERR;
         }
         rc = bmp388_set_normal_mode(itf, &g_bmp388_dev);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_set_normal_mode failed %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_set_normal_mode failed %d\n", rc);
             goto ERR;
         }
         break;
     default:
         rc = SYS_EINVAL;
-        BMP388_LOG(ERROR, "******invalid BMP388 interrupt type\n");
+        BMP388_LOG_ERROR("******invalid BMP388 interrupt type\n");
         goto ERR;
 
     }
@@ -2634,15 +2630,15 @@ int8_t bmp3_get_fifo_data(struct sensor_itf *itf, const struct bmp3_dev *dev)
         reset_fifo_index(dev->fifo);
         /* Get the total no of bytes available in FIFO */
         rslt = bmp3_get_fifo_length(itf, &fifo_len, dev);
-        BMP388_LOG(ERROR, "*****fifo_len is %d\n", fifo_len);
+        BMP388_LOG_ERROR("*****fifo_len is %d\n", fifo_len);
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "*****fifo_len is %d\n", fifo_len);
+        BMP388_LOG_ERROR("*****fifo_len is %d\n", fifo_len);
 #endif
         /* For sensor time frame */
         if (dev->fifo->settings.time_en == TRUE) {
             fifo_len = fifo_len + 4 + 7*3;
 #if BMP388_DEBUG
-            BMP388_LOG(ERROR, "*****fifo_len added timefifo length is %d\n", fifo_len);
+            BMP388_LOG_ERROR("*****fifo_len added timefifo length is %d\n", fifo_len);
 #endif
         }
         /* Update the fifo length in the fifo structure */
@@ -2654,7 +2650,7 @@ int8_t bmp3_get_fifo_data(struct sensor_itf *itf, const struct bmp3_dev *dev)
 #if FIFOPARSE_DEBUG
         if (rslt == 0) {
             for (i = 0; i < fifo_len; i++)
-                BMP388_LOG(ERROR, "*****i is %d buffer[i] is %d\n", i, fifo->data.buffer[i]);
+                BMP388_LOG_ERROR("*****i is %d buffer[i] is %d\n", i, fifo->data.buffer[i]);
         }
 #endif
     } else {
@@ -2814,8 +2810,8 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
 {
     uint8_t t_p_frame = 0;
 #if FIFOPARSE_DEBUG
-    BMP388_LOG(ERROR, "****  header is %d\n",  header);
-    BMP388_LOG(ERROR, "****  byte_index is %d\n",  *byte_index);
+    BMP388_LOG_ERROR("****  header is %d\n",  header);
+    BMP388_LOG_ERROR("****  byte_index is %d\n",  *byte_index);
 #endif
     switch (header) {
     case FIFO_TEMP_PRESS_FRAME:
@@ -2823,8 +2819,8 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         *parsed_frames = *parsed_frames + 1;
         t_p_frame = BMP3_PRESS | BMP3_TEMP;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** parsed_frames %d\n", *parsed_frames);
-        BMP388_LOG(ERROR, "**** FIFO_TEMP_PRESS_FRAME\n");
+        BMP388_LOG_ERROR("**** parsed_frames %d\n", *parsed_frames);
+        BMP388_LOG_ERROR("**** FIFO_TEMP_PRESS_FRAME\n");
 #endif
         break;
 
@@ -2833,8 +2829,8 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         *parsed_frames = *parsed_frames + 1;
         t_p_frame = BMP3_TEMP;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** parsed_frames %d\n", *parsed_frames);
-        BMP388_LOG(ERROR, "**** FIFO_TEMP_FRAME\n");
+        BMP388_LOG_ERROR("**** parsed_frames %d\n", *parsed_frames);
+        BMP388_LOG_ERROR("**** FIFO_TEMP_FRAME\n");
 #endif
         break;
 
@@ -2843,8 +2839,8 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         *parsed_frames = *parsed_frames + 1;
         t_p_frame = BMP3_PRESS;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** parsed_frames %d\n", *parsed_frames);
-        BMP388_LOG(ERROR, "**** FIFO_PRESS_FRAME\n");
+        BMP388_LOG_ERROR("**** parsed_frames %d\n", *parsed_frames);
+        BMP388_LOG_ERROR("**** FIFO_PRESS_FRAME\n");
 #endif
         break;
 
@@ -2853,9 +2849,9 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         fifo->no_need_sensortime = true;
         fifo->sensortime_updated = true;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** FIFO_TIME_FRAME\n");
+        BMP388_LOG_ERROR("**** FIFO_TIME_FRAME\n");
 #endif
-        BMP388_LOG(ERROR, "**** FIFO_TIME_FRAME\n");
+        BMP388_LOG_ERROR("**** FIFO_TIME_FRAME\n");
 
         break;
 
@@ -2863,7 +2859,7 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         fifo->data.config_change = 1;
         *byte_index = *byte_index + 1;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** FIFO_CONFIG_CHANGE\n");
+        BMP388_LOG_ERROR("**** FIFO_CONFIG_CHANGE\n");
 #endif
         break;
 
@@ -2871,7 +2867,7 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         fifo->data.config_err = 1;
         *byte_index = *byte_index + 1;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** FIFO_ERROR_FRAME\n");
+        BMP388_LOG_ERROR("**** FIFO_ERROR_FRAME\n");
 #endif
         break;
 
@@ -2879,7 +2875,7 @@ static uint8_t parse_fifo_data_frame(uint8_t header, struct bmp3_fifo *fifo, uin
         fifo->data.config_err = 1;
         *byte_index = *byte_index + 1;
 #if FIFOPARSE_DEBUG
-        BMP388_LOG(ERROR, "**** unknown FIFO_FRAME\n");
+        BMP388_LOG_ERROR("**** unknown FIFO_FRAME\n");
 #endif
         break;
 
@@ -2916,9 +2912,9 @@ int8_t bmp3_extract_fifo_data(struct bmp3_data *data, struct bmp3_dev *dev)
             }
         }
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "******byte_index %d\n", byte_index);
-        BMP388_LOG(ERROR, "******parsed_frames %d\n", parsed_frames);
-        BMP388_LOG(ERROR, "******dev->fifo->no_need_sensortime %d\n", dev->fifo->no_need_sensortime);
+        BMP388_LOG_ERROR("******byte_index %d\n", byte_index);
+        BMP388_LOG_ERROR("******parsed_frames %d\n", parsed_frames);
+        BMP388_LOG_ERROR("******dev->fifo->no_need_sensortime %d\n", dev->fifo->no_need_sensortime);
 #endif
         /* Check if any frames are parsed in FIFO */
         if (parsed_frames != 0) {
@@ -2957,21 +2953,21 @@ int bmp388_run_self_test(struct sensor_itf *itf, int *result)
     if (rc) {
         *result = -1;
         rc = SYS_EINVAL;
-        BMP388_LOG(ERROR, "******read BMP388 chipID failed %d\n", rc);
+        BMP388_LOG_ERROR("******read BMP388 chipID failed %d\n", rc);
         return rc;
     }
 
     if (chip_id != BMP3_CHIP_ID) {
         *result = -1;
         rc = SYS_EINVAL;
-        BMP388_LOG(ERROR, "******self_test gets BMP388 chipID failed 0x%x\n", chip_id);
+        BMP388_LOG_ERROR("******self_test gets BMP388 chipID failed 0x%x\n", chip_id);
         return rc;
     } else {
-        BMP388_LOG(ERROR, "******self_test gets BMP388 chipID 0x%x\n", chip_id);
+        BMP388_LOG_ERROR("******self_test gets BMP388 chipID 0x%x\n", chip_id);
     }
     rc = bmp388_get_sensor_data(itf, &g_bmp388_dev, &sensor_data);
     if (rc) {
-        BMP388_LOG(ERROR, "bmp388_get_sensor_data failed %d\n", rc);
+        BMP388_LOG_ERROR("bmp388_get_sensor_data failed %d\n", rc);
         *result = -1;
         rc = SYS_EINVAL;
         return rc;
@@ -2981,14 +2977,14 @@ int bmp388_run_self_test(struct sensor_itf *itf, int *result)
 
     if ((pressure < 300) || (pressure > 1250))
     {
-        BMP388_LOG(ERROR, "pressure data abnormal\n");
+        BMP388_LOG_ERROR("pressure data abnormal\n");
         *result = -1;
         rc = SYS_EINVAL;
         return rc;
     }
     if ((temperature < -40) || (temperature > 85))
     {
-        BMP388_LOG(ERROR, "temperature data abnormal\n");
+        BMP388_LOG_ERROR("temperature data abnormal\n");
         *result = -1;
         rc = SYS_EINVAL;
         return rc;
@@ -3111,7 +3107,7 @@ init_intpin(struct bmp388 *bmp388, hal_gpio_irq_handler_t handler,
     }
 
     if (pin < 0) {
-        BMP388_LOG(ERROR, "Interrupt pin not configured\n");
+        BMP388_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
@@ -3127,7 +3123,7 @@ init_intpin(struct bmp388 *bmp388, hal_gpio_irq_handler_t handler,
                         trig,
                         HAL_GPIO_PULL_NONE);
     if (rc != 0) {
-        BMP388_LOG(ERROR, "Failed to initialise interrupt pin %d\n", pin);
+        BMP388_LOG_ERROR("Failed to initialise interrupt pin %d\n", pin);
         return rc;
     }
 
@@ -3145,7 +3141,7 @@ disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num
     if (int_to_disable == 0) {
         return SYS_EINVAL;
     }
-    BMP388_LOG(ERROR, "*****disable_interrupt entered \n");
+    BMP388_LOG_ERROR("*****disable_interrupt entered \n");
 
     bmp388 = (struct bmp388 *)SENSOR_GET_DEVICE(sensor);
     itf = SENSOR_GET_ITF(sensor);
@@ -3155,7 +3151,7 @@ disable_interrupt(struct sensor *sensor, uint8_t int_to_disable, uint8_t int_num
 
     /* disable int pin */
     if (!pdd->int_enable) {
-        BMP388_LOG(ERROR, "*****disable_interrupt disable int pin \n");
+        BMP388_LOG_ERROR("*****disable_interrupt disable int pin \n");
         hal_gpio_irq_disable(itf->si_ints[int_num].host_pin);
         /* disable interrupt in device */
         rc = bmp388_set_int_enable(itf, 0, int_to_disable);
@@ -3182,7 +3178,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
     int rc;
 
     if (!int_to_enable) {
-        BMP388_LOG(ERROR, "*****enable_interrupt int_to_enable is 0 \n");
+        BMP388_LOG_ERROR("*****enable_interrupt int_to_enable is 0 \n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -3193,7 +3189,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
 
     rc = bmp388_clear_int(itf);
     if (rc) {
-        BMP388_LOG(ERROR, "*****enable_interrupt bmp388_clear_int failed%d\n", rc);
+        BMP388_LOG_ERROR("*****enable_interrupt bmp388_clear_int failed%d\n", rc);
         goto err;
     }
 
@@ -3203,7 +3199,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
 
         rc = bmp388_set_int_enable(itf, 1, int_to_enable);
         if (rc) {
-            BMP388_LOG(ERROR, "*****enable_interrupt bmp388_set_int_enable failed%d\n", rc);
+            BMP388_LOG_ERROR("*****enable_interrupt bmp388_set_int_enable failed%d\n", rc);
             goto err;
         }
     }
@@ -3217,7 +3213,7 @@ enable_interrupt(struct sensor *sensor, uint8_t int_to_enable, uint8_t int_num)
     }
 
     if (rc) {
-        BMP388_LOG(ERROR, "*****enable_interrupt bmp388_set_int1/int2_pin_cfg failed%d\n", rc);
+        BMP388_LOG_ERROR("*****enable_interrupt bmp388_set_int1/int2_pin_cfg failed%d\n", rc);
         disable_interrupt(sensor, int_to_enable, int_num);
         goto err;
     }
@@ -3310,19 +3306,19 @@ bmp388_poll_read(struct sensor *sensor, sensor_type_t sensor_type,
     g_bmp388_dev.settings.op_mode = BMP3_FORCED_MODE;
     rc = bmp388_set_forced_mode_with_osr(itf, &g_bmp388_dev);
     if (rc) {
-        BMP388_LOG(ERROR, "bmp388_set_forced_mode_with_osr failed %d\n", rc);
+        BMP388_LOG_ERROR("bmp388_set_forced_mode_with_osr failed %d\n", rc);
         goto err;
     }
 
     rc = bmp388_get_sensor_data(itf, &g_bmp388_dev, &sensor_data);
     if (rc) {
-        BMP388_LOG(ERROR, "bmp388_get_sensor_data failed %d\n", rc);
+        BMP388_LOG_ERROR("bmp388_get_sensor_data failed %d\n", rc);
         goto err;
     }
 
     rc = bmp388_do_report(sensor, sensor_type, data_func, data_arg, &sensor_data);
     if (rc) {
-        BMP388_LOG(ERROR, "bmp388_do_report failed %d\n", rc);
+        BMP388_LOG_ERROR("bmp388_do_report failed %d\n", rc);
         goto err;
     }
 
@@ -3378,7 +3374,7 @@ bmp388_stream_read(struct sensor *sensor,
 
     /* If the read isn't looking for pressure or temperature data, don't do anything. */
     if ((!(sensor_type & SENSOR_TYPE_PRESSURE)) && (!(sensor_type & SENSOR_TYPE_TEMPERATURE))) {
-        BMP388_LOG(ERROR, "unsupported sensor type for bmp388\n");
+        BMP388_LOG_ERROR("unsupported sensor type for bmp388\n");
         return SYS_EINVAL;
     }
 
@@ -3391,7 +3387,7 @@ bmp388_stream_read(struct sensor *sensor,
 
 
     if (cfg->read_mode.mode != BMP388_READ_M_STREAM) {
-        BMP388_LOG(ERROR, "*****bmp388_stream_read mode is not stream\n");
+        BMP388_LOG_ERROR("*****bmp388_stream_read mode is not stream\n");
         return SYS_EINVAL;
     }
 
@@ -3412,7 +3408,7 @@ bmp388_stream_read(struct sensor *sensor,
     undo_interrupt(&bmp388->intr);
 
     if (pdd->interrupt) {
-        BMP388_LOG(ERROR, "*****bmp388_stream_read interrupt is not null\n");
+        BMP388_LOG_ERROR("*****bmp388_stream_read interrupt is not null\n");
         return SYS_EBUSY;
     }
 
@@ -3422,7 +3418,7 @@ bmp388_stream_read(struct sensor *sensor,
     rc = enable_interrupt(sensor, cfg->read_mode.int_type,
                         cfg->read_mode.int_num);
     if (rc) {
-        BMP388_LOG(ERROR, "*****bmp388_stream_read enable_interrupt failed%d\n", rc);
+        BMP388_LOG_ERROR("*****bmp388_stream_read enable_interrupt failed%d\n", rc);
         return rc;
     }
 #else
@@ -3431,7 +3427,7 @@ bmp388_stream_read(struct sensor *sensor,
     /* enable normal mode for fifo feature */
     rc = bmp388_set_normal_mode(itf, &g_bmp388_dev);
     if (rc) {
-        BMP388_LOG(ERROR, "******bmp388_set_normal_mode failed %d\n", rc);
+        BMP388_LOG_ERROR("******bmp388_set_normal_mode failed %d\n", rc);
         goto err;
     }
 #endif
@@ -3460,10 +3456,10 @@ bmp388_stream_read(struct sensor *sensor,
 #if MYNEWT_VAL(BMP388_INT_ENABLE)
         rc = wait_interrupt(&bmp388->intr, cfg->read_mode.int_num);
         if (rc) {
-            BMP388_LOG(ERROR, "*****bmp388_stream_read wait_interrupt failed%d\n", rc);
+            BMP388_LOG_ERROR("*****bmp388_stream_read wait_interrupt failed%d\n", rc);
             goto err;
         } else {
-            BMP388_LOG(ERROR, "*****wait_interrupt got the interrupt\n");
+            BMP388_LOG_ERROR("*****wait_interrupt got the interrupt\n");
         }
 #endif
 
@@ -3495,7 +3491,7 @@ try_count = 0xFFFF;
 #if MYNEWT_VAL(BMP388_FIFO_ENABLE)
         if (try_count > 0) {
 #if FIFOPARSE_DEBUG
-            BMP388_LOG(ERROR, "*****try_count is %d\n", try_count);
+            BMP388_LOG_ERROR("*****try_count is %d\n", try_count);
 #endif
             rc = bmp3_get_fifo_data(itf, &g_bmp388_dev);
             if (fifo.settings.time_en)
@@ -3507,10 +3503,10 @@ try_count = 0xFFFF;
             if (g_bmp388_dev.fifo->data.frame_not_available)
             {
                 /* no valid fifo frame in sensor */
-                BMP388_LOG(ERROR, "**** fifo frames not valid %d\n", rc);
+                BMP388_LOG_ERROR("**** fifo frames not valid %d\n", rc);
             } else {
 #if BMP388_DEBUG
-                BMP388_LOG(ERROR, "*****parsed_frames is %d\n", g_bmp388_dev.fifo->data.parsed_frames);
+                BMP388_LOG_ERROR("*****parsed_frames is %d\n", g_bmp388_dev.fifo->data.parsed_frames);
 #endif
                 frame_length = g_bmp388_dev.fifo->data.req_frames;
                 if (frame_length > g_bmp388_dev.fifo->data.parsed_frames) {
@@ -3521,19 +3517,19 @@ try_count = 0xFFFF;
                 {
                     rc = bmp388_do_report(sensor, sensor_type, read_func, read_arg, &sensor_data[i]);
                     if (rc) {
-                        BMP388_LOG(ERROR, "bmp388_do_report failed %d\n", rc);
+                        BMP388_LOG_ERROR("bmp388_do_report failed %d\n", rc);
                         goto err;
                     }
                 }
 
                 if (g_bmp388_dev.fifo->sensortime_updated) {
-                    BMP388_LOG(ERROR, "*****bmp388 sensor time %d\n", g_bmp388_dev.fifo->data.sensor_time);
+                    BMP388_LOG_ERROR("*****bmp388 sensor time %d\n", g_bmp388_dev.fifo->data.sensor_time);
                     g_bmp388_dev.fifo->sensortime_updated = false;
                 }
             }
         }else {
 
-            BMP388_LOG(ERROR, "FIFO water mark unreached\n");
+            BMP388_LOG_ERROR("FIFO water mark unreached\n");
             rc = SYS_EINVAL;
             goto err;
         }
@@ -3543,18 +3539,18 @@ try_count = 0xFFFF;
             g_bmp388_dev.settings.op_mode = BMP3_FORCED_MODE;
             rc = bmp388_set_forced_mode_with_osr(itf, &g_bmp388_dev);
             if (rc) {
-                BMP388_LOG(ERROR, "bmp388_set_forced_mode_with_osr failed %d\n", rc);
+                BMP388_LOG_ERROR("bmp388_set_forced_mode_with_osr failed %d\n", rc);
                 goto err;
             }
             rc = bmp388_get_sensor_data(itf, &g_bmp388_dev, &sensor_data);
             if (rc) {
-                BMP388_LOG(ERROR, "bmp388_get_sensor_data failed %d\n", rc);
+                BMP388_LOG_ERROR("bmp388_get_sensor_data failed %d\n", rc);
                 goto err;
             }
 
             rc = bmp388_do_report(sensor, sensor_type, read_func, read_arg, &sensor_data);
             if (rc) {
-                BMP388_LOG(ERROR, "bmp388_do_report failed %d\n", rc);
+                BMP388_LOG_ERROR("bmp388_do_report failed %d\n", rc);
                 goto err;
             }
 
@@ -3562,8 +3558,8 @@ try_count = 0xFFFF;
 #endif
 
         if (time_ms != 0 && OS_TIME_TICK_GT(os_time_get(), stop_ticks)) {
-            BMP388_LOG(INFO, "stream time expired\n");
-            BMP388_LOG(INFO, "you can make BMP388_MAX_STREAM_MS bigger to extend stream time duration\n");
+            BMP388_LOG_INFO("stream time expired\n");
+            BMP388_LOG_INFO("you can make BMP388_MAX_STREAM_MS bigger to extend stream time duration\n");
             break;
         }
 
@@ -3593,12 +3589,12 @@ bmp388_sensor_read(struct sensor *sensor, sensor_type_t type,
     struct bmp388 *bmp388;
     struct sensor_itf *itf;
 #if BMP388_DEBUG
-    BMP388_LOG(ERROR, "bmp388_sensor_read entered\n");
+    BMP388_LOG_ERROR("bmp388_sensor_read entered\n");
 #endif
     /* If the read isn't looking for pressure data, don't do anything. */
     if ((!(type & SENSOR_TYPE_PRESSURE)) && (!(type & SENSOR_TYPE_TEMPERATURE))) {
         rc = SYS_EINVAL;
-        BMP388_LOG(ERROR, "bmp388_sensor_read unsupported sensor type\n");
+        BMP388_LOG_ERROR("bmp388_sensor_read unsupported sensor type\n");
         goto err;
     }
 
@@ -3639,7 +3635,7 @@ bmp388_sensor_read(struct sensor *sensor, sensor_type_t type,
     }
 err:
     if (rc) {
-        BMP388_LOG(ERROR, "bmp388_sensor_read read failed\n");
+        BMP388_LOG_ERROR("bmp388_sensor_read read failed\n");
         return SYS_EINVAL;
     } else {
         return SYS_EOK;
@@ -3729,11 +3725,11 @@ bmp388_sensor_handle_interrupt(struct sensor *sensor)
 #endif
     itf = SENSOR_GET_ITF(sensor);
 
-    BMP388_LOG(ERROR, "******bmp388_sensor_handle_interrupt entered\n");
+    BMP388_LOG_ERROR("******bmp388_sensor_handle_interrupt entered\n");
 
     rc = bmp3_get_status(itf, &g_bmp388_dev);
     if (rc) {
-        BMP388_LOG(ERROR, "Could not get status err=0x%02x\n", rc);
+        BMP388_LOG_ERROR("Could not get status err=0x%02x\n", rc);
         goto err;
     }
 
@@ -3742,7 +3738,7 @@ bmp388_sensor_handle_interrupt(struct sensor *sensor)
         (bmp388->cfg.int_enable_type == BMP388_FIFO_FULL_INT)) {
         rc = bmp3_fifo_flush(itf, &g_bmp388_dev);
         if (rc) {
-            BMP388_LOG(ERROR, "fifo flush failed, err=0x%02x\n", rc);
+            BMP388_LOG_ERROR("fifo flush failed, err=0x%02x\n", rc);
             goto err;
         }
     }
@@ -3753,14 +3749,14 @@ bmp388_sensor_handle_interrupt(struct sensor *sensor)
                      g_bmp388_dev.status.intr.drdy;
 
     if (int_status_all == 0) {
-        BMP388_LOG(ERROR, "Could not get any INT happened status \n");
+        BMP388_LOG_ERROR("Could not get any INT happened status \n");
         rc = SYS_EINVAL;
         goto err;
     }
 #if CLEAR_INT_AFTER_ISR
     rc = bmp388_clear_int(itf);
     if (rc) {
-        BMP388_LOG(ERROR, "Could not clear int src err=0x%02x\n", rc);
+        BMP388_LOG_ERROR("Could not clear int src err=0x%02x\n", rc);
         goto err;
     }
 #endif
@@ -3812,7 +3808,7 @@ bmp388_init(struct os_dev *dev, void *arg)
     }
 
 #if BMP388_DEBUG
-    BMP388_LOG(ERROR, "******bmp388_init entered\n");
+    BMP388_LOG_ERROR("******bmp388_init entered\n");
 #endif
     bmp388 = (struct bmp388 *) dev;
 
@@ -3861,7 +3857,7 @@ bmp388_init(struct os_dev *dev, void *arg)
         g_bmp388_dev.intf = BMP3_SPI_INTF;
         rc = hal_spi_disable(sensor->s_itf.si_num);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_init hal_spi_disable failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_init hal_spi_disable failed, rc = %d\n", rc);
             goto err;
         }
 
@@ -3870,19 +3866,19 @@ bmp388_init(struct os_dev *dev, void *arg)
             /* If spi is already enabled, for nrf52, it returns -1, We should not
             * fail if the spi is already enabled
             */
-            BMP388_LOG(ERROR, "******bmp388_init hal_spi_config failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_init hal_spi_config failed, rc = %d\n", rc);
             goto err;
         }
 
         rc = hal_spi_enable(sensor->s_itf.si_num);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_init hal_spi_enable failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_init hal_spi_enable failed, rc = %d\n", rc);
             goto err;
         }
 
         rc = hal_gpio_init_out(sensor->s_itf.si_cs_pin, 1);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_init hal_gpio_init_out failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_init hal_gpio_init_out failed, rc = %d\n", rc);
             goto err;
         }
 
@@ -3890,7 +3886,7 @@ bmp388_init(struct os_dev *dev, void *arg)
         g_bmp388_dev.intf = BMP3_I2C_INTF;
 
 #if BMP388_DEBUG
-        BMP388_LOG(ERROR, "******bmp388_init entered\n");
+        BMP388_LOG_ERROR("******bmp388_init entered\n");
 #endif
 
     }
@@ -3905,14 +3901,14 @@ bmp388_init(struct os_dev *dev, void *arg)
 
     rc = init_intpin(bmp388, bmp388_int_irq_handler, sensor);
     if (rc) {
-        BMP388_LOG(ERROR, "******init_intpin failed \n");
+        BMP388_LOG_ERROR("******init_intpin failed \n");
         return rc;
     }
 
 #endif
 
 #if BMP388_DEBUG
-    BMP388_LOG(ERROR, "******bmp388_init exited \n");
+    BMP388_LOG_ERROR("******bmp388_init exited \n");
 #endif
     return 0;
 err:
@@ -3937,7 +3933,7 @@ bmp388_config(struct bmp388 *bmp388, struct bmp388_cfg *cfg)
     sensor = &(bmp388->sensor);
 
 #if BMP388_DEBUG
-    BMP388_LOG(ERROR, "******bmp388_config entered\n");
+    BMP388_LOG_ERROR("******bmp388_config entered\n");
 #endif
 
 #if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
@@ -3953,13 +3949,13 @@ bmp388_config(struct bmp388 *bmp388, struct bmp388_cfg *cfg)
             /* If spi is already enabled, for nrf52, it returns -1, We should not
             * fail if the spi is already enabled
             */
-            BMP388_LOG(ERROR, "******bmp388_config hal_spi_config failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_config hal_spi_config failed, rc = %d\n", rc);
             goto err;
         }
 
         rc = hal_spi_enable(sensor->s_itf.si_num);
         if (rc) {
-            BMP388_LOG(ERROR, "******bmp388_config hal_spi_enable failed, rc = %d\n", rc);
+            BMP388_LOG_ERROR("******bmp388_config hal_spi_enable failed, rc = %d\n", rc);
             goto err;
         }
     }
@@ -3969,7 +3965,7 @@ bmp388_config(struct bmp388 *bmp388, struct bmp388_cfg *cfg)
 
     rc = bmp3_init(itf, &g_bmp388_dev);
     if (rc) {
-        BMP388_LOG(ERROR, "******config bmp3_init failed %d\n", rc);
+        BMP388_LOG_ERROR("******config bmp3_init failed %d\n", rc);
         goto err;
     }
 
@@ -3980,10 +3976,10 @@ bmp388_config(struct bmp388 *bmp388, struct bmp388_cfg *cfg)
 
     if (chip_id != BMP3_CHIP_ID) {
         rc = SYS_EINVAL;
-        BMP388_LOG(ERROR, "******config gets BMP388 chipID failed 0x%x\n", chip_id);
+        BMP388_LOG_ERROR("******config gets BMP388 chipID failed 0x%x\n", chip_id);
         goto err;
     } else {
-        BMP388_LOG(ERROR, "******config gets BMP388 chipID 0x%x\n", chip_id);
+        BMP388_LOG_ERROR("******config gets BMP388 chipID 0x%x\n", chip_id);
     }
 
     rc = bmp388_set_int_pp_od(itf, cfg->int_pp_od);
@@ -4049,7 +4045,7 @@ bmp388_config(struct bmp388 *bmp388, struct bmp388_cfg *cfg)
     bmp388->cfg.mask = cfg->mask;
 
 #if BMP388_DEBUG
-    BMP388_LOG(ERROR, "******bmp388_config exited\n");
+    BMP388_LOG_ERROR("******bmp388_config exited\n");
 #endif
 
     return 0;

--- a/hw/drivers/sensors/bmp388/syscfg.yml
+++ b/hw/drivers/sensors/bmp388/syscfg.yml
@@ -62,9 +62,6 @@ syscfg.defs:
     BMP388_ITF_LOCK_TMO:
         description: 'BMP388 interface lock timeout in milliseconds'
         value: 1000
-    BMP388_LOG_MODULE:
-        description: 'Numeric module ID to use for BMP388 log messages'
-        value: 213
     BMP388_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -74,3 +71,17 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    BMP388_LOG_MODULE:
+        description: 'Numeric module ID to use for BMP388 log messages.'
+        value: 213
+    BMP388_LOG_LVL:
+        description: 'Minimum level for the BMP388 log.'
+        value: 1
+
+syscfg.logs:
+    BMP388_LOG:
+        module: MYNEWT_VAL(BMP388_LOG_MODULE)
+        level: MYNEWT_VAL(BMP388_LOG_LVL)

--- a/hw/drivers/sensors/bno055/src/bno055.c
+++ b/hw/drivers/sensors/bno055/src/bno055.c
@@ -50,9 +50,6 @@ STATS_NAME_END(bno055_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(bno055_stat_section) g_bno055stats;
 
-#define BNO055_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(BNO055_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API.*/
 static int bno055_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -88,7 +85,7 @@ bno055_write8(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC, 1,
                            MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR,
+        BNO055_LOG_ERROR(
                    "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
                    data_struct.address, reg, value);
         STATS_INC(g_bno055stats, errors);
@@ -136,7 +133,7 @@ bno055_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        BNO055_LOG_ERROR("I2C access failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_bno055stats, errors);
         goto err;
@@ -147,7 +144,7 @@ bno055_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10,
                            len, MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        BNO055_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    data_struct.address, reg);
         STATS_INC(g_bno055stats, errors);;
     }
@@ -189,7 +186,7 @@ bno055_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
                            MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR,
+        BNO055_LOG_ERROR(
                    "I2C register write failed at address 0x%02X:0x%02X\n",
                    data_struct.address, reg);
         STATS_INC(g_bno055stats, errors);
@@ -202,7 +199,7 @@ bno055_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(BNO055_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        BNO055_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        BNO055_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    data_struct.address, reg);
         STATS_INC(g_bno055stats, errors);
     }
@@ -250,7 +247,7 @@ bno055_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        BNO055_LOG_ERROR("I2C access failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_bno055stats, errors);
         goto err;
@@ -262,7 +259,7 @@ bno055_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                           MYNEWT_VAL(BNO055_I2C_RETRIES));
     if (rc) {
-        BNO055_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        BNO055_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    data_struct.address, reg);
         STATS_INC(g_bno055stats, errors);
     }
@@ -649,7 +646,7 @@ bno055_placement_cfg(struct sensor_itf *itf, uint8_t placement)
         remap_sign = BNO055_REMAP_SIGN_P7;
         break;
     default:
-        BNO055_LOG(ERROR, "Invalid Axis config, Assuming P1(default) \n");
+        BNO055_LOG_ERROR("Invalid Axis config, Assuming P1(default) \n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -817,7 +814,7 @@ bno055_config(struct bno055 *bno055, struct bno055_cfg *cfg)
         }
 
         if (cfg->bc_opr_mode != mode) {
-            BNO055_LOG(ERROR, "Config mode and read mode do not match.\n");
+            BNO055_LOG_ERROR("Config mode and read mode do not match.\n");
             rc = SYS_EINVAL;
             goto err;
         }
@@ -917,7 +914,7 @@ bno055_find_reg(sensor_type_t type, uint8_t *reg)
             *reg = BNO055_GRAVITY_DATA_X_LSB_ADDR;
             break;
         default:
-            BNO055_LOG(ERROR, "Not supported sensor type: %d\n", (int)type);
+            BNO055_LOG_ERROR("Not supported sensor type: %d\n", (int)type);
             rc = SYS_EINVAL;
             break;
     }
@@ -1029,7 +1026,7 @@ bno055_get_vector_data(struct sensor_itf *itf, void *datastruct, int type)
             sad->sad_z_is_valid = 1;
             break;
         default:
-            BNO055_LOG(ERROR, "Not supported sensor type: %d\n", type);
+            BNO055_LOG_ERROR("Not supported sensor type: %d\n", type);
             rc = SYS_EINVAL;
             goto err;
     }

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -33,11 +33,23 @@ syscfg.defs:
     BNO055_ITF_LOCK_TMO:
         description: 'BNO055 interface lock timeout in milliseconds'
         value: 1000
-    BNO055_LOG_MODULE:
-        description: 'Numeric module ID to use for BNO055 log messages'
-        value: 85
     BNO055_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the BNO055 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    BNO055_LOG_MODULE:
+        description: 'Numeric module ID to use for BNO055 log messages.'
+        value: 85
+    BNO055_LOG_LVL:
+        description: 'Minimum level for the BNO055 log.'
+        value: 1
+
+syscfg.logs:
+    BNO055_LOG:
+        module: MYNEWT_VAL(BNO055_LOG_MODULE)
+        level: MYNEWT_VAL(BNO055_LOG_LVL)
+

--- a/hw/drivers/sensors/dps368/include/dps368/dps368.h
+++ b/hw/drivers/sensors/dps368/include/dps368/dps368.h
@@ -281,10 +281,6 @@ struct dps368 {
     STATS_SECT_DECL(dps368_stat_section) stats;
 };
 
-
-#define DPS368_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(DPS368_LOG_MODULE), __VA_ARGS__)
-
 /**
  * Initialize the dps368.
  *

--- a/hw/drivers/sensors/dps368/src/dps368_comm_interface.c
+++ b/hw/drivers/sensors/dps368/src/dps368_comm_interface.c
@@ -48,7 +48,7 @@ dps368_i2c_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
             MYNEWT_VAL(DPS368_I2C_RETRIES));
 
     if (rc) {
-        DPS368_LOG(ERROR,
+        DPS368_LOG_ERROR(
                 "Could not write to 0x%02X:0x%02X with value 0x%02X\n",
                 itf->si_addr, reg, value);
     }
@@ -78,7 +78,7 @@ dps368_spi_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, reg & ~DPS368_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        DPS368_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        DPS368_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                 itf->si_num, reg);
         goto err;
     }
@@ -87,7 +87,7 @@ dps368_spi_write_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        DPS368_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n", itf->si_num,
+        DPS368_LOG_ERROR("SPI_%u write failed addr:0x%02X\n", itf->si_num,
                 reg);
         goto err;
     }
@@ -134,7 +134,7 @@ dps368_i2c_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
             MYNEWT_VAL(DPS368_I2C_TIMEOUT_TICKS) * (size + 1), 1,
             MYNEWT_VAL(DPS368_I2C_RETRIES));
     if (rc) {
-        DPS368_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        DPS368_LOG_ERROR("I2C access failed at address 0x%02X\n",
                 itf->si_addr);
         return rc;
     }
@@ -170,7 +170,7 @@ dps368_spi_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     retval = hal_spi_tx_val(itf->si_num, reg | DPS368_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        DPS368_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        DPS368_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                 itf->si_num, reg);
         goto err;
     }
@@ -180,7 +180,7 @@ dps368_spi_read_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            DPS368_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n", itf->si_num,
+            DPS368_LOG_ERROR("SPI_%u read failed addr:0x%02X\n", itf->si_num,
                     reg);
             goto err;
         }

--- a/hw/drivers/sensors/dps368/syscfg.yml
+++ b/hw/drivers/sensors/dps368/syscfg.yml
@@ -37,9 +37,6 @@ syscfg.defs:
     DPS368_ITF_LOCK_TMO:
         description: 'DPS368 interface lock timeout in milliseconds'
         value: 1000
-    DPS368_LOG_MODULE:
-        description: 'Numeric module ID to use for DPS368 log messages'
-        value: 36
     DPS368_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -64,3 +61,18 @@ syscfg.defs:
     DPS368_DFLT_CONF_MODE:
         description: 'Default Mode for sensor: Valid values are 0, 1,2,5,6,7. Refere enum in driver package'
         value: 7 #Background for both P and T
+
+    ### Log settings.
+
+    DPS368_LOG_MODULE:
+        description: 'Numeric module ID to use for DPS368 log messages.'
+        value: 36
+    DPS368_LOG_LVL:
+        description: 'Minimum level for the DPS368 log.'
+        value: 1
+
+syscfg.logs:
+    DPS368_LOG:
+        module: MYNEWT_VAL(DPS368_LOG_MODULE)
+        level: MYNEWT_VAL(DPS368_LOG_LVL)
+

--- a/hw/drivers/sensors/icp101xx/src/icp101xx.c
+++ b/hw/drivers/sensors/icp101xx/src/icp101xx.c
@@ -40,9 +40,6 @@ STATS_NAME_START(icp101xx_stat_section)
     STATS_NAME(icp101xx_stat_section, write_errors)
 STATS_NAME_END(icp101xx_stat_section)
 
-#define ICP101XX_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(ICP101XX_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API.*/
 static int icp101xx_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -96,7 +93,7 @@ icp101xx_sensor_read(struct sensor *sensor, sensor_type_t type,
     }
     if (icp101xx->cfg.skip_first_data) {
         icp101xx->cfg.skip_first_data = 0;
-        ICP101XX_LOG(DEBUG, "Skip 1rst data. Measurement not yet started.\n");
+        ICP101XX_LOG_DEBUG("Skip 1rst data. Measurement not yet started.\n");
         goto err;
     }
 
@@ -193,7 +190,7 @@ icp101xx_write_reg(struct sensor_itf *itf, uint16_t reg, uint8_t *buf,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC, 1,
                            MYNEWT_VAL(ICP101XX_I2C_RETRIES));
     if (rc) {
-        ICP101XX_LOG(ERROR,
+        ICP101XX_LOG_ERROR(
                      "Failed to write to 0x%02X:0x%02X\n",
                       data_struct.address, reg);
     }
@@ -230,7 +227,7 @@ icp101xx_read_reg(struct sensor_itf *itf, uint16_t reg, uint8_t *buf,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10,
                            1, MYNEWT_VAL(ICP101XX_I2C_RETRIES));
     if (rc) {
-        ICP101XX_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        ICP101XX_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         goto err;
     }
@@ -241,7 +238,7 @@ icp101xx_read_reg(struct sensor_itf *itf, uint16_t reg, uint8_t *buf,
     rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10,
                           1, MYNEWT_VAL(ICP101XX_I2C_RETRIES));
     if (rc) {
-        ICP101XX_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        ICP101XX_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, reg);
     }
 
@@ -278,7 +275,7 @@ icp101xx_read(struct sensor_itf *itf, uint8_t * buf, uint32_t len)
     rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10,
                           1, MYNEWT_VAL(ICP101XX_I2C_RETRIES));
     if (rc) {
-        ICP101XX_LOG(ERROR, "Failed to read %d bytes from 0x%x\n", 
+        ICP101XX_LOG_ERROR("Failed to read %d bytes from 0x%x\n", 
                      data_struct.address);
     }
 
@@ -333,7 +330,7 @@ check_crc(uint8_t *frame)
     uint8_t crc = compute_crc(frame);
 
     if (crc != frame[ICP101XX_RESP_FRAME_LEN - 1]) {
-        ICP101XX_LOG(ERROR, "CRC computed 0x%x doesn't match 0x%x\n", crc,
+        ICP101XX_LOG_ERROR("CRC computed 0x%x doesn't match 0x%x\n", crc,
                      frame[ICP101XX_RESP_FRAME_LEN - 1]);
     }
     return (crc == frame[ICP101XX_RESP_FRAME_LEN - 1]);
@@ -378,7 +375,7 @@ read_otp(struct icp101xx *icp101xx, struct icp101xx_cfg *cfg, int16_t *calibrati
         }
     }
 
-    ICP101XX_LOG(DEBUG, "OTP : %d %d %d %d\n", 
+    ICP101XX_LOG_DEBUG("OTP : %d %d %d %d\n", 
                  calibration_data[0], calibration_data[1], calibration_data[2],
                  calibration_data[3]);
     
@@ -649,7 +646,7 @@ icp101xx_config(struct icp101xx *icp101xx, struct icp101xx_cfg *cfg)
         }
 
         if (id != ICP101XX_ID) {
-            ICP101XX_LOG(ERROR, "Bad chip id : %04X\n", id);
+            ICP101XX_LOG_ERROR("Bad chip id : %04X\n", id);
             rc = SYS_EINVAL;
             goto err;
         }
@@ -737,8 +734,8 @@ icp101xx_get_data(struct icp101xx *icp101xx, struct icp101xx_cfg *cfg,
     if (rc) {
         goto err;
     }
-    /* ICP101XX_LOG(DEBUG, "raw P = %d\n", raw_press); */
-    /* ICP101XX_LOG(DEBUG, "raw T = %d\n", raw_temp); */
+    /* ICP101XX_LOG_DEBUG("raw P = %d\n", raw_press); */
+    /* ICP101XX_LOG_DEBUG("raw T = %d\n", raw_temp); */
 
     rc = process_data(cfg, raw_press, raw_temp,
                       &pressure_pa, &temperature_degc);

--- a/hw/drivers/sensors/icp101xx/syscfg.yml
+++ b/hw/drivers/sensors/icp101xx/syscfg.yml
@@ -42,11 +42,22 @@ syscfg.defs:
     ICP101XX_SPEC_CALC:
         description: 'ICP101XX Spec calculation insetad of built in one'
         value : 1
-    ICP101XX_LOG_MODULE:
-        description: 'Numeric module ID to use for ICP101XX log messages'
-        value: 86
     ICP101XX_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the ICP101XX sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    ICP101XX_LOG_MODULE:
+        description: 'Numeric module ID to use for ICP101XX log messages.'
+        value: 86
+    ICP101XX_LOG_LVL:
+        description: 'Minimum level for the ICP101XX log.'
+        value: 1
+
+syscfg.logs:
+    ICP101XX_LOG:
+        module: MYNEWT_VAL(ICP101XX_LOG_MODULE)
+        level: MYNEWT_VAL(ICP101XX_LOG_LVL)

--- a/hw/drivers/sensors/kxtj3/syscfg.yml
+++ b/hw/drivers/sensors/kxtj3/syscfg.yml
@@ -45,11 +45,23 @@ syscfg.defs:
     KXTJ3_SHELL_DEV_NAME:
         description: 'KXTJ3 Shell device name'
         value: "\"kxtj3_0\""
-    KXTJ3_LOG_MODULE:
-        description: 'Numeric module ID to use for KXTJ3 log messages'
-        value: 85
     KXTJ3_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the KXTJ3 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    KXTJ3_LOG_MODULE:
+        description: 'Numeric module ID to use for KXTJ3 log messages.'
+        value: 85
+    KXTJ3_LOG_LVL:
+        description: 'Minimum level for the KXTJ3 log.'
+        value: 1
+
+syscfg.logs:
+    KXTJ3_LOG:
+        module: MYNEWT_VAL(KXTJ3_LOG_MODULE)
+        level: MYNEWT_VAL(KXTJ3_LOG_LVL)
+

--- a/hw/drivers/sensors/lis2de12/src/lis2de12.c
+++ b/hw/drivers/sensors/lis2de12/src/lis2de12.c
@@ -189,9 +189,6 @@ STATS_NAME_END(lis2de12_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lis2de12_stat_section) g_lis2de12stats;
 
-#define LIS2DE12_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LIS2DE12_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lis2de12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -259,7 +256,7 @@ lis2de12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DE12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DE12_I2C_RETRIES));
     if (rc) {
-        LIS2DE12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DE12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2de12stats, read_errors);
         goto err;
@@ -271,7 +268,7 @@ lis2de12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DE12_I2C_TIMEOUT_TICKS), len,
                           MYNEWT_VAL(LIS2DE12_I2C_RETRIES));
     if (rc) {
-        LIS2DE12_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        LIS2DE12_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, addr);
         STATS_INC(g_lis2de12stats, read_errors);
         goto err;
@@ -321,7 +318,7 @@ lis2de12_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     retval = hal_spi_tx_val(itf->si_num, addr);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DE12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DE12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2de12stats, read_errors);
         goto err;
@@ -332,7 +329,7 @@ lis2de12_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         retval = hal_spi_tx_val(itf->si_num, 0x55);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DE12_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LIS2DE12_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2de12stats, read_errors);
             goto err;
@@ -389,7 +386,7 @@ lis2de12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DE12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DE12_I2C_RETRIES));
     if (rc) {
-        LIS2DE12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DE12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2de12stats, write_errors);
 
@@ -432,7 +429,7 @@ lis2de12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DE12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DE12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2de12stats, write_errors);
         goto err;
@@ -443,7 +440,7 @@ lis2de12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DE12_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+            LIS2DE12_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2de12stats, write_errors);
             goto err;
@@ -703,7 +700,7 @@ lis2de12_set_full_scale(struct sensor_itf *itf, uint8_t fs)
     uint8_t reg;
 
     if (fs > LIS2DE12_FS_16G) {
-        LIS2DE12_LOG(ERROR, "Invalid full scale value\n");
+        LIS2DE12_LOG_ERROR("Invalid full scale value\n");
         return SYS_EINVAL;
     }
 
@@ -780,7 +777,7 @@ lis2de12_set_rate(struct sensor_itf *itf, uint8_t rate)
     uint8_t reg;
 
     if (rate > LIS2DE12_DATA_RATE_HN_1344HZ_L_5376HZ) {
-        LIS2DE12_LOG(ERROR, "Invalid rate value\n");
+        LIS2DE12_LOG_ERROR("Invalid rate value\n");
         return SYS_EINVAL;
     }
 
@@ -1102,12 +1099,12 @@ init_intpin(struct lis2de12 *lis2de12, int int_num, hal_gpio_irq_handler_t handl
                                HAL_GPIO_PULL_NONE);
     }
     if (pin < 0) {
-        LIS2DE12_LOG(ERROR, "Interrupt pin not configured\n");
+        LIS2DE12_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
     if (rc != 0) {
-        LIS2DE12_LOG(ERROR, "Failed to initialize interrupt pin %d\n", pin);
+        LIS2DE12_LOG_ERROR("Failed to initialize interrupt pin %d\n", pin);
         return rc;
     }
 
@@ -2092,7 +2089,7 @@ lis2de12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2de12_clear_int1(itf, &int_src_bytes[0]);
     if (rc) {
-        LIS2DE12_LOG(ERROR, "Could not read INT1_SRC (err=0x%02x)\n", rc);
+        LIS2DE12_LOG_ERROR("Could not read INT1_SRC (err=0x%02x)\n", rc);
         goto err;
     }
 
@@ -2101,7 +2098,7 @@ lis2de12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2de12_clear_int2(itf, &int_src_bytes[1]);
     if (rc) {
-        LIS2DE12_LOG(ERROR, "Could not read INT1_SRC (err=0x%02x)\n", rc);
+        LIS2DE12_LOG_ERROR("Could not read INT1_SRC (err=0x%02x)\n", rc);
         goto err;
     }
 
@@ -2175,7 +2172,7 @@ lis2de12_sensor_handle_interrupt(struct sensor *sensor)
         /* Read click interrupt state from device */
         rc = lis2de12_clear_click(itf, &click_src);
         if (rc) {
-            LIS2DE12_LOG(ERROR, "Could not read int src err=0x%02x\n", rc);
+            LIS2DE12_LOG_ERROR("Could not read int src err=0x%02x\n", rc);
             return rc;
         }
 

--- a/hw/drivers/sensors/lis2de12/syscfg.yml
+++ b/hw/drivers/sensors/lis2de12/syscfg.yml
@@ -21,9 +21,6 @@ syscfg.defs:
     LIS2DE12_ITF_LOCK_TMO:
         description: 'LIS2DE12 interface lock timeout in milliseconds'
         value: 1000
-    LIS2DE12_LOG_MODULE:
-        description: 'Numeric module ID to use for LIS2DE12 log messages'
-        value: 110
     LIS2DE12_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -69,3 +66,18 @@ syscfg.defs:
     LIS2DE12_INT2_CFG_ACTIVE:
         description: 'Set 0 for active-low, 1 for active-high'
         value: 1
+
+    ### Log settings.
+
+    LIS2DE12_LOG_MODULE:
+        description: 'Numeric module ID to use for LIS2DE12 log messages.'
+        value: 110
+    LIS2DE12_LOG_LVL:
+        description: 'Minimum level for the LIS2DE12 log.'
+        value: 1
+
+syscfg.logs:
+    LIS2DE12_LOG:
+        module: MYNEWT_VAL(LIS2DE12_LOG_MODULE)
+        level: MYNEWT_VAL(LIS2DE12_LOG_LVL)
+

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -188,9 +188,6 @@ STATS_NAME_END(lis2dh12_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lis2dh12_stat_section) g_lis2dh12stats;
 
-#define LIS2DH12_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LIS2DH12_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lis2dh12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -263,7 +260,7 @@ lis2dh12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
-        LIS2DH12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DH12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2dh12stats, read_errors);
         goto err;
@@ -275,7 +272,7 @@ lis2dh12_i2c_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
-        LIS2DH12_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        LIS2DH12_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, addr);
         STATS_INC(g_lis2dh12stats, read_errors);
         goto err;
@@ -327,7 +324,7 @@ lis2dh12_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     retval = hal_spi_tx_val(itf->si_num, addr);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DH12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DH12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2dh12stats, read_errors);
         goto err;
@@ -338,7 +335,7 @@ lis2dh12_spi_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         retval = hal_spi_tx_val(itf->si_num, 0x55);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DH12_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LIS2DH12_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2dh12stats, read_errors);
             goto err;
@@ -395,7 +392,7 @@ lis2dh12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DH12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DH12_I2C_RETRIES));
     if (rc) {
-        LIS2DH12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DH12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2dh12stats, write_errors);
         goto err;
@@ -439,7 +436,7 @@ lis2dh12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DH12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DH12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2dh12stats, write_errors);
         goto err;
@@ -450,7 +447,7 @@ lis2dh12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DH12_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+            LIS2DH12_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2dh12stats, write_errors);
             goto err;
@@ -716,7 +713,7 @@ lis2dh12_set_full_scale(struct sensor_itf *itf, uint8_t fs)
     uint8_t reg;
 
     if (fs > LIS2DH12_FS_16G) {
-        LIS2DH12_LOG(ERROR, "Invalid full scale value\n");
+        LIS2DH12_LOG_ERROR("Invalid full scale value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -806,7 +803,7 @@ lis2dh12_set_rate(struct sensor_itf *itf, uint8_t rate)
     uint8_t reg;
 
     if (rate > LIS2DH12_DATA_RATE_HN_1344HZ_L_5376HZ) {
-        LIS2DH12_LOG(ERROR, "Invalid rate value\n");
+        LIS2DH12_LOG_ERROR("Invalid rate value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -1144,12 +1141,12 @@ init_intpin(struct lis2dh12 *lis2dh12, int int_num, hal_gpio_irq_handler_t handl
                                HAL_GPIO_PULL_NONE);
     }
     if (pin < 0) {
-        LIS2DH12_LOG(ERROR, "Interrupt pin not configured\n");
+        LIS2DH12_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
     if (rc != 0) {
-        LIS2DH12_LOG(ERROR, "Failed to initialize interrupt pin %d\n", pin);
+        LIS2DH12_LOG_ERROR("Failed to initialize interrupt pin %d\n", pin);
         return rc;
     }
 
@@ -2183,7 +2180,7 @@ lis2dh12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2dh12_clear_int1(itf, &int_src_bytes[0]);
     if (rc) {
-        LIS2DH12_LOG(ERROR, "Could not read INT1_SRC (err=0x%02x)\n", rc);
+        LIS2DH12_LOG_ERROR("Could not read INT1_SRC (err=0x%02x)\n", rc);
         goto err;
     }
 
@@ -2192,7 +2189,7 @@ lis2dh12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2dh12_clear_int2(itf, &int_src_bytes[1]);
     if (rc) {
-        LIS2DH12_LOG(ERROR, "Could not read INT1_SRC (err=0x%02x)\n", rc);
+        LIS2DH12_LOG_ERROR("Could not read INT1_SRC (err=0x%02x)\n", rc);
         goto err;
     }
 
@@ -2266,7 +2263,7 @@ lis2dh12_sensor_handle_interrupt(struct sensor *sensor)
         /* Read click interrupt state from device */
         rc = lis2dh12_clear_click(itf, &click_src);
         if (rc) {
-            LIS2DH12_LOG(ERROR, "Could not read int src err=0x%02x\n", rc);
+            LIS2DH12_LOG_ERROR("Could not read int src err=0x%02x\n", rc);
             return rc;
         }
 

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -21,9 +21,6 @@ syscfg.defs:
     LIS2DH12_ITF_LOCK_TMO:
         description: 'LIS2DH12 interface lock timeout in milliseconds'
         value: 1000
-    LIS2DH12_LOG_MODULE:
-        description: 'Numeric module ID to use for LIS2DH12 log messages'
-        value: 110
     LIS2DH12_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -69,3 +66,17 @@ syscfg.defs:
     LIS2DH12_INT2_CFG_ACTIVE:
         description: 'Set 0 for active-low, 1 for active-high'
         value: 0
+
+    ### Log settings.
+
+    LIS2DH12_LOG_MODULE:
+        description: 'Numeric module ID to use for LIS2DH12 log messages.'
+        value: 110
+    LIS2DH12_LOG_LVL:
+        description: 'Minimum level for the LIS2DH12 log.'
+        value: 1
+
+syscfg.logs:
+    LIS2DH12_LOG:
+        module: MYNEWT_VAL(LIS2DH12_LOG_MODULE)
+        level: MYNEWT_VAL(LIS2DH12_LOG_LVL)

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -82,9 +82,6 @@ STATS_NAME_END(lis2ds12_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lis2ds12_stat_section) g_lis2ds12stats;
 
-#define LIS2DS12_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LIS2DS12_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lis2ds12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -143,7 +140,7 @@ lis2ds12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(LIS2DS12_I2C_RETRIES));
     if (rc) {
-        LIS2DS12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DS12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2ds12stats, write_errors);
         goto err;
@@ -187,7 +184,7 @@ lis2ds12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DS12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DS12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2ds12stats, write_errors);
         goto err;
@@ -198,7 +195,7 @@ lis2ds12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DS12_LOG(ERROR, "SPI_%u write failed addr:0x%02X:0x%02X\n",
+            LIS2DS12_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2ds12stats, write_errors);
             goto err;
@@ -265,7 +262,7 @@ lis2ds12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(LIS2DS12_I2C_RETRIES));
     if (rc) {
-        LIS2DS12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DS12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      itf->si_addr);
         STATS_INC(g_lis2ds12stats, write_errors);
         return rc;
@@ -278,7 +275,7 @@ lis2ds12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8
                           MYNEWT_VAL(LIS2DS12_I2C_RETRIES));
 
     if (rc) {
-        LIS2DS12_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        LIS2DS12_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      itf->si_addr, reg);
         STATS_INC(g_lis2ds12stats, read_errors);
     }
@@ -312,7 +309,7 @@ lis2ds12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DS12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DS12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, reg);
         STATS_INC(g_lis2ds12stats, read_errors);
         goto err;
@@ -323,7 +320,7 @@ lis2ds12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DS12_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LIS2DS12_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                          itf->si_num, reg);
             STATS_INC(g_lis2ds12stats, read_errors);
             goto err;
@@ -524,7 +521,7 @@ lis2ds12_set_full_scale(struct sensor_itf *itf, uint8_t fs)
     uint8_t reg;
 
     if (fs > LIS2DS12_FS_16G) {
-        LIS2DS12_LOG(ERROR, "Invalid full scale value\n");
+        LIS2DS12_LOG_ERROR("Invalid full scale value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -589,7 +586,7 @@ lis2ds12_set_rate(struct sensor_itf *itf, uint8_t rate)
 
     // TODO probably not the best check for me
     if (rate > LIS2DS12_DATA_RATE_LP_10BIT_400HZ) {
-        LIS2DS12_LOG(ERROR, "Invalid rate value\n");
+        LIS2DS12_LOG_ERROR("Invalid rate value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -1837,7 +1834,7 @@ init_intpin(struct lis2ds12 *lis2ds12, hal_gpio_irq_handler_t handler,
     }
 
     if (pin < 0) {
-        LIS2DS12_LOG(ERROR, "Interrupt pin not configured\n");
+        LIS2DS12_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
@@ -1853,7 +1850,7 @@ init_intpin(struct lis2ds12 *lis2ds12, hal_gpio_irq_handler_t handler,
                            trig,
                            HAL_GPIO_PULL_NONE);
     if (rc != 0) {
-        LIS2DS12_LOG(ERROR, "Failed to initialise interrupt pin %d\n", pin);
+        LIS2DS12_LOG_ERROR("Failed to initialise interrupt pin %d\n", pin);
         return rc;
     } 
 
@@ -2395,7 +2392,7 @@ lis2ds12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2ds12_clear_int(itf, int_src);
     if (rc) {
-        LIS2DS12_LOG(ERROR, "Could not read int src err=0x%02x\n", rc);
+        LIS2DS12_LOG_ERROR("Could not read int src err=0x%02x\n", rc);
         return rc;
     }
 

--- a/hw/drivers/sensors/lis2ds12/syscfg.yml
+++ b/hw/drivers/sensors/lis2ds12/syscfg.yml
@@ -44,11 +44,23 @@ syscfg.defs:
     LIS2DS12_ITF_LOCK_TMO:
         description: 'LIS2DS12 interface lock timeout in milliseconds'
         value: 1000
-    LIS2DS12_LOG_MODULE:
-        description: 'Numeric module ID to use for LIS2DS12 log messages'
-        value: 212
     LIS2DS12_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the LIS2DS12 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    LIS2DS12_LOG_MODULE:
+        description: 'Numeric module ID to use for LIS2DS12 log messages.'
+        value: 212
+    LIS2DS12_LOG_LVL:
+        description: 'Minimum level for the LIS2DS12 log.'
+        value: 1
+
+syscfg.logs:
+    LIS2DS12_LOG:
+        module: MYNEWT_VAL(LIS2DS12_LOG_MODULE)
+        level: MYNEWT_VAL(LIS2DS12_LOG_LVL)
+

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -182,9 +182,6 @@ STATS_NAME_END(lis2dw12_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lis2dw12_stat_section) g_lis2dw12stats;
 
-#define LIS2DW12_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LIS2DW12_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lis2dw12_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -244,7 +241,7 @@ lis2dw12_i2c_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DW12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
     if (rc) {
-        LIS2DW12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DW12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lis2dw12stats, write_errors);
         goto err;
@@ -288,7 +285,7 @@ lis2dw12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DW12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DW12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lis2dw12stats, write_errors);
         goto err;
@@ -299,7 +296,7 @@ lis2dw12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DW12_LOG(ERROR, "SPI_%u write failed addr:0x%02X:0x%02X\n",
+            LIS2DW12_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2dw12stats, write_errors);
             goto err;
@@ -396,7 +393,7 @@ lis2dw12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(LIS2DW12_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
     if (rc) {
-        LIS2DW12_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LIS2DW12_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      itf->si_addr);
         STATS_INC(g_lis2dw12stats, write_errors);
         return rc;
@@ -409,7 +406,7 @@ lis2dw12_i2c_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
                           MYNEWT_VAL(LIS2DW12_I2C_RETRIES));
 
     if (rc) {
-        LIS2DW12_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        LIS2DW12_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      itf->si_addr, reg);
         STATS_INC(g_lis2dw12stats, read_errors);
     }
@@ -443,7 +440,7 @@ lis2dw12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
 
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LIS2DW12_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LIS2DW12_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, reg);
         STATS_INC(g_lis2dw12stats, read_errors);
         goto err;
@@ -454,7 +451,7 @@ lis2dw12_spi_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DW12_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LIS2DW12_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                          itf->si_num, reg);
             STATS_INC(g_lis2dw12stats, read_errors);
             goto err;
@@ -635,7 +632,7 @@ lis2dw12_set_full_scale(struct sensor_itf *itf, uint8_t fs)
     uint8_t reg;
 
     if (fs > LIS2DW12_FS_16G) {
-        LIS2DW12_LOG(ERROR, "Invalid full scale value\n");
+        LIS2DW12_LOG_ERROR("Invalid full scale value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -699,7 +696,7 @@ lis2dw12_set_rate(struct sensor_itf *itf, uint8_t rate)
     uint8_t reg;
 
     if (rate > LIS2DW12_DATA_RATE_1600HZ) {
-        LIS2DW12_LOG(ERROR, "Invalid rate value\n");
+        LIS2DW12_LOG_ERROR("Invalid rate value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -2362,7 +2359,7 @@ init_intpin(struct lis2dw12 *lis2dw12, hal_gpio_irq_handler_t handler,
     }
 
     if (pin < 0) {
-        LIS2DW12_LOG(ERROR, "Interrupt pin not configured\n");
+        LIS2DW12_LOG_ERROR("Interrupt pin not configured\n");
         return SYS_EINVAL;
     }
 
@@ -2378,7 +2375,7 @@ init_intpin(struct lis2dw12 *lis2dw12, hal_gpio_irq_handler_t handler,
                            trig,
                            HAL_GPIO_PULL_NONE);
     if (rc != 0) {
-        LIS2DW12_LOG(ERROR, "Failed to initialise interrupt pin %d\n", pin);
+        LIS2DW12_LOG_ERROR("Failed to initialise interrupt pin %d\n", pin);
         return rc;
     }
 
@@ -3005,7 +3002,7 @@ lis2dw12_sensor_handle_interrupt(struct sensor *sensor)
          */
         rc = lis2dw12_get_int_status(itf, &int_status);
         if (rc) {
-            LIS2DW12_LOG(ERROR, "Could not read int status err=0x%02x\n", rc);
+            LIS2DW12_LOG_ERROR("Could not read int status err=0x%02x\n", rc);
             return rc;
         }
 
@@ -3017,7 +3014,7 @@ lis2dw12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2dw12_get_sixd_src(itf, &sixd_src);
     if (rc) {
-        LIS2DW12_LOG(ERROR, "Could not read sixd src err=0x%02x\n", rc);
+        LIS2DW12_LOG_ERROR("Could not read sixd src err=0x%02x\n", rc);
         goto err;
     }
 
@@ -3058,7 +3055,7 @@ lis2dw12_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lis2dw12_clear_int(itf, &int_src);
     if (rc) {
-        LIS2DW12_LOG(ERROR, "Could not read int src err=0x%02x\n", rc);
+        LIS2DW12_LOG_ERROR("Could not read int src err=0x%02x\n", rc);
         return rc;
     }
 

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -47,9 +47,6 @@ syscfg.defs:
     LIS2DW12_ITF_LOCK_TMO:
         description: 'LIS2DW12 interface lock timeout in milliseconds'
         value: 1000
-    LIS2DW12_LOG_MODULE:
-        description: 'Numeric module ID to use for LIS2DW12 log messages'
-        value: 213
     LIS2DW12_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -59,3 +56,17 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    LIS2DW12_LOG_MODULE:
+        description: 'Numeric module ID to use for LIS2DW12 log messages.'
+        value: 213
+    LIS2DW12_LOG_LVL:
+        description: 'Minimum level for the LIS2DW12 log.'
+        value: 1
+
+syscfg.logs:
+    LIS2DW12_LOG:
+        module: MYNEWT_VAL(LIS2DW12_LOG_MODULE)
+        level: MYNEWT_VAL(LIS2DW12_LOG_LVL)

--- a/hw/drivers/sensors/lps33hw/src/lps33hw.c
+++ b/hw/drivers/sensors/lps33hw/src/lps33hw.c
@@ -64,9 +64,6 @@ STATS_NAME_END(lps33hw_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lps33hw_stat_section) g_lps33hwstats;
 
-#define LPS33HW_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LPS33HW_LOG_MODULE), __VA_ARGS__)
-
 #define LPS33HW_PRESS_OUT_DIV (40.96f)
 #define LPS33HW_TEMP_OUT_DIV (100.0f)
 #define LPS33HW_PRESS_THRESH_DIV (16)
@@ -241,7 +238,7 @@ lps33hw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
                            MYNEWT_VAL(LPS33HW_I2C_RETRIES));
 
     if (rc) {
-        LPS33HW_LOG(ERROR,
+        LPS33HW_LOG_ERROR(
                     "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
                     itf->si_addr, reg, value);
         STATS_INC(g_lps33hwstats, read_errors);
@@ -272,7 +269,7 @@ lps33hw_spi_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, reg & ~LPS33HW_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33HW_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LPS33HW_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33hwstats, write_errors);
         goto err;
@@ -282,7 +279,7 @@ lps33hw_spi_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33HW_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+        LPS33HW_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33hwstats, write_errors);
         goto err;
@@ -365,7 +362,7 @@ lps33hw_spi_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     retval = hal_spi_tx_val(itf->si_num, reg | LPS33HW_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33HW_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LPS33HW_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33hwstats, read_errors);
         goto err;
@@ -376,7 +373,7 @@ lps33hw_spi_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LPS33HW_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LPS33HW_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                         itf->si_num, reg);
             STATS_INC(g_lps33hwstats, read_errors);
             goto err;
@@ -423,7 +420,7 @@ lps33hw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
                                          MYNEWT_VAL(LPS33HW_I2C_TIMEOUT_TICKS) * (size + 1),
                                          1, MYNEWT_VAL(LPS33HW_I2C_RETRIES));
     if (rc) {
-        LPS33HW_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LPS33HW_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     itf->si_addr);
         STATS_INC(g_lps33hwstats, read_errors);
         return rc;
@@ -705,7 +702,7 @@ lps33hw_disable_interrupt(struct sensor *sensor)
 static int
 lps33hw_sensor_handle_interrupt(struct sensor *sensor)
 {
-    LPS33HW_LOG(ERROR, "Unhandled interrupt\n");
+    LPS33HW_LOG_ERROR("Unhandled interrupt\n");
     return 0;
 }
 
@@ -1074,7 +1071,7 @@ lps33hw_read_interrupt_handler(void *arg)
 
     rc = lps33hw_get_pressure(itf, &press);
     if (rc) {
-        LPS33HW_LOG(ERROR, "Get pressure failed\n");
+        LPS33HW_LOG_ERROR("Get pressure failed\n");
         spd.spd_press_is_valid = 0;
     } else {
         spd.spd_press = press;

--- a/hw/drivers/sensors/lps33hw/syscfg.yml
+++ b/hw/drivers/sensors/lps33hw/syscfg.yml
@@ -35,9 +35,6 @@ syscfg.defs:
     LPS33HW_ITF_LOCK_TMO:
         description: 'LPS33HW interface lock timeout in milliseconds'
         value: 1000
-    LPS33HW_LOG_MODULE:
-        description: 'Numeric module ID to use for LPS33HW log messages'
-        value: 133
     LPS33HW_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -50,3 +47,18 @@ syscfg.defs:
     LPS33HW_ONE_SHOT_MODE:
         description: 'Enables one shot mode on the sensor'
         value: 0
+
+    ### Log settings.
+
+    LPS33HW_LOG_MODULE:
+        description: 'Numeric module ID to use for LPS33HW log messages.'
+        value: 133
+    LPS33HW_LOG_LVL:
+        description: 'Minimum level for the LPS33HW log.'
+        value: 1
+
+syscfg.logs:
+    LPS33HW_LOG:
+        module: MYNEWT_VAL(LPS33HW_LOG_MODULE)
+        level: MYNEWT_VAL(LPS33HW_LOG_LVL)
+

--- a/hw/drivers/sensors/lps33thw/src/lps33thw.c
+++ b/hw/drivers/sensors/lps33thw/src/lps33thw.c
@@ -65,9 +65,6 @@ STATS_NAME_END(lps33thw_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lps33thw_stat_section) g_lps33thwstats;
 
-#define LPS33THW_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LPS33THW_LOG_MODULE), __VA_ARGS__)
-
 #define LPS33THW_PRESS_OUT_DIV (40.96f)
 #define LPS33THW_TEMP_OUT_DIV (100.0f)
 #define LPS33THW_PRESS_THRESH_DIV (16)
@@ -234,7 +231,7 @@ lps33thw_i2c_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
                            MYNEWT_VAL(LPS33THW_I2C_RETRIES));
 
     if (rc) {
-        LPS33THW_LOG(ERROR,
+        LPS33THW_LOG_ERROR(
                     "Failed to write to 0x%02X:0x%02X with value 0x%02X\n",
                     itf->si_addr, reg, value);
         STATS_INC(g_lps33thwstats, read_errors);
@@ -265,7 +262,7 @@ lps33thw_spi_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, reg & ~LPS33THW_SPI_READ_CMD_BIT);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33THW_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LPS33THW_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33thwstats, write_errors);
         goto err;
@@ -275,7 +272,7 @@ lps33thw_spi_set_reg(struct sensor_itf *itf, uint8_t reg, uint8_t value)
     rc = hal_spi_tx_val(itf->si_num, value);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33THW_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+        LPS33THW_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33thwstats, write_errors);
         goto err;
@@ -358,7 +355,7 @@ lps33thw_spi_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
     retval = hal_spi_tx_val(itf->si_num, reg | LPS33THW_SPI_READ_CMD_BIT);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LPS33THW_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LPS33THW_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                     itf->si_num, reg);
         STATS_INC(g_lps33thwstats, read_errors);
         goto err;
@@ -369,7 +366,7 @@ lps33thw_spi_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
         retval = hal_spi_tx_val(itf->si_num, 0);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LPS33THW_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LPS33THW_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                         itf->si_num, reg);
             STATS_INC(g_lps33thwstats, read_errors);
             goto err;
@@ -422,7 +419,7 @@ lps33thw_i2c_get_regs(struct sensor_itf *itf, uint8_t reg, uint8_t size,
                                          MYNEWT_VAL(LPS33THW_I2C_TIMEOUT_TICKS) * (size + 1),
                                          1, MYNEWT_VAL(LPS33THW_I2C_RETRIES));
     if (rc) {
-        LPS33THW_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LPS33THW_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      itf->si_addr);
         STATS_INC(g_lps33thwstats, read_errors);
         return rc;
@@ -700,7 +697,7 @@ lps33thw_disable_interrupt(struct sensor *sensor)
 static int
 lps33thw_sensor_handle_interrupt(struct sensor *sensor)
 {
-    LPS33THW_LOG(ERROR, "Unhandled interrupt\n");
+    LPS33THW_LOG_ERROR("Unhandled interrupt\n");
     return 0;
 }
 
@@ -1073,7 +1070,7 @@ lps33thw_read_interrupt_handler(void *arg)
 
     rc = lps33thw_get_pressure(itf, &spd.spd_press);
     if (rc) {
-        LPS33THW_LOG(ERROR, "Get pressure failed\n");
+        LPS33THW_LOG_ERROR("Get pressure failed\n");
         spd.spd_press_is_valid = 0;
     } else {
         spd.spd_press_is_valid = 1;

--- a/hw/drivers/sensors/lps33thw/syscfg.yml
+++ b/hw/drivers/sensors/lps33thw/syscfg.yml
@@ -23,9 +23,6 @@ syscfg.defs:
     LPS33THW_ITF_LOCK_TMO:
         description: 'LPS33THW interface lock timeout in milliseconds'
         value: 1000
-    LPS33THW_LOG_MODULE:
-        description: 'Numeric module ID to use for LPS33THW log messages'
-        value: 233
     LPS33THW_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -57,3 +54,18 @@ syscfg.defs.BUS_DRIVER_PRESENT:
     LPS33THW_SHELL_NODE_NAME:
         description: 'Bus node name for the LPS33THW'
         value: '"lps33thw"'
+
+    ### Log settings.
+
+    LPS33THW_LOG_MODULE:
+        description: 'Numeric module ID to use for LPS33THW log messages.'
+        value: 233
+    LPS33THW_LOG_LVL:
+        description: 'Minimum level for the LPS33THW log.'
+        value: 1
+
+syscfg.logs:
+    LPS33THW_LOG:
+        module: MYNEWT_VAL(LPS33THW_LOG_MODULE)
+        level: MYNEWT_VAL(LPS33THW_LOG_LVL)
+

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -67,9 +67,6 @@ STATS_NAME_END(lsm303dlhc_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lsm303dlhc_stat_section) g_lsm303dlhcstats;
 
-#define LSM303DLHC_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LSM303DLHC_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lsm303dlhc_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -112,9 +109,9 @@ lsm303dlhc_write8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(LSM303DLHC_I2C_RETRIES));
     if (rc) {
-        LSM303DLHC_LOG(ERROR,
-                       "Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
-                       addr, reg, value);
+        LSM303DLHC_LOG_ERROR(
+                "Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
+                addr, reg, value);
         STATS_INC(g_lsm303dlhcstats, errors);
     }
 
@@ -156,7 +153,7 @@ lsm303dlhc_read8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(LSM303DLHC_I2C_RETRIES));
     if (rc) {
-        LSM303DLHC_LOG(ERROR, "I2C access failed at address 0x%02X\n", addr);
+        LSM303DLHC_LOG_ERROR("I2C access failed at address 0x%02X\n", addr);
         STATS_INC(g_lsm303dlhcstats, errors);
         goto err;
     }
@@ -167,8 +164,8 @@ lsm303dlhc_read8(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
                           MYNEWT_VAL(LSM303DLHC_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        LSM303DLHC_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
-                       addr, reg);
+        LSM303DLHC_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
+                             addr, reg);
         STATS_INC(g_lsm303dlhcstats, errors);
     }
 
@@ -213,7 +210,7 @@ lsm303dlhc_read48(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(LSM303DLHC_I2C_RETRIES));
     if (rc) {
-        LSM303DLHC_LOG(ERROR, "I2C access failed at address 0x%02X\n", addr);
+        LSM303DLHC_LOG_ERROR("I2C access failed at address 0x%02X\n", addr);
         STATS_INC(g_lsm303dlhcstats, errors);
         goto err;
     }
@@ -225,8 +222,8 @@ lsm303dlhc_read48(struct sensor_itf *itf, uint8_t addr, uint8_t reg,
                           MYNEWT_VAL(LSM303DLHC_I2C_RETRIES));
 
     if (rc) {
-        LSM303DLHC_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
-                       addr, reg);
+        LSM303DLHC_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
+                             addr, reg);
         STATS_INC(g_lsm303dlhcstats, errors);
     }
 

--- a/hw/drivers/sensors/lsm303dlhc/syscfg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/syscfg.yml
@@ -20,11 +20,22 @@ syscfg.defs:
     LSM303DLHC_ITF_LOCK_TMO:
         description: 'LSM303DLHC interface lock timeout in milliseconds'
         value: 1000
-    LSM303DLHC_LOG_MODULE:
-        description: 'Numeric module ID to use for LSM303DLHC log messages'
-        value: 195
     LSM303DLHC_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the LSM303DLHC sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    LSM303DLHC_LOG_MODULE:
+        description: 'Numeric module ID to use for LSM303DLHC log messages.'
+        value: 195
+    LSM303DLHC_LOG_LVL:
+        description: 'Minimum level for the LSM303DLHC log.'
+        value: 1
+
+syscfg.logs:
+    LSM303DLHC_LOG:
+        module: MYNEWT_VAL(LSM303DLHC_LOG_MODULE)
+        level: MYNEWT_VAL(LSM303DLHC_LOG_LVL)

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -126,9 +126,6 @@ STATS_NAME_END(lsm6dso_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(lsm6dso_stat_section) g_lsm6dsostats;
 
-#define LSM6DSO_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(LSM6DSO_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int lsm6dso_sensor_read(struct sensor *, sensor_type_t,
                                sensor_data_func_t, void *, uint32_t);
@@ -184,7 +181,7 @@ static int lsm6dso_i2c_readlen(struct sensor_itf *itf, uint8_t addr,
                            1,
                            MYNEWT_VAL(LSM6DSO_I2C_RETRIES));
     if (rc) {
-        LSM6DSO_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LSM6DSO_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lsm6dsostats, read_errors);
         goto err;
@@ -198,7 +195,7 @@ static int lsm6dso_i2c_readlen(struct sensor_itf *itf, uint8_t addr,
                           MYNEWT_VAL(LSM6DSO_I2C_TIMEOUT_TICKS), len,
                           MYNEWT_VAL(LSM6DSO_I2C_RETRIES));
     if (rc) {
-        LSM6DSO_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        LSM6DSO_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, addr);
         STATS_INC(g_lsm6dsostats, read_errors);
         goto err;
@@ -242,7 +239,7 @@ static int lsm6dso_spi_readlen(struct sensor_itf *itf, uint8_t addr,
     retval = hal_spi_tx_val(itf->si_num, addr);
     if (retval == 0xFFFF) {
         rc = SYS_EINVAL;
-        LSM6DSO_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LSM6DSO_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lsm6dsostats, read_errors);
         goto err;
@@ -253,7 +250,7 @@ static int lsm6dso_spi_readlen(struct sensor_itf *itf, uint8_t addr,
         retval = hal_spi_tx_val(itf->si_num, 0xFF);
         if (retval == 0xFFFF) {
             rc = SYS_EINVAL;
-            LSM6DSO_LOG(ERROR, "SPI_%u read failed addr:0x%02X\n",
+            LSM6DSO_LOG_ERROR("SPI_%u read failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lsm6dsostats, read_errors);
             goto err;
@@ -302,7 +299,7 @@ static int lsm6dso_i2c_writelen(struct sensor_itf *itf, uint8_t addr,
                            MYNEWT_VAL(LSM6DSO_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(LSM6DSO_I2C_RETRIES));
     if (rc) {
-        LSM6DSO_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        LSM6DSO_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_lsm6dsostats, write_errors);
         return rc;
@@ -334,7 +331,7 @@ static int lsm6dso_spi_writelen(struct sensor_itf *itf, uint8_t addr,
     rc = hal_spi_tx_val(itf->si_num, addr);
     if (rc == 0xFFFF) {
         rc = SYS_EINVAL;
-        LSM6DSO_LOG(ERROR, "SPI_%u register write failed addr:0x%02X\n",
+        LSM6DSO_LOG_ERROR("SPI_%u register write failed addr:0x%02X\n",
                      itf->si_num, addr);
         STATS_INC(g_lsm6dsostats, write_errors);
         goto err;
@@ -345,7 +342,7 @@ static int lsm6dso_spi_writelen(struct sensor_itf *itf, uint8_t addr,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LSM6DSO_LOG(ERROR, "SPI_%u write failed addr:0x%02X\n",
+            LSM6DSO_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lsm6dsostats, write_errors);
             goto err;
@@ -553,7 +550,7 @@ static int lsm6dso_get_gyro_sensitivity(uint8_t fs, int *val)
         *val = LSM6DSO_G_SENSITIVITY_2000DPS;
         break;
     default:
-        LSM6DSO_LOG(ERROR, "Invalid Gyro FS: %d\n", fs);
+        LSM6DSO_LOG_ERROR("Invalid Gyro FS: %d\n", fs);
 
         return SYS_EINVAL;
     }
@@ -585,7 +582,7 @@ static int lsm6dso_get_acc_sensitivity(uint8_t fs, int *val)
         *val = LSM6DSO_XL_SENSITIVITY_16G;
         break;
     default:
-        LSM6DSO_LOG(ERROR, "Invalid Acc FS: %d\n", fs);
+        LSM6DSO_LOG_ERROR("Invalid Acc FS: %d\n", fs);
 
         return SYS_EINVAL;
     }
@@ -1016,7 +1013,7 @@ int lsm6dso_clear_int_pin_cfg(struct sensor_itf *itf, uint8_t int_pin,
         reg = LSM6DSO_MD2_CFG_ADDR;
         break;
     default:
-        LSM6DSO_LOG(ERROR, "Invalid int pin %d\n", int_pin);
+        LSM6DSO_LOG_ERROR("Invalid int pin %d\n", int_pin);
 
         return SYS_EINVAL;
     }
@@ -1060,7 +1057,7 @@ int lsm6dso_set_int_pin_cfg(struct sensor_itf *itf, uint8_t int_pin,
         reg = LSM6DSO_MD2_CFG_ADDR;
         break;
     default:
-        LSM6DSO_LOG(ERROR, "Invalid int pin %d\n", int_pin);
+        LSM6DSO_LOG_ERROR("Invalid int pin %d\n", int_pin);
 
         return SYS_EINVAL;
     }
@@ -1522,7 +1519,7 @@ static int init_intpin(struct lsm6dso *lsm6dso, hal_gpio_irq_handler_t handler,
     }
 
     if (pin < 0) {
-        LSM6DSO_LOG(ERROR, "Interrupt pin not configured\n");
+        LSM6DSO_LOG_ERROR("Interrupt pin not configured\n");
 
         return SYS_EINVAL;
     }
@@ -1536,7 +1533,7 @@ static int init_intpin(struct lsm6dso *lsm6dso, hal_gpio_irq_handler_t handler,
     rc = hal_gpio_irq_init(pin, handler, arg,
                            trig, HAL_GPIO_PULL_NONE);
     if (rc) {
-        LSM6DSO_LOG(ERROR, "Failed to initialise interrupt pin %d\n", pin);
+        LSM6DSO_LOG_ERROR("Failed to initialise interrupt pin %d\n", pin);
 
         return rc;
     }
@@ -1665,7 +1662,7 @@ int disable_fifo_interrupt(struct sensor *sensor, sensor_type_t type,
         reg = LSM6DSO_INT2_CTRL;
         break;
     default:
-        LSM6DSO_LOG(ERROR, "Invalid int pin %d\n", int_pin);
+        LSM6DSO_LOG_ERROR("Invalid int pin %d\n", int_pin);
         rc = SYS_EINVAL;
         goto err;
     }
@@ -1733,7 +1730,7 @@ int enable_fifo_interrupt(struct sensor *sensor, sensor_type_t type,
         break;
     default:
         rc = SYS_EINVAL;
-        LSM6DSO_LOG(ERROR, "Invalid int pin %d\n", int_pin);
+        LSM6DSO_LOG_ERROR("Invalid int pin %d\n", int_pin);
         goto err;
     }
 
@@ -2099,7 +2096,7 @@ int lsm6dso_get_ag_data(struct sensor_itf *itf, sensor_type_t type, void *data,
             sensitivity = cfg->acc_sensitivity;
            break;
         default:
-            LSM6DSO_LOG(ERROR, "Invalid sensor type: %d\n", type);
+            LSM6DSO_LOG_ERROR("Invalid sensor type: %d\n", type);
             return SYS_EINVAL;
     }
 
@@ -2157,7 +2154,7 @@ int lsm6dso_read_fifo(struct sensor_itf *itf,
         sensitivity = cfg->acc_sensitivity;
         break;
     default:
-         LSM6DSO_LOG(ERROR, "Invalid sensor tag: %d\n", payload[0]);
+         LSM6DSO_LOG_ERROR("Invalid sensor tag: %d\n", payload[0]);
          return SYS_ENODEV;
     }
 
@@ -2568,7 +2565,7 @@ static int lsm6dso_sensor_handle_interrupt(struct sensor *sensor)
 
     rc = lsm6dso_clear_int(itf, int_src);
     if (rc) {
-        LSM6DSO_LOG(ERROR, "Could not read int src err=0x%02x\n", rc);
+        LSM6DSO_LOG_ERROR("Could not read int src err=0x%02x\n", rc);
         return rc;
     }
 

--- a/hw/drivers/sensors/lsm6dso/syscfg.yml
+++ b/hw/drivers/sensors/lsm6dso/syscfg.yml
@@ -21,9 +21,6 @@ syscfg.defs:
     LSM6DSO_ITF_LOCK_TMO:
         description: 'LSM6DSO interface lock timeout in milliseconds'
         value: 1000
-    LSM6DSO_LOG_MODULE:
-        description: 'Numeric module ID to use for LSM6DSO log messages'
-        value: 110
     LSM6DSO_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -66,3 +63,18 @@ syscfg.defs:
     LSM6DSO_INT2_PIN_DEVICE:
         description: 'Interrupt pin number 1 or 2 on accelerometer device'
         value: 2
+
+    ### Log settings.
+
+    LSM6DSO_LOG_MODULE:
+        description: 'Numeric module ID to use for LSM6DSO log messages.'
+        value: 110
+    LSM6DSO_LOG_LVL:
+        description: 'Minimum level for the LSM6DSO log.'
+        value: 1
+
+syscfg.logs:
+    LSM6DSO_LOG:
+        module: MYNEWT_VAL(LSM6DSO_LOG_MODULE)
+        level: MYNEWT_VAL(LSM6DSO_LOG_LVL)
+

--- a/hw/drivers/sensors/mpu6050/src/mpu6050.c
+++ b/hw/drivers/sensors/mpu6050/src/mpu6050.c
@@ -48,9 +48,6 @@ STATS_NAME_END(mpu6050_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(mpu6050_stat_section) g_mpu6050stats;
 
-#define MPU6050_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(MPU6050_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int mpu6050_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -95,7 +92,7 @@ mpu6050_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
                            MYNEWT_VAL(MPU6050_I2C_RETRIES));
 
     if (rc) {
-        MPU6050_LOG(ERROR,
+        MPU6050_LOG_ERROR(
                     "Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
                     itf->si_addr, reg, value);
         STATS_INC(g_mpu6050stats, read_errors);
@@ -139,7 +136,7 @@ mpu6050_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
                            MYNEWT_VAL(MPU6050_I2C_RETRIES));
     if (rc) {
-        MPU6050_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        MPU6050_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     itf->si_addr);
         STATS_INC(g_mpu6050stats, write_errors);
         return rc;
@@ -151,7 +148,7 @@ mpu6050_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(MPU6050_I2C_RETRIES));
 
     if (rc) {
-        MPU6050_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        MPU6050_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     itf->si_addr, reg);
         STATS_INC(g_mpu6050stats, read_errors);
     }
@@ -194,7 +191,7 @@ mpu6050_read48(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 0,
                            MYNEWT_VAL(MPU6050_I2C_RETRIES));
     if (rc) {
-        MPU6050_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        MPU6050_LOG_ERROR("I2C access failed at address 0x%02X\n",
                     itf->si_addr);
         STATS_INC(g_mpu6050stats, write_errors);
         return rc;
@@ -207,7 +204,7 @@ mpu6050_read48(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer)
                           MYNEWT_VAL(MPU6050_I2C_RETRIES));
 
     if (rc) {
-        MPU6050_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        MPU6050_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                     itf->si_addr, reg);
         STATS_INC(g_mpu6050stats, read_errors);
     }

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -65,9 +65,6 @@ STATS_NAME_END(ms5837_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(ms5837_stat_section) g_ms5837stats;
 
-#define MS5837_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(MS5837_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int ms5837_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -348,7 +345,7 @@ ms5837_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
-        MS5837_LOG(ERROR, "I2C write command write failed at address 0x%02X\n",
+        MS5837_LOG_ERROR("I2C write command write failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_ms5837stats, write_errors);
     }
@@ -397,7 +394,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
-        MS5837_LOG(ERROR, "I2C read command write failed at address 0x%02X\n",
+        MS5837_LOG_ERROR("I2C read command write failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_ms5837stats, write_errors);
         goto err;
@@ -409,7 +406,7 @@ ms5837_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_read(itf->si_num, &data_struct, MYNEWT_VAL(MS5837_I2C_TIMEOUT_TICKS), 1,
                           MYNEWT_VAL(MS5837_I2C_RETRIES));
     if (rc) {
-        MS5837_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        MS5837_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    data_struct.address, addr);
         STATS_INC(g_ms5837stats, read_errors);
         goto err;
@@ -455,7 +452,7 @@ ms5837_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
     rc = ms5837_crc_check(payload, (payload[MS5837_IDX_CRC] & 0xF000) >> 12);
     if (rc) {
         rc = SYS_EINVAL;
-        MS5837_LOG(ERROR, "Failure in CRC, 0x%02X\n",
+        MS5837_LOG_ERROR("Failure in CRC, 0x%02X\n",
                    payload[MS5837_IDX_CRC] &  0xF000 >> 12);
         STATS_INC(g_ms5837stats, eeprom_crc_errors);
         goto err;

--- a/hw/drivers/sensors/ms5837/syscfg.yml
+++ b/hw/drivers/sensors/ms5837/syscfg.yml
@@ -20,9 +20,6 @@ syscfg.defs:
     MS5837_ITF_LOCK_TMO:
         description: 'MS5837 interface lock timeout in milliseconds'
         value: 1000
-    MS5837_LOG_MODULE:
-        description: 'Numeric module ID to use for MS5837 log messages'
-        value: 140
     MS5837_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -32,3 +29,17 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    MS5837_LOG_MODULE:
+        description: 'Numeric module ID to use for MS5837 log messages.'
+        value: 140
+    MS5837_LOG_LVL:
+        description: 'Minimum level for the MS5837 log.'
+        value: 1
+
+syscfg.logs:
+    MS5837_LOG:
+        module: MYNEWT_VAL(MS5837_LOG_MODULE)
+        level: MYNEWT_VAL(MS5837_LOG_LVL)

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -68,9 +68,6 @@ STATS_NAME_END(ms5840_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(ms5840_stat_section) g_ms5840stats;
 
-#define MS5840_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(MS5840_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int ms5840_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -349,7 +346,7 @@ ms5840_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write(itf->si_num, &data_struct, MYNEWT_VAL(MS5840_I2C_TIMEOUT_TICKS), 1,
                            MYNEWT_VAL(MS5840_I2C_RETRIES));
     if (rc) {
-        MS5840_LOG(ERROR, "I2C write command write failed at address 0x%02X\n",
+        MS5840_LOG_ERROR("I2C write command write failed at address 0x%02X\n",
                    data_struct.address);
         STATS_INC(g_ms5840stats, write_errors);
     }
@@ -401,7 +398,7 @@ ms5840_readlen(struct sensor_itf *itf, uint8_t addr, uint8_t *buffer,
     rc = i2cn_master_write_read_transact(itf->si_num, &wdata, &rdata, MYNEWT_VAL(MS5840_I2C_TIMEOUT_TICKS) * 2,
                                          1, MYNEWT_VAL(MS5840_I2C_RETRIES));
     if (rc) {
-        MS5840_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        MS5840_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                    itf->si_addr, addr);
         STATS_INC(g_ms5840stats, read_errors);
     }
@@ -442,7 +439,7 @@ ms5840_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
     rc = ms5840_crc_check(payload, (payload[MS5840_IDX_CRC] & 0xF000) >> 12);
     if (rc) {
         rc = SYS_EINVAL;
-        MS5840_LOG(ERROR, "Failure in CRC, 0x%02X\n",
+        MS5840_LOG_ERROR("Failure in CRC, 0x%02X\n",
                    payload[MS5840_IDX_CRC] &  0xF000 >> 12);
         STATS_INC(g_ms5840stats, eeprom_crc_errors);
         goto err;

--- a/hw/drivers/sensors/ms5840/syscfg.yml
+++ b/hw/drivers/sensors/ms5840/syscfg.yml
@@ -20,9 +20,6 @@ syscfg.defs:
     MS5840_ITF_LOCK_TMO:
         description: 'MS5840 interface lock timeout in milliseconds'
         value: 1000
-    MS5840_LOG_MODULE:
-        description: 'Numeric module ID to use for MS5840 log messages'
-        value: 170
     MS5840_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
@@ -32,3 +29,18 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+
+    ### Log settings.
+
+    MS5840_LOG_MODULE:
+        description: 'Numeric module ID to use for MS5840 log messages.'
+        value: 170
+    MS5840_LOG_LVL:
+        description: 'Minimum level for the MS5840 log.'
+        value: 1
+
+syscfg.logs:
+    MS5840_LOG:
+        module: MYNEWT_VAL(MS5840_LOG_MODULE)
+        level: MYNEWT_VAL(MS5840_LOG_LVL)
+

--- a/hw/drivers/sensors/tcs34725/src/tcs34725.c
+++ b/hw/drivers/sensors/tcs34725/src/tcs34725.c
@@ -59,9 +59,6 @@ STATS_NAME_END(tcs34725_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(tcs34725_stat_section) g_tcs34725stats;
 
-#define TCS34725_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(TCS34725_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int tcs34725_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -102,7 +99,7 @@ tcs34725_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TCS34725_I2C_RETRIES));
     if (rc) {
-        TCS34725_LOG(ERROR,
+        TCS34725_LOG_ERROR(
                      "Failed to write to 0x%02X:0x%02X with value 0x%02lX\n",
                      data_struct.address, reg, value);
         STATS_INC(g_tcs34725stats, errors);
@@ -144,7 +141,7 @@ tcs34725_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TCS34725_I2C_RETRIES));
     if (rc) {
-        TCS34725_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        TCS34725_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_tcs34725stats, errors);
         goto err;
@@ -156,7 +153,7 @@ tcs34725_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(TCS34725_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        TCS34725_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        TCS34725_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, reg);
         STATS_INC(g_tcs34725stats, errors);
     }
@@ -200,7 +197,7 @@ tcs34725_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t l
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TCS34725_I2C_RETRIES));
     if (rc) {
-        TCS34725_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        TCS34725_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_tcs34725stats, errors);
         goto err;
@@ -213,7 +210,7 @@ tcs34725_readlen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t l
                           MYNEWT_VAL(TCS34725_I2C_RETRIES));
 
     if (rc) {
-        TCS34725_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        TCS34725_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, reg);
         STATS_INC(g_tcs34725stats, errors);
         goto err;
@@ -265,7 +262,7 @@ tcs34725_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t 
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TCS34725_I2C_RETRIES));
     if (rc) {
-        TCS34725_LOG(ERROR, "I2C access failed at address 0x%02X\n",
+        TCS34725_LOG_ERROR("I2C access failed at address 0x%02X\n",
                      data_struct.address);
         STATS_INC(g_tcs34725stats, errors);
         goto err;
@@ -277,7 +274,7 @@ tcs34725_writelen(struct sensor_itf *itf, uint8_t reg, uint8_t *buffer, uint8_t 
                            len, MYNEWT_VAL(TCS34725_I2C_RETRIES));
 
     if (rc) {
-        TCS34725_LOG(ERROR, "Failed to read from 0x%02X:0x%02X\n",
+        TCS34725_LOG_ERROR("Failed to read from 0x%02X:0x%02X\n",
                      data_struct.address, reg);
         STATS_INC(g_tcs34725stats, errors);
         goto err;
@@ -499,7 +496,7 @@ tcs34725_set_gain(struct sensor_itf *itf, uint8_t gain)
     int rc;
 
     if (gain > TCS34725_GAIN_60X) {
-        TCS34725_LOG(ERROR, "Invalid gain value\n");
+        TCS34725_LOG_ERROR("Invalid gain value\n");
         rc = SYS_EINVAL;
         goto err;
     }

--- a/hw/drivers/sensors/tcs34725/syscfg.yml
+++ b/hw/drivers/sensors/tcs34725/syscfg.yml
@@ -33,11 +33,22 @@ syscfg.defs:
     TCS34725_ITF_LOCK_TMO:
         description: 'TCS34725 interface lock timeout in milliseconds'
         value: 1000
-    TCS34725_LOG_MODULE:
-        description: 'Numeric module ID to use for TCS34725 log messages'
-        value: 254
     TCS34725_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the TCS34725 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    TCS34725_LOG_MODULE:
+        description: 'Numeric module ID to use for TCS34725 log messages.'
+        value: 254
+    TCS34725_LOG_LVL:
+        description: 'Minimum level for the TCS34725 log.'
+        value: 1
+
+syscfg.logs:
+    TCS34725_LOG:
+        module: MYNEWT_VAL(TCS34725_LOG_MODULE)
+        level: MYNEWT_VAL(TCS34725_LOG_LVL)

--- a/hw/drivers/sensors/tsl2561/src/tsl2561.c
+++ b/hw/drivers/sensors/tsl2561/src/tsl2561.c
@@ -65,9 +65,6 @@ STATS_NAME_END(tsl2561_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(tsl2561_stat_section) g_tsl2561stats;
 
-#define TSL2561_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(TSL2561_LOG_MODULE), __VA_ARGS__)
-
 /* Exports for the sensor API */
 static int tsl2561_sensor_read(struct sensor *, sensor_type_t,
         sensor_data_func_t, void *, uint32_t);
@@ -99,7 +96,7 @@ tsl2561_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2561_I2C_RETRIES));
     if (rc) {
-        TSL2561_LOG(ERROR,
+        TSL2561_LOG_ERROR(
                     "Failed to write 0x%02X:0x%02X with value 0x%02lX\n",
                     data_struct.address, reg, value);
         STATS_INC(g_tsl2561stats, errors);
@@ -130,7 +127,7 @@ tsl2561_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2561_I2C_RETRIES));
     if (rc) {
-        TSL2561_LOG(ERROR,
+        TSL2561_LOG_ERROR(
                     "Failed to write @0x%02X with value 0x%02X 0x%02X\n",
                     reg, payload[0], payload[1]);
     }
@@ -162,7 +159,7 @@ tsl2561_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2561_I2C_RETRIES));
     if (rc) {
-        TSL2561_LOG(ERROR, "Failed to address sensor\n");
+        TSL2561_LOG_ERROR("Failed to address sensor\n");
         goto err;
     }
 
@@ -172,7 +169,7 @@ tsl2561_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(TSL2561_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        TSL2561_LOG(ERROR, "Failed to read @0x%02X\n", reg);
+        TSL2561_LOG_ERROR("Failed to read @0x%02X\n", reg);
     }
 
 err:
@@ -202,7 +199,7 @@ tsl2561_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2561_I2C_RETRIES));
     if (rc) {
-        TSL2561_LOG(ERROR, "Failed to address sensor\n");
+        TSL2561_LOG_ERROR("Failed to address sensor\n");
         goto err;
     }
 
@@ -213,7 +210,7 @@ tsl2561_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
                           MYNEWT_VAL(TSL2561_I2C_RETRIES));
     *value = (uint16_t)payload[0] | ((uint16_t)payload[1] << 8);
     if (rc) {
-        TSL2561_LOG(ERROR, "Failed to read @0x%02X\n", reg);
+        TSL2561_LOG_ERROR("Failed to read @0x%02X\n", reg);
         goto err;
     }
 
@@ -348,7 +345,7 @@ tsl2561_set_gain(struct sensor_itf *itf, uint8_t gain)
     uint8_t int_time;
 
     if ((gain != TSL2561_LIGHT_GAIN_1X) && (gain != TSL2561_LIGHT_GAIN_16X)) {
-        TSL2561_LOG(ERROR, "Invalid gain value\n");
+        TSL2561_LOG_ERROR("Invalid gain value\n");
         rc = SYS_EINVAL;
         goto err;
     }
@@ -509,7 +506,7 @@ tsl2561_enable_interrupt(struct sensor_itf *itf, uint8_t enable)
     uint8_t persist_val;
 
     if (enable > 1) {
-        TSL2561_LOG(ERROR,
+        TSL2561_LOG_ERROR(
                     "Invalid value 0x%02X in tsl2561_enable_interrupt\n",
                     enable);
         rc = SYS_EINVAL;

--- a/hw/drivers/sensors/tsl2561/syscfg.yml
+++ b/hw/drivers/sensors/tsl2561/syscfg.yml
@@ -36,11 +36,23 @@ syscfg.defs:
     TSL2561_ITF_LOCK_TMO:
         description: 'TSL2561 interface lock timeout in milliseconds'
         value: 1000
-    TSL2561_LOG_MODULE:
-        description: 'Numeric module ID to use for TSL2561 log messages'
-        value: 107
     TSL2561_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the TSL2561 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    TSL2561_LOG_MODULE:
+        description: 'Numeric module ID to use for TSL2561 log messages.'
+        value: 107
+    TSL2561_LOG_LVL:
+        description: 'Minimum level for the TSL2561 log.'
+        value: 1
+
+syscfg.logs:
+    TSL2561_LOG:
+        module: MYNEWT_VAL(TSL2561_LOG_MODULE)
+        level: MYNEWT_VAL(TSL2561_LOG_LVL)
+

--- a/hw/drivers/sensors/tsl2591/src/tsl2591.c
+++ b/hw/drivers/sensors/tsl2591/src/tsl2591.c
@@ -54,9 +54,6 @@ STATS_NAME_END(tsl2591_stat_section)
 /* Global variable used to hold stats data */
 STATS_SECT_DECL(tsl2591_stat_section) g_tsl2591stats;
 
-#define TSL2591_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(TSL2591_LOG_MODULE), __VA_ARGS__)
-
 #if MYNEWT_VAL(TSL2591_ITIME_DELAY)
 static int g_tsl2591_itime_delay_ms;
 #endif
@@ -92,7 +89,7 @@ tsl2591_write8(struct sensor_itf *itf, uint8_t reg, uint32_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2591_I2C_RETRIES));
     if (rc) {
-        TSL2591_LOG(ERROR,
+        TSL2591_LOG_ERROR(
                     "Failed to write 0x%02X:0x%02X with value 0x%02lX\n",
                     data_struct.address, reg, value);
         STATS_INC(g_tsl2591stats, errors);
@@ -123,7 +120,7 @@ tsl2591_write16(struct sensor_itf *itf, uint8_t reg, uint16_t value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2591_I2C_RETRIES));
     if (rc) {
-        TSL2591_LOG(ERROR,
+        TSL2591_LOG_ERROR(
                     "Failed to write @0x%02X with value 0x%02X 0x%02X\n",
                     reg, payload[0], payload[1]);
         STATS_INC(g_tsl2591stats, errors);
@@ -156,7 +153,7 @@ tsl2591_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2591_I2C_RETRIES));
     if (rc) {
-        TSL2591_LOG(ERROR, "Failed to address sensor\n");
+        TSL2591_LOG_ERROR("Failed to address sensor\n");
         STATS_INC(g_tsl2591stats, errors);
         goto err;
     }
@@ -167,7 +164,7 @@ tsl2591_read8(struct sensor_itf *itf, uint8_t reg, uint8_t *value)
                           MYNEWT_VAL(TSL2591_I2C_RETRIES));
     *value = payload;
     if (rc) {
-        TSL2591_LOG(ERROR, "Failed to read @0x%02X\n", reg);
+        TSL2591_LOG_ERROR("Failed to read @0x%02X\n", reg);
         STATS_INC(g_tsl2591stats, errors);
     }
 
@@ -198,7 +195,7 @@ tsl2591_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
     rc = i2cn_master_write(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10, 1,
                            MYNEWT_VAL(TSL2591_I2C_RETRIES));
     if (rc) {
-        TSL2591_LOG(ERROR, "Failed to address sensor\n");
+        TSL2591_LOG_ERROR("Failed to address sensor\n");
         STATS_INC(g_tsl2591stats, errors);
         goto err;
     }
@@ -210,7 +207,7 @@ tsl2591_read16(struct sensor_itf *itf, uint8_t reg, uint16_t *value)
                           MYNEWT_VAL(TSL2591_I2C_RETRIES));
     *value = (uint16_t)payload[0] | ((uint16_t)payload[1] << 8);
     if (rc) {
-        TSL2591_LOG(ERROR, "Failed to read @0x%02X\n", reg);
+        TSL2591_LOG_ERROR("Failed to read @0x%02X\n", reg);
         STATS_INC(g_tsl2591stats, errors);
         goto err;
     }
@@ -314,7 +311,7 @@ tsl2591_set_gain(struct sensor_itf *itf, uint8_t gain)
         && (gain != TSL2591_LIGHT_GAIN_MED)
         && (gain != TSL2591_LIGHT_GAIN_HIGH)
         && (gain != TSL2591_LIGHT_GAIN_MAX)) {
-            TSL2591_LOG(ERROR, "Invalid gain value\n");
+            TSL2591_LOG_ERROR("Invalid gain value\n");
             rc = SYS_EINVAL;
             goto err;
     }

--- a/hw/drivers/sensors/tsl2591/syscfg.yml
+++ b/hw/drivers/sensors/tsl2591/syscfg.yml
@@ -39,11 +39,23 @@ syscfg.defs:
     TSL2591_ITIME_DELAY:
         description: 'Enable an internal read delay based on integration time'
         value: 0
-    TSL2591_LOG_MODULE:
-        description: 'Numeric module ID to use for TSL2591 log messages'
-        value: 108
     TSL2591_I2C_RETRIES:
         description: >
             Number of retries to use for failed I2C communication.  A retry is
             used when the TSL2591 sends an unexpected NACK.
         value: 2
+
+    ### Log settings.
+
+    TSL2591_LOG_MODULE:
+        description: 'Numeric module ID to use for TSL2591 log messages.'
+        value: 108
+    TSL2591_LOG_LVL:
+        description: 'Minimum level for the TSL2591 log.'
+        value: 1
+
+syscfg.logs:
+    TSL2591_LOG:
+        module: MYNEWT_VAL(TSL2591_LOG_MODULE)
+        level: MYNEWT_VAL(TSL2591_LOG_LVL)
+

--- a/hw/mcu/dialog/da1469x/hosttest/src/testcases/da1469x_snc_test_cases.c
+++ b/hw/mcu/dialog/da1469x/hosttest/src/testcases/da1469x_snc_test_cases.c
@@ -165,7 +165,7 @@ TEST_CASE(da1469x_snc_test_case_1)
 {
     int rc;
 
-    MODLOG_INFO(LOG_MODULE_TEST, "DA1469x snc test 1");
+    TEST_LOG_INFO("DA1469x snc test 1");
 
     /*
      * Initialize to some non-zero number. The test program should increment
@@ -192,14 +192,14 @@ TEST_CASE(da1469x_snc_test_case_1)
     /* Configure the SNC (base address and divider) */
     rc = da1469x_snc_config(&snc_program, SNC_CLK_DIV_1);
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc config failed");
+        TEST_LOG_INFO("snc config failed");
         TEST_ASSERT_FATAL(0);
     }
 
     /* Initialize the SNC */
     rc = da1469x_snc_sw_init();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc init failed");
+        TEST_LOG_INFO("snc init failed");
         TEST_ASSERT_FATAL(0);
     }
 
@@ -209,7 +209,7 @@ TEST_CASE(da1469x_snc_test_case_1)
      */
     da1469x_snc_irq_config(SNC_IRQ_MASK_NONE, NULL, NULL);
     if ((SNC->SNC_CTRL_REG & SNC_SNC_CTRL_REG_SNC_IRQ_CONFIG_Msk) != 0) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc irq config failed");
+        TEST_LOG_INFO("snc irq config failed");
         TEST_ASSERT_FATAL(0);
     }
 
@@ -219,44 +219,44 @@ TEST_CASE(da1469x_snc_test_case_1)
     /* Wait 1 second for program to finish. */
     os_time_delay(OS_TICKS_PER_SEC);
     if (!da1469x_snc_program_is_done()) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed (not done)");
+        TEST_LOG_INFO("snc test failed (not done)");
         da1469x_snc_sw_stop();
         TEST_ASSERT_FATAL(0);
     }
 
     /* Check test var 1 and test var 2 have correct values */
     if (da1469x_test_var1 != 11) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: inc by 1");
+        TEST_LOG_INFO("snc test failed: inc by 1");
         TEST_ASSERT_FATAL(0);
     }
     if (da1469x_test_var2 != 14) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: inc by 4");
+        TEST_LOG_INFO("snc test failed: inc by 4");
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 3 should be 0 */
     if (da1469x_test_var3 != 0) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: RDCBI and/or COBR_EQ");
+        TEST_LOG_INFO("snc test failed: RDCBI and/or COBR_EQ");
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 4 should be 10 */
     if (da1469x_test_var4 != 11) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: COBR loop. tv4=%lu",
+        TEST_LOG_INFO("snc test failed: COBR loop. tv4=%lu",
                     da1469x_test_var4);
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 5 should be 20 */
     if (da1469x_test_var5 != 21) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: COBR loop 2. tv5=%lu",
+        TEST_LOG_INFO("snc test failed: COBR loop 2. tv5=%lu",
                     da1469x_test_var5);
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 8 should be equal to test var 7 */
     if (da1469x_test_var8 != da1469x_test_var7) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: WADAD direct. tv7=%lx"
+        TEST_LOG_INFO("snc test failed: WADAD direct. tv7=%lx"
                                      " tv8=%lx",
                     da1469x_test_var7, da1469x_test_var8);
         TEST_ASSERT_FATAL(0);
@@ -264,7 +264,7 @@ TEST_CASE(da1469x_snc_test_case_1)
 
     /* Test var 11 should have value in test var 7 */
     if (da1469x_test_var11 != da1469x_test_var7) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: WADAD indirect. tv7=%lx"
+        TEST_LOG_INFO("snc test failed: WADAD indirect. tv7=%lx"
                                      " tv11=%lx",
                     da1469x_test_var7, da1469x_test_var11);
         TEST_ASSERT_FATAL(0);
@@ -273,7 +273,7 @@ TEST_CASE(da1469x_snc_test_case_1)
 
     /* Test var 12 should be those two values xor'd (should equal 0xFFA77F) */
     if (da1469x_test_var12 != (SNC_TEST_XOR_MASK ^ 0xC3A78F)) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: TOBRE. tv12=%lx",
+        TEST_LOG_INFO("snc test failed: TOBRE. tv12=%lx",
                     da1469x_test_var12);
         TEST_ASSERT_FATAL(0);
     }
@@ -281,14 +281,14 @@ TEST_CASE(da1469x_snc_test_case_1)
     /* SNC control registers should have both IRQ bits set */
     if ((SNC->SNC_CTRL_REG & SNC_SNC_CTRL_REG_SNC_IRQ_CONFIG_Msk) !=
         SNC_SNC_CTRL_REG_SNC_IRQ_CONFIG_Msk) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: TOBRE register %lx",
+        TEST_LOG_INFO("snc test failed: TOBRE register %lx",
                     SNC->SNC_CTRL_REG);
         TEST_ASSERT_FATAL(0);
     }
 
     /* Contents of test var 13 should equal address of test var 12 */
     if (da1469x_test_var13 != (uint32_t)&da1469x_test_var12) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: WADVA direct. &tv12=%lx"
+        TEST_LOG_INFO("snc test failed: WADVA direct. &tv12=%lx"
                                      " tv13=%lx",
                     &da1469x_test_var12,
                     da1469x_test_var13);
@@ -297,21 +297,21 @@ TEST_CASE(da1469x_snc_test_case_1)
 
     /* Test var 15 should be equal 0x33333333 */
     if (da1469x_test_var15 != 0x33333333) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: WADVA indirect tv15=%lx",
+        TEST_LOG_INFO("snc test failed: WADVA indirect tv15=%lx",
                     da1469x_test_var15);
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 0 should be equal to 1 */
     if (da1469x_test_var0 != 1) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: RDCGR RAMRAM tv0=%lx",
+        TEST_LOG_INFO("snc test failed: RDCGR RAMRAM tv0=%lx",
                     da1469x_test_var0);
         TEST_ASSERT_FATAL(0);
     }
 
     /* Test var 16 should be equal to 0 */
     if (da1469x_test_var16 != 0) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: RDCBI reg tv16=%lx",
+        TEST_LOG_INFO("snc test failed: RDCBI reg tv16=%lx",
                     da1469x_test_var16);
         TEST_ASSERT_FATAL(0);
     }
@@ -319,7 +319,7 @@ TEST_CASE(da1469x_snc_test_case_1)
     /* Check for hard fault or bus status errors */
     if (SNC->SNC_STATUS_REG & (SNC_SNC_STATUS_REG_HARD_FAULT_STATUS_Msk |
                                SNC_SNC_STATUS_REG_BUS_ERROR_STATUS_Msk)) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed: ERR snc status %lx",
+        TEST_LOG_INFO("snc test failed: ERR snc status %lx",
                     SNC->SNC_STATUS_REG);
         TEST_ASSERT_FATAL(0);
     }
@@ -327,11 +327,11 @@ TEST_CASE(da1469x_snc_test_case_1)
     da1469x_snc_sw_stop();
     rc = da1469x_snc_sw_deinit();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc s/w deinit failed");
+        TEST_LOG_INFO("snc s/w deinit failed");
         TEST_ASSERT_FATAL(0);
     }
 
-    MODLOG_INFO(LOG_MODULE_TEST, "snc test 1 success");
+    TEST_LOG_INFO("snc test 1 success");
 }
 
 /*====================== TEST CASE 2 =====================================
@@ -359,19 +359,19 @@ TEST_CASE(da1469x_snc_test_case_2)
 {
     int rc;
 
-    MODLOG_INFO(LOG_MODULE_TEST, "DA1469x snc test 2");
+    TEST_LOG_INFO("DA1469x snc test 2");
 
     /* Configure the SNC (base address and divider) */
     rc = da1469x_snc_config(&snc_prog_test_case2, SNC_CLK_DIV_1);
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc config failed");
+        TEST_LOG_INFO("snc config failed");
         TEST_ASSERT_FATAL(0);
     }
 
     /* Initialize the SNC */
     rc = da1469x_snc_sw_init();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc init failed");
+        TEST_LOG_INFO("snc init failed");
         TEST_ASSERT_FATAL(0);
     }
 
@@ -387,25 +387,25 @@ TEST_CASE(da1469x_snc_test_case_2)
     /* This program should finish very quickly */
     os_time_delay(OS_TICKS_PER_SEC / 10);
     if (!da1469x_snc_program_is_done()) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test 2 failed (not done)");
+        TEST_LOG_INFO("snc test 2 failed (not done)");
         da1469x_snc_sw_stop();
         TEST_ASSERT_FATAL(0);
     }
 
     /* Check that the counter got incremented */
     if (g_snc_tc2_cntr != 1) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed tc2=%u", g_snc_tc2_cntr);
+        TEST_LOG_INFO("snc test failed tc2=%u", g_snc_tc2_cntr);
         TEST_ASSERT_FATAL(0);
     }
 
     da1469x_snc_sw_stop();
     rc = da1469x_snc_sw_deinit();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc s/w deinit failed");
+        TEST_LOG_INFO("snc s/w deinit failed");
         TEST_ASSERT_FATAL(0);
     }
 
-    MODLOG_INFO(LOG_MODULE_TEST, "snc test 2 success");
+    TEST_LOG_INFO("snc test 2 success");
 }
 
 /*
@@ -416,19 +416,19 @@ TEST_CASE(da1469x_snc_test_case_3)
 {
     int rc;
 
-    MODLOG_INFO(LOG_MODULE_TEST, "DA1469x snc test 3");
+    TEST_LOG_INFO("DA1469x snc test 3");
 
     /* Configure the SNC (base address and divider) */
     rc = da1469x_snc_config(&snc_prog_test_case2, SNC_CLK_DIV_1);
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc config failed");
+        TEST_LOG_INFO("snc config failed");
         TEST_ASSERT_FATAL(0);
     }
 
     /* Initialize the SNC */
     rc = da1469x_snc_sw_init();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc init failed");
+        TEST_LOG_INFO("snc init failed");
         TEST_ASSERT_FATAL(0);
     }
 
@@ -444,24 +444,24 @@ TEST_CASE(da1469x_snc_test_case_3)
     /* This program should finish very quickly */
     os_time_delay(OS_TICKS_PER_SEC / 10);
     if (!da1469x_snc_program_is_done()) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test 3 failed (not done)");
+        TEST_LOG_INFO("snc test 3 failed (not done)");
         da1469x_snc_sw_stop();
         TEST_ASSERT_FATAL(0);
     }
 
     /* Check that the counter got incremented */
     if (g_snc_tc2_cntr != 1) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc test failed tc2=%u", g_snc_tc2_cntr);
+        TEST_LOG_INFO("snc test failed tc2=%u", g_snc_tc2_cntr);
         TEST_ASSERT_FATAL(0);
     }
 
     da1469x_snc_sw_stop();
     rc = da1469x_snc_sw_deinit();
     if (rc) {
-        MODLOG_INFO(LOG_MODULE_TEST, "snc s/w deinit failed");
+        TEST_LOG_INFO("snc s/w deinit failed");
         TEST_ASSERT_FATAL(0);
     }
 
-    MODLOG_INFO(LOG_MODULE_TEST, "snc test 3 success");
+    TEST_LOG_INFO("snc test 3 success");
 }
 #endif

--- a/net/oic/include/oic/messaging/coap/coap.h
+++ b/net/oic/include/oic/messaging/coap/coap.h
@@ -246,7 +246,7 @@ extern STATS_SECT_DECL(coap_stats) coap_stats;
 /* option format serialization (TX) */
 #define COAP_SERIALIZE_INT_OPT(pkt, m, number, field, text)             \
     if (IS_OPTION(pkt, number)) {                                       \
-        OC_LOG(DEBUG, " %s [%u]\n", text, (unsigned int)pkt->field);    \
+        OC_LOG_DEBUG(" %s [%u]\n", text, (unsigned int)pkt->field);    \
         if (coap_append_int_opt(m, number, current_number, pkt->field)) { \
             goto err_mem;                                               \
         }                                                               \
@@ -254,7 +254,7 @@ extern STATS_SECT_DECL(coap_stats) coap_stats;
     }
 #define COAP_SERIALIZE_BYTE_OPT(pkt, m, number, field, text)            \
     if (IS_OPTION(pkt, number)) {                                       \
-        OC_LOG(DEBUG, " %s %u ", text, pkt->field##_len);               \
+        OC_LOG_DEBUG(" %s %u ", text, pkt->field##_len);               \
         OC_LOG_HEX(LOG_LEVEL_DEBUG, pkt->field, pkt->field##_len);      \
         if (coap_append_array_opt(m, number, current_number, pkt->field, \
                                   pkt->field##_len, '\0')) {            \
@@ -264,7 +264,7 @@ extern STATS_SECT_DECL(coap_stats) coap_stats;
     }
 #define COAP_SERIALIZE_STRING_OPT(pkt, m, number, field, splitter, text) \
     if (IS_OPTION(pkt, number)) {                                       \
-        OC_LOG(DEBUG, " %s", text);                                     \
+        OC_LOG_DEBUG(" %s", text);                                     \
         OC_LOG_STR(LOG_LEVEL_DEBUG, pkt->field, pkt->field##_len);      \
         if (coap_append_array_opt(m, number, current_number,            \
                                   (uint8_t *)pkt->field,                \
@@ -275,7 +275,7 @@ extern STATS_SECT_DECL(coap_stats) coap_stats;
     }
 #define COAP_SERIALIZE_BLOCK_OPT(pkt, m, number, field, text)           \
     if (IS_OPTION(pkt, number)) {                                       \
-        OC_LOG(DEBUG, " %s [%lu%s (%u B/blk)]\n", text,                 \
+        OC_LOG_DEBUG(" %s [%lu%s (%u B/blk)]\n", text,                 \
                      (unsigned long)pkt->field##_num,                   \
                      pkt->field##_more ? "+" : "", pkt->field##_size);  \
         uint32_t block = pkt->field##_num << 4;                         \
@@ -283,7 +283,7 @@ extern STATS_SECT_DECL(coap_stats) coap_stats;
             block |= 0x8;                                               \
         }                                                               \
         block |= 0xF & coap_log_2(pkt->field##_size / 16);              \
-        OC_LOG(DEBUG, " %s encoded: 0x%lX\n", text,                     \
+        OC_LOG_DEBUG(" %s encoded: 0x%lX\n", text,                     \
                      (unsigned long)block);                             \
         if (coap_append_int_opt(m, number, current_number, block)) {    \
             goto err_mem;                                               \

--- a/net/oic/include/oic/oc_log.h
+++ b/net/oic/include/oic/oc_log.h
@@ -30,8 +30,6 @@ extern "C" {
  */
 #if MYNEWT_VAL(OC_LOGGING)
 
-#define OC_LOG(lvl_, ...) MODLOG_ ## lvl_(LOG_MODULE_IOTIVITY, __VA_ARGS__)
-
 struct oc_endpoint;
 void oc_log_endpoint(uint8_t lvl, struct oc_endpoint *);
 void oc_log_bytes(uint8_t lvl, void *addr, int len, int print_char);
@@ -76,7 +74,6 @@ void oc_log_bytes_mbuf(uint8_t lvl, struct os_mbuf *, int off, int len,
 
 #else
 
-#define OC_LOG(lvl_, ...)
 #define OC_LOG_ENDPOINT(...)
 #define OC_LOG_STR(...)
 #define OC_LOG_STR_MBUF(...)

--- a/net/oic/src/api/oc_buffer.c
+++ b/net/oic/src/api/oc_buffer.c
@@ -75,7 +75,7 @@ oc_buffer_tx(struct os_event *ev)
 
     while ((m = os_mqueue_get(&oc_outq)) != NULL) {
         STAILQ_NEXT(OS_MBUF_PKTHDR(m), omp_next) = NULL;
-        OC_LOG(DEBUG, "oc_buffer_tx: ");
+        OC_LOG_DEBUG("oc_buffer_tx: ");
         OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, OC_MBUF_ENDPOINT(m));
 #ifdef OC_CLIENT
         if (OC_MBUF_ENDPOINT(m)->ep.oe_flags & OC_ENDPOINT_MULTICAST) {
@@ -85,7 +85,7 @@ oc_buffer_tx(struct os_event *ev)
 #ifdef OC_SECURITY
             /* XXX convert this */
             if (OC_MBUF_ENDPOINT(m)->flags & SECURED) {
-                OC_LOG(DEBUG, "oc_buffer_tx: DTLS\n");
+                OC_LOG_DEBUG("oc_buffer_tx: DTLS\n");
 
                 if (!oc_sec_dtls_connected(oe)) {
                     oc_process_post(&oc_dtls_handler,
@@ -114,7 +114,7 @@ oc_buffer_rx(struct os_event *ev)
 #endif
 
     while ((m = os_mqueue_get(&oc_inq)) != NULL) {
-        OC_LOG(DEBUG, "oc_buffer_rx: ");
+        OC_LOG_DEBUG("oc_buffer_rx: ");
         OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, OC_MBUF_ENDPOINT(m));
 
 #ifdef OC_SECURITY
@@ -123,7 +123,7 @@ oc_buffer_rx(struct os_event *ev)
          */
         b = m->om_data[0];
         if (b > 19 && b < 64) {
-            OC_LOG(DEBUG, "oc_buffer_rx: encrypted request\n");
+            OC_LOG_DEBUG("oc_buffer_rx: encrypted request\n");
             oc_process_post(&oc_dtls_handler, oc_events[UDP_TO_DTLS_EVENT], m);
         } else {
             coap_receive(m);

--- a/net/oic/src/api/oc_main.c
+++ b/net/oic/src/api/oc_main.c
@@ -78,7 +78,7 @@ oc_main_init(oc_handler_t *handler)
         goto err;
     }
 
-    OC_LOG(INFO, "oic: Initialized\n");
+    OC_LOG_INFO("oic: Initialized\n");
 
 #ifdef OC_CLIENT
     if (handler->requests_entry) {
@@ -104,7 +104,7 @@ void
 oc_main_shutdown(void)
 {
     if (initialized == false) {
-        OC_LOG(ERROR, "oic: not initialized\n");
+        OC_LOG_ERROR("oic: not initialized\n");
         return;
     }
 

--- a/net/oic/src/api/oc_ri.c
+++ b/net/oic/src/api/oc_ri.c
@@ -555,22 +555,22 @@ oc_ri_invoke_coap_entity_handler(struct coap_packet_rx *request,
 
   if (bad_request) {
     if (!m) {
-        OC_LOG(ERROR, "ocri: No bufs\n");
+        OC_LOG_ERROR("ocri: No bufs\n");
         response_buffer.code = oc_status_code(OC_STATUS_SERVICE_UNAVAILABLE);
     } else {
-        OC_LOG(ERROR, "ocri: Bad request\n");
+        OC_LOG_ERROR("ocri: Bad request\n");
         /* Return a 4.00 response */
         response_buffer.code = oc_status_code(OC_STATUS_BAD_REQUEST);
     }
     success = false;
   } else if (!cur_resource) {
-    OC_LOG(ERROR, "ocri: Could not find resource\n");
+    OC_LOG_ERROR("ocri: Could not find resource\n");
     /* Return a 4.04 response if the requested resource was not found */
     response_buffer.response_length = 0;
     response_buffer.code = oc_status_code(OC_STATUS_NOT_FOUND);
     success = false;
   } else if (!method_impl) {
-    OC_LOG(ERROR, "ocri: Could not find method\n");
+    OC_LOG_ERROR("ocri: Could not find method\n");
     /* Return a 4.05 response if the resource does not implement the
      * request method.
      */
@@ -578,7 +578,7 @@ oc_ri_invoke_coap_entity_handler(struct coap_packet_rx *request,
     response_buffer.code = oc_status_code(OC_STATUS_METHOD_NOT_ALLOWED);
     success = false;
   } else if (!authorized) {
-    OC_LOG(ERROR, "ocri: Subject not authorized\n");
+    OC_LOG_ERROR("ocri: Subject not authorized\n");
     /* If the requestor (subject) does not have access granted via an
      * access control entry in the ACL, then it is not authorized to
      * access the resource. A 4.03 response is sent.

--- a/net/oic/src/messaging/coap/coap.c
+++ b/net/oic/src/messaging/coap/coap.c
@@ -159,7 +159,7 @@ coap_append_int_opt(struct os_mbuf *m, unsigned int number,
     if (0xFFFFFFFF & value) {
         ++i;
     }
-    OC_LOG(DEBUG, "OPTION %u (delta %u, len %zu)\n",
+    OC_LOG_DEBUG("OPTION %u (delta %u, len %zu)\n",
                  number, number - current_number, i);
 
     rc = coap_append_opt_hdr(m, number - current_number, i);
@@ -194,7 +194,7 @@ coap_append_array_opt(struct os_mbuf *m,
     uint8_t *part_end = NULL;
     size_t blk;
 
-    OC_LOG(DEBUG, "ARRAY type %u, len %zu\n", number, length);
+    OC_LOG_DEBUG("ARRAY type %u, len %zu\n", number, length);
 
     if (split_char != '\0') {
         for (j = 0; j <= length + 1; ++j) {
@@ -211,7 +211,7 @@ coap_append_array_opt(struct os_mbuf *m,
                     return rc;
                 }
 
-                OC_LOG(DEBUG, "OPTION type %u, delta %u, len %zu\n", number,
+                OC_LOG_DEBUG("OPTION type %u, delta %u, len %zu\n", number,
                     number - current_number, (int)blk);
 
                 ++j; /* skip the splitter */
@@ -229,7 +229,7 @@ coap_append_array_opt(struct os_mbuf *m,
             return rc;
         }
 
-        OC_LOG(DEBUG, "OPTION type %u, delta %u, len %zu\n", number,
+        OC_LOG_DEBUG("OPTION type %u, delta %u, len %zu\n", number,
             number - current_number, length);
     }
 
@@ -353,7 +353,7 @@ coap_serialize_message(coap_packet_t *pkt, struct os_mbuf *m)
     /* Initialize */
     pkt->version = 1;
 
-    OC_LOG(DEBUG, "coap_tx: 0x%x\n", (unsigned)m);
+    OC_LOG_DEBUG("coap_tx: 0x%x\n", (unsigned)m);
 
     tcp_hdr = oc_endpoint_use_tcp(OC_MBUF_ENDPOINT(m));
 
@@ -480,7 +480,7 @@ coap_serialize_message(coap_packet_t *pkt, struct os_mbuf *m)
         }
         os_mbuf_concat(m, pkt->payload_m);
     }
-    OC_LOG(DEBUG, "coap_tx: serialized %u B (header len %u, payload len %u)\n",
+    OC_LOG_DEBUG("coap_tx: serialized %u B (header len %u, payload len %u)\n",
         OS_MBUF_PKTLEN(m), OS_MBUF_PKTLEN(m) - pkt->payload_len,
         pkt->payload_len);
 
@@ -496,7 +496,7 @@ err_mem:
 void
 coap_send_message(struct os_mbuf *m, int dup)
 {
-    OC_LOG(INFO, "coap_send_message(): (%u) %s\n", OS_MBUF_PKTLEN(m),
+    OC_LOG_INFO("coap_send_message(): (%u) %s\n", OS_MBUF_PKTLEN(m),
       dup ? "dup" : "");
 
     STATS_INC(coap_stats, oframe);
@@ -668,7 +668,7 @@ err_short:
     }
     cur_opt += pkt->token_len;
 
-    OC_LOG(DEBUG, "Token (len %u) ", pkt->token_len);
+    OC_LOG_DEBUG("Token (len %u) ", pkt->token_len);
     OC_LOG_HEX(LOG_LEVEL_DEBUG, pkt->token, pkt->token_len);
 
     /* parse options */
@@ -726,7 +726,7 @@ err_short:
         opt_num += opt_delta;
 
         if (opt_num < COAP_OPTION_SIZE1) {
-            OC_LOG(DEBUG, "OPTION %u (delta %u, len %zu): ",
+            OC_LOG_DEBUG("OPTION %u (delta %u, len %zu): ",
                          opt_num, opt_delta, opt_len);
             SET_OPTION(pkt, opt_num);
         }
@@ -734,11 +734,11 @@ err_short:
         switch (opt_num) {
         case COAP_OPTION_CONTENT_FORMAT:
             pkt->content_format = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Content-Format [%u]\n", pkt->content_format);
+            OC_LOG_DEBUG("Content-Format [%u]\n", pkt->content_format);
             break;
         case COAP_OPTION_MAX_AGE:
             pkt->max_age = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Max-Age [%lu]\n", (unsigned long)pkt->max_age);
+            OC_LOG_DEBUG("Max-Age [%lu]\n", (unsigned long)pkt->max_age);
             break;
 #if 0
         case COAP_OPTION_ETAG:
@@ -746,13 +746,13 @@ err_short:
             if (os_mbuf_copydata(m, cur_opt, pkt->etag_len, pkt->etag)) {
                 goto err_short;
             }
-            OC_LOG(DEBUG, "ETag %u ");
+            OC_LOG_DEBUG("ETag %u ");
             OC_LOG_HEX(LOG_LEVEL_DEBUG, pkt->etag, pkt->etag_len);
             break;
 #endif
         case COAP_OPTION_ACCEPT:
             pkt->accept = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Accept [%u]\n", pkt->accept);
+            OC_LOG_DEBUG("Accept [%u]\n", pkt->accept);
             break;
 #if 0
         case COAP_OPTION_IF_MATCH:
@@ -762,12 +762,12 @@ err_short:
                                  pkt->if_match)) {
                 goto err_short;
             }
-            OC_LOG(DEBUG, "If-Match %u ");
+            OC_LOG_DEBUG("If-Match %u ");
             OC_LOG_HEX(LOG_LEVEL_DEBUG, pkt->if_match, pkt->if_match_len);
             break;
         case COAP_OPTION_IF_NONE_MATCH:
             pkt->if_none_match = 1;
-            OC_LOG(DEBUG, "If-None-Match\n");
+            OC_LOG_DEBUG("If-None-Match\n");
             break;
 
         case COAP_OPTION_PROXY_URI:
@@ -775,7 +775,7 @@ err_short:
             pkt->proxy_uri_off = cur_opt;
             pkt->proxy_uri_len = opt_len;
 #endif
-            OC_LOG(DEBUG, "Proxy-Uri NOT IMPLEMENTED\n");
+            OC_LOG_DEBUG("Proxy-Uri NOT IMPLEMENTED\n");
             coap_error_message =
               "This is a constrained server (MyNewt)";
             STATS_INC(coap_stats, ierr);
@@ -786,7 +786,7 @@ err_short:
             pkt->proxy_scheme_off = cur_opt;
             pkt->proxy_scheme_len = opt_len;
 #endif
-            OC_LOG(DEBUG, "Proxy-Scheme NOT IMPLEMENTED\n");
+            OC_LOG_DEBUG("Proxy-Scheme NOT IMPLEMENTED\n");
             coap_error_message =
               "This is a constrained server (MyNewt)";
             STATS_INC(coap_stats, ierr);
@@ -796,20 +796,20 @@ err_short:
         case COAP_OPTION_URI_HOST:
             pkt->uri_host_off = cur_opt;
             pkt->uri_host_len = opt_len;
-            OC_LOG(DEBUG, "Uri-Host ");
+            OC_LOG_DEBUG("Uri-Host ");
             OC_LOG_STR_MBUF(LOG_LEVEL_DEBUG, m, pkt->uri_host_off,
                             pkt->uri_host_len);
             break;
         case COAP_OPTION_URI_PORT:
             pkt->uri_port = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Uri-Port [%u]\n", pkt->uri_port);
+            OC_LOG_DEBUG("Uri-Port [%u]\n", pkt->uri_port);
             break;
 #endif
         case COAP_OPTION_URI_PATH:
             /* coap_merge_multi_option() operates in-place on the buf */
             coap_merge_multi_option(m, &pkt->uri_path_off, &pkt->uri_path_len,
                                     cur_opt, opt_len, '/');
-            OC_LOG(DEBUG, "Uri-Path ");
+            OC_LOG_DEBUG("Uri-Path ");
             OC_LOG_STR_MBUF(LOG_LEVEL_DEBUG, m, pkt->uri_path_off,
                             pkt->uri_path_len);
             break;
@@ -817,7 +817,7 @@ err_short:
             /* coap_merge_multi_option() operates in-place on the mbuf */
             coap_merge_multi_option(m, &pkt->uri_query_off, &pkt->uri_query_len,
                                     cur_opt, opt_len, '&');
-            OC_LOG(DEBUG, "Uri-Query ");
+            OC_LOG_DEBUG("Uri-Query ");
             OC_LOG_STR_MBUF(LOG_LEVEL_DEBUG, m, pkt->uri_query_off,
                             pkt->uri_query_len);
             break;
@@ -826,7 +826,7 @@ err_short:
             /* coap_merge_multi_option() operates in-place on the mbuf */
             coap_merge_multi_option(m, &pkt->loc_path_off, &pkt->loc_path_len,
                                     cur_opt, opt_len, '/');
-            OC_LOG(DEBUG, "Location-Path ");
+            OC_LOG_DEBUG("Location-Path ");
             OC_LOG_STR_MBUF(LOG_LEVEL_DEBUG, m, pkt->loc_path,
                             pkt->loc_path_len);
             break;
@@ -834,14 +834,14 @@ err_short:
             /* coap_merge_multi_option() operates in-place on the mbuf */
             coap_merge_multi_option(m, &pkt->loc_query_off, &pkt->loc_query_len,
                                     cur_opt, opt_len, '&');
-            OC_LOG(DEBUG, "Location-Query ");
+            OC_LOG_DEBUG("Location-Query ");
             OC_LOG_STR_MBUF(LOG_LEVEL_DEBUG, m, pkt->loc_query_off,
                             pkt->loc_query_len);
             break;
 #endif
         case COAP_OPTION_OBSERVE:
             pkt->observe = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Observe [%lu]\n", (unsigned long)pkt->observe);
+            OC_LOG_DEBUG("Observe [%lu]\n", (unsigned long)pkt->observe);
             break;
         case COAP_OPTION_BLOCK2:
             pkt->block2_num = coap_parse_int_option(m, cur_opt, opt_len);
@@ -850,7 +850,7 @@ err_short:
             pkt->block2_offset =
               (pkt->block2_num & ~0x0000000F) << (pkt->block2_num & 0x07);
             pkt->block2_num >>= 4;
-            OC_LOG(DEBUG, "Block2 [%lu%s (%u B/blk)]\n",
+            OC_LOG_DEBUG("Block2 [%lu%s (%u B/blk)]\n",
                          (unsigned long)pkt->block2_num,
                          pkt->block2_more ? "+" : "", pkt->block2_size);
             break;
@@ -861,20 +861,20 @@ err_short:
             pkt->block1_offset =
               (pkt->block1_num & ~0x0000000F) << (pkt->block1_num & 0x07);
             pkt->block1_num >>= 4;
-            OC_LOG(DEBUG, "Block1 [%lu%s (%u B/blk)]\n",
+            OC_LOG_DEBUG("Block1 [%lu%s (%u B/blk)]\n",
                          (unsigned long)pkt->block1_num,
                          pkt->block1_more ? "+" : "", pkt->block1_size);
             break;
         case COAP_OPTION_SIZE2:
             pkt->size2 = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Size2 [%lu]\n", (unsigned long)pkt->size2);
+            OC_LOG_DEBUG("Size2 [%lu]\n", (unsigned long)pkt->size2);
             break;
         case COAP_OPTION_SIZE1:
             pkt->size1 = coap_parse_int_option(m, cur_opt, opt_len);
-            OC_LOG(DEBUG, "Size1 [%lu]\n", (unsigned long)pkt->size1);
+            OC_LOG_DEBUG("Size1 [%lu]\n", (unsigned long)pkt->size1);
             break;
         default:
-            OC_LOG(DEBUG, "unknown (%u)\n", opt_num);
+            OC_LOG_DEBUG("unknown (%u)\n", opt_num);
             /* check if critical (odd) */
             if (opt_num & 1) {
                 coap_error_message = "Unsupported critical option";

--- a/net/oic/src/messaging/coap/engine.c
+++ b/net/oic/src/messaging/coap/engine.c
@@ -64,7 +64,7 @@ coap_receive(struct os_mbuf **mp)
 
     erbium_status_code = NO_ERROR;
 
-    OC_LOG(INFO, "CoAP: received datalen=%u\n", OS_MBUF_PKTLEN(*mp));
+    OC_LOG_INFO("CoAP: received datalen=%u\n", OS_MBUF_PKTLEN(*mp));
 
     memcpy(&endpoint, OC_MBUF_ENDPOINT(*mp),
            oc_endpoint_size(OC_MBUF_ENDPOINT(*mp)));
@@ -75,21 +75,21 @@ coap_receive(struct os_mbuf **mp)
 
     m = *mp;
 /*TODO duplicates suppression, if required by application */
-    OC_LOG(DEBUG, "  Parsed: CoAP version: %u, token: 0x%02X%02X, mid: %u\n",
+    OC_LOG_DEBUG("  Parsed: CoAP version: %u, token: 0x%02X%02X, mid: %u\n",
                  message->version, message->token[0], message->token[1],
                  message->mid);
     switch (message->type) {
     case COAP_TYPE_CON:
-        OC_LOG(DEBUG, "  type: CON\n");
+        OC_LOG_DEBUG("  type: CON\n");
         break;
     case COAP_TYPE_NON:
-        OC_LOG(DEBUG, "  type: NON\n");
+        OC_LOG_DEBUG("  type: NON\n");
         break;
     case COAP_TYPE_ACK:
-        OC_LOG(DEBUG, "  type: ACK\n");
+        OC_LOG_DEBUG("  type: ACK\n");
         break;
     case COAP_TYPE_RST:
-        OC_LOG(DEBUG, "  type: RST\n");
+        OC_LOG_DEBUG("  type: RST\n");
         break;
     default:
         break;
@@ -99,20 +99,20 @@ coap_receive(struct os_mbuf **mp)
         /* handle requests */
         switch (message->code) {
         case COAP_GET:
-            OC_LOG(DEBUG, "  method: GET\n");
+            OC_LOG_DEBUG("  method: GET\n");
             break;
         case COAP_PUT:
-            OC_LOG(DEBUG, "  method: PUT\n");
+            OC_LOG_DEBUG("  method: PUT\n");
             break;
         case COAP_POST:
-            OC_LOG(DEBUG, "  method: POST\n");
+            OC_LOG_DEBUG("  method: POST\n");
             break;
         case COAP_DELETE:
-            OC_LOG(DEBUG, "  method: DELETE\n");
+            OC_LOG_DEBUG("  method: DELETE\n");
             break;
         }
 
-        OC_LOG(DEBUG, "  Payload: %d bytes\n", message->payload_len);
+        OC_LOG_DEBUG("  Payload: %d bytes\n", message->payload_len);
 
         /* use transaction buffer for response to confirmable request */
         transaction = coap_new_transaction(message->mid, OC_MBUF_ENDPOINT(m));
@@ -144,7 +144,7 @@ coap_receive(struct os_mbuf **mp)
         }
         if (coap_get_header_block2(message, &block_num, NULL,
                                    &block_size, &block_offset)) {
-            OC_LOG(DEBUG, " Blockwise: block request %u (%u/%u) @ %u bytes\n",
+            OC_LOG_DEBUG(" Blockwise: block request %u (%u/%u) @ %u bytes\n",
                          (unsigned int) block_num, block_size,
                          COAP_MAX_BLOCK_SIZE, (unsigned int) block_offset);
             block_size = MIN(block_size, COAP_MAX_BLOCK_SIZE);
@@ -163,7 +163,7 @@ coap_receive(struct os_mbuf **mp)
                 if (IS_OPTION(message, COAP_OPTION_BLOCK1) &&
                   response->code < BAD_REQUEST_4_00 &&
                   !IS_OPTION(response, COAP_OPTION_BLOCK1)) {
-                    OC_LOG(ERROR, " Block1 option NOT IMPLEMENTED\n");
+                    OC_LOG_ERROR(" Block1 option NOT IMPLEMENTED\n");
 
                     erbium_status_code = NOT_IMPLEMENTED_5_01;
                     coap_error_message = "NoBlock1Support";
@@ -176,7 +176,7 @@ coap_receive(struct os_mbuf **mp)
                      * unaware of blockwise transfer
                      */
                     if (new_offset == block_offset) {
-                        OC_LOG(DEBUG, " Block: unaware resource %u/%u\n",
+                        OC_LOG_DEBUG(" Block: unaware resource %u/%u\n",
                                      response->payload_len, block_size);
                         if (block_offset >= response->payload_len) {
                             response->code = BAD_OPTION_4_02;
@@ -199,7 +199,7 @@ coap_receive(struct os_mbuf **mp)
 
                         /* resource provides chunk-wise data */
                     } else {
-                        OC_LOG(DEBUG, " Block: aware resource, off %d\n",
+                        OC_LOG_DEBUG(" Block: aware resource, off %d\n",
                                      (int) new_offset);
                         coap_set_header_block2(response, block_num,
                                                new_offset != -1 ||
@@ -213,7 +213,7 @@ coap_receive(struct os_mbuf **mp)
 
                     /* Resource requested Block2 transfer */
                 } else if (new_offset != 0) {
-                    OC_LOG(DEBUG, " block: no block option, using block sz %u\n",
+                    OC_LOG_DEBUG(" block: no block option, using block sz %u\n",
                                  COAP_MAX_BLOCK_SIZE);
 
                     coap_set_header_block2(response, 0, new_offset != -1,
@@ -268,7 +268,7 @@ out:
             coap_send_transaction(transaction);
         }
     } else if (erbium_status_code == CLEAR_TRANSACTION) {
-        OC_LOG(DEBUG, " Clearing transaction for manual response\n");
+        OC_LOG_DEBUG(" Clearing transaction for manual response\n");
         /* used in server for separate response */
         coap_clear_transaction(transaction);
     }

--- a/net/oic/src/messaging/coap/observe.c
+++ b/net/oic/src/messaging/coap/observe.c
@@ -81,7 +81,7 @@ add_observer(oc_resource_t *resource, oc_endpoint_t *endpoint,
         o->obs_counter = observe_counter;
         o->resource = resource;
         resource->num_observers++;
-        OC_LOG(DEBUG, "Adding observer (%u/%u) for /%s [0x%02X%02X]\n",
+        OC_LOG_DEBUG("Adding observer (%u/%u) for /%s [0x%02X%02X]\n",
           coap_observer_pool.mp_num_blocks - coap_observer_pool.mp_num_free,
           coap_observer_pool.mp_num_blocks, o->url, o->token[0], o->token[1]);
         SLIST_INSERT_HEAD(&oc_observers, o, next);
@@ -95,7 +95,7 @@ add_observer(oc_resource_t *resource, oc_endpoint_t *endpoint,
 void
 coap_remove_observer(coap_observer_t *o)
 {
-    OC_LOG(DEBUG, "Removing observer for /%s [0x%02X%02X]\n",
+    OC_LOG_DEBUG("Removing observer for /%s [0x%02X%02X]\n",
                  o->url, o->token[0], o->token[1]);
     SLIST_REMOVE(&oc_observers, o, coap_observer, next);
     os_memblock_put(&coap_observer_pool, o);
@@ -224,7 +224,7 @@ coap_notify_observers(oc_resource_t *resource,
 
     if (resource) {
         if (!resource->num_observers) {
-            OC_LOG(DEBUG, "coap_notify_observers: no observers left\n");
+            OC_LOG_DEBUG("coap_notify_observers: no observers left\n");
             return 0;
         }
         response_buffer.block_offset = NULL;
@@ -245,7 +245,7 @@ coap_notify_observers(oc_resource_t *resource,
         response.separate_response = 0;
         num_observers = obs->resource->num_observers;
         if (!response_buf && resource) {
-            OC_LOG(DEBUG, "coap_notify_observers: GET request to resource\n");
+            OC_LOG_DEBUG("coap_notify_observers: GET request to resource\n");
             /* performing GET on the resource */
             m = os_msys_get_pkthdr(0, 0);
             if (!m) {
@@ -257,7 +257,7 @@ coap_notify_observers(oc_resource_t *resource,
             resource->get_handler(&request, resource->default_interface);
             response_buf = &response_buffer;
             if (response_buf->code == OC_IGNORE) {
-                OC_LOG(ERROR, "coap_notify_observers: Resource ignored req\n");
+                OC_LOG_ERROR("coap_notify_observers: Resource ignored req\n");
                 os_mbuf_free_chain(m);
                 return num_observers;
             }
@@ -276,7 +276,7 @@ coap_notify_observers(oc_resource_t *resource,
             req->mid = 0;
             memcpy(req->token, obs->token, obs->token_len);
             req->token_len = obs->token_len;
-            OC_LOG(DEBUG, "Resource is SLOW; creating separate response\n");
+            OC_LOG_DEBUG("Resource is SLOW; creating separate response\n");
             if (coap_separate_accept(req, response.separate_response,
                                      &obs->endpoint, 0) == 1) {
                 response.separate_response->active = 1;
@@ -287,7 +287,7 @@ coap_notify_observers(oc_resource_t *resource,
                 (transaction = coap_new_transaction(coap_get_mid(),
                                                     &obs->endpoint))) {
 
-                OC_LOG(DEBUG, "coap_notify_observers: notifying observer\n");
+                OC_LOG_DEBUG("coap_notify_observers: notifying observer\n");
 
                 /* update last MID for RST matching */
                 obs->last_mid = transaction->mid;
@@ -299,7 +299,7 @@ coap_notify_observers(oc_resource_t *resource,
                 notification->mid = transaction->mid;
                 if (!oc_endpoint_has_conn(&obs->endpoint) &&
                     obs->obs_counter % COAP_OBSERVE_REFRESH_INTERVAL == 0) {
-                    OC_LOG(DEBUG, "coap_observe_notify: forcing CON "
+                    OC_LOG_DEBUG("coap_observe_notify: forcing CON "
                                  "notification to check for client liveness\n");
                     notification->type = COAP_TYPE_CON;
                 }

--- a/net/oic/src/messaging/coap/separate.c
+++ b/net/oic/src/messaging/coap/separate.c
@@ -93,7 +93,7 @@ coap_separate_accept(struct coap_packet_rx *coap_req,
     erbium_status_code = CLEAR_TRANSACTION;
     /* send separate ACK for CON */
     if (coap_req->type == COAP_TYPE_CON) {
-        OC_LOG(DEBUG, "Sending ACK for separate response\n");
+        OC_LOG_DEBUG("Sending ACK for separate response\n");
         coap_packet_t ack[1];
         /* ACK with empty code (0) */
         coap_init_message(ack, COAP_TYPE_ACK, 0, coap_req->mid);

--- a/net/oic/src/messaging/coap/transactions.c
+++ b/net/oic/src/messaging/coap/transactions.c
@@ -100,7 +100,7 @@ coap_send_transaction(coap_transaction_t *t)
 
     confirmable = (COAP_TYPE_CON == t->type) ? true : false;
 
-    OC_LOG(DEBUG, "Sending transaction %u\n", t->mid);
+    OC_LOG_DEBUG("Sending transaction %u\n", t->mid);
 
     if (confirmable) {
         if (t->retrans_counter < COAP_MAX_RETRANSMIT) {
@@ -110,11 +110,11 @@ coap_send_transaction(coap_transaction_t *t)
                   COAP_RESPONSE_TIMEOUT_TICKS +
                   (oc_random_rand() %
                     (oc_clock_time_t)COAP_RESPONSE_TIMEOUT_BACKOFF_MASK);
-                OC_LOG(DEBUG, "Initial interval " OC_CLK_FMT "\n",
+                OC_LOG_DEBUG("Initial interval " OC_CLK_FMT "\n",
                              t->retrans_tmo);
             } else {
                 t->retrans_tmo <<= 1; /* double */
-                OC_LOG(DEBUG, "Doubled " OC_CLK_FMT "\n", t->retrans_tmo);
+                OC_LOG_DEBUG("Doubled " OC_CLK_FMT "\n", t->retrans_tmo);
             }
 
             os_callout_reset(&t->retrans_timer, t->retrans_tmo);
@@ -124,7 +124,7 @@ coap_send_transaction(coap_transaction_t *t)
             t = NULL;
         } else {
             /* timed out */
-            OC_LOG(DEBUG, "Timeout\n");
+            OC_LOG_DEBUG("Timeout\n");
 
 #ifdef OC_SERVER
             /* handle observers */
@@ -191,7 +191,7 @@ coap_transaction_retrans(struct os_event *ev)
 {
     coap_transaction_t *t = ev->ev_arg;
     ++(t->retrans_counter);
-    OC_LOG(DEBUG, "Retransmitting %u (%u)\n", t->mid, t->retrans_counter);
+    OC_LOG_DEBUG("Retransmitting %u (%u)\n", t->mid, t->retrans_counter);
     coap_send_transaction(t);
 }
 

--- a/net/oic/src/port/mynewt/adaptor.c
+++ b/net/oic/src/port/mynewt/adaptor.c
@@ -97,7 +97,7 @@ oc_send_buffer(struct os_mbuf *m)
     if (ot) {
         ot->ot_tx_ucast(m);
     } else {
-        OC_LOG(ERROR, "Unknown transport option %u\n", oe->ep.oe_type);
+        OC_LOG_ERROR("Unknown transport option %u\n", oe->ep.oe_type);
         os_mbuf_free_chain(m);
     }
 }
@@ -150,7 +150,7 @@ oc_get_trans_security(const struct oc_endpoint *oe)
             return 0;
         }
     }
-    OC_LOG(ERROR, "Unknown transport option %u\n", oe->ep.oe_type);
+    OC_LOG_ERROR("Unknown transport option %u\n", oe->ep.oe_type);
     return 0;
 }
 

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -237,7 +237,7 @@ oc_ble_reass(struct os_mbuf *om1, uint16_t conn_handle, uint8_t srv_idx)
     STATS_INC(oc_ble_stats, iseg);
     STATS_INCN(oc_ble_stats, ibytes, pkt1->omp_len);
 
-    OC_LOG(DEBUG, "oc_gatt rx seg %u-%x-%u\n", conn_handle,
+    OC_LOG_DEBUG("oc_gatt rx seg %u-%x-%u\n", conn_handle,
                  (unsigned)pkt1, pkt1->omp_len);
 
     STAILQ_FOREACH(pkt2, &oc_ble_reass_q, omp_next) {
@@ -268,7 +268,7 @@ oc_ble_reass(struct os_mbuf *om1, uint16_t conn_handle, uint8_t srv_idx)
         if (OS_MBUF_USRHDR_LEN(om1) < sizeof(struct oc_endpoint_ble)) {
             om2 = os_msys_get_pkthdr(0, sizeof(struct oc_endpoint_ble));
             if (!om2) {
-                OC_LOG(ERROR, "oc_gatt_rx: Could not allocate mbuf\n");
+                OC_LOG_ERROR("oc_gatt_rx: Could not allocate mbuf\n");
                 STATS_INC(oc_ble_stats, ierr);
                 return -1;
             }

--- a/net/oic/src/port/mynewt/conns.c
+++ b/net/oic/src/port/mynewt/conns.c
@@ -73,7 +73,7 @@ oc_conn_ev_queue(struct oc_conn_ev *oce)
 void
 oc_conn_created(struct oc_conn_ev *oce)
 {
-    OC_LOG(DEBUG, "oc_conn_created: ");
+    OC_LOG_DEBUG("oc_conn_created: ");
     OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, &oce->oce_oe);
     oce->oce_type = OC_ENDPOINT_CONN_EV_OPEN;
     oc_conn_ev_queue(oce);
@@ -82,7 +82,7 @@ oc_conn_created(struct oc_conn_ev *oce)
 void
 oc_conn_removed(struct oc_conn_ev *oce)
 {
-    OC_LOG(DEBUG, "oc_conn_removed: ");
+    OC_LOG_DEBUG("oc_conn_removed: ");
     OC_LOG_ENDPOINT(LOG_LEVEL_DEBUG, &oce->oce_oe);
     oce->oce_type = OC_ENDPOINT_CONN_EV_CLOSE;
     oc_conn_ev_queue(oce);

--- a/net/oic/src/port/mynewt/ip4_adaptor.c
+++ b/net/oic/src/port/mynewt/ip4_adaptor.c
@@ -163,7 +163,7 @@ oc_send_buffer_ip4_int(struct os_mbuf *m, int is_mcast)
             }
             rc = mn_sendto(oc_ucast4, n, (struct mn_sockaddr *)&to);
             if (rc != 0) {
-                OC_LOG(ERROR, "Failed to send buffer %u on %x\n",
+                OC_LOG_ERROR("Failed to send buffer %u on %x\n",
                              OS_MBUF_PKTHDR(m)->omp_len, if2_idx);
                 STATS_INC(oc_ip4_stats, oerr);
                 os_mbuf_free_chain(n);
@@ -178,7 +178,7 @@ oc_send_buffer_ip4_int(struct os_mbuf *m, int is_mcast)
             } else {
                 rc = mn_sendto(oc_ucast4, m, (struct mn_sockaddr *) &to);
                 if (rc != 0) {
-                    OC_LOG(ERROR, "Failed sending buffer %u on itf %x\n",
+                    OC_LOG_ERROR("Failed sending buffer %u on itf %x\n",
                                  OS_MBUF_PKTHDR(m)->omp_len, if2_idx);
                     STATS_INC(oc_ip4_stats, oerr);
                     os_mbuf_free_chain(m);
@@ -190,7 +190,7 @@ oc_send_buffer_ip4_int(struct os_mbuf *m, int is_mcast)
     } else {
         rc = mn_sendto(oc_ucast4, m, (struct mn_sockaddr *) &to);
         if (rc != 0) {
-            OC_LOG(ERROR, "Failed to send buffer %u ucast\n",
+            OC_LOG_ERROR("Failed to send buffer %u ucast\n",
                          OS_MBUF_PKTHDR(m)->omp_len);
             STATS_INC(oc_ip4_stats, oerr);
             os_mbuf_free_chain(m);
@@ -230,7 +230,7 @@ oc_attempt_rx_ip4_sock(struct mn_socket *rxsock)
     STATS_INCN(oc_ip4_stats, ibytes, OS_MBUF_PKTLEN(n));
     m = os_msys_get_pkthdr(0, sizeof(struct oc_endpoint_ip));
     if (!m) {
-        OC_LOG(ERROR, "Could not allocate RX buffer\n");
+        OC_LOG_ERROR("Could not allocate RX buffer\n");
         goto rx_attempt_err;
     }
     OS_MBUF_PKTHDR(m)->omp_len = OS_MBUF_PKTHDR(n)->omp_len;
@@ -314,7 +314,7 @@ oc_connectivity_init_ip4(void)
 
     rc = mn_socket(&oc_ucast4, MN_PF_INET, MN_SOCK_DGRAM, 0);
     if (rc != 0 || !oc_ucast4) {
-        OC_LOG(ERROR, "Could not create oc unicast v4 socket\n");
+        OC_LOG_ERROR("Could not create oc unicast v4 socket\n");
         return rc;
     }
     mn_socket_set_cbs(oc_ucast4, oc_ucast4, &oc_sock4_cbs);
@@ -323,7 +323,7 @@ oc_connectivity_init_ip4(void)
     rc = mn_socket(&oc_mcast4, MN_PF_INET, MN_SOCK_DGRAM, 0);
     if (rc != 0 || !oc_mcast4) {
         mn_close(oc_ucast4);
-        OC_LOG(ERROR, "Could not create oc multicast v4 socket\n");
+        OC_LOG_ERROR("Could not create oc multicast v4 socket\n");
         return rc;
     }
     mn_socket_set_cbs(oc_mcast4, oc_mcast4, &oc_sock4_cbs);
@@ -336,7 +336,7 @@ oc_connectivity_init_ip4(void)
 
     rc = mn_bind(oc_ucast4, (struct mn_sockaddr *)&sin);
     if (rc != 0) {
-        OC_LOG(ERROR, "Could not bind oc unicast v4 socket\n");
+        OC_LOG_ERROR("Could not bind oc unicast v4 socket\n");
         goto oc_connectivity_init_err;
     }
 
@@ -364,13 +364,13 @@ oc_connectivity_init_ip4(void)
             continue;
         }
 
-        OC_LOG(DEBUG, "Joined Coap v4 mcast group on %s\n", itf.mif_name);
+        OC_LOG_DEBUG("Joined Coap v4 mcast group on %s\n", itf.mif_name);
     }
 
     sin.msin_port = htons(COAP_PORT_UNSECURED);
     rc = mn_bind(oc_mcast4, (struct mn_sockaddr *)&sin);
     if (rc != 0) {
-        OC_LOG(ERROR, "Could not bind oc v4 multicast socket\n");
+        OC_LOG_ERROR("Could not bind oc v4 multicast socket\n");
         goto oc_connectivity_init_err;
     }
 #endif

--- a/net/oic/src/port/mynewt/ip_adaptor.c
+++ b/net/oic/src/port/mynewt/ip_adaptor.c
@@ -165,7 +165,7 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
             to.msin6_scope_id = itf2.mif_idx;
             rc = mn_sendto(oc_ucast6, n, (struct mn_sockaddr *) &to);
             if (rc != 0) {
-                OC_LOG(ERROR, "Failed to send buffer %u on itf %d\n",
+                OC_LOG_ERROR("Failed to send buffer %u on itf %d\n",
                              OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
                 STATS_INC(oc_ip_stats, oerr);
                 os_mbuf_free_chain(n);
@@ -176,7 +176,7 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
             to.msin6_scope_id = itf2.mif_idx;
             rc = mn_sendto(oc_ucast6, m, (struct mn_sockaddr *) &to);
             if (rc != 0) {
-                OC_LOG(ERROR, "Failed sending buffer %u on itf %d\n",
+                OC_LOG_ERROR("Failed sending buffer %u on itf %d\n",
                              OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
                 STATS_INC(oc_ip_stats, oerr);
                 os_mbuf_free_chain(m);
@@ -187,7 +187,7 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
     } else {
         rc = mn_sendto(oc_ucast6, m, (struct mn_sockaddr *) &to);
         if (rc != 0) {
-            OC_LOG(ERROR, "Failed to send buffer %u on itf %d\n",
+            OC_LOG_ERROR("Failed to send buffer %u on itf %d\n",
                          OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
             STATS_INC(oc_ip_stats, oerr);
             os_mbuf_free_chain(m);
@@ -228,7 +228,7 @@ oc_attempt_rx_ip6_sock(struct mn_socket *rxsock)
     STATS_INCN(oc_ip_stats, ibytes, OS_MBUF_PKTLEN(n));
     m = os_msys_get_pkthdr(0, sizeof(struct oc_endpoint_ip));
     if (!m) {
-        OC_LOG(ERROR, "Could not allocate RX buffer\n");
+        OC_LOG_ERROR("Could not allocate RX buffer\n");
         goto rx_attempt_err;
     }
     OS_MBUF_PKTHDR(m)->omp_len = OS_MBUF_PKTHDR(n)->omp_len;
@@ -314,7 +314,7 @@ oc_connectivity_init_ip6(void)
 
     rc = mn_socket(&oc_ucast6, MN_PF_INET6, MN_SOCK_DGRAM, 0);
     if (rc != 0 || !oc_ucast6) {
-        OC_LOG(ERROR, "Could not create oc unicast socket\n");
+        OC_LOG_ERROR("Could not create oc unicast socket\n");
         return rc;
     }
     mn_socket_set_cbs(oc_ucast6, oc_ucast6, &oc_sock6_cbs);
@@ -323,7 +323,7 @@ oc_connectivity_init_ip6(void)
     rc = mn_socket(&oc_mcast6, MN_PF_INET6, MN_SOCK_DGRAM, 0);
     if (rc != 0 || !oc_mcast6) {
         mn_close(oc_ucast6);
-        OC_LOG(ERROR, "Could not create oc multicast socket\n");
+        OC_LOG_ERROR("Could not create oc multicast socket\n");
         return rc;
     }
     mn_socket_set_cbs(oc_mcast6, oc_mcast6, &oc_sock6_cbs);
@@ -338,7 +338,7 @@ oc_connectivity_init_ip6(void)
 
     rc = mn_bind(oc_ucast6, (struct mn_sockaddr *)&sin);
     if (rc != 0) {
-        OC_LOG(ERROR, "Could not bind oc unicast socket\n");
+        OC_LOG_ERROR("Could not bind oc unicast socket\n");
         goto oc_connectivity_init_err;
     }
 
@@ -366,13 +366,13 @@ oc_connectivity_init_ip6(void)
             continue;
         }
 
-        OC_LOG(DEBUG, "Joined Coap mcast group on %s\n", itf.mif_name);
+        OC_LOG_DEBUG("Joined Coap mcast group on %s\n", itf.mif_name);
     }
 
     sin.msin6_port = htons(COAP_PORT_UNSECURED);
     rc = mn_bind(oc_mcast6, (struct mn_sockaddr *)&sin);
     if (rc != 0) {
-        OC_LOG(ERROR, "Could not bind oc multicast socket\n");
+        OC_LOG_ERROR("Could not bind oc multicast socket\n");
         goto oc_connectivity_init_err;
     }
 #endif

--- a/net/oic/src/port/mynewt/log.c
+++ b/net/oic/src/port/mynewt/log.c
@@ -47,7 +47,7 @@ oc_log_endpoint(uint8_t lvl, struct oc_endpoint *oe)
             str = "<unkwn>";
         }
     }
-    modlog_printf(LOG_MODULE_IOTIVITY, lvl, "%s\n", str);
+    modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "%s\n", str);
 }
 
 void
@@ -57,15 +57,15 @@ oc_log_bytes(uint8_t lvl, void *addr, int len, int print_char)
     uint8_t *p = (uint8_t *)addr;
 
     (void)p;
-    modlog_printf(LOG_MODULE_IOTIVITY, lvl, "[");
+    modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "[");
     for (i = 0; i < len; i++) {
         if (print_char) {
-            modlog_printf(LOG_MODULE_IOTIVITY, lvl, "%c", p[i]);
+            modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "%c", p[i]);
         } else {
-            modlog_printf(LOG_MODULE_IOTIVITY, lvl, "%02x", p[i]);
+            modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "%02x", p[i]);
         }
     }
-    modlog_printf(LOG_MODULE_IOTIVITY, lvl, "]\n");
+    modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "]\n");
 }
 
 void
@@ -76,7 +76,7 @@ oc_log_bytes_mbuf(uint8_t lvl, struct os_mbuf *m, int off, int len,
     uint8_t tmp[4];
     int blen;
 
-    modlog_printf(LOG_MODULE_IOTIVITY, lvl, "[");
+    modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "[");
     while (len) {
         blen = len;
         if (blen > sizeof(tmp)) {
@@ -85,13 +85,13 @@ oc_log_bytes_mbuf(uint8_t lvl, struct os_mbuf *m, int off, int len,
         os_mbuf_copydata(m, off, blen, tmp);
         for (i = 0; i < blen; i++) {
             if (print_char) {
-                modlog_printf(LOG_MODULE_IOTIVITY, lvl, "%c", tmp[i]);
+                modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "%c", tmp[i]);
             } else {
-                modlog_printf(LOG_MODULE_IOTIVITY, lvl, "%02x", tmp[i]);
+                modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "%02x", tmp[i]);
             }
         }
         off += blen;
         len -= blen;
     }
-    modlog_printf(LOG_MODULE_IOTIVITY, lvl, "]\n");
+    modlog_printf(MYNEWT_VAL(OC_LOG_MOD), lvl, "]\n");
 }

--- a/net/oic/src/port/mynewt/lora_adaptor.c
+++ b/net/oic/src/port/mynewt/lora_adaptor.c
@@ -325,7 +325,7 @@ oc_lora_deliver(struct oc_lora_state *os)
     if (OS_MBUF_USRHDR_LEN(m) < sizeof(struct oc_endpoint_lora)) {
         n = os_msys_get_pkthdr(0, sizeof(struct oc_endpoint_lora));
         if (!n) {
-            OC_LOG(ERROR, "oc_lora_deliver: Could not allocate mbuf\n");
+            OC_LOG_ERROR("oc_lora_deliver: Could not allocate mbuf\n");
             STATS_INC(oc_lora_stats, ierr);
             os_mbuf_free_chain(m);
             return;

--- a/net/oic/src/port/mynewt/serial_adaptor.c
+++ b/net/oic/src/port/mynewt/serial_adaptor.c
@@ -120,7 +120,7 @@ oc_send_buffer_serial(struct os_mbuf *m)
 {
     /* send over the shell output */
     if (shell_nlip_output(m)) {
-        OC_LOG(ERROR, "oc_transport_serial: nlip output failed\n");
+        OC_LOG_ERROR("oc_transport_serial: nlip output failed\n");
     }
 }
 
@@ -139,7 +139,7 @@ oc_attempt_rx_serial(void)
 
     m = os_msys_get_pkthdr(0, sizeof(struct oc_endpoint_plain));
     if (!m) {
-        OC_LOG(ERROR, "Could not allocate OC message buffer\n");
+        OC_LOG_ERROR("Could not allocate OC message buffer\n");
         goto rx_attempt_err;
     }
     OS_MBUF_PKTHDR(m)->omp_len = OS_MBUF_PKTHDR(n)->omp_len;

--- a/net/oic/src/port/oc_assert.h
+++ b/net/oic/src/port/oc_assert.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #define oc_abort(msg)                                                   \
     do {                                                                \
-      OC_LOG(ERROR, "error: %s\nAbort.\n", msg);                         \
+      OC_LOG_ERROR("error: %s\nAbort.\n", msg);                         \
       assert(0);                                                        \
   } while (0)
 

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -90,10 +90,6 @@ syscfg.defs:
         description: 'Support COAP delayed responses for slow resousrces.'
         value: 1
 
-    OC_LOGGING:
-        description: 'Logging enabled'
-        value: 0
-
     OC_TRANS_SECURITY:
         description: >
             Enables per-resource transport layer security requirements.
@@ -133,3 +129,20 @@ syscfg.defs:
         description: >
             Sysinit stage for the LoRa OIC transport.
         value: 301
+
+    ### Log settings.
+
+    OC_LOGGING:
+        description: 'Logging enabled'
+        value: 0
+    OC_LOG_MOD:
+        description: 'Numeric module ID to use for OC log messages.'
+        value: 7
+    OC_LOG_LVL:
+        description: 'Minimum level for the OC log.'
+        value: 1
+
+syscfg.logs:
+    OC_LOG:
+        module: MYNEWT_VAL(OC_LOG_MOD)
+        level: MYNEWT_VAL(OC_LOG_LVL)

--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -67,7 +67,6 @@ struct log;
 #define LOG_MODULE_IOTIVITY         7
 #define LOG_MODULE_TEST             8
 
-#define LOG_MODULE_PERUSER          (64)
 #define LOG_MODULE_MAX              (255)
 
 #define LOG_ETYPE_STRING         (0)

--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -53,16 +53,20 @@ struct log;
     (LOG_LEVEL_CRITICAL == level ? "CRITICAL" :\
      "UNKNOWN")))))
 
-/* Log module, eventually this can be a part of the filter. */
-#define LOG_MODULE_DEFAULT          (0)
-#define LOG_MODULE_OS               (1)
-#define LOG_MODULE_NEWTMGR          (2)
-#define LOG_MODULE_NIMBLE_CTLR      (3)
-#define LOG_MODULE_NIMBLE_HOST      (4)
-#define LOG_MODULE_NFFS             (5)
-#define LOG_MODULE_REBOOT           (6)
-#define LOG_MODULE_IOTIVITY         (7)
-#define LOG_MODULE_TEST             (8)
+/* XXX: These module IDs are defined for backwards compatibility.  Application
+ * code should use the syscfg settings directly.  These defines will be removed
+ * in a future release.
+ */
+#define LOG_MODULE_DEFAULT          0
+#define LOG_MODULE_OS               1
+#define LOG_MODULE_NEWTMGR          2
+#define LOG_MODULE_NIMBLE_CTLR      3
+#define LOG_MODULE_NIMBLE_HOST      4
+#define LOG_MODULE_NFFS             5
+#define LOG_MODULE_REBOOT           6
+#define LOG_MODULE_IOTIVITY         7
+#define LOG_MODULE_TEST             8
+
 #define LOG_MODULE_PERUSER          (64)
 #define LOG_MODULE_MAX              (255)
 

--- a/sys/log/common/syscfg.yml
+++ b/sys/log/common/syscfg.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -5,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
+# 
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,25 +18,15 @@
 #
 
 syscfg.defs:
-    MPU6050_ITF_LOCK_TMO:
-        description: 'MPU6050 interface lock timeout in milliseconds'
-        value: 1000
-    MPU6050_I2C_RETRIES:
-        description: >
-            Number of retries to use for failed I2C communication.  A retry is
-            used when the MPU6050 sends an unexpected NACK.
-        value: 2
-
-    ### Log settings.
-
-    MPU6050_LOG_MODULE:
-        description: 'Numeric module ID to use for MPU6050 log messages.'
-        value: 115
-    MPU6050_LOG_LVL:
-        description: 'Minimum level for the MPU6050 log.'
+    DFLT_LOG_MOD:
+        description: 'Numeric module ID to use for default log messages.'
+        value: 0
+    DFLT_LOG_LVL:
+        description: 'Minimum level for the default log.'
         value: 1
 
 syscfg.logs:
-    MPU6050_LOG:
-        module: MYNEWT_VAL(MPU6050_LOG_MODULE)
-        level: MYNEWT_VAL(MPU6050_LOG_LVL)
+    DFLT_LOG:
+        module: MYNEWT_VAL(DFLT_LOG_MOD)
+        level: MYNEWT_VAL(DFLT_LOG_LVL)
+

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -212,11 +212,7 @@ struct log *log_list_get_next(struct log *);
  *
  * This function associates user log module with given name.
  *
- * If \p id is non-zero, module is registered with selected id.
- * If \p id is zero, module id is selected automatically (first available).
- *
- * Up to `LOG_MAX_USER_MODULES` (syscfg) modules can be registered with ids
- * starting from `LOG_MODULE_PERUSER`.
+ * Up to `LOG_MAX_USER_MODULES` (syscfg) modules can be registered.
  *
  * @param id    Selected module id
  * @param name  Module name

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -219,24 +219,38 @@ log_module_get_name(uint8_t module)
 {
     if (module < LOG_MODULE_PERUSER) {
         switch (module) {
-        case LOG_MODULE_DEFAULT:
+#ifdef MYNEWT_VAL_DFLT_LOG_MOD
+        case MYNEWT_VAL(DFLT_LOG_MOD):
             return "DEFAULT";
-        case LOG_MODULE_OS:
+#endif
+#ifdef MYNEWT_VAL_OS_LOG_MOD
+        case MYNEWT_VAL(OS_LOG_MOD):
             return "OS";
-        case LOG_MODULE_NEWTMGR:
-            return "NEWTMGR";
-        case LOG_MODULE_NIMBLE_CTLR:
+#endif
+#ifdef MYNEWT_VAL_BLE_LL_LOG_MOD
+        case MYNEWT_VAL(BLE_LL_LOG_MOD):
             return "NIMBLE_CTLR";
-        case LOG_MODULE_NIMBLE_HOST:
+#endif
+#ifdef MYNEWT_VAL_BLE_HS_LOG_MOD
+        case MYNEWT_VAL(BLE_HS_LOG_MOD):
             return "NIMBLE_HOST";
-        case LOG_MODULE_NFFS:
+#endif
+#ifdef MYNEWT_VAL_NFFS_LOG_MOD
+        case MYNEWT_VAL(NFFS_LOG_MOD):
             return "NFFS";
-        case LOG_MODULE_REBOOT:
+#endif
+#ifdef MYNEWT_VAL_REBOOT_LOG_MOD
+        case MYNEWT_VAL(REBOOT_LOG_MOD):
             return "REBOOT";
-        case LOG_MODULE_IOTIVITY:
+#endif
+#ifdef MYNEWT_VAL_OC_LOG_MOD
+        case MYNEWT_VAL(OC_LOG_MOD):
             return "IOTIVITY";
-        case LOG_MODULE_TEST:
+#endif
+#ifdef MYNEWT_VAL_TEST_LOG_MOD
+        case MYNEWT_VAL(TEST_LOG_MOD):
             return "TEST";
+#endif
         }
     } else if (module - LOG_MODULE_PERUSER < MYNEWT_VAL(LOG_MAX_USER_MODULES)) {
         return g_log_module_list[module - LOG_MODULE_PERUSER];

--- a/sys/log/modlog/include/modlog/modlog.h
+++ b/sys/log/modlog/include/modlog/modlog.h
@@ -341,6 +341,8 @@ modlog_printf(uint8_t module, uint8_t level, const char *msg, ...)
     MODLOG_ ## ml_lvl_((ml_mod_), __VA_ARGS__)
 
 /**
+ * XXX: Deprecated.  Use LOG_DFLT instead.
+ *
  * @brief Writes a formatted text entry with the specified level to the
  * default log module.
  *
@@ -378,9 +380,6 @@ modlog_printf(uint8_t module, uint8_t level, const char *msg, ...)
 
 #undef LOG_CRITICAL
 #define LOG_CRITICAL    MODLOG_CRITICAL
-
-#undef LOG_DFLT
-#define LOG_DFLT        MODLOG_DFLT
 
 #endif
 

--- a/sys/mfg/include/mfg/mfg.h
+++ b/sys/mfg/include/mfg/mfg.h
@@ -146,7 +146,4 @@ int mfg_read_tlv_mmr_ref(const struct mfg_reader *reader,
  */
 void mfg_init(void);
 
-#define MFG_LOG(lvl_, ...) \
-    MODLOG_ ## lvl_(MYNEWT_VAL(MFG_LOG_MODULE), __VA_ARGS__)
-
 #endif

--- a/sys/mfg/src/mfg.c
+++ b/sys/mfg/src/mfg.c
@@ -415,5 +415,5 @@ mfg_init(void)
     return;
 
 err:
-    MFG_LOG(ERROR, "failed to read MMRs: rc=%d", rc);
+    MFG_LOG_ERROR("failed to read MMRs: rc=%d", rc);
 }

--- a/sys/mfg/syscfg.yml
+++ b/sys/mfg/syscfg.yml
@@ -27,6 +27,18 @@ syscfg.defs:
         description: >
             Sysinit stage for manufacturing support.
         value: 100
+
+    ### Log settings.
+
     MFG_LOG_MODULE:
-        description: 'Numeric module ID to use for manufacturing log messages'
+        description: 'Numeric module ID to use for manufacturing log messages.'
         value: 128
+    MFG_LOG_LVL:
+        description: 'Minimum level for the manufacturing log.'
+        value: 15 # Disable logging by default.
+
+syscfg.logs:
+    MFG_LOG:
+        module: MYNEWT_VAL(MFG_LOG_MODULE)
+        level: MYNEWT_VAL(MFG_LOG_LVL)
+

--- a/sys/reboot/syscfg.yml
+++ b/sys/reboot/syscfg.yml
@@ -49,3 +49,7 @@ syscfg.defs:
         description: >
             Sysinit stage for reboot functionality.
         value: 200
+
+    REBOOT_LOG_MOD:
+        description: 'Numeric module ID to use for reboot log messages.'
+        value: 6

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -941,7 +941,7 @@ int
 shell_register(const char *module_name, const struct shell_cmd *commands)
 {
     if (num_of_shell_entities >= MYNEWT_VAL(SHELL_MAX_MODULES)) {
-        MODLOG_ERROR(LOG_MODULE_DEFAULT, "Max number of modules reached\n");
+        DFLT_LOG_ERROR("Max number of modules reached\n");
         assert(0);
     }
 
@@ -964,7 +964,7 @@ shell_cmd_register(const struct shell_cmd *sc)
     int rc;
 
     if (num_compat_commands >= MYNEWT_VAL(SHELL_MAX_COMPAT_COMMANDS)) {
-        MODLOG_ERROR(LOG_MODULE_DEFAULT,
+        DFLT_LOG_ERROR(
                      "Max number of compat commands reached\n");
         assert(0);
     }
@@ -975,7 +975,7 @@ shell_cmd_register(const struct shell_cmd *sc)
 
         rc = set_default_module(SHELL_COMPAT_MODULE_NAME);
         if (rc != 0) {
-            MODLOG_ERROR(LOG_MODULE_DEFAULT,
+            DFLT_LOG_ERROR(
                          "Illegal module %s, default is not changed\n",
                          SHELL_COMPAT_MODULE_NAME);
         }

--- a/test/runtest/src/runtest.c
+++ b/test/runtest/src/runtest.c
@@ -154,8 +154,7 @@ runtest_log_result(const char *msg, bool passed)
         runtest_total_fails++;
     }
 
-    MODLOG_INFO(
-        LOG_MODULE_TEST,
+    TEST_LOG_INFO(
         "{\"k\":\"%s\",\"n\":\"%s\",\"s\":\"%s\",\"m\":\"%s\",\"r\":%d}",
         runtest_token, n, s, m, passed);
 }
@@ -199,8 +198,8 @@ runtest_test_complete(void)
 {
 #if MYNEWT_VAL(RUNTEST_LOG)
     if (runtest_total_tests > 0) {
-        MODLOG_INFO(LOG_MODULE_TEST, "%s Done", runtest_token);
-        MODLOG_INFO(LOG_MODULE_TEST,
+        TEST_LOG_INFO("%s Done", runtest_token);
+        TEST_LOG_INFO(
                     "%s TESTBENCH TEST %s - Tests run:%d pass:%d fail:%d %s",
                     RUNTEST_PREFIX,
                     runtest_total_fails ? "FAILED" : "PASSED",

--- a/test/testutil/syscfg.yml
+++ b/test/testutil/syscfg.yml
@@ -24,3 +24,17 @@ syscfg.defs:
         description: >
             Sysinit stage for testutil functionality.
         value: 1
+
+    ### Log settings.
+
+    TEST_LOG_MOD:
+        description: 'Numeric module ID to use for test log messages.'
+        value: 8
+    TEST_LOG_LVL:
+        description: 'Minimum level for the test log.'
+        value: 1
+
+syscfg.logs:
+    TEST_LOG:
+        module: MYNEWT_VAL(TEST_LOG_MOD)
+        level: MYNEWT_VAL(TEST_LOG_LVL)


### PR DESCRIPTION
Define logs in packages' syscfg files

Defining logs in syscfg files provides a few benefits:

1. Ability to set log level per module at build time.  Setting a global log level of 0 (`LOG_LEVEL=0`) might produce an image that is too big.  Instead, we can enable debug logging only for the modules we are interested in.

2. Easier to visualize system log configuration (see below).

3. Log modules can be remapped at build time in case of conflicts.

The following procedure was used for choosing module and level syscfg names:

1. If the package already defines these settings, keep them unchanged.
2. Otherwise, define:

* `<package-name>_LOG_MOD`
* `<package-name>_LOG_LVL`

To see the system-wide log configuration, use either of these commands:

```
newt target logcfg brief <target-name>
newt target logcfg show <target-name>
```

Example output:
```
newt target logcfg brief slinky-nordic_pca10056

Brief log config for targets/slinky-nordic_pca10056:
           LOG | MODULE   | LEVEL
---------------+----------+--------------
      DFLT_LOG | 0        | 1 (INFO)
    IMGMGR_LOG | 176      | 0 (DEBUG)
```

```
newt target logcfg show slinky-nordic_pca10056

Log config for targets/slinky-nordic_pca10056:
DFLT_LOG:
    Package: @apache-mynewt-core/sys/log/common
    Module:  0                [DFLT_LOG_MOD]
    Level:   1 (INFO)         [DFLT_LOG_LVL]

IMGMGR_LOG:
    Package: @apache-mynewt-core/mgmt/imgmgr
    Module:  176              [IMGMGR_LOG_MOD]
    Level:   0 (DEBUG)        [IMGMGR_LOG_LVL]
```