### PR TITLE
[DO NOT MERGE]mcu/dialog/da14699: define adc pin selection in mcu.h

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import serial
+import io
+import click
+import os
+
+
+@click.argument('infile')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Close out OTP configuration script')
+def load(infile, uart):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=10,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    try:
+        f = open(infile, "rb")
+    except IOError:
+        raise SystemExit("Failed to open input file")
+
+    data = f.read()
+    crc = 0
+    for i in range(len(data)):
+        crc = crc ^ data[i]
+
+    # serial load protocol is the following:
+    # - on reset, board sends 0x2 and listens for 100ms or so
+    # - host sends 0x1 followed by length of file to transfer
+    # - board responds with 0x6
+    # - host sends file
+    # - board responds with bytewise XOR of file
+    # - If XOR matches, host sends 0x6 as final ack
+    # - board boots image after receiving ACK from host
+
+#    if len(msg) == 0:
+#        raise SystemExit("Read timed out, exiting")
+
+    print("Please reset board to enter ROM uart recovery")
+
+    while True:
+        msg = ser.read(1)
+        print(msg)
+        if msg[0] == 0x2:
+            print("Detected serial boot protocol")
+            msg = bytes([0x1])
+            msg += bytes([len(data) & 0xff])
+            msg += bytes([len(data) >> 8])
+            ser.write(msg)
+
+            msg = ser.read()
+            if len(msg) == 0:
+                raise SystemExit("Failed to receive SOH ACK, aborting")
+
+            if msg[0] != 0x6:
+                raise SystemExit("Received invalid response, aborting")
+
+            print("Loading application to RAM")
+            try:
+                ser.write(data)
+            except serial.SerialException:
+                raise SystemExit("Failed to write executable, aborting")
+
+            msg = ser.read()
+            if len(msg) == 0:
+                raise SystemExit("Failed to receive XOR of bytes")
+
+            if crc != msg[0]:
+                raise SystemExit("Failed CRC check")
+
+            msg = bytes([0x6])
+
+            try:
+                ser.write(msg)
+            except serial.SerialException:
+                raise SystemExit("Failed to write final ACK, aborting")
+            print("Successfuly loaded RAM, board will now boot executable")
+            break
+        else:
+            continue
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(load)
+
+
+if __name__ == '__main__':
+    cli()

