### PR TITLE
sensors build fixes

### DIFF
--- a/hw/drivers/sensors/dps368/src/dps368.c
+++ b/hw/drivers/sensors/dps368/src/dps368.c
@@ -309,7 +309,7 @@ dps368_set_oem_parameters(struct sensor_itf *itf)
         goto done;
     }
 
-    DPS368_LOG(INFO,"DPS368:OEM Parameters are set\n");
+    DPS368_LOG_INFO("DPS368:OEM Parameters are set\n");
 
 done:
     return rc;
@@ -381,7 +381,7 @@ dps368_set_mode(struct dps368 *dps368, dps3xx_operating_modes_e mode)
 
     if (dps368->mode == mode) {
         return 0;
-        DPS368_LOG(INFO, "Sensor is already in requested mode\n");
+        DPS368_LOG_INFO("Sensor is already in requested mode\n");
     }
 
 
@@ -727,9 +727,9 @@ int dps368_soft_reset(struct sensor *sensor)
     }
 
     if (ready == 0) {
-        DPS368_LOG(INFO, "Sensor is not ready after reset\n");
+        DPS368_LOG_INFO("Sensor is not ready after reset\n");
     } else {
-        DPS368_LOG(INFO, "Sensor is ready after reset\n");
+        DPS368_LOG_INFO("Sensor is ready after reset\n");
     }
 
     /*perform post init sequence*/
@@ -780,7 +780,7 @@ int dps368_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    DPS368_LOG(INFO,"DPS368init:sensor_init:OK\n");
+    DPS368_LOG_INFO("DPS368init:sensor_init:OK\n");
 
     /* Add the pressure and temperature driver */
     rc = sensor_set_driver(sensor, SENSOR_TYPE_PRESSURE |
@@ -791,7 +791,7 @@ int dps368_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    DPS368_LOG(INFO,"DPS368init:sensor_set_driver:OK\n");
+    DPS368_LOG_INFO("DPS368init:sensor_set_driver:OK\n");
 
     rc = sensor_set_interface(sensor, arg);
 
@@ -799,7 +799,7 @@ int dps368_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    DPS368_LOG(INFO,"DPS368init:sensor_set_interface:OK\n");
+    DPS368_LOG_INFO("DPS368init:sensor_set_interface:OK\n");
 
     rc = sensor_mgr_register(sensor);
 
@@ -807,7 +807,7 @@ int dps368_init(struct os_dev *dev, void *arg)
         return rc;
     }
 
-    DPS368_LOG(INFO,"DPS368init:sensor_mgr_register:OK\n");
+    DPS368_LOG_INFO("DPS368init:sensor_mgr_register:OK\n");
 
 #if !MYNEWT_VAL(BUS_DRIVER_PRESENT)
     if (sensor->s_itf.si_type == SENSOR_ITF_SPI) {
@@ -862,14 +862,14 @@ int dps368_config(struct dps368 *dps368, struct dps368_cfg_s *cfg)
         }
 
         if (sensor_exist == 1) {
-            DPS368_LOG(INFO, "DPS368:Found during config init sequence\n");
+            DPS368_LOG_INFO("DPS368:Found during config init sequence\n");
         }
 
         if ((rc = dps368_soft_reset(&dps368->sensor))) {
             return rc;
         }
 
-        DPS368_LOG(INFO, "DPS368:Soft reset: OK\n");
+        DPS368_LOG_INFO("DPS368:Soft reset: OK\n");
 
         if ((rc = dps368_is_trim_complete(itf, &ready))) {
             STATS_INC(dps368->stats, read_errors); 
@@ -884,7 +884,7 @@ int dps368_config(struct dps368 *dps368, struct dps368_cfg_s *cfg)
                 return rc;
             }
 
-            DPS368_LOG(INFO, "DPS368:Calibration data prepared\n");
+            DPS368_LOG_INFO("DPS368:Calibration data prepared\n");
         }
 
     } else if (cfg->config_opt & DPS3xx_RECONF_ALL) {
@@ -913,13 +913,13 @@ int dps368_config(struct dps368 *dps368, struct dps368_cfg_s *cfg)
         return rc;
     }
 
-    DPS368_LOG(INFO, "DPS368:Reconfig done\n");
+    DPS368_LOG_INFO("DPS368:Reconfig done\n");
 
     if ((rc = dps368_set_mode(dps368, updated_cfg.mode))) {
         return rc;
     }
 
