### PR TITLE
da1469x split mcu

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
@@ -38,6 +38,14 @@ syscfg.defs:
         description: 'Specifies path to ED25519 private key PEM file'
         value: ''
 
+syscfg.defs.BUS_DRIVER_PRESENT:
+    BSP_FLASH_SPI_NAME:
+        description: 'SPIFLASH device name'
+        value: '"spiflash0"'
+    BSP_FLASH_SPI_BUS:
+        description: 'bus name SPIFLASH is connected to'
+        value:
+
 syscfg.vals:
     MCU_TARGET: DA14699
     MCU_DCDC_ENABLE: 1

--- a/hw/mcu/dialog/da14699/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da14699/include/mcu/mcu.h
@@ -114,8 +114,10 @@ typedef enum {
 #define MCU_GPIO_MODE_OUTPUT                0x300    /**< GPIO as an output */
 #define MCU_GPIO_MODE_OUTPUT_OPEN_DRAIN     0x700    /**< GPIO as an open-drain output */
 
+#define MCU_GPIO_PORT0_PIN_COUNT            32
 #define MCU_GPIO_PORT0(pin)		((0 * 32) + (pin))
 #define MCU_GPIO_PORT1(pin)		((1 * 32) + (pin))
+#define MCU_DMA_CHAN_MAX                    8
 
 void mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func);
 void mcu_gpio_enter_sleep(void);

--- a/hw/mcu/dialog/da14699/pkg.yml
+++ b/hw/mcu/dialog/da14699/pkg.yml
@@ -17,39 +17,17 @@
 # under the License.
 #
 
-pkg.name: hw/mcu/dialog/da1469x
-pkg.description: MCU definition for Dialog DA1469x ARM Cortex-M33 chips
+pkg.name: hw/mcu/dialog/da14699
+pkg.description: MCU definition for Dialog DA14699 ARM Cortex-M33 chip
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - dialog
     - da1469x
+    - da14699
 
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/cmsis-core"
-    - "@apache-mynewt-core/hw/mcu/dialog"
+    - "@apache-mynewt-core/hw/mcu/dialog/da1469x"
 
-pkg.deps.CHARGER:
-    - "@apache-mynewt-core/hw/drivers/chg_ctrl/da1469x_charger"
-
-pkg.deps.TRNG:
-    - "@apache-mynewt-core/hw/drivers/trng/trng_da1469x"
-
-pkg.deps.'UART_0 || UART_1 || UART_2':
-    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
-
-pkg.deps.'(I2C_0 || I2C_1) && BUS_DRIVER_PRESENT':
-    - "@apache-mynewt-core/hw/bus/drivers/i2c_hal"
-
-pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER) && BUS_DRIVER_PRESENT':
-    - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
-
-pkg.deps.GPADC:
-    - "@apache-mynewt-core/hw/drivers/adc/gpadc_da1469x"
-
-pkg.deps.SDADC:
-    - "@apache-mynewt-core/hw/drivers/adc/sdadc_da1469x"
-
-pkg.init:
-    da1469x_lpclk_init: 1

--- a/hw/mcu/dialog/da14699/syscfg.yml
+++ b/hw/mcu/dialog/da14699/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,19 +16,8 @@
 # under the License.
 #
 
-pkg.name: hw/bsp/dialog_da1469x-dk-pro
-pkg.type: bsp
-pkg.description: BSP definition for the Dialog DA1469x PRO development kit with DA14699 daughter board.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-    - dialog
-    - da1469x
-
-pkg.cflags.HARDFLOAT:
-    - '-mfloat-abi=hard'
-    - '-mfpu=fpv5-sp-d16'
-
-pkg.deps:
-    - "@apache-mynewt-core/libc/baselibc"
-    - "@apache-mynewt-core/hw/mcu/dialog/da14699"
+syscfg.vals:
+    # MCU_TARGET have to be set in BSP due to newt limitation that dose not
+    # allow overriding values defined by other packages event if they
+    # are not set
+#    MCU_TARGET: DA14699

--- a/hw/mcu/dialog/da1469x/include/mcu/cmsis_nvic.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/cmsis_nvic.h
@@ -8,7 +8,7 @@
 #define MBED_CMSIS_NVIC_H
 
 #include <stdint.h>
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #define NVIC_USER_IRQ_OFFSET  16
 #define NVIC_NUM_VECTORS      (NVIC_USER_IRQ_OFFSET + 40)

