### PR TITLE
lsm6dso bus driver updates

### DIFF
--- a/hw/drivers/sensors/lsm6dso/include/lsm6dso/lsm6dso.h
+++ b/hw/drivers/sensors/lsm6dso/include/lsm6dso/lsm6dso.h
@@ -348,6 +348,17 @@ lsm6dso_get_ag_data(struct sensor_itf *itf, sensor_type_t type, void *data,
  */
 int lsm6dso_run_self_test(struct sensor_itf *itf, int *result);
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+int lsm6dso_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                                  const struct bus_i2c_node_cfg *i2c_cfg,
+                                  struct sensor_itf *sensor_itf);
+
+int lsm6dso_create_spi_sensor_dev(struct bus_spi_node *node, const char *name,
+                                  const struct bus_spi_node_cfg *spi_cfg,
+                                  struct sensor_itf *sensor_itf);
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -383,7 +383,6 @@ int lsm6dso_writelen(struct sensor_itf *itf, uint8_t addr,
          */
         uint8_t payload[19];
     } write_data;
-    struct lsm6dso *dev = (struct lsm6dso *)itf->si_dev;
 
     if (len > sizeof(write_data.payload)) {
         return -1;
@@ -406,9 +405,9 @@ int lsm6dso_writelen(struct sensor_itf *itf, uint8_t addr,
     }
 
     sensor_itf_unlock(itf);
+err:
 #endif /* BUS_DRIVER_PRESENT */
 
-err:
     return rc;
 }
 

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso_shell.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso_shell.c
@@ -76,12 +76,25 @@ static struct shell_cmd lsm6dso_shell_cmd_struct = {
     .sc_cmd_func = lsm6dso_shell_cmd
 };
 
