### PR TITLE
Fixed lis2dh12 to work on scales above 2G.

### DIFF
--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -757,7 +757,7 @@ lis2dh12_get_full_scale(struct sensor_itf *itf, uint8_t *fs)
         goto err;
     }
 
-    *fs = (reg & LIS2DH12_CTRL_REG4_FS) >> 4;
+    *fs = (reg & LIS2DH12_CTRL_REG4_FS);
 
     return 0;
 err:


### PR DESCRIPTION
Fixed lis2dh12_get_full_scale to actually report the correct scale, by not shifting it.
Value returned by lis2dh12_get_full_scale->lis2dh12_get_fs is utilized for calculation in poll_read and stream_read, and would provide incorrect values when utilizing any sensitivity value other than 2G.