--- a/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
@@ -20,7 +20,7 @@
 #ifndef __MCU_CORTEX_M33_H_
 #define __MCU_CORTEX_M33_H_
 
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_dma.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_dma.h
@@ -22,7 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
@@ -22,7 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pdc.h
@@ -22,7 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_retreg.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_retreg.h
@@ -78,7 +78,7 @@ void da1469x_retreg_restore(struct da1469x_retreg *retregs, uint8_t count);
 static inline void
 da1469x_retreg_invalidate(struct da1469x_retreg *retreg)
 {
-    retreg->reg = MCU_RETREG_ADDR_DUMMY;
+    retreg->reg = (uint32_t *)MCU_RETREG_ADDR_DUMMY;
     retreg->value = 0;
 }
 

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_retreg.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_retreg.h
@@ -21,7 +21,7 @@
 #define __MCU_DA1469X_RETREG_H_
 
 #include <stdint.h>
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_snc.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_snc.h
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include "mcu/mcu.h"
-#include "DA1469xAB.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
@@ -27,7 +27,7 @@
 #include "mcu/da1469x_cmac.h"
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_pdc.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #define CMAC_SYM_CONFIG     ((void *)(0x00818f20 + MEMCTRL->CMI_CODE_BASE_REG))
 #define CMAC_SYM_CONFIG_DYN ((void *)(0x00821af8 + MEMCTRL->CMI_CODE_BASE_REG))

--- a/hw/mcu/dialog/da1469x/src/da1469x_dma.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_dma.c
@@ -26,7 +26,9 @@
 
 #define MCU_DMA_CHAN2CIDX(_chan)    ((_chan) - ((struct da1469x_dma_regs *)DMA))
 #define MCU_DMA_CIDX2CHAN(_cidx)    (&((struct da1469x_dma_regs *)DMA)[(_cidx)])
+#ifndef MCU_DMA_CHAN_MAX
 #define MCU_DMA_CHAN_MAX            (8)
