### PR TITLE
hw/sensors/bma253: Change data units from g to m/s2

### DIFF
--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -3522,9 +3522,9 @@ bma253_read_and_handle_fifo_data(struct bma253 *bma253,
                 accel_scale);
 
 
-        sad.sad_x = accel_data[AXIS_X].accel_g;
-        sad.sad_y = accel_data[AXIS_Y].accel_g;
-        sad.sad_z = accel_data[AXIS_Z].accel_g;
+        sad.sad_x = accel_data[AXIS_X].accel_g * STANDARD_ACCEL_GRAVITY;
+        sad.sad_y = accel_data[AXIS_Y].accel_g * STANDARD_ACCEL_GRAVITY;
+        sad.sad_z = accel_data[AXIS_Z].accel_g * STANDARD_ACCEL_GRAVITY;
         sad.sad_x_is_valid = 1;
         sad.sad_y_is_valid = 1;
         sad.sad_z_is_valid = 1;
@@ -5178,9 +5178,9 @@ bma253_poll_read(struct sensor * sensor,
             return rc;
         }
 
-        sad.sad_x = accel_data[AXIS_X].accel_g;
-        sad.sad_y = accel_data[AXIS_Y].accel_g;
-        sad.sad_z = accel_data[AXIS_Z].accel_g;
+        sad.sad_x = accel_data[AXIS_X].accel_g * STANDARD_ACCEL_GRAVITY;
+        sad.sad_y = accel_data[AXIS_Y].accel_g * STANDARD_ACCEL_GRAVITY;
+        sad.sad_z = accel_data[AXIS_Z].accel_g * STANDARD_ACCEL_GRAVITY;
         sad.sad_x_is_valid = 1;
         sad.sad_y_is_valid = 1;
         sad.sad_z_is_valid = 1;


### PR DESCRIPTION
All other accelerometers report values in m/s2 while bma253
reported in g.

Now bma253 also reports data to user callback in m/s2.