-static struct sensor_itf g_sensor_itf = {
-    .si_type = MYNEWT_VAL(LSM6DSO_SHELL_ITF_TYPE),
-    .si_num = MYNEWT_VAL(LSM6DSO_SHELL_ITF_NUM),
-    .si_cs_pin = MYNEWT_VAL(LSM6DSO_SHELL_CSPIN),
-    .si_addr = MYNEWT_VAL(LSM6DSO_SHELL_ITF_ADDR)
-};
+static struct sensor_itf *g_sensor_itf;
+static struct lsm6dso *g_lsm6dso;
+
+static int
+lsm6dso_shell_open_device(void)
+{
+    if (g_sensor_itf) {
+        return 0;
+    }
+
+    g_lsm6dso = (struct lsm6dso *)os_dev_open(MYNEWT_VAL(LSM6DSO_SHELL_DEV), 1000,
+                                              NULL);
+    if (g_lsm6dso) {
+        g_sensor_itf = &g_lsm6dso->sensor.s_itf;
+        return 0;
+    }
+
+    return SYS_ENODEV;
+}
 
 static int lsm6dso_shell_err_invalid_arg(char *cmd_name)
 {
@@ -149,7 +162,7 @@ static int lsm6dso_shell_cmd_dump(int argc, char **argv)
     }
 
     for (i = sreg; i <= ereg; i++) {
-        rc = lsm6dso_readlen(&g_sensor_itf, i, &value, 1);
+        rc = lsm6dso_readlen(g_sensor_itf, i, &value, 1);
         if (rc) {
             console_printf("dump failed %d\n", rc);
         } else {
@@ -180,7 +193,7 @@ static int lsm6dso_shell_cmd_read(int argc, char **argv)
         return lsm6dso_shell_err_invalid_arg(argv[2]);
    }
 
-    rc = lsm6dso_readlen(&g_sensor_itf, reg, &value, 1);
+    rc = lsm6dso_readlen(g_sensor_itf, reg, &value, 1);
     if (rc) {
         console_printf("read failed %d\n", rc);
     } else {
@@ -210,7 +223,7 @@ static int lsm6dso_shell_cmd_write(int argc, char **argv)
        return lsm6dso_shell_err_invalid_arg(argv[2]);
     }
 
-    rc = lsm6dso_writelen(&g_sensor_itf, reg, &value, 1);
+    rc = lsm6dso_writelen(g_sensor_itf, reg, &value, 1);
     if (rc) {
         console_printf("write failed %d\n", rc);
     }
@@ -223,7 +236,7 @@ static int lsm6dso_shell_cmd_test(int argc, char **argv)
     int rc;
     int result;
 
-    rc = lsm6dso_run_self_test(&g_sensor_itf, &result);
+    rc = lsm6dso_run_self_test(g_sensor_itf, &result);
     if (rc) {
         console_printf("test not started %d\n", rc);
     } else {
@@ -239,6 +252,11 @@ static int lsm6dso_shell_cmd(int argc, char **argv)
         lsm6dso_shell_help();
 
         return 0;
+    }
+
+    if (lsm6dso_shell_open_device()) {
+        console_printf("Error: device not found \"%s\"\n",
+                       MYNEWT_VAL(LSM6DSO_SHELL_DEV));
     }
 
     if (argc > 1 && strcmp(argv[1], "dump") == 0) {

--- a/hw/drivers/sensors/lsm6dso/syscfg.yml
+++ b/hw/drivers/sensors/lsm6dso/syscfg.yml
@@ -30,18 +30,25 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
+    LSM6DSO_SHELL_DEV:
+        description: 'Name of LSM6DSO device to use in shell'
+        value: '"lsm6dso_0"'
     LSM6DSO_SHELL_ITF_NUM:
         description: 'Shell interface number for the LSM6DSO'
         value: 0
+        deprecated: 1
     LSM6DSO_SHELL_ITF_TYPE:
         description: 'Shell interface type for the LSM6DSO'
         value: 1
+        deprecated: 1
     LSM6DSO_SHELL_CSPIN:
         description: 'CS pin for LSM6DSO'
         value : -1
+        deprecated: 1
     LSM6DSO_SHELL_ITF_ADDR:
         description: 'Slave address for LSM6DSO'
         value : 0x6b
+        deprecated: 1
     LSM6DSO_NOTIF_STATS:
         description: 'Enable notification stats'
         value: 1

--- a/hw/sensor/creator/pkg.yml
+++ b/hw/sensor/creator/pkg.yml
@@ -30,6 +30,8 @@ pkg.deps.DRV2605_OFB:
     - "@apache-mynewt-core/hw/drivers/drv2605"
 pkg.deps.LSM303DLHC_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lsm303dlhc"
+pkg.deps.LSM6DSO_OFB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lsm6dso"
 pkg.deps.MPU6050_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/mpu6050"
 pkg.deps.TSL2561_OFB:

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -29,6 +29,24 @@ syscfg.defs:
     LSM303DLHC_OFB:
         description: 'LSM303 is present'
         value : 0
+    LSM6DSO_OFB:
+        description: 'LSM6DSO is present'
+        value : 0
+    LSM6DSO_OFB_I2C_NUM:
+        description: 'I2C interface used for LSM6DS0'
+        value: 0
+        restrictions:
+         - '(LSM6DSO_OFB == 0) ||
+            ((LSM6DSO_OFB_I2C_NUM == 0) && (I2C_0 == 1)) ||
+            ((LSM6DSO_OFB_I2C_NUM == 1) && (I2C_1 == 1)) ||
+            ((LSM6DSO_OFB_I2C_NUM == 2) && (I2C_2 == 1))'
+    LSM6DSO_OFB_I2C_BUS:
+        description: 'I2C interface used for LSM6DSO'
+        value : '"i2c0"'
+    LSM6DSO_OFB_I2C_ADDR:
+        description: 'I2C address of LSM6DSO 0x6A or 0x6B'
+        value: 0x6A
+        range: 0x6A,0x6B
     MPU6050_OFB:
         description: 'MPU6050 is present'
         value : 0


### PR DESCRIPTION
Small fixes to bus driver build.
Shell now can work with bus driver build
Sensor creator  can create lsm6dso device.

Code was verified to build but was not tested on any hardware due to lack of device.