### PR TITLE
Nrf52840 spi 3

### DIFF
--- a/hw/bsp/nordic_pca10056/src/arch/cortex_m4/gcc_startup_nrf52840.s
+++ b/hw/bsp/nordic_pca10056/src/arch/cortex_m4/gcc_startup_nrf52840.s
@@ -129,9 +129,11 @@ __isr_vector:
     .long   UARTE1_IRQHandler
     .long   QSPI_IRQHandler
     .long   CRYPTOCELL_IRQHandler
-    .long   SPIM3_IRQHandler
     .long   0                           /*Reserved */
     .long   PWM3_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   SPIM3_IRQHandler
 
 
     .size    __isr_vector, . - __isr_vector

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -46,7 +46,7 @@ typedef void (*nrf52_spi_irq_handler_t)(void);
  */
 
 /* The maximum number of SPI interfaces we will allow */
-#define NRF52_HAL_SPI_MAX (3)
+#define NRF52_HAL_SPI_MAX (4)
 
 /* Used to disable all interrupts */
 #define NRF_SPI_IRQ_DISABLE_ALL 0xFFFFFFFF
@@ -101,6 +101,47 @@ struct nrf52_hal_spi nrf52_hal_spi1;
 #if MYNEWT_VAL(SPI_2_MASTER)  || MYNEWT_VAL(SPI_2_SLAVE)
 struct nrf52_hal_spi nrf52_hal_spi2;
 #endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+struct nrf52_hal_spi nrf52_hal_spi3;
+
+static uint32_t m_anomaly_198_preserved_value;
+static void
+anomaly_198_enable(uint8_t const * p_buffer, size_t buf_len)
+{
+    uint32_t buffer_end_addr;
+    uint32_t block_addr;
+    uint32_t block_flag;
+    uint32_t occupied_blocks;
+    m_anomaly_198_preserved_value = *((volatile uint32_t *)0x40000E00);
+
+    if (buf_len == 0) {
+        return;
+    }
+    buffer_end_addr = ((uint32_t)p_buffer) + buf_len;
+    block_addr      = ((uint32_t)p_buffer) & ~0x1FFF;
+    block_flag      = (1UL << ((block_addr >> 13) & 0xFFFF));
+    occupied_blocks = 0;
+
+    if (block_addr >= 0x20010000) {
+        occupied_blocks = (1UL << 8);
+    } else {
+        do {
+            occupied_blocks |= block_flag;
+            block_flag <<= 1;
+            block_addr  += 0x2000;
+        } while ((block_addr < buffer_end_addr) && (block_addr < 0x20012000));
+    }
+
+    *((volatile uint32_t *)0x40000E00) = occupied_blocks;
+}
+
+static void
+anomaly_198_disable(void)
+{
+    *((volatile uint32_t *)0x40000E00) = m_anomaly_198_preserved_value;
+}
+
+#endif
 
 static const struct nrf52_hal_spi *nrf52_hal_spis[NRF52_HAL_SPI_MAX] = {
 #if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
@@ -118,6 +159,11 @@ static const struct nrf52_hal_spi *nrf52_hal_spis[NRF52_HAL_SPI_MAX] = {
 #else
     NULL,
 #endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+    &nrf52_hal_spi3,
+#else
+    NULL,
+#endif
 };
 
 #define NRF52_HAL_SPI_RESOLVE(__n, __v)                     \
@@ -131,7 +177,7 @@ static const struct nrf52_hal_spi *nrf52_hal_spis[NRF52_HAL_SPI_MAX] = {
         goto err;                                           \
     }
 
-#if (MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER))
+#if (MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER) || MYNEWT_VAL(SPI_3_MASTER))
 static void
 nrf52_irqm_handler(struct nrf52_hal_spi *spi)
 {
@@ -286,6 +332,21 @@ nrf52_spi2_irq_handler(void)
 }
 #endif
 
+#if MYNEWT_VAL(SPI_3_MASTER)
+void
+nrf52_spi3_irq_handler(void)
+{
+    os_trace_isr_enter();
+    if (nrf52_hal_spi3.spi_type == HAL_SPI_TYPE_MASTER) {
+        anomaly_198_disable();
+#if MYNEWT_VAL(SPI_3_MASTER)
+        nrf52_irqm_handler(&nrf52_hal_spi3);
+#endif
+    }
+    os_trace_isr_exit();
+}
+#endif
+
 static void
 hal_spi_stop_transfer(NRF_SPIM_Type *spim)
 {
@@ -389,12 +450,13 @@ hal_spi_config_master(struct nrf52_hal_spi *spi,
         case 8000:
             frequency = SPIM_FREQUENCY_FREQUENCY_M8;
             break;
-#if defined(SPIM_FREQUENCY_FREQUENCY_M16)
+            /* 16 and 32 MHz is only supported on SPI_3_MASTER */
+#if defined(SPIM_FREQUENCY_FREQUENCY_M16) && MYNEWT_VAL(SPI_3_MASTER)
         case 16000:
             frequency = SPIM_FREQUENCY_FREQUENCY_M16;
             break;
 #endif
-#if defined(SPIM_FREQUENCY_FREQUENCY_M32)
+#if defined(SPIM_FREQUENCY_FREQUENCY_M32) && MYNEWT_VAL(SPI_3_MASTER)
         case 32000:
             frequency = SPIM_FREQUENCY_FREQUENCY_M32;
             break;
@@ -644,6 +706,18 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
 #else
             assert(0);
 #endif
+        }
+#else
+        goto err;
+#endif
+    } else if (spi_num == 3) {
+#if MYNEWT_VAL(SPI_3_MASTER)
+        spi->irq_num = SPIM3_IRQn;
+        irq_handler = nrf52_spi3_irq_handler;
+        if (spi_type == HAL_SPI_TYPE_MASTER) {
+            spi->nhs_spi.spim = NRF_SPIM3;
+        } else {
+            assert(0);
         }
 #else
         goto err;
@@ -1055,6 +1129,11 @@ hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int len)
             goto err;
         }
         spim = spi->nhs_spi.spim;
