### PR TITLE
sensors/shell: Minor device name unification for some drivers

### DIFF
--- a/hw/drivers/sensors/bno055/src/bno055_shell.c
+++ b/hw/drivers/sensors/bno055/src/bno055_shell.c
@@ -52,8 +52,8 @@ bno055_shell_open_device(void)
         return 0;
     }
 
-    g_bno055 = (struct bno055 *)os_dev_open(MYNEWT_VAL(BNO055_SHELL_DEV), 1000,
-                                            NULL);
+    g_bno055 = (struct bno055 *)os_dev_open(MYNEWT_VAL(BNO055_SHELL_DEV_NAME),
+                                            1000, NULL);
     if (g_bno055) {
         g_sensor_itf = &g_bno055->sensor.s_itf;
         return 0;
@@ -491,7 +491,7 @@ bno055_shell_cmd(int argc, char **argv)
 
     if (bno055_shell_open_device()) {
         console_printf("Error: device not found \"%s\"\n",
-                       MYNEWT_VAL(BNO055_SHELL_DEV));
+                       MYNEWT_VAL(BNO055_SHELL_DEV_NAME));
     }
     /* Read command (get a new data sample) */
     if (argc > 1 && strcmp(argv[1], "r") == 0) {

--- a/hw/drivers/sensors/bno055/syscfg.yml
+++ b/hw/drivers/sensors/bno055/syscfg.yml
@@ -21,7 +21,7 @@ syscfg.defs:
     BNO055_CLI:
         description: 'Enable shell support for the BNO055'
         value: 0
-    BNO055_SHELL_DEV:
+    BNO055_SHELL_DEV_NAME:
         description: 'System defined device to use in shell'
         value: '"bno055_0"'
     BNO055_ITF_LOCK_TMO:

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
@@ -50,7 +50,7 @@ lis2dh12_shell_open_device(void)
         return 0;
     }
 
-    g_lis2dh12 = (struct lis2dh12 *)os_dev_open(MYNEWT_VAL(LIS2DH12_SHELL_DEV),
+    g_lis2dh12 = (struct lis2dh12 *)os_dev_open(MYNEWT_VAL(LIS2DH12_SHELL_DEV_NAME),
                                                 1000, NULL);
     if (g_lis2dh12) {
         g_sensor_itf = &g_lis2dh12->sensor.s_itf;
@@ -330,7 +330,7 @@ lis2dh12_shell_cmd(int argc, char **argv)
 
     if (lis2dh12_shell_open_device()) {
         console_printf("Error: device not found \"%s\"\n",
-                       MYNEWT_VAL(LIS2DH12_SHELL_DEV));
+                       MYNEWT_VAL(LIS2DH12_SHELL_DEV_NAME));
         return 0;
     }
 

--- a/hw/drivers/sensors/lis2dh12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dh12/syscfg.yml
@@ -30,7 +30,7 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
-    LIS2DH12_SHELL_DEV:
+    LIS2DH12_SHELL_DEV_NAME:
         description: >
             Device name for lis2dh12 device used in shell
         value:

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso_shell.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso_shell.c
@@ -86,8 +86,8 @@ lsm6dso_shell_open_device(void)
         return 0;
     }
 
-    g_lsm6dso = (struct lsm6dso *)os_dev_open(MYNEWT_VAL(LSM6DSO_SHELL_DEV), 1000,
-                                              NULL);
+    g_lsm6dso = (struct lsm6dso *)os_dev_open(MYNEWT_VAL(LSM6DSO_SHELL_DEV_NAME),
+                                              1000, NULL);
     if (g_lsm6dso) {
         g_sensor_itf = &g_lsm6dso->sensor.s_itf;
         return 0;
@@ -256,7 +256,7 @@ static int lsm6dso_shell_cmd(int argc, char **argv)
 
     if (lsm6dso_shell_open_device()) {
         console_printf("Error: device not found \"%s\"\n",
-                       MYNEWT_VAL(LSM6DSO_SHELL_DEV));
+                       MYNEWT_VAL(LSM6DSO_SHELL_DEV_NAME));
     }
 
     if (argc > 1 && strcmp(argv[1], "dump") == 0) {

--- a/hw/drivers/sensors/lsm6dso/syscfg.yml
+++ b/hw/drivers/sensors/lsm6dso/syscfg.yml
@@ -30,7 +30,7 @@ syscfg.defs:
         description: >
             Number of OS ticks to wait for each I2C transaction to complete.
         value: 3
-    LSM6DSO_SHELL_DEV:
+    LSM6DSO_SHELL_DEV_NAME:
         description: 'Name of LSM6DSO device to use in shell'
         value: '"lsm6dso_0"'
     LSM6DSO_SHELL_ITF_NUM:


### PR DESCRIPTION
Recently added syscfg values to specify device that should be
accessed in drivers specific shells did not adhere to convention
adapted by other drivers.
Existing names were: BMA253_SHELL_DEV_NAME, BMP388_SHELL_DEV_NAME, ...
new ones had missing suffix _NAME.
It did not result in any problem but since those are new additions
there is no need to change well adopted schema.
Change names will be:
LIS2DH12_SHELL_DEV_NAME,
BNO055_SHELL_DEV_NAME,
LSM6DSO_SHELL_DEV_NAME