### PR TITLE
da1469x: enable switching to rcx clock source

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -66,6 +66,18 @@ void da1469x_clock_lp_xtal32k_enable(void);
 void da1469x_clock_lp_xtal32k_switch(void);
 
 /**
+ * Enable RCX
+ */
+void da1469x_clock_lp_rcx_enable(void);
+
+/**
+ * Switch lp_clk to RCX
+ *
+ * Caller shall ensure RCX is already settled.
+ */
+void da1469x_clock_lp_rcx_switch(void);
+
+/**
  * Disable RCX
  */
 void da1469x_clock_lp_rcx_disable(void);

--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -120,6 +120,20 @@ da1469x_clock_lp_xtal32k_switch(void)
 }
 
 void
+da1469x_clock_lp_rcx_enable(void)
+{
+    CRG_TOP->CLK_RCX_REG  |= CRG_TOP_CLK_RCX_REG_RCX_ENABLE_Msk;
+}
+
+void
+da1469x_clock_lp_rcx_switch(void)
+{
+    CRG_TOP->CLK_CTRL_REG = (CRG_TOP->CLK_CTRL_REG &
+                             ~CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Msk) |
+                            (1 << CRG_TOP_CLK_CTRL_REG_LP_CLK_SEL_Pos);
+}
+
+void
 da1469x_clock_lp_rcx_disable(void)
 {
     CRG_TOP->CLK_RCX_REG &= ~CRG_TOP_CLK_RCX_REG_RCX_ENABLE_Msk;

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -32,6 +32,7 @@ bool g_mcu_lpclk_available;
 
 static da1469x_lpclk_cb *g_da1469x_lpclk_cmac_cb;
 
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
 static void
 da1469x_lpclk_settle_tmr_cb(void *arg)
 {
@@ -43,6 +44,7 @@ da1469x_lpclk_settle_tmr_cb(void *arg)
         g_da1469x_lpclk_cmac_cb();
     }
 }
+#endif
 
 void
 da1469x_lpclk_register_cmac_cb(da1469x_lpclk_cb *cb)
@@ -57,11 +59,15 @@ da1469x_lpclk_register_cmac_cb(da1469x_lpclk_cb *cb)
 void
 da1469x_lpclk_init(void)
 {
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
     static struct hal_timer lpclk_settle_tmr;
-
     da1469x_clock_lp_xtal32k_enable();
-
     os_cputime_timer_init(&lpclk_settle_tmr, da1469x_lpclk_settle_tmr_cb, NULL);
     os_cputime_timer_relative(&lpclk_settle_tmr,
                               MYNEWT_VAL(MCU_CLOCK_XTAL32K_SETTLE_TIME_MS) * 1000);
+#endif
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
+    da1469x_clock_lp_rcx_enable();
+    da1469x_clock_lp_rcx_switch();
+#endif
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -31,7 +31,7 @@ syscfg.defs:
         description: >
             Specifies whether or not to enable SIMO DC-DC Converter.
         value: 0
-    
+
     MCU_GPIO_RETAINABLE_NUM:
         description: >
             Number of GPIO pins which can have its state retained in
@@ -39,6 +39,14 @@ syscfg.defs:
             PD_COM will be disabled before entering deep sleep and thus
             state of any configured GPIO has to be retained and restored.
         value: 4
+
+    MCU_LPCLK_SOURCE:
+        description: >
+            Selected low power clock source. default RC32K.
+        value:
+        choices:
+            - RCX       # ~14.5 kHz crystal oscillator
+            - XTAL32K   # 32 kHz crystal oscillator
 
     MCU_CLOCK_XTAL32M_SETTLE_TIME_US:
         description: >
@@ -326,6 +334,19 @@ syscfg.defs:
         value: 0
         restrictions:
             - '!GPADC_BATTERY'
+
+    LP_RCX:
+        description:
+        value: 0
+
+    LP_XTAL32K:
+        description:
+        value: 0
+
+syscfg.vals.LP_RCX:
+    MCU_LPCLK_SOURCE: RCX
+syscfg.vals.LP_XTAL32K:
+    MCU_LPCLK_SOURCE: XTAL32K
 
 syscfg.restrictions:
     - "QSPI_FLASH_ADDRESS_LENGTH==24"


### PR DESCRIPTION
Changing the code to configure for different low power clock sources. Originally, it was assumed that the XTAL32K would be on board. However, this is not necessarily true. The change here is to make switching to the XTAL32K configurable. Also adding a configurable setting to switch to the RCX if desired. @andrzej-kaczmarek @kasjer 