-    DPS368_LOG(INFO, "DPS368:Mode is set\n");
+    DPS368_LOG_INFO("DPS368:Mode is set\n");
 
     if ((rc = sensor_set_type_mask(&(dps368->sensor), cfg->chosen_type))) {
         return rc;
@@ -942,7 +942,7 @@ dps368_sensor_read(struct sensor *sensor, sensor_type_t type,
 
     if (dps368->mode == DPS3xx_MODE_IDLE) {
 
-        DPS368_LOG(ERROR,
+        DPS368_LOG_ERROR(
                 "Could not stream as mode is inappropriate\n "
                 "First set mode to Background or Command and then try again\n");
         return rc;

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -43,7 +43,7 @@
 #define LIS2DS12_ST_NUM_READINGS 5
 
 //SLEEP_CHG and SLEEP_STATE interrupts aren't available on int1 or int2 so dont need to be enabled
-const struct lis2ds12_notif_cfg dflt_notif_cfg[] = {
+static const struct lis2ds12_notif_cfg dflt_notif_cfg[] = {
     { SENSOR_EVENT_TYPE_SINGLE_TAP,   0, LIS2DS12_INT1_CFG_SINGLE_TAP  },
     { SENSOR_EVENT_TYPE_DOUBLE_TAP,   0, LIS2DS12_INT1_CFG_DOUBLE_TAP  },
     { SENSOR_EVENT_TYPE_FREE_FALL,    0, LIS2DS12_INT1_CFG_FF          },

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -46,7 +46,7 @@
 
 #define LIS2DW12_ST_NUM_READINGS 5
 
-const struct lis2dw12_notif_cfg dflt_notif_cfg[] = {
+static const struct lis2dw12_notif_cfg dflt_notif_cfg[] = {
     {
       .event     = SENSOR_EVENT_TYPE_SINGLE_TAP,
       .int_num   = 0,

--- a/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
+++ b/hw/drivers/sensors/lsm303dlhc/src/lsm303dlhc.c
@@ -439,8 +439,8 @@ lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
                 mg_lsb = 0.012F;
                 break;
             default:
-                LSM303DLHC_LOG(
-                    ERROR, "Unknown accel range: 0x%02X. Assuming +/-2G.\n",
+                LSM303DLHC_LOG_ERROR(
+                    "Unknown accel range: 0x%02X. Assuming +/-2G.\n",
                     lsm->cfg.accel_range);
                 mg_lsb = 0.001F;
                 break;
@@ -515,7 +515,7 @@ lsm303dlhc_sensor_read(struct sensor *sensor, sensor_type_t type,
                 gauss_lsb_z = 205;
                 break;
             default:
-                LSM303DLHC_LOG(ERROR,
+                LSM303DLHC_LOG_ERROR(
                                "Unknown mag gain: 0x%02X. Assuming +/-1.3g.\n",
                                lsm->cfg.mag_gain);
                 gauss_lsb_xy = 1100;

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -56,7 +56,7 @@ static struct hal_spi_settings spi_lsm6dso_settings = {
 #endif /* BUS_DRIVER_PRESENT */
 
 /* Default event notification */
-const struct lsm6dso_notif_cfg dflt_notif_cfg[] = {
+static const struct lsm6dso_notif_cfg dflt_notif_cfg[] = {
     {
         .event = SENSOR_EVENT_TYPE_SINGLE_TAP,
         .int_num = 0,

--- a/hw/sensor/creator/pkg.yml
+++ b/hw/sensor/creator/pkg.yml
@@ -60,6 +60,10 @@ pkg.deps.LIS2DW12_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lis2dw12"
 pkg.deps.LIS2DH12_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
+pkg.deps.LIS2DS12_OFB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2ds12"
+pkg.deps.BME680_OFB:
+    - "@apache-mynewt-core/hw/drivers/sensors/bme680"
 pkg.deps.LPS33HW_OFB:
     - "@apache-mynewt-core/hw/drivers/sensors/lps33hw"
 pkg.deps.LPS33THW_OFB:

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -441,7 +441,8 @@ static struct sensor_itf spi2c_0_itf_bma253 = {
 #endif
 #endif
 
-#if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(BMA2XX_OFB)
+#if MYNEWT_VAL(BMA2XX_OFB)
+#if MYNEWT_VAL(I2C_0)
 static struct sensor_itf spi2c_0_itf_bma2xx = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
@@ -453,8 +454,7 @@ static struct sensor_itf spi2c_0_itf_bma2xx = {
             MYNEWT_VAL(BMA2XX_INT_CFG_ACTIVE)}
     },
 };
-#endif
-#if MYNEWT_VAL(SPI_0_MASTER) && MYNEWT_VAL(BMA2XX_OFB)
+#elif MYNEWT_VAL(SPI_0_MASTER)
 //TODO:  Make INT pin nums configurable.  Leaving hardcoded
 //to handle multiple bma2xx sensor interface examples
 static struct sensor_itf spi2c_0_itf_bma2xx = {
@@ -468,6 +468,7 @@ static struct sensor_itf spi2c_0_itf_bma2xx = {
             MYNEWT_VAL(BMA2XX_INT_CFG_ACTIVE)}
     },
 };
+#endif
 #endif
 
 #if MYNEWT_VAL(BMP388_OFB)

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -374,7 +374,7 @@ static struct sensor_itf i2c_0_itf_tsl = {
 #endif
 
 #if MYNEWT_VAL(I2C_0) && MYNEWT_VAL(TSL2591_OFB)
-static struct sensor_itf i2c_0_itf_tsl = {
+static struct sensor_itf i2c_0_itf_tsl2591 = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
     /*  I2C address for the TSL2591 (0x29) */
@@ -1804,7 +1804,7 @@ sensor_dev_create(void)
 
 #if MYNEWT_VAL(TSL2591_OFB)
     rc = os_dev_create((struct os_dev *) &tsl2591, "tsl2591_0",
-      OS_DEV_INIT_PRIMARY, 0, tsl2591_init, (void *)&i2c_0_itf_tsl);
+      OS_DEV_INIT_PRIMARY, 0, tsl2591_init, (void *)&i2c_0_itf_tsl2591);
     assert(rc == 0);
 
     rc = config_tsl2591_sensor();


### PR DESCRIPTION
Changes to sensor drivers and sensor creator that will eliminate build errors when all sensor are enabled in sensor creator.

No functionality changes in drivers or sensor_creator.