### PR TITLE
sensor_itf host_pin fix

### DIFF
--- a/hw/drivers/sensors/bma253/src/bma253.c
+++ b/hw/drivers/sensors/bma253/src/bma253.c
@@ -3868,7 +3868,7 @@ init_intpin(struct bma253 * bma253,
 
     for (i = 0; i < MYNEWT_VAL(SENSOR_MAX_INTERRUPTS_PINS); i++){
         pin = bma253->sensor.s_itf.si_ints[i].host_pin;
-        if (pin > 0) {
+        if (pin >= 0) {
             break;
         }
     }

--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -3251,7 +3251,7 @@ init_intpin(struct bma2xx *bma2xx,
 
     for (i = 0; i < MYNEWT_VAL(SENSOR_MAX_INTERRUPTS_PINS); i++){
         pin = bma2xx->sensor.s_itf.si_ints[i].host_pin;
-        if (pin > 0) {
+        if (pin >= 0) {
             break;
         }
     }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -514,7 +514,7 @@ struct sensor_timestamp {
 };
 
 struct sensor_int {
-    uint8_t host_pin;
+    int8_t host_pin;
     uint8_t device_pin;
     uint8_t active;
 };


### PR DESCRIPTION
There were inconsistency between host_pin filed and it's usages.
host_pin was unsigned and most drivers were expecting it to be signed.
- host_pin changed to be signed
- bma253, bma2xx fixed to handle 0 for host_pin correctly