### PR TITLE
os/kernel: Fix os_cputime_ticks_to_usecs

### DIFF
--- a/kernel/os/src/os_cputime_pwr2.c
+++ b/kernel/os/src/os_cputime_pwr2.c
@@ -82,7 +82,8 @@ os_cputime_ticks_to_usecs(uint32_t ticks)
 
     shift = __builtin_popcount(MYNEWT_VAL(OS_CPUTIME_FREQ) - 1) - 6;
 
-    usecs = ((ticks >> shift) * 15625) + (((ticks & 0x1ff) * 15625) >> shift);
+    usecs = ((ticks >> shift) * 15625) +
+            (((ticks & ~(~0U << shift)) * 15625) >> shift);
     return usecs;
 }
 


### PR DESCRIPTION
Function was correctly computing values only when
OS_CPUTIME_FREQ was 32768.
For other values computation could be incorrect depending
on ticks.

Hard-coded mask 0x1FF was only good for 32768.
Now mask is also computed.

To make decision easier assembly before and after change for frequency 32768:
```
080168a4 <os_cputime_ticks_to_usecs>:
    uint32_t usecs;
    uint32_t shift;

    shift = __builtin_popcount(MYNEWT_VAL(OS_CPUTIME_FREQ) - 1) - 6;

    usecs = ((ticks >> shift) * 15625) + (((ticks & 0x1ff) * 15625) >> shift);
 80168a4:	0a41      	lsrs	r1, r0, #9
 80168a6:	f643 5209 	movw	r2, #15625	; 0x3d09
 80168aa:	f3c0 0308 	ubfx	r3, r0, #0, #9
 80168ae:	fb02 f303 	mul.w	r3, r2, r3
 80168b2:	0a5b      	lsrs	r3, r3, #9
    return usecs;
}
 80168b4:	fb02 3001 	mla	r0, r2, r1, r3
 80168b8:	4770      	bx	lr

-------------------
080168a4 <os_cputime_ticks_to_usecs>:
    uint32_t usecs;
    uint32_t shift;

    shift = __builtin_popcount(MYNEWT_VAL(OS_CPUTIME_FREQ) - 1) - 6;

    usecs = ((ticks >> shift) * 15625) +
 80168a4:	0a41      	lsrs	r1, r0, #9
 80168a6:	f643 5209 	movw	r2, #15625	; 0x3d09
            (((ticks & ~(~0U << shift)) * 15625) >> shift);
 80168aa:	f3c0 0308 	ubfx	r3, r0, #0, #9
 80168ae:	fb02 f303 	mul.w	r3, r2, r3
 80168b2:	0a5b      	lsrs	r3, r3, #9
    return usecs;
}
 80168b4:	fb02 3001 	mla	r0, r2, r1, r3
 80168b8:	4770      	bx	lr
```