+#if MYNEWT_VAL(SPI_3_MASTER)
+        if (spim == NRF_SPIM3) {
+            anomaly_198_enable(txbuf, len);
+        }
+#endif
         spim->INTENCLR = SPIM_INTENCLR_END_Msk;
         spi->spi_xfr_flag = 1;
 

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
@@ -33,7 +33,7 @@
 #include "bus/drivers/i2c_hal.h"
 #endif
 #endif
-#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER)
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER) || MYNEWT_VAL(SPI_3_MASTER)
 #include "bus/drivers/spi_hal.h"
 #endif
 #endif
@@ -216,6 +216,24 @@ static const struct nrf52_hal_spi_cfg os_bsp_spi2s_cfg = {
     .miso_pin     = MYNEWT_VAL(SPI_2_SLAVE_PIN_MISO),
     .ss_pin       = MYNEWT_VAL(SPI_2_SLAVE_PIN_SS),
 };
+#endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static const struct bus_spi_dev_cfg spi3_cfg = {
+    .spi_num = 3,
+    .pin_sck = MYNEWT_VAL(SPI_3_MASTER_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
+};
+static struct bus_spi_dev spi3_bus;
+#else
+static const struct nrf52_hal_spi_cfg os_bsp_spi3m_cfg = {
+    .sck_pin      = MYNEWT_VAL(SPI_3_MASTER_PIN_SCK),
+    .mosi_pin     = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
+    .miso_pin     = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
+    /* For SPI master, SS pin is controlled as regular GPIO */
+};
+#endif
 #endif
 
 static void
@@ -444,6 +462,16 @@ nrf52_periph_create_spi(void)
 #if MYNEWT_VAL(SPI_2_SLAVE)
     rc = hal_spi_init(2, (void *)&os_bsp_spi2s_cfg, HAL_SPI_TYPE_SLAVE);
     assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bus_spi_hal_dev_create("spi3", &spi3_bus,
+                                (struct bus_spi_dev_cfg *)&spi3_cfg);
+    assert(rc == 0);
+#else
+    rc = hal_spi_init(3, (void *)&os_bsp_spi3m_cfg, HAL_SPI_TYPE_MASTER);
+    assert(rc == 0);
+#endif
 #endif
 }
 

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -220,7 +220,6 @@ syscfg.defs:
         description: 'Enable nRF52xxx SPI Master 3'
         value: 0
         restrictions:
-            - "!SPI_3_SLAVE"
             - 'MCU_TARGET == "nRF52840" || !SPI_3_MASTER'
     SPI_3_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_3_MASTER'
@@ -230,25 +229,6 @@ syscfg.defs:
         value: ''
     SPI_3_MASTER_PIN_MISO:
         description: 'MISO pin for SPI_3_MASTER'
-        value: ''
-
-    SPI_3_SLAVE:
-        description: 'Enable nRF52xxx SPI Slave 3'
-        value: 0
-        restrictions:
-            - "!SPI_3_MASTER"
-            - 'MCU_TARGET == "nRF52840" || !SPI_3_SLAVE'
-    SPI_3_SLAVE_PIN_SCK:
-        description: 'SCK pin for SPI_3_SLAVE'
-        value: ''
-    SPI_3_SLAVE_PIN_MOSI:
-        description: 'MOSI pin for SPI_3_SLAVE'
-        value: ''
-    SPI_3_SLAVE_PIN_MISO:
-        description: 'MISO pin for SPI_3_SLAVE'
-        value: ''
-    SPI_3_SLAVE_PIN_SS:
-        description: 'SS pin for SPI_3_SLAVE'
         value: ''
 
     ADC_0:
@@ -473,6 +453,5 @@ syscfg.restrictions:
     - "!SPI_0_SLAVE || (SPI_0_SLAVE_PIN_SCK && SPI_0_SLAVE_PIN_MOSI && SPI_0_SLAVE_PIN_MISO && SPI_0_SLAVE_PIN_SS)"
     - "!SPI_1_SLAVE || (SPI_1_SLAVE_PIN_SCK && SPI_1_SLAVE_PIN_MOSI && SPI_1_SLAVE_PIN_MISO && SPI_1_SLAVE_PIN_SS)"
     - "!SPI_2_SLAVE || (SPI_2_SLAVE_PIN_SCK && SPI_2_SLAVE_PIN_MOSI && SPI_2_SLAVE_PIN_MISO && SPI_2_SLAVE_PIN_SS)"
-    - "!SPI_3_SLAVE || (SPI_3_SLAVE_PIN_SCK && SPI_3_SLAVE_PIN_MOSI && SPI_3_SLAVE_PIN_MISO && SPI_3_SLAVE_PIN_SS)"
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"
     - "!UART_1 || (UART_1_PIN_TX && UART_1_PIN_RX)"


### PR DESCRIPTION
The SPI_3_MASTER interface in NRF52840 has some nice features I felt were missing in mynewt. Primarily because of the 16 or 32MHz speed only spi3m can offer. 

Note that spi3m only works as master, and it only seems to work for non-blocking read/write. Suggestions for making the blocking calls work are most welcome. 

I included the workaround for errata 198 ([nRF52840_Rev_1_Errata_v1.0.pdf](https://infocenter.nordicsemi.com/pdf/nRF52840_Rev_1_Errata_v1.0.pdf)) which may not apply to production boards?  