--- a/hw/bsp/dialog_da1469x-dk-pro/otp_tool.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/otp_tool.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import serial
+import io
+import click
+import struct
+import binascii
+from typing import NamedTuple
+from enum import Enum
+import os
+
+
+class Cmd(object):
+    OTP_READ_KEY = 0
+    OTP_WRITE_KEY = 1
+    FLASH_READ = 2
+    FLASH_WRITE = 3
+    OTP_READ_CONFIG = 4
+    OTP_APPEND_VALUE = 5
+    OTP_INIT = 6
+
+
+class cmd_no_payload(NamedTuple):
+    som: int
+    cmd: int
+
+
+class cmd_read_key(NamedTuple):
+    som: int
+    cmd: int
+    segment: int
+    slot: int
+
+
+class cmd_write_key(NamedTuple):
+    som: int
+    cmd: int
+    segment: int
+    slot: int
+
+
+class cmd_append_value(NamedTuple):
+    som: int
+    cmd: int
+    length: int
+
+
+class cmd_response(NamedTuple):
+    som: int
+    cmd: int
+    status: int
+    length: int
+
+
+class cmd_flash_op(NamedTuple):
+    som: int
+    cmd: int
+    address: int
+    length: int
+
+
+def crc16(data: bytearray, offset, length):
+    if data is None or offset < 0:
+        return
+
+    if offset > len(data) - 1 and offset + length > len(data):
+        return 0
+
+    crc = 0
+    for i in range(length):
+        crc ^= data[offset + i] << 8
+
+        for j in range(8):
+            if (crc & 0x8000) > 0:
+                crc = (crc << 1) ^ 0x1021
+            else:
+                crc = crc << 1
+    return crc & 0xFFFF
+
+
+def validate_slot_index(ctx, param, value):
+    if value in range(8):
+        return value
+    else:
+        raise click.BadParameter("Slot value has to be between 0 and 7")
+
+
+@click.option('-i', '--index', required=True, type=int, help='key slot index',
+              callback=validate_slot_index)
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.option('-s', '--segment', type=click.Choice(['signature', 'data',
+              'qspi']), help='OTP segment', required=True)
+@click.command(help='Read a single key from OTP key segment')
+def otp_read_key(index, segment, uart):
+    seg_map = {'signature': 0, 'data': 1, 'qspi': 2}
+
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    cmd = cmd_read_key(0xaa55aa55, Cmd.OTP_READ_KEY, seg_map[segment], index)
+    data = struct.pack('IIII', *cmd)
+
+    try:
+        ser.write(data)
+    except serial.SerialException:
+        raise SystemExit("Failed to write to %s" % uart)
+
+    data = ser.read(16)
+    if len(data) != 16:
+        raise SystemExit("Failed to receive response, exiting")
+
+    response = cmd_response._make(struct.unpack_from('IIII', data))
+    if response.status == 0:
+        key = ser.read(32)
+        print("key:" + key.hex())
+    else:
+        raise SystemExit("Error reading key with status %s" %
+                         hex(response.status))
+
+
+@click.argument('infile')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.option('-i', '--index', required=True, type=int, help='key slot index',
+              callback=validate_slot_index)
+@click.option('-s', '--segment', type=click.Choice(['signature', 'data',
+              'qspi']), help='OTP segment', required=True,)
+@click.command(help='Write a single key to OTP key segment')
+def otp_write_key(infile, index, segment, uart):
+
+    key = bytearray()
+    try:
+        with open(infile, "rb") as f:
+            buf = f.read(32)
+            key = struct.unpack('IIIIIIII', buf)
+    except IOError:
+        raise SystemExit("Failed to read key from file")
+
+    seg_map = {'signature': 0, 'data': 1, 'qspi': 2}
+
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    cmd = cmd_write_key(0xaa55aa55, Cmd.OTP_WRITE_KEY, seg_map[segment], index)
+    # swap endianness of data to little endian
+
+    msg = struct.pack('IIII', *cmd)
+    key_bytes = struct.pack('>IIIIIIII', *key)
+    msg += (key_bytes)
+    msg += struct.pack('H', crc16(key_bytes, 0, 32))
+
+    ser.write(msg)
+
+    data = ser.read(16)
+    if len(data) != 16:
+        raise SystemExit("Failed to receive response, exiting")
+
+    response = cmd_response._make(struct.unpack_from('IIII', data))
+    if response.status == 0:
+        print("Key successfully updated")
+    else:
+        raise SystemExit('Error writing key with status %s ' %
+                         hex(response.status))
+
+
+def generate_payload(data):
+    msg = bytearray()
+
+    for entry in data:
+        msg += entry.to_bytes(4, 'little')
+
+    return msg
+
+
+@ click.argument('outfile')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Read data from OTP configuration script area')
+def otp_read_config(uart, outfile):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    # length is unused, so set to 0
+    cmd = cmd_append_value(0xaa55aa55, Cmd.OTP_READ_CONFIG, 0)
+    data = struct.pack('III', *cmd)
+
+    try:
+        ser.write(data)
+    except serial.SerialException:
+        raise SystemExit("Failed to write to %s" % uart)
+
+    data = ser.read(16)
+    if len(data) != 16:
+        raise SystemExit("Failed to receive response, exiting")
+
+    response = cmd_response._make(struct.unpack_from('IIII', data))
+    if response.status == 0:
+        data = ser.read(response.length)
+        if len(data) != response.length:
+            raise SystemExit("Failed to receive data, exiting")
+
+        print("Successfully read configuration script, writing to file: " + outfile)
+    try:
+        with open(outfile, "wb") as f:
+            f.write(data)
+    except IOError:
+        raise SystemExit("Failed to write config data to file")
+
+
+@click.argument('outfile')
+@click.option('-a', '--address', type=str, required=True,
+              help='flash address, hexadecimal')
+@click.option('-l', '--length', type=int, required=True, help='length to read')
+@click.option('-b', '--block-size', type=int, default=1024, help='block size')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Read from flash')
+def flash_read(uart, length, outfile, address, block_size):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    try:
+        f = open(outfile, "wb")
+    except IOError:
+        raise SystemExit("Failed to open output file")
+
+    bytes_left = length
+    offset = int(address, 16)
+    while bytes_left > 0:
+        if bytes_left > block_size:
+            trans_length = block_size
+        else:
+            trans_length = bytes_left
+
+        cmd = cmd_flash_op(0xaa55aa55, Cmd.FLASH_READ, offset, trans_length)
+        data = struct.pack('IIII', *cmd)
+
+        try:
+            ser.write(data)
+        except serial.SerialException:
+            raise SystemExit("Failed to write cmd to %s" % uart)
+
+        data = ser.read(16)
+        if len(data) != 16:
+            raise SystemExit("Failed to receive response, exiting")
+
+        response = cmd_response._make(struct.unpack_from('IIII', data))
+        if response.status == 0:
+            data = ser.read(response.length)
+            if len(data) != response.length:
+                raise SystemExit("Failed to receive response, exiting")
+            f.write(data)
+
+        else:
+            SystemExit("Error in read response, exiting")
+            break
+
+        bytes_left -= trans_length
+        offset += trans_length
+
+    print("Successfully read flash, wrote contents to " + outfile)
+
+
+@click.argument('infile')
+@click.option('-a', '--address', type=str, required=True, help='flash address')
+@click.option('-b', '--block-size', type=int, default=1024, help='block size')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Write to flash')
+def flash_write(uart, infile, address, block_size):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    try:
+        f = open(infile, "rb")
+    except IOError:
+        raise SystemExit("Failed to open input file")
+
+    length = os.path.getsize(infile)
+
+    bytes_left = length
+    offset = int(address, 16)
+    while bytes_left > 0:
+        if bytes_left > block_size:
+            trans_length = block_size
+        else:
+            trans_length = bytes_left
+
+        cmd = cmd_flash_op(0xaa55aa55, Cmd.FLASH_WRITE, offset,
+                           trans_length + 2)
+        data = struct.pack('IIII', *cmd)
+
+        f_bytes = f.read(trans_length)
+        data += f_bytes
+        data += struct.pack('H', crc16(f_bytes, 0, trans_length))
+
+        try:
+            ser.write(data)
+        except serial.SerialException:
+            raise SystemExit("Failed to write cmd to %s" % uart)
+
+        data = ser.read(16)
+        if len(data) != 16:
+            raise SystemExit("Failed to receive response, exiting")
+
+        response = cmd_response._make(struct.unpack_from('IIII', data))
+        if response.status == 0:
+            data = ser.read(response.length)
+            if len(data) != response.length:
+                raise SystemExit("Failed to receive response, exiting")
+            f.write(data)
+
+        else:
+            SystemExit("Error in read response, exiting")
+            break
+
+        bytes_left -= trans_length
+        offset += trans_length
+
+    print("Successfully wrote flash")
+
+
+def send_otp_config_payload(uart, data):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    data_bytes = generate_payload(data)
+
+    # length is unused, so set to 0
+    cmd = cmd_append_value(0xaa55aa55, Cmd.OTP_APPEND_VALUE,
+                           len(data_bytes) + 2)
+    msg = struct.pack('III', *cmd)
+
+    msg += data_bytes
+    msg += struct.pack('H', crc16(data_bytes, 0, len(data_bytes)))
+
+    try:
+        ser.write(msg)
+    except serial.SerialException:
+        raise SystemExit("Failed to write to %s" % uart)
+
+    data = ser.read(16)
+    if len(data) != 16:
+        raise SystemExit("Failed to receive response, exiting")
+
+    response = cmd_response._make(struct.unpack_from('IIII', data))
+    if response.status == 0:
+        data = ser.read(response.length)
+        if len(data) != response.length:
+            raise SystemExit("Failed to receive data, exiting")
+
+
+@click.command(help='Append register value to OTP configuration script')
+@click.option('-a', '--address', type=str, required=True,
+              help='register address in hexadecimal')
+@click.option('-v', '--value', type=str, required=True,
+              help='register value in hexadecimal')
+@click.option('-u', '--uart', required=True, help='uart port')
+def otp_append_register(uart, address, value):
+
+    send_otp_config_payload(uart, [int(address, 16), int(value, 16)])
+
+
+@click.option('-t', '--trim', type=str, required=True,
+              multiple=True, help='trim value')
+@click.option('-i', '--index', type=int, required=True,
+              help='Trim value id')
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Append trim value to OTP configuration script')
+def otp_append_trim(uart, trim, index):
+
+    data = []
+    data.append(0x90000000 + (len(trim) << 8) + index)
+    for entry in trim:
+        data.append(int(entry, 16))
+
+    send_otp_config_payload(uart, data)
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Disable development mode')
+def disable_development_mode(uart):
+
+    send_otp_config_payload(uart, [0x70000000])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Enable secure boot')
+def enable_secure_boot(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x1])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Write lock OTP QSPI key area')
+def disable_qspi_key_write(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x40])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Read lock OTP QSPI key area')
+def disable_qspi_key_read(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x80])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Write lock OTP user key area')
+def disable_user_key_write(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x10])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Read lock OTP user key area')
+def disable_user_key_read(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x20])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Write lock OTP signature key area')
+def disable_signature_key_write(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x8])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Disable CMAC debugger')
+def disable_cmac_debugger(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x4])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Disable SWD debugger')
+def disable_swd_debugger(uart):
+
+    send_otp_config_payload(uart, [0x500000cc, 0x2])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Close out OTP configuration script')
+def close_config_script(uart):
+
+    send_otp_config_payload(uart, [0x0])
+
+
+@click.option('-u', '--uart', required=True, help='uart port')
+@click.command(help='Initialize blank OTP Config script')
+def init_config_script(uart):
+    try:
+        ser = serial.Serial(port=uart, baudrate=115200, timeout=1,
+                            bytesize=8, stopbits=serial.STOPBITS_ONE)
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
+    # length is unused, so set to 0
+    cmd = cmd_append_value(0xaa55aa55, Cmd.OTP_INIT, 0)
+    msg = struct.pack('III', *cmd)
+
+    try:
+        ser.write(msg)
+    except serial.SerialException:
+        raise SystemExit("Failed to write to %s" % uart)
+
+    data = ser.read(16)
+    if len(data) != 16:
+        raise SystemExit("Failed to receive response, exiting")
+
+    response = cmd_response._make(struct.unpack_from('IIII', data))
+    if response.status != 0:
+        raise SystemExit('Failed to initialize OTP with status %d'
+                         % response.status)
+    else:
+        SystemExit("Successfully initialized blank OTP")
+
+    print(response)
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(otp_read_config)
+cli.add_command(otp_read_key)
+cli.add_command(otp_write_key)
+cli.add_command(flash_read)
+cli.add_command(flash_write)
+cli.add_command(otp_append_register)
+cli.add_command(otp_append_trim)
+cli.add_command(disable_development_mode)
+cli.add_command(enable_secure_boot)
+cli.add_command(disable_qspi_key_write)
+cli.add_command(disable_qspi_key_read)
+cli.add_command(disable_user_key_write)
+cli.add_command(disable_user_key_read)
+cli.add_command(disable_signature_key_write)
+cli.add_command(disable_cmac_debugger)
+cli.add_command(disable_swd_debugger)
+cli.add_command(close_config_script)
+cli.add_command(init_config_script)
+
+
+if __name__ == '__main__':
+    cli()

