### PR TITLE
sensors: Fix BME280 and MS5837 package description

### DIFF
--- a/hw/drivers/sensors/bme280/pkg.yml
+++ b/hw/drivers/sensors/bme280/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: hw/drivers/sensors/bme280
-pkg.description: Driver for the BME280 light to digital sensor
+pkg.description: Driver for the BME280 humidity and pressure sensor
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "https://mynewt.apache.org"
 pkg.keywords:

--- a/hw/drivers/sensors/ms5837/pkg.yml
+++ b/hw/drivers/sensors/ms5837/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: hw/drivers/sensors/ms5837
-pkg.description: Driver for the MS5837 light to digital sensor
+pkg.description: Driver for the MS5837 pressure sensor
 pkg.author: "Vipul Rahane <vipul@runtime.io>"
 pkg.homepage: "http://www.runtime.io/"
 pkg.keywords:


### PR DESCRIPTION
Package description stated that those were light sensors.
BME280 is humidity and pressure sensor
MS5837 is pressure sensor