### PR TITLE
sys/log: Re-add LOG_MODULE_PERUSER

### DIFF
--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -67,6 +67,7 @@ struct log;
 #define LOG_MODULE_IOTIVITY         7
 #define LOG_MODULE_TEST             8
 
+#define LOG_MODULE_PERUSER          64
 #define LOG_MODULE_MAX              (255)
 
 #define LOG_ETYPE_STRING         (0)


### PR DESCRIPTION
This constant was removed in a recent commit (46a14478933942708562e33a4650f2fede37342e).  We should keep this constant around to maintain backwards compatibility.  Applications may define their own log modules with IDs based on this constant.