### PR TITLE
stm32 hal_timer small fixes

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_timer.c
+++ b/hw/mcu/stm/stm32_common/src/hal_timer.c
@@ -94,7 +94,7 @@ stm32_tmr_cbs(struct stm32_hal_tmr *tmr)
     }
     ht = TAILQ_FIRST(&tmr->sht_timers);
     if (ht) {
-        tmr->sht_regs->CCR1 = ht->expiry;
+        tmr->sht_regs->CCR1 = ht->expiry & 0xFFFFU;
     } else {
         TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1, TIM_CCx_DISABLE);
         tmr->sht_regs->DIER &= ~TIM_DIER_CC1IE;
@@ -740,7 +740,7 @@ hal_timer_start_at(struct hal_timer *timer, uint32_t tick)
     } else {
         if (timer == TAILQ_FIRST(&tmr->sht_timers)) {
             TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1, TIM_CCx_ENABLE);
-            tmr->sht_regs->CCR1 = timer->expiry;
+            tmr->sht_regs->CCR1 = timer->expiry & 0xFFFFU;
             tmr->sht_regs->DIER |= TIM_DIER_CC1IE;
         }
     }
@@ -780,7 +780,7 @@ hal_timer_stop(struct hal_timer *timer)
         timer->link.tqe_prev = NULL;
         if (reset_ocmp) {
             if (ht) {
-                tmr->sht_regs->CCR1 = ht->expiry;
+                tmr->sht_regs->CCR1 = ht->expiry & 0xFFFFU;
             } else {
                 TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1,
                   TIM_CCx_DISABLE);

--- a/hw/mcu/stm/stm32_common/src/hal_timer.c
+++ b/hw/mcu/stm/stm32_common/src/hal_timer.c
@@ -509,7 +509,7 @@ hal_timer_config(int num, uint32_t freq_hz)
 
     memset(&init, 0, sizeof(init));
     init.Period = 0xffff;
-    init.Prescaler = prescaler;
+    init.Prescaler = prescaler - 1;
     init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     init.CounterMode = TIM_COUNTERMODE_UP;
 
@@ -576,7 +576,7 @@ hal_timer_get_resolution(int num)
     if (num >= STM32_HAL_TIMER_MAX || !(tmr = stm32_tmr_devs[num])) {
         return -1;
     }
-    return (STM32_NSEC_PER_SEC / (SystemCoreClock / tmr->sht_regs->PSC));
+    return (STM32_NSEC_PER_SEC / (SystemCoreClock / (1 + tmr->sht_regs->PSC)));
 }
 
 static uint32_t

--- a/hw/mcu/stm/stm32_common/src/hal_timer.c
+++ b/hw/mcu/stm/stm32_common/src/hal_timer.c
@@ -96,7 +96,6 @@ stm32_tmr_cbs(struct stm32_hal_tmr *tmr)
     if (ht) {
         tmr->sht_regs->CCR1 = ht->expiry & 0xFFFFU;
     } else {
-        TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1, TIM_CCx_DISABLE);
         tmr->sht_regs->DIER &= ~TIM_DIER_CC1IE;
     }
 }
@@ -739,7 +738,6 @@ hal_timer_start_at(struct hal_timer *timer, uint32_t tick)
         tmr->sht_regs->DIER |= TIM_DIER_CC1IE;
     } else {
         if (timer == TAILQ_FIRST(&tmr->sht_timers)) {
-            TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1, TIM_CCx_ENABLE);
             tmr->sht_regs->CCR1 = timer->expiry & 0xFFFFU;
             tmr->sht_regs->DIER |= TIM_DIER_CC1IE;
         }
@@ -782,8 +780,6 @@ hal_timer_stop(struct hal_timer *timer)
             if (ht) {
                 tmr->sht_regs->CCR1 = ht->expiry & 0xFFFFU;
             } else {
-                TIM_CCxChannelCmd(tmr->sht_regs, TIM_CHANNEL_1,
-                  TIM_CCx_DISABLE);
                 tmr->sht_regs->DIER &= ~TIM_DIER_CC1IE;
             }
         }


### PR DESCRIPTION
- Prescaler was not correctly handled resulting in slightly wrong time calculation
- using TIM2 (which can be 32 bits on some MCU) could not work correctly
- redundant code removed