### PR TITLE
da1469x build corrections

### DIFF
--- a/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
+++ b/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
@@ -22,11 +22,11 @@
 #include <assert.h>
 
 #include <os/mynewt.h>
+#include <mcu/mcu.h>
 #include <da1469x_charger/da1469x_charger.h>
 #include <bsp/bsp.h>
 #if MYNEWT_VAL(DA1469X_CHARGER_USE_CHARGE_CONTROL)
 #include <charge-control/charge_control.h>
-#include <DA1469xAB.h>
 #endif
 
 int

--- a/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger_shell.c
+++ b/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger_shell.c
@@ -26,7 +26,7 @@
 #include <da1469x_charger/da1469x_charger.h>
 #include <parse/parse.h>
 #include <stdio.h>
-#include <DA1469xAB.h>
+#include <mcu/mcu.h>
 #if MYNEWT_VAL(SDADC_BATTERY)
 #include <sdadc_da1469x/sdadc_da1469x.h>
 #endif

--- a/hw/drivers/pwm/pwm_da1469x/src/pwm_da1469x.c
+++ b/hw/drivers/pwm/pwm_da1469x/src/pwm_da1469x.c
@@ -23,7 +23,7 @@
 #include "os/util.h"
 #include "mcu/mcu.h"
 #include "mcu/da1469x_hal.h"
-#include <DA1469xAB.h>
+#include <mcu/mcu.h>
 
 struct da1469x_pwm {
     TIMER_Type *timer_regs;

--- a/hw/mcu/dialog/da1469x/pkg.yml
+++ b/hw/mcu/dialog/da1469x/pkg.yml
@@ -45,6 +45,9 @@ pkg.deps.'(I2C_0 || I2C_1) && BUS_DRIVER_PRESENT':
 pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER) && BUS_DRIVER_PRESENT':
     - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
 
+pkg.deps.'(PWM_0 || PWM_1 || PWM_2)':
+    - "@apache-mynewt-core/hw/drivers/pwm/pwm_da1469x"
+
 pkg.deps.GPADC:
     - "@apache-mynewt-core/hw/drivers/adc/gpadc_da1469x"
 


### PR DESCRIPTION
- Few places still included DA1469xAB.h instead of mcu.h.
- When PWM_x is enabled correct packages are included.