### PR TITLE
Fixes for lis2dh12

### DIFF
--- a/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
+++ b/hw/drivers/sensors/lis2dh12/include/lis2dh12/lis2dh12.h
@@ -216,7 +216,8 @@ struct lis2dh12_cfg {
     uint8_t latch_int2    : 1;
     uint8_t d4d_int1      : 1;
     uint8_t d4d_int2      : 1;
-    uint8_t int_pp_od     : 1;
+    /* Interrupt polarity 0 - active high */
+    uint8_t int_pol       : 1;
 
     /* Power mode */
     uint8_t power_mode;

--- a/hw/sensor/creator/pkg.yml
+++ b/hw/sensor/creator/pkg.yml
@@ -56,6 +56,8 @@ pkg.deps.BMP388_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/bmp388"
 pkg.deps.LIS2DW12_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lis2dw12"
+pkg.deps.LIS2DH12_OFB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
 pkg.deps.LPS33HW_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lps33hw"
 pkg.deps.LPS33THW_OFB:

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -140,6 +140,34 @@ syscfg.defs:
     LIS2DW12_OFB:
         description: 'LIS2DW12 is present'
         value : 0
+    LIS2DH12_OFB:
+        description: 'LIS2DH12 is present'
+        value : 0
+    LIS2DH12_OFB_I2C_NUM:
+        description: 'I2C interface used for LIS2DH12'
+        value:
+        restrictions:
+         - '(LIS2DH12_OFB == 0) ||
+            ((LIS2DH12_OFB_I2C_NUM == 0) && (I2C_0 == 1)) ||
+            ((LIS2DH12_OFB_I2C_NUM == 1) && (I2C_1 == 1)) ||
+            ((LIS2DH12_OFB_I2C_NUM == 2) && (I2C_2 == 1)) ||
+            ((LIS2DH12_OFB_I2C_NUM == -1))'
+    LIS2DH12_OFB_ITF_ADDR:
+        description: 'I2C address of LIS2DH12 0x18 or 0x19'
+        value: 0x18
+        range: 0x18,0x19
+    LIS2DH12_OFB_INT1_PIN_HOST:
+        description: 'Host pin for LIS2DH12 INT1 pin'
+        value: -1
+    LIS2DH12_OFB_INT2_PIN_HOST:
+        description: 'Host pin for LIS2DH12 INT2 pin'
+        value: -1
+    LIS2DH12_OFB_INT_CFG_ACTIVE:
+        description: 'Set 0 for active-low, 1 for active-high'
+        value: 1
+    LIS2DH12_OFB_BUS:
+        description: 'I2C or SPI interface used for LIS2DH12'
+        value: '"i2c0"'
     BMA2XX_OFB:
         description: 'A sensor in the BMA2XX family is present'
         value : 0


### PR DESCRIPTION
Added lis2dh12 to sensor creator
Change lis2dh12_set_int_pp_od() to lis2dh12_get_int_polarity() - code was copied from lis2dw12 and then modified. Names did not reflect was was actually done.
Interrupt level configuration was changed to look like in other drivers.