### PR TITLE
sensor_creator: Fix ADXL345 configuration for bus driver

### DIFF
--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -439,7 +439,12 @@ static const struct bus_spi_node_cfg adxl345_node_cfg = {
     .freq = 4000,
 };
 #endif
-static struct sensor_itf adxl345_itf;
+static struct sensor_itf adxl345_itf = {
+    .si_ints = {
+        { MYNEWT_VAL(ADXL345_INT_PIN_HOST), MYNEWT_VAL(ADXL345_INT_PIN_DEVICE),
+          MYNEWT_VAL(ADXL345_INT_CFG_ACTIVE)}
+    }
+};
 #else
 static struct sensor_itf adxl_itf = {
     .si_type = SENSOR_ITF_I2C,


### PR DESCRIPTION
Bus driver configuration had missing interrupt settings.
Now same configuration for interrupt is applied for
bus-driver and non-bus-driver build.