### PR TITLE
Remove _LOG_MODULE conflicts

### DIFF
--- a/hw/drivers/sensors/bmp388/syscfg.yml
+++ b/hw/drivers/sensors/bmp388/syscfg.yml
@@ -76,7 +76,7 @@ syscfg.defs:
 
     BMP388_LOG_MODULE:
         description: 'Numeric module ID to use for BMP388 log messages.'
-        value: 213
+        value: 214
     BMP388_LOG_LVL:
         description: 'Minimum level for the BMP388 log.'
         value: 1

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -37,7 +37,7 @@ syscfg.defs:
 
     BNO055_LOG_MODULE:
         description: 'Numeric module ID to use for BNO055 log messages.'
-        value: 85
+        value: 87
     BNO055_LOG_LVL:
         description: 'Minimum level for the BNO055 log.'
         value: 1

--- a/hw/drivers/sensors/lis2de12/syscfg.yml
+++ b/hw/drivers/sensors/lis2de12/syscfg.yml
@@ -71,7 +71,7 @@ syscfg.defs:
 
     LIS2DE12_LOG_MODULE:
         description: 'Numeric module ID to use for LIS2DE12 log messages.'
-        value: 110
+        value: 112
     LIS2DE12_LOG_LVL:
         description: 'Minimum level for the LIS2DE12 log.'
         value: 1

--- a/hw/drivers/sensors/lsm303dlhc/syscfg.yml
+++ b/hw/drivers/sensors/lsm303dlhc/syscfg.yml
@@ -30,7 +30,7 @@ syscfg.defs:
 
     LSM303DLHC_LOG_MODULE:
         description: 'Numeric module ID to use for LSM303DLHC log messages.'
-        value: 195
+        value: 196
     LSM303DLHC_LOG_LVL:
         description: 'Minimum level for the LSM303DLHC log.'
         value: 1

--- a/hw/drivers/sensors/lsm6dso/syscfg.yml
+++ b/hw/drivers/sensors/lsm6dso/syscfg.yml
@@ -68,7 +68,7 @@ syscfg.defs:
 
     LSM6DSO_LOG_MODULE:
         description: 'Numeric module ID to use for LSM6DSO log messages.'
-        value: 110
+        value: 113
     LSM6DSO_LOG_LVL:
         description: 'Minimum level for the LSM6DSO log.'
         value: 1


### PR DESCRIPTION
Some sensors had same xxx_LOG_MODULE id values.
This prevented usage of those sensor together.

This changes duplicated ID's to unused ones.