### PR TITLE
kernel/os: Catch returns from tasks

### DIFF
--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -144,6 +144,16 @@ os_arch_in_critical(void)
     return (isr_ctx & 1);
 }
 
+static void
+os_arch_task_return_handler(void)
+{
+    /*
+     * If you are stuck here it means that task finished by
+     * simple return which is not supported.
+     */
+    while (1);
+}
+
 os_stack_t *
 os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
 {
@@ -154,8 +164,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Get stack frame pointer */
     s = (os_stack_t *) ((uint8_t *) stack_top - sizeof(*sf));
 
-    /* Zero out R1-R3, R12, LR */
-    for (i = 9; i < 14; ++i) {
+    /* Zero out R1-R3, R12 */
+    for (i = 9; i < 13; ++i) {
         s[i] = 0;
     }
 
@@ -167,6 +177,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     sf->xpsr = INITIAL_xPSR;
     sf->pc = (uint32_t)t->t_func;
     sf->r0 = (uint32_t)t->t_arg;
+    /* Set function to cache returns from tasks. */
+    sf->lr = (uint32_t)os_arch_task_return_handler;
 
     return (s);
 }

--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -150,6 +150,16 @@ os_arch_in_critical(void)
     return (isr_ctx & 1);
 }
 
+static void
+os_arch_task_return_handler(void)
+{
+    /*
+     * If you are stuck here it means that task finished by
+     * simple return which is not supported.
+     */
+    while (1);
+}
+
 os_stack_t *
 os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
 {
@@ -160,8 +170,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Get stack frame pointer */
     s = (os_stack_t *) ((uint8_t *) stack_top - sizeof(*sf));
 
-    /* Zero out R1-R3, R12, LR */
-    for (i = 9; i < 14; ++i) {
+    /* Zero out R1-R3, R12 */
+    for (i = 9; i < 13; ++i) {
         s[i] = 0;
     }
 
@@ -173,6 +183,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     sf->xpsr = INITIAL_xPSR;
     sf->pc = (uint32_t)t->t_func;
     sf->r0 = (uint32_t)t->t_arg;
+    /* Set function to cache returns from tasks. */
+    sf->lr = (uint32_t)os_arch_task_return_handler;
 #if MYNEWT_VAL(HARDFLOAT)
     sf->exc_lr = INITIAL_LR;
 #endif

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -150,6 +150,16 @@ os_arch_in_critical(void)
     return (isr_ctx & 1);
 }
 
+static void
+os_arch_task_return_handler(void)
+{
+    /*
+     * If you are stuck here it means that task finished by
+     * simple return which is not supported.
+     */
+    while (1);
+}
+
 os_stack_t *
 os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
 {
@@ -160,8 +170,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Get stack frame pointer */
     s = (os_stack_t *) ((uint8_t *) stack_top - sizeof(*sf));
 
-    /* Zero out R1-R3, R12, LR */
-    for (i = 9; i < 14; ++i) {
+    /* Zero out R1-R3, R12 */
+    for (i = 9; i < 13; ++i) {
         s[i] = 0;
     }
 
@@ -173,6 +183,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     sf->xpsr = INITIAL_xPSR;
     sf->pc = (uint32_t)t->t_func;
     sf->r0 = (uint32_t)t->t_arg;
+    /* Set function to cache returns from tasks. */
+    sf->lr = (uint32_t)os_arch_task_return_handler;
 #if MYNEWT_VAL(HARDFLOAT)
     sf->exc_lr = INITIAL_LR;
 #endif

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -150,6 +150,16 @@ os_arch_in_critical(void)
     return (isr_ctx & 1);
 }
 
+static void
+os_arch_task_return_handler(void)
+{
+    /*
+     * If you are stuck here it means that task finished by
+     * simple return which is not supported.
+     */
+    while (1);
+}
+
 os_stack_t *
 os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
 {
@@ -160,8 +170,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Get stack frame pointer */
     s = (os_stack_t *) ((uint8_t *) stack_top - sizeof(*sf));
 
-    /* Zero out R1-R3, R12, LR */
-    for (i = 9; i < 14; ++i) {
+    /* Zero out R1-R3, R12 */
+    for (i = 9; i < 13; ++i) {
         s[i] = 0;
     }
 
@@ -173,6 +183,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     sf->xpsr = INITIAL_xPSR;
     sf->pc = (uint32_t)t->t_func;
     sf->r0 = (uint32_t)t->t_arg;
+    /* Set function to cache returns from tasks. */
+    sf->lr = (uint32_t)os_arch_task_return_handler;
 #if MYNEWT_VAL(HARDFLOAT)
     sf->exc_lr = INITIAL_LR;
 #endif

--- a/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
+++ b/kernel/os/src/arch/rv32imac/os_arch_rv32imac.c
@@ -159,6 +159,16 @@ os_arch_in_critical(void)
     return !(read_csr(mstatus) & MSTATUS_MIE);
 }
 
+void
+os_arch_task_return_handler(void)
+{
+    /*
+     * If you are stuck here it means that task finished by
+     * simple return which is not supported.
+     */
+    while (1);
+}
+
 /* assumes stack_top will be 8 aligned */
 
 os_stack_t *
@@ -179,6 +189,8 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Set remaining portions of stack frame */
     sf->pc = (uint32_t) t->t_func;
     sf->a0 = (uint32_t) t->t_arg;
+    /* Set function to cache returns from tasks. */
+    sf->ra = (os_stack_t)os_arch_task_return_handler;
 
     return (os_stack_t *) sf;
 }


### PR DESCRIPTION
New mynewt user may not noticed that tasks function should not
return which is common in other systems.
If user tasks do return for arm and riscv platform PC will be
set to 0 and that will soon result in hard fault exception.
In such case, even if hard fault handler is called, further
stack corruption can happen since SP will reach top and will
point to memory that do not belong to stack any more.
Inexperienced or new myenwt user can find it difficult to
track this simple problem.

This adds minimal changes to arm and riscv architecture code
that can help catch such problems easily.