### PR TITLE
Sysconfig for breakpoint-on-reset

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -67,10 +67,14 @@ hal_system_reset(void)
     hal_system_reset_cb();
 #endif
 
-    while (1) {
-        if (hal_debugger_connected()) {
+    while (1)
+    {
+#if MYNEWT_VAL(MCU_DEBUG_HALT_ON_RESET)
+        if(hal_debugger_connected())
+        {
             asm("bkpt");
         }
+#endif
         NVIC_SystemReset();
     }
 }

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -81,6 +81,12 @@ syscfg.defs:
             Used internally by the newt tool.
         value: 1
 
+    MCU_DEBUG_HALT_ON_RESET:
+        description: >
+            Specifies the required alignment for internal flash writes.
+            Used internally by the newt tool.
+        value: 1
+
     RAM_RESIDENT:
         description: 'Compile app to be loaded to RAM'
         value: 0

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -83,8 +83,8 @@ syscfg.defs:
 
     MCU_DEBUG_HALT_ON_RESET:
         description: >
-            Specifies the required alignment for internal flash writes.
-            Used internally by the newt tool.
+            Enables a breakpoint in hal_system_reset() when a debugger is attached.
+            Has no effect when debugger is not present.
         value: 1
 
     RAM_RESIDENT:


### PR DESCRIPTION
This PR adds a sysconfig that controls whether or not to set a breakpoint when hal_system_reset() is called. The default value is set to 1, so it defaults to the same as the current behavior.