### PR TITLE
Initialize QSPI_BURSTCMDx_REG registers in hal_flash_init()

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -382,5 +382,11 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
 static int
 da1469x_hff_init(const struct hal_flash *dev)
 {
+#if MYNEWT_VAL(MCU_QSPIC_BURSTCMDA_INIT_VAL) >= 0
+    QSPIC->QSPIC_BURSTCMDA_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDA_INIT_VAL);
+#endif
+#if MYNEWT_VAL(MCU_QSPIC_BURSTCMDB_INIT_VAL) >= 0
+    QSPIC->QSPIC_BURSTCMDB_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDB_INIT_VAL);
+#endif
     return 0;
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -31,7 +31,7 @@ syscfg.defs:
         description: >
             Specifies whether or not to enable SIMO DC-DC Converter.
         value: 0
-    
+
     MCU_GPIO_RETAINABLE_NUM:
         description: >
             Number of GPIO pins which can have its state retained in
@@ -113,6 +113,14 @@ syscfg.defs:
             data before writing, i.e. each such transfer will be split into
             chunks of this size. Buffer is created on stack.
         value: 128
+    MCU_QSPIC_BURSTCMDA_INIT_VAL:
+        description: >
+            Initialization value for QSPIC_BURSTCMDA_REG
+        value: -1
+    MCU_QSPIC_BURSTCMDB_INIT_VAL:
+        description: >
+            Initialization value for QSPIC_BURSTCMDB_REG
+        value: -1
 
 # MCU peripherals definitions
     I2C_0:


### PR DESCRIPTION
The QSPI_BURSTCMDA_REG and  QSPI_BURSTCMDB_REG registers must be configured with specific values for the target flash type. The da1469x will attempt to configure these registers from OTP or from a header prepended to the flash boot image. In the absence of either of these, the register values must be configured by initialization code (typically this would be code loaded to RAM). 

This PR adds syscfgs QSPI_BURSTCMDA_INIT_VAL and QSPI_BURSTCMDB_INIT_VAL which
can be set to enable initialization of the corresponding registers by hal_flash_init(). When the syscfg values are set to the default value, -1, the register initialization will not be performed.   

For background see Sec. 6.7 BOOTING in the DA1469x datasheet.