### PR TITLE
Fix include issue in da1469x_charger driver

### DIFF
--- a/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
+++ b/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
@@ -26,7 +26,7 @@
 #include <bsp/bsp.h>
 #if MYNEWT_VAL(DA1469X_CHARGER_USE_CHARGE_CONTROL)
 #include <charge-control/charge_control.h>
-#include <DA1469xAB.h>
+#include <mcu/mcu.h>
 #endif
 
 int

--- a/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger_shell.c
+++ b/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger_shell.c
@@ -26,7 +26,7 @@
 #include <da1469x_charger/da1469x_charger.h>
 #include <parse/parse.h>
 #include <stdio.h>
-#include <DA1469xAB.h>
+#include <mcu/mcu.h>
 #if MYNEWT_VAL(SDADC_BATTERY)
 #include <sdadc_da1469x/sdadc_da1469x.h>
 #endif


### PR DESCRIPTION
The include of DA1469xAB.h results in a file not found when da1469x alternate mcu types are used. The issue can be resolved by including mcu.h instead of DA1469xAB.h. 
