### PR TITLE
hw/mcu/da1469x: Make number of GPIO interrupts configurable

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -29,7 +29,7 @@
 #include "bsp/bsp.h"
 
 /* GPIO interrupts */
-#define HAL_GPIO_MAX_IRQ        (4)
+#define HAL_GPIO_MAX_IRQ        MYNEWT_VAL(MCU_GPIO_MAX_IRQ)
 
 #define GPIO_REG(name) ((__IO uint32_t *)(GPIO_BASE + offsetof(GPIO_Type, name)))
 #define WAKEUP_REG(name) ((__IO uint32_t *)(WAKEUP_BASE + offsetof(WAKEUP_Type, name)))
@@ -358,6 +358,8 @@ hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
     hal_gpio_irq_setup();
 
     i = hal_gpio_find_empty_slot();
+    /* If assert failed increase syscfg value MCU_GPIO_MAX_IRQ */
+    assert(i >= 0);
     if (i < 0) {
         return -1;
     }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -39,6 +39,11 @@ syscfg.defs:
             PD_COM will be disabled before entering deep sleep and thus
             state of any configured GPIO has to be retained and restored.
         value: 4
+    MCU_GPIO_MAX_IRQ:
+        desriptin: >
+            Maximum number of GPIO interrupts that can be configured at
+            once.
+        value: 4
 
     MCU_CLOCK_XTAL32M_SETTLE_TIME_US:
         description: >


### PR DESCRIPTION
Value 4 for number of GPIO interrupts may not be sufficient.
This just makes it configurable.

In case GPIO interrupt slots run out it's batter to assert
at meaningful place instead of some driver code.