### PR TITLE
Fixes for ms5837 ms5840 drivers

### DIFF
--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -436,7 +436,7 @@ ms5837_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
 {
     int idx;
     int rc;
-    uint16_t payload[MS5837_NUMBER_COEFFS];
+    uint16_t payload[MS5837_NUMBER_COEFFS + 1];
 
     for(idx = 0; idx < MS5837_NUMBER_COEFFS; idx++) {
         rc = ms5837_readlen(itf, MS5837_CMD_PROM_READ_ADDR0 + idx * 2,

--- a/hw/drivers/sensors/ms5837/src/ms5837.c
+++ b/hw/drivers/sensors/ms5837/src/ms5837.c
@@ -445,8 +445,7 @@ ms5837_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
             goto err;
         }
 
-        payload[idx] = (((payload[idx] & 0xFF00) >> 8)|
-                        ((payload[idx] & 0x00FF) << 8));
+        payload[idx] = be16toh(payload[idx]);
     }
 
     rc = ms5837_crc_check(payload, (payload[MS5837_IDX_CRC] & 0xF000) >> 12);

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -423,7 +423,7 @@ ms5840_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
 {
     int idx;
     int rc;
-    uint16_t payload[MS5840_NUMBER_COEFFS];
+    uint16_t payload[MS5840_NUMBER_COEFFS + 1];
 
     for(idx = 0; idx < MS5840_NUMBER_COEFFS; idx++) {
         rc = ms5840_readlen(itf, MS5840_CMD_PROM_READ_ADDR0 + idx * 2,

--- a/hw/drivers/sensors/ms5840/src/ms5840.c
+++ b/hw/drivers/sensors/ms5840/src/ms5840.c
@@ -432,8 +432,7 @@ ms5840_read_eeprom(struct sensor_itf *itf, uint16_t *coeff)
             goto err;
         }
 
-        payload[idx] = (((payload[idx] & 0xFF00) >> 8)|
-                        ((payload[idx] & 0x00FF) << 8));
+        payload[idx] = be16toh(payload[idx]);
     }
 
     rc = ms5840_crc_check(payload, (payload[MS5840_IDX_CRC] & 0xF000) >> 12);


### PR DESCRIPTION
- both driver suffered from buffer overrun during eeprom reading.
- read eeprom would failed on big endian platforms due to invalid byte order conversion.