### PR TITLE
[MBEDTLS] Add option to use fewer AES tables

### DIFF
--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -193,6 +193,11 @@ extern "C" {
 #else
 #undef MBEDTLS_AES_ROM_TABLES
 #endif
+#if MYNEWT_VAL(MBEDTLS_AES_FEWER_TABLES)
+#define MBEDTLS_AES_FEWER_TABLES
+#else
+#undef MBEDTLS_AES_FEWER_TABLES
+#endif
 #if MYNEWT_VAL(MBEDTLS_ARC4_C) == 0
 #undef MBEDTLS_ARC4_C
 #endif

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -51,6 +51,8 @@ syscfg.defs:
     value: 1
   MBEDTLS_AES_ROM_TABLES:
     value: 0
+  MBEDTLS_AES_FEWER_TABLES:
+    value: 0
   MBEDTLS_ARC4_C:
     value: 0
   MBEDTLS_BLOWFISH_C:


### PR DESCRIPTION
This reduces usage of ROM/RAM (depending on the setting of `MBEDTLS_AES_ROM_TABLES`) to 2KB instead of 8KB. When using fewer tables, a single T-Table is used, and extra lookups require shifts, which has shown to be negligible in practice.

This new syscfg, `MBEDTLS_AES_FEWER_TABLES`, together with `MBEDTLS_AES_ROM_TABLES`, both of which are orthogonal, give me the following numbers, running a swap upgrade on the FRDM-K64F board:

                         FEWER_TABLES
                     0                1
              +----------------+--------------+
              | size: 29984    | size: 29888  |
            0 | swap: 18s      | swap: 18s    |
              | flash: 13398   | flash: 13302 |
              | ram: 8752      | ram: 2608    |    
              +----------------+--------------+ ROM_TABLES
              | size: 38156    | size: 32028  |
            1 | swap: 19s      | swap: 19s    |
              | flash: 21570   | flash: 15442 |
              | ram: 4         | ram: 4       |
              +----------------+--------------+

Where "size" denotes the size of the resulting bootloader, "swap" the time it takes to swap 2 400KB encrypted images, "flash" and "ram" are the mbedtls size as output by `newt size`.

PS: `MBEDTLS_AES_FEWER_TABLES` is not made default on this commit.