### PR TITLE
bus/i2c_da1469x: Fix read with DMA

### DIFF
--- a/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
+++ b/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
@@ -503,6 +503,7 @@ i2c_da1469x_read(struct bus_dev *bdev, struct bus_node *bnode,
     dd->transfer.started = 1;
     dd->i2c_isr = i2c_da1469x_fill_fifo_for_rx;
     if (length >= MIN_DMA_SIZE) {
+        i2c_regs->I2C_DMA_CR_REG = 0;
         /*
          * To read I2C controller with DMA output FIFO must be fed with
          * read requests. In this case only one value is needed if DMA source


### PR DESCRIPTION
Internal trigger signal from I2C to DMA seems to be active
even when read FIFO is empty after some transactions.
It could be that when RDMAE bit is enabled for some normal
DMA transaction (and it is not cleared afterwards) next
read without DMA also enables trigger.
Then next read with DMA has trigger enabled and read
transfer starts as soon as read DMA is setup even though
I2C transmission did not started yet.
That results in extra byte read by DMA.

Clearing DMA_CR reg solves the issue.
TX only cleared DMA_CR register already.