+#endif
 
 #define MCU_DMA_SET_MUX(_cidx, _periph)             \
     do {                                            \
@@ -43,8 +45,14 @@ struct da1469x_dma_interrupt_cfg {
     void *arg;
 };
 
+#if (MCU_DMA_CHAN_MAX) > 8
 static uint8_t g_da1469x_dma_acquired;
 static uint8_t g_da1469x_dma_isr_set;
+#else
+static uint16_t g_da1469x_dma_acquired;
+static uint16_t g_da1469x_dma_isr_set;
+#endif
+
 static struct da1469x_dma_interrupt_cfg g_da1469x_dma_isr_cfg[MCU_DMA_CHAN_MAX];
 
 static inline int

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -20,12 +20,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "mcu/mcu.h"
 #include "mcu/da1469x_clock.h"
 #include "mcu/da1469x_lpclk.h"
 #include "hal/hal_system.h"
 #include "hal/hal_timer.h"
 #include "os/os_cputime.h"
-#include "DA1469xAB.h"
 #include "da1469x_priv.h"
 
 bool g_mcu_lpclk_available;

--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -20,11 +20,11 @@
 #include <assert.h>
 #include <string.h>
 #include "syscfg/syscfg.h"
+#include "mcu/mcu.h"
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_prail.h"
 #include "mcu/da1469x_retreg.h"
 #include "os/util.h"
-#include "DA1469xAB.h"
 
 #define POWER_CTRL_REG_SET(_field, _val)                                        \
     CRG_TOP->POWER_CTRL_REG =                                                   \

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -23,7 +23,6 @@
 #include "mcu/da1469x_prail.h"
 #include "mcu/mcu.h"
 #include "hal/hal_system.h"
-#include "DA1469xAB.h"
 #include "da1469x_priv.h"
 
 #if MYNEWT_VAL(MCU_DEEP_SLEEP)

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -23,7 +23,7 @@
 #include "defs/sections.h"
 #include "mcu/da1469x_hal.h"
 #include "hal/hal_flash_int.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #define CODE_QSPI_INLINE    __attribute__((always_inline)) inline
 

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -27,7 +27,6 @@
 #include "mcu/cmsis_nvic.h"
 #include "hal/hal_gpio.h"
 #include "bsp/bsp.h"
-#include "DA1469xAB.h"
 
 /* GPIO interrupts */
 #define HAL_GPIO_MAX_IRQ        (4)

--- a/hw/mcu/dialog/da1469x/src/hal_i2c.c
+++ b/hw/mcu/dialog/da1469x/src/hal_i2c.c
@@ -26,7 +26,6 @@
 #include "mcu/mcu.h"
 #include "hal/hal_i2c.h"
 #include "hal/hal_gpio.h"
-#include "DA1469xAB.h"
 
 #define DA1469X_HAL_I2C_MAX (2)
 

--- a/hw/mcu/dialog/da1469x/src/hal_os_tick.c
+++ b/hw/mcu/dialog/da1469x/src/hal_os_tick.c
@@ -24,7 +24,7 @@
 #include "hal/hal_system.h"
 #include "os/os_trace_api.h"
 #include "da1469x_priv.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 struct hal_os_tick {
     int ticks_per_ostick;

--- a/hw/mcu/dialog/da1469x/src/hal_spi.c
+++ b/hw/mcu/dialog/da1469x/src/hal_spi.c
@@ -25,7 +25,6 @@
 #include <mcu/da1469x_hal.h>
 #include <hal/hal_spi.h>
 #include <mcu/mcu.h>
-#include "DA1469xAB.h"
 
 /* The maximum number of SPI interfaces we will allow */
 #define DA1469X_HAL_SPI_MAX (2)

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -24,7 +24,6 @@
 #include "mcu/da1469x_pdc.h"
 #include "hal/hal_system.h"
 #include "os/os_cputime.h"
-#include "DA1469xAB.h"
 
 #if !MYNEWT_VAL(BOOT_LOADER)
 static enum hal_reset_reason g_hal_reset_reason;

--- a/hw/mcu/dialog/da1469x/src/hal_system_start.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system_start.c
@@ -21,7 +21,6 @@
 #include <stdint.h>
 #include "mcu/mcu.h"
 #include "mcu/da1469x_hal.h"
-#include "DA1469xAB.h"
 
 void __attribute__((naked))
 hal_system_start(void *img_start)

--- a/hw/mcu/dialog/da1469x/src/hal_timer.c
+++ b/hw/mcu/dialog/da1469x/src/hal_timer.c
@@ -23,7 +23,7 @@
 #include "mcu/da1469x_hal.h"
 #include "hal/hal_timer.h"
 #include "defs/error.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #define DA1469X_TIMER_COUNT         (3)
 

--- a/hw/mcu/dialog/da1469x/src/hal_uart.c
+++ b/hw/mcu/dialog/da1469x/src/hal_uart.c
@@ -28,7 +28,6 @@
 #include "defs/error.h"
 #include "os/os_trace_api.h"
 #include "os/util.h"
-#include "DA1469xAB.h"
 
 #define DA1469X_UART_COUNT      3
 

--- a/hw/mcu/dialog/da1469x/src/hal_watchdog.c
+++ b/hw/mcu/dialog/da1469x/src/hal_watchdog.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include "hal/hal_watchdog.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 static uint32_t g_hal_watchdog_reload_val;
 

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -21,7 +21,7 @@
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 #include "da1469x_priv.h"
 
 #define PMU_ALL_SLEEP_MASK      (CRG_TOP_PMU_CTRL_REG_TIM_SLEEP_Msk | \

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -39,12 +39,14 @@ void SystemInit(void)
     int idx;
 #endif
 
+    /* TODO: Check chip version.
     assert(CHIP_VERSION->CHIP_ID1_REG == '2');
     assert(CHIP_VERSION->CHIP_ID2_REG == '5');
     assert(CHIP_VERSION->CHIP_ID3_REG == '2');
     assert(CHIP_VERSION->CHIP_ID4_REG == '2');
     assert(CHIP_VERSION->CHIP_REVISION_REG == 'A');
     assert(CHIP_VERSION->CHIP_TEST1_REG == 'B');
+     */
 
     /* Enable FPU when using hard-float */
 #if (__FPU_USED == 1)


### PR DESCRIPTION
DA1469x is not considered to be a MCU family.
One specific MCU da14699 is defined instead.

Custom chips based on this family can reuse code present in da1469x package.