--- a/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
+++ b/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
@@ -47,16 +47,16 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
         /* single-ended */
         switch (src) {
         case 0:
-            pin0 = MCU_GPIO_PORT1(9);
+            pin0 = MCU_GP_ADC_SEL0;
             break;
         case 1:
-            pin0 = MCU_GPIO_PORT0(25);
+            pin0 = MCU_GP_ADC_SEL1;
             break;
         case 2:
-            pin0 = MCU_GPIO_PORT0(8);
+            pin0 = MCU_GP_ADC_SEL2;
             break;
         case 3:
-            pin0 = MCU_GPIO_PORT0(9);
+            pin0 = MCU_GP_ADC_SEL3;
             break;
         case 4:
             /* VDDD */
@@ -77,16 +77,16 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
             /* 9: VSSA */
             break;
         case 16:
-            pin0 = MCU_GPIO_PORT1(13);
+            pin0 = MCU_GP_ADC_SEL16;
             break;
         case 17:
-            pin0 = MCU_GPIO_PORT1(12);
+            pin0 = MCU_GP_ADC_SEL17;
             break;
         case 18:
-            pin0 = MCU_GPIO_PORT1(18);
+            pin0 = MCU_GP_ADC_SEL18;
             break;
         case 19:
-            pin0 = MCU_GPIO_PORT1(19);
+            pin0 = MCU_GP_ADC_SEL19;
             break;
         case 20:
             /* diff temp sensor */
@@ -98,12 +98,12 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
         /* differential */
         switch (src) {
         case 0:
-            pin0 = MCU_GPIO_PORT1(9);
-            pin1 = MCU_GPIO_PORT0(25);
+            pin0 = MCU_GP_ADC_DIFF0_P0;
+            pin1 = MCU_GP_ADC_DIFF0_P1;
             break;
         case 1:
-            pin0 = MCU_GPIO_PORT0(8);
-            pin1 = MCU_GPIO_PORT0(9);
+            pin0 = MCU_GP_ADC_DIFF1_P0;
+            pin1 = MCU_GP_ADC_DIFF1_P1;
             break;
         default:
             break;

--- a/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
+++ b/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
@@ -29,14 +29,14 @@
 static struct da1469x_sdadc_dev *da1469x_sdadc_dev;
 
 static const int da1469x_sdadc_src2pin[] = {
-    MCU_GPIO_PORT1(9),  /* 0 */
-    MCU_GPIO_PORT0(25), /* 1 */
-    MCU_GPIO_PORT0(8),  /* 2 */
-    MCU_GPIO_PORT0(9),  /* 3 */
-    MCU_GPIO_PORT1(14), /* 4 */
-    MCU_GPIO_PORT1(20), /* 5 */
-    MCU_GPIO_PORT1(21), /* 6 */
-    MCU_GPIO_PORT1(22), /* 7 */
+    MCU_SD_ADC_SRC0,  /* 0 */
+    MCU_SD_ADC_SRC1, /* 1 */
+    MCU_SD_ADC_SRC2,  /* 2 */
+    MCU_SD_ADC_SRC3,  /* 3 */
+    MCU_SD_ADC_SRC4, /* 4 */
+    MCU_SD_ADC_SRC5, /* 5 */
+    MCU_SD_ADC_SRC6, /* 6 */
+    MCU_SD_ADC_SRC7, /* 7 */
 };
 #define DA1469X_SDADC_SRC2PIN_SZ                                        \
     (sizeof(da1469x_sdadc_src2pin) / sizeof(da1469x_sdadc_src2pin[0]))

--- a/hw/mcu/dialog/da14699/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da14699/include/mcu/mcu.h
@@ -119,6 +119,28 @@ typedef enum {
 #define MCU_GPIO_PORT1(pin)		((1 * 32) + (pin))
 #define MCU_DMA_CHAN_MAX                    8
 
+#define MCU_GP_ADC_SEL0               MCU_GPIO_PORT1(9)
+#define MCU_GP_ADC_SEL1               MCU_GPIO_PORT0(25)
+#define MCU_GP_ADC_SEL2               MCU_GPIO_PORT0(8)
+#define MCU_GP_ADC_SEL3               MCU_GPIO_PORT0(9)
+#define MCU_GP_ADC_SEL16              MCU_GPIO_PORT1(13)
+#define MCU_GP_ADC_SEL17              MCU_GPIO_PORT1(12)
+#define MCU_GP_ADC_SEL18              MCU_GPIO_PORT1(18)
+#define MCU_GP_ADC_SEL19              MCU_GPIO_PORT1(19)
+#define MCU_GP_ADC_DIFF0_P0           MCU_GPIO_PORT1(9)
+#define MCU_GP_ADC_DIFF0_P1           MCU_GPIO_PORT0(25)
+#define MCU_GP_ADC_DIFF1_P0           MCU_GPIO_PORT0(8)
+#define MCU_GP_ADC_DIFF1_P1           MCU_GPIO_PORT0(9)
+
+#define MCU_SD_ADC_SRC0               MCU_GPIO_PORT1(9)
+#define MCU_SD_ADC_SRC1               MCU_GPIO_PORT0(25)
+#define MCU_SD_ADC_SRC2               MCU_GPIO_PORT0(8)
+#define MCU_SD_ADC_SRC3               MCU_GPIO_PORT0(9)
+#define MCU_SD_ADC_SRC4               MCU_GPIO_PORT1(14)
+#define MCU_SD_ADC_SRC5               MCU_GPIO_PORT1(20)
+#define MCU_SD_ADC_SRC6               MCU_GPIO_PORT1(21)
+#define MCU_SD_ADC_SRC7               MCU_GPIO_PORT1(22)
+
 void mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func);
 void mcu_gpio_enter_sleep(void);
 void mcu_gpio_exit_sleep(void);

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_otp.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_otp.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_OTP_H_
+#define __MCU_DA1469X_OTP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OTPM_BASE 0x10080000UL
+#define OTPM_SIZE 0x4096
+
+#define OTP_INVALID_SIZE_ALIGNMENT -1
+#define OTP_INVALID_ADDRESS -2
+#define OTP_PROGRAM_VERIFY_FAILED -3
+
+int da1469x_otp_write(uint32_t address, const void *src,
+                             uint32_t num_bytes);
+
+int da1469x_otp_read(uint32_t address, void *dst, uint32_t num_bytes);
+
+void da1469x_otp_init(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_OTP_H_ */

--- a/hw/mcu/dialog/da1469x/src/da1469x_otp.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_otp.c
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <assert.h>
+#include "syscfg/syscfg.h"
+#include <mcu/mcu.h>
+#include "da1469x_priv.h"
+#include <mcu/da1469x_otp.h>
+
+enum otpc_mode_val {
+    OTPC_MODE_PDOWN = 0,
+    OTPC_MODE_DSTBY,
+    OTPC_MODE_STBY,
+    OTPC_MODE_READ,
+    OTPC_MODE_PROG,
+    OTPC_MODE_PVFY,
+    OTPC_MODE_RINI,
+};
+
+static inline void
+da1469x_otp_set_mode(enum otpc_mode_val mode)
+{
+    OTPC->OTPC_MODE_REG = (OTPC->OTPC_MODE_REG &
+                           ~OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Msk) |
+                          (mode << OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Pos);
+    while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_MRDY_Msk));
+}
+
+
+int
+da1469x_otp_read(uint32_t address, void *dst, uint32_t num_bytes)
+{
+    uint32_t *src_addr = (uint32_t *)address;
+    uint32_t *dst_addr = dst;
+
+    if (address < OTPM_BASE || (address + num_bytes) > (OTPM_BASE + OTPM_SIZE)) {
+       return OTP_INVALID_ADDRESS;
+    }
+
+    if (num_bytes & 0x3) {
+       return OTP_INVALID_SIZE_ALIGNMENT;
+    }
+
+    /* Enable OTP clock and set mode to standby */
+    CRG_TOP->CLK_AMBA_REG |= CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+    da1469x_otp_set_mode(OTPC_MODE_READ);
+
+    for (; num_bytes; dst_addr++, src_addr++, num_bytes -= 4) {
+        *dst_addr = *src_addr;
+    }
+
+    da1469x_otp_set_mode(OTPC_MODE_DSTBY);
+
+    /* Disable OTP clock */
+    CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+    return 0;
+}
+
+int
+da1469x_otp_write(uint32_t address, const void *src, uint32_t num_bytes)
+{
+    uint32_t *dst_addr = (uint32_t *)address;
+    const uint32_t *src_addr = src;
+    int ret = 0;
+
+    if (address < OTPM_BASE || (address + num_bytes) > (OTPM_BASE + OTPM_SIZE)) {
+       return OTP_INVALID_ADDRESS;
+    }
+
+    if (num_bytes & 0x3) {
+       return OTP_INVALID_SIZE_ALIGNMENT;
+    }
+
+    /* Enable OTP clock and set mode to standby */
+    CRG_TOP->CLK_AMBA_REG |= CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+    do {
+        da1469x_otp_set_mode(OTPC_MODE_PROG);
+
+        /* wait for programming to go idle and data buffer to be empty */
+        while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_PRDY_Msk));
+        while (!(OTPC->OTPC_STAT_REG &
+                 OTPC_OTPC_STAT_REG_OTPC_STAT_PBUF_EMPTY_Msk));
+
+        /* fill data buffer with a word and trigger via the PADDR reg */
+        OTPC->OTPC_PWORD_REG = *src_addr;
+        OTPC->OTPC_PADDR_REG = ((uint32_t)dst_addr >> 2) &
+                               OTPC_OTPC_PADDR_REG_OTPC_PADDR_Msk;
+
+        while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_PRDY_Msk));
+
+        /* set mode to verify */
+        da1469x_otp_set_mode(OTPC_MODE_PVFY);
+
+        /* read data and compare to source */
+        if (*dst_addr != *src_addr) {
+            ret = OTP_PROGRAM_VERIFY_FAILED;
+            goto fail_write;
+        }
+
+        da1469x_otp_set_mode(OTPC_MODE_STBY);
+        num_bytes -= 4;
+        src_addr++;
+        dst_addr++;
+    } while (num_bytes);
+
+fail_write:
+
+    /* Disable OTP clock */
+    CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+    return ret;
+}
+
+void
+da1469x_otp_init(void)
+{
+    /* Enable OTP clock and set mode to standby */
+    CRG_TOP->CLK_AMBA_REG |= CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+    da1469x_otp_set_mode(OTPC_MODE_STBY);
+
+    /* set clk timing */
+    OTPC->OTPC_TIM1_REG = 0x0999101f;  /* 32 MHz default */
+    OTPC->OTPC_TIM2_REG = 0xa4040409;
+
+    /* Disable OTP clock */
+    CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+
+}

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -382,5 +382,11 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
 static int
 da1469x_hff_init(const struct hal_flash *dev)
 {
+#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDA_INIT_VAL)
+    QSPIC->QSPIC_BURSTCMDA_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDA_INIT_VAL);
+#endif
+#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDB_INIT_VAL)
+    QSPIC->QSPIC_BURSTCMDB_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDB_INIT_VAL);
+#endif
     return 0;
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -125,6 +125,20 @@ syscfg.defs:
             data before writing, i.e. each such transfer will be split into
             chunks of this size. Buffer is created on stack.
         value: 128
+    MCU_QSPIC_BURSTCMDA_INIT_VAL:
+        description: >
+            Initialization value for QSPIC_BURSTCMDA_REG. May be used to allow
+            RAM_RESIDENT applications to configure the QSPIC with settings that
+            would typically be applied via OTP or flash header configuration.
+        value: ''
+        restrictions:
+        - (RAM_RESIDENT)
+    MCU_QSPIC_BURSTCMDB_INIT_VAL:
+        description: >
+            Initialization value for QSPIC_BURSTCMDB_REG
+        value: ''
+        restrictions:
+        - (RAM_RESIDENT)
 
 # MCU peripherals definitions
     I2C_0:


### PR DESCRIPTION
Moved da14699 specific adc gpio pin selection out of da1469x_gpadc.c and da1469x_sdadc.c. Defining these in da14699 mcu.h for portability.