### PR TITLE
hw/mcu/dialog; add da1469x_flash_setup()

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -68,6 +68,22 @@ struct da1469x_hal_spi_cfg {
     int8_t pin_ss;
 };
 
+/**
+ * Allow QSPI and the connected flash to be setup.
+ * This allows proper operation when configation script is not
+ * executed/present yet.
+ *
+ * @param dev    Pointer to device
+ * @param bursta BURSTCMDA_REG register setting
+ * @param burstb BURSTCMDB_REG register setting
+ * @param cmds   Array of byte sized commands sent over SPI to flash
+ * @param len    Number of command bytes
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+void da1469x_flash_setup(const struct hal_flash *dev, uint32_t bursta,
+                         uint32_t burstb, uint8_t *cmds, int len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -307,6 +307,28 @@ da1469x_qspi_erase_sector(const struct hal_flash *dev, uint32_t sector_address)
     return 0;
 }
 
+void
+da1469x_flash_setup(const struct hal_flash *dev, uint32_t bursta,
+                    uint32_t burstb, uint8_t *cmds, int len)
+{
+    int i;
+
+    da1469x_qspi_mode_manual(NULL);
+    da1469x_qspi_mode_single(NULL);
+
+    QSPIC->QSPIC_BURSTCMDA_REG = bursta;
+    QSPIC->QSPIC_BURSTCMDB_REG = burstb;
+
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
+    for (i = 0; i < len; i++) {
+        da1469x_qspi_write8(NULL, cmds[i]);
+    }
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
+
+    da1469x_qspi_mode_quad(NULL);
+    da1469x_qspi_mode_auto(NULL);
+}
+
 static int
 da1469x_hff_read(const struct hal_flash *dev, uint32_t address, void *dst,
                  uint32_t num_bytes)


### PR DESCRIPTION
This can be used in scenario where board does not have configuration script yet setting
up QSPI, but you need access to flash. E.g.. from flash_loader.