### PR TITLE
hw/mcu/dialog: syscfgs for QSPIC_BURSTCMDA_REG, QSPIC_BURSTCMDB_REG

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -379,8 +379,36 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
     return 0;
 }
 
-static int
-da1469x_hff_init(const struct hal_flash *dev)
+#if MYNEWT_VAL(MCU_QSPIC_APP_CFG)
+static sec_text_ram_core void
+da1469x_hff_mcu_custom_init(const struct hal_flash *dev)
 {
+    uint32_t primask;
+    uint32_t ctrlmode_reg = QSPIC->QSPIC_CTRLMODE_REG;
+    __HAL_DISABLE_INTERRUPTS(primask);
+    da1469x_qspi_mode_manual(dev);
+#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDA_INIT_VAL)
+    QSPIC->QSPIC_BURSTCMDA_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDA_INIT_VAL);
+#endif
+#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDB_INIT_VAL)
+    QSPIC->QSPIC_BURSTCMDB_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDB_INIT_VAL);
+#endif
+#if defined (MYNEWT_VAL_MCU_QSPIC_CTRLMODE_INIT_VAL)
+    QSPIC->QSPIC_CTRLMODE_REG = MYNEWT_VAL(MCU_QSPIC_CTRLMODE_INIT_VAL);
+#endif
+    if (ctrlmode_reg & QSPIC_QSPIC_CTRLMODE_REG_QSPIC_AUTO_MD_Msk) {
+        /* restore auto mode */
+        da1469x_qspi_mode_auto(dev);
+    }
+    __HAL_ENABLE_INTERRUPTS(primask);
+}
+#endif
+
+static int
+    da1469x_hff_init(const struct hal_flash *dev)
+{
+#if MYNEWT_VAL(MCU_QSPIC_APP_CFG)
+    da1469x_hff_mcu_custom_init(dev);
+#endif
     return 0;
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -125,6 +125,30 @@ syscfg.defs:
             data before writing, i.e. each such transfer will be split into
             chunks of this size. Buffer is created on stack.
         value: 128
+    MCU_QSPIC_APP_CFG:
+        description: >
+            Enable application initialization of QSPIC settings. Syscfg values that
+            are defined for QSPIC_BURSTCMDA_REG, QSPIC_BURSTCMDB_REG or
+            QSPIC_CTRLMODE_REG will be applied by hal_flash_init.
+        value: 0
+    MCU_QSPIC_BURSTCMDA_INIT_VAL:
+        description: >
+            MCU initialization value for QSPIC_BURSTCMDA_REG
+        value: ''
+        restrictions:
+        - (MCU_QSPIC_APP_CFG)
+    MCU_QSPIC_BURSTCMDB_INIT_VAL:
+        description: >
+            MCU initialization value for QSPIC_BURSTCMDB_REG
+        value: ''
+        restrictions:
+        - (MCU_QSPIC_APP_CFG)
+    MCU_QSPIC_CTRLMODE_INIT_VAL:
+        description: >
+            MCU initialization value for QSPIC_CTRLMODE_REG
+        value: ''
+        restrictions:
+        - (MCU_QSPIC_APP_CFG)
 
 # MCU peripherals definitions
     I2C_0:


### PR DESCRIPTION
The QSPI_BURSTCMDA_REG and QSPI_BURSTCMDB_REG registers must be configured with specific values for the target flash type. The da1469x will attempt to configure these registers from OTP or from a header prepended to the flash boot image. In the absence of either of these, these register values should be configurable by initialization code. Typically this would be code like apps/flash_loader which runs using RAM_RESIDENT and requires flash access. 

This PR adds syscfgs MCU_QSPI_BURSTCMDA_INIT_VAL and MCU_QSPI_BURSTCMDB_INIT_VAL which can be used to optionally initialize the corresponding registers in hal_flash_init(). The register initialization is done only if the syscfg value is non-empty. 

Restrictions: RAM_RESIDENT must be 1. 

Example (configure QSPIC to single mode):
MCU_QSPIC_BURSTCMDA_INIT_VAL: 0x3
MCU_QSPIC_BURSTCMDB_INIT_VAL: 0x0

For background see Sec. 6.7 BOOTING in the DA1469x datasheet.