### PR TITLE
hw/mcu/da1469x: Fix DMA for more then one peripheral

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_dma.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_dma.c
@@ -32,8 +32,8 @@
     do {                                            \
         DMA->DMA_REQ_MUX_REG =                      \
             (DMA->DMA_REQ_MUX_REG &                 \
-             ~(0xf << ((_cidx) * 4))) |             \
-            ((_periph) << ((_cidx) * 4));           \
+             ~(0xf << ((_cidx) * 2))) |             \
+            ((_periph) << ((_cidx) * 2));           \
     } while (0)
 #define MCU_DMA_GET_MUX(_cidx)                      \
     (DMA->DMA_REQ_MUX_REG >> ((_cidx) * 4) & 0xf)


### PR DESCRIPTION
DMA_REQ_MUX_REG value was correctly setup only for
first pair of channels.
Requesting second pair (channels 2/3) modified bit field
DMA45_SEL instead of DMA23_SEL and so on.