### PR TITLE
mcu/dialog: define adc pin selections in mcu.h

### DIFF
--- a/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
+++ b/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
@@ -47,16 +47,16 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
         /* single-ended */
         switch (src) {
         case 0:
-            pin0 = MCU_GPIO_PORT1(9);
+            pin0 = MCU_PIN_GPADC_SEL0;
             break;
         case 1:
-            pin0 = MCU_GPIO_PORT0(25);
+            pin0 = MCU_PIN_GPADC_SEL1;
             break;
         case 2:
-            pin0 = MCU_GPIO_PORT0(8);
+            pin0 = MCU_PIN_GPADC_SEL2;
             break;
         case 3:
-            pin0 = MCU_GPIO_PORT0(9);
+            pin0 = MCU_PIN_GPADC_SEL3;
             break;
         case 4:
             /* VDDD */
@@ -77,16 +77,16 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
             /* 9: VSSA */
             break;
         case 16:
-            pin0 = MCU_GPIO_PORT1(13);
+            pin0 = MCU_PIN_GPADC_SEL16;
             break;
         case 17:
-            pin0 = MCU_GPIO_PORT1(12);
+            pin0 = MCU_PIN_GPADC_SEL17;
             break;
         case 18:
-            pin0 = MCU_GPIO_PORT1(18);
+            pin0 = MCU_PIN_GPADC_SEL18;
             break;
         case 19:
-            pin0 = MCU_GPIO_PORT1(19);
+            pin0 = MCU_PIN_GPADC_SEL19;
             break;
         case 20:
             /* diff temp sensor */
@@ -98,12 +98,12 @@ da1469x_gpadc_resolve_pins(uint32_t ctrl, int *pin0p, int *pin1p)
         /* differential */
         switch (src) {
         case 0:
-            pin0 = MCU_GPIO_PORT1(9);
-            pin1 = MCU_GPIO_PORT0(25);
+            pin0 = MCU_PIN_GPADC_DIFF0_P0;
+            pin1 = MCU_PIN_GPADC_DIFF0_P1;
             break;
         case 1:
-            pin0 = MCU_GPIO_PORT0(8);
-            pin1 = MCU_GPIO_PORT0(9);
+            pin0 = MCU_PIN_GPADC_DIFF1_P0;
+            pin1 = MCU_PIN_GPADC_DIFF1_P1;
             break;
         default:
             break;

--- a/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
+++ b/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
@@ -29,14 +29,14 @@
 static struct da1469x_sdadc_dev *da1469x_sdadc_dev;
 
 static const int da1469x_sdadc_src2pin[] = {
-    MCU_GPIO_PORT1(9),  /* 0 */
-    MCU_GPIO_PORT0(25), /* 1 */
-    MCU_GPIO_PORT0(8),  /* 2 */
-    MCU_GPIO_PORT0(9),  /* 3 */
-    MCU_GPIO_PORT1(14), /* 4 */
-    MCU_GPIO_PORT1(20), /* 5 */
-    MCU_GPIO_PORT1(21), /* 6 */
-    MCU_GPIO_PORT1(22), /* 7 */
+    MCU_PIN_SDADC0,  /* 0 */
+    MCU_PIN_SDADC1,  /* 1 */
+    MCU_PIN_SDADC2,  /* 2 */
+    MCU_PIN_SDADC3,  /* 3 */
+    MCU_PIN_SDADC4,  /* 4 */
+    MCU_PIN_SDADC5,  /* 5 */
+    MCU_PIN_SDADC6,  /* 6 */
+    MCU_PIN_SDADC7,  /* 7 */
 };
 #define DA1469X_SDADC_SRC2PIN_SZ                                        \
     (sizeof(da1469x_sdadc_src2pin) / sizeof(da1469x_sdadc_src2pin[0]))

--- a/hw/mcu/dialog/da14699/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da14699/include/mcu/mcu.h
@@ -119,6 +119,28 @@ typedef enum {
 #define MCU_GPIO_PORT1(pin)		((1 * 32) + (pin))
 #define MCU_DMA_CHAN_MAX                    8
 
+#define MCU_PIN_GPADC_SEL0               MCU_GPIO_PORT1(9)
+#define MCU_PIN_GPADC_SEL1               MCU_GPIO_PORT0(25)
+#define MCU_PIN_GPADC_SEL2               MCU_GPIO_PORT0(8)
+#define MCU_PIN_GPADC_SEL3               MCU_GPIO_PORT0(9)
+#define MCU_PIN_GPADC_SEL16              MCU_GPIO_PORT1(13)
+#define MCU_PIN_GPADC_SEL17              MCU_GPIO_PORT1(12)
+#define MCU_PIN_GPADC_SEL18              MCU_GPIO_PORT1(18)
+#define MCU_PIN_GPADC_SEL19              MCU_GPIO_PORT1(19)
+#define MCU_PIN_GPADC_DIFF0_P0           MCU_GPIO_PORT1(9)
+#define MCU_PIN_GPADC_DIFF0_P1           MCU_GPIO_PORT0(25)
+#define MCU_PIN_GPADC_DIFF1_P0           MCU_GPIO_PORT0(8)
+#define MCU_PIN_GPADC_DIFF1_P1           MCU_GPIO_PORT0(9)
+
+#define MCU_PIN_SDADC0               MCU_GPIO_PORT1(9)
+#define MCU_PIN_SDADC1               MCU_GPIO_PORT0(25)
+#define MCU_PIN_SDADC2               MCU_GPIO_PORT0(8)
+#define MCU_PIN_SDADC3               MCU_GPIO_PORT0(9)
+#define MCU_PIN_SDADC4               MCU_GPIO_PORT1(14)
+#define MCU_PIN_SDADC5               MCU_GPIO_PORT1(20)
+#define MCU_PIN_SDADC6               MCU_GPIO_PORT1(21)
+#define MCU_PIN_SDADC7               MCU_GPIO_PORT1(22)
+
 void mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func);
 void mcu_gpio_enter_sleep(void);
 void mcu_gpio_exit_sleep(void);


### PR DESCRIPTION
Moved da14699 specific adc gpio pin selection out of da1469x_gpadc.c and da1469x_sdadc.c. Defining these in da14699 mcu.h for portability. @kasjer 