### PR TITLE
sensor_creator: Fix bmp280/bme280 configuration

### DIFF
--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -246,18 +246,18 @@ struct bus_spi_node_cfg bmp280_node_cfg = {
 };
 #endif
 static struct sensor_itf bmp280_itf;
-#elif MYNEWT_VAL(I2C_0)
+#elif MYNEWT_VAL(BMP280_OFB_I2C_NUM) >= 0
 static struct sensor_itf i2c_0_itf_bmp = {
     .si_type = SENSOR_ITF_I2C,
-    .si_num = 0,
-    .si_addr = BMP280_DFLT_I2C_ADDR
+    .si_num = MYNEWT_VAL(BMP280_OFB_I2C_NUM),
+    .si_addr = MYNEWT_VAL(BMP280_OFB_I2C_ADDR),
 };
 #endif
 #endif
 
 #if MYNEWT_VAL(SPI_0_MASTER) && MYNEWT_VAL(BME280_OFB)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-struct bus_spi_node_cfg flash_spi_cfg = {
+struct bus_spi_node_cfg bme280_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BME280_OFB_SPI_BUS),
     .pin_cs = MYNEWT_VAL(BME280_OFB_CS),
     .mode = BUS_SPI_MODE_0,
@@ -1554,7 +1554,7 @@ sensor_dev_create(void)
 #if MYNEWT_VAL(BME280_OFB)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
     rc = bme280_create_spi_sensor_dev(&bme280.spi_node, "bme280_0",
-                                      &flash_spi_cfg, &bme280_itf);
+                                      &bme280_spi_cfg, &bme280_itf);
     assert(rc == 0);
 #else
     rc = os_dev_create((struct os_dev *) &bme280, "bme280_0",


### PR DESCRIPTION
bme280:
spi configuration variable name had misleading name flash_spi_cfg
now it is called bme280_spi_cfg.

bmp280:
Non-bus-driver build has not configurable address and was hardwired to I2C_0.
Now address and interface respect what is in syscfg.