### PR TITLE
kernel/os: Make ticks_to_usecs optimized on debug build

### DIFF
--- a/kernel/os/src/os_cputime_pwr2.c
+++ b/kernel/os/src/os_cputime_pwr2.c
@@ -79,23 +79,8 @@ os_cputime_ticks_to_usecs(uint32_t ticks)
 {
     uint32_t usecs;
     uint32_t shift;
-    uint32_t freq;
 
-    /* Given: `freq = 2^n`, calculate `n`. */
-    /* Note: this looks like a lot of work, but gcc can optimize it away since
-     * `freq` is known at compile time.
-     */
-    freq = MYNEWT_VAL(OS_CPUTIME_FREQ);
-    shift = 0;
-    while (freq != 0) {
-        freq >>= 1;
-        shift++;
-    }
-
-    if (shift <= 7) {
-        return 0;
-    }
-    shift -= 7;
+    shift = __builtin_popcount(MYNEWT_VAL(OS_CPUTIME_FREQ) - 1) - 6;
 
     usecs = ((ticks >> shift) * 15625) + (((ticks & 0x1ff) * 15625) >> shift);
     return usecs;


### PR DESCRIPTION
Current routine is optimized-out only in optimized builds (GCC 8.2.1)
but it can be easily made optimizable on all builds by using builtin for
bit counting.

There is also no need for extra check on computed 'shift' value since
os_cputime_pwr2.c is onlu used if OS_CPUTIME_FREQ is >=256 so it will be
removed by compiler anyway after optimization.

Note that comment in original code was a bit misleading since 'shift'
was equal to 'n+1', not 'n' thus different subtraction is used in new
code.