### PR TITLE
sensor_creator: Add BMA253 bus driver support

### DIFF
--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -364,7 +364,24 @@ static struct sensor_itf i2c_0_itf_ms40 = {
 };
 #endif
 
-#if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(BMA253_OFB)
+#if MYNEWT_VAL(BMA253_OFB)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static const struct bus_i2c_node_cfg bma253_i2c_cfg = {
+    .node_cfg = {
+        .bus_name = MYNEWT_VAL(BMA253_OFB_BUS),
+    },
+    .addr = MYNEWT_VAL(BMA253_OFB_I2C_ADDR),
+    .freq = 400,
+};
+static struct sensor_itf spi2c_0_itf_bma253 = {
+    .si_ints = {
+        { MYNEWT_VAL(BMA253_OFB_INT1_PIN), MYNEWT_VAL(BMA253_INT_PIN_DEVICE),
+            MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)},
+        { MYNEWT_VAL(BMA253_OFB_INT1_PIN), MYNEWT_VAL(BMA253_INT2_PIN_DEVICE),
+            MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)}
+    },
+};
+#elif MYNEWT_VAL(I2C_0)
 static struct sensor_itf spi2c_0_itf_bma253 = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
@@ -376,6 +393,7 @@ static struct sensor_itf spi2c_0_itf_bma253 = {
             MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)}
     },
 };
+#endif
 #endif
 
 #if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(BMA2XX_OFB)
@@ -1608,9 +1626,15 @@ sensor_dev_create(void)
 #endif
 
 #if MYNEWT_VAL(BMA253_OFB)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = bma253_create_i2c_sensor_dev(&bma253.node, "bma253_0",
+                                      &bma253_i2c_cfg, &spi2c_0_itf_bma253);
+    assert(rc == 0);
+#else
     rc = os_dev_create((struct os_dev *)&bma253, "bma253_0",
       OS_DEV_INIT_PRIMARY, 0, bma253_init, &spi2c_0_itf_bma253);
     assert(rc == 0);
+#endif
 
     rc = config_bma253_sensor();
     assert(rc == 0);

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -104,6 +104,20 @@ syscfg.defs:
     BMA253_OFB:
         description: 'BMA253 is present'
         value : 0
+    BMA253_OFB_BUS:
+        description: 'I2C or SPI interface used for BMA253'
+        value: '"i2c0"'
+    BMA253_OFB_INT1_PIN:
+        description: >
+            MCU's pin for INT1 of BMA253
+        value: -1
+    BMA253_OFB_INT2_PIN:
+        description: >
+            MCU's pin for INT2 of BMA253
+        value: -1
+    BMA253_OFB_I2C_ADDR:
+        description: 'I2C address of BMA253 0x18 or 0x19'
+        value: 0x18
     ADXL345_OFB:
         description: 'ADXL345 is present'
         value : 0


### PR DESCRIPTION
Sensor creator can create BMA253 device for bus driver builds.