### PR TITLE
sensors: Fix printf-style formatting in logs

### DIFF
--- a/hw/drivers/sensors/bma2xx/src/bma2xx.c
+++ b/hw/drivers/sensors/bma2xx/src/bma2xx.c
@@ -229,7 +229,7 @@ spi_writereg(struct sensor_itf * itf, uint8_t addr, uint8_t payload,
         rc = hal_spi_tx_val(itf->si_num, payload);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            BMA2XX_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+            BMA2XX_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                        itf->si_num, addr);
             goto err;
         }

--- a/hw/drivers/sensors/icp101xx/src/icp101xx.c
+++ b/hw/drivers/sensors/icp101xx/src/icp101xx.c
@@ -275,7 +275,7 @@ icp101xx_read(struct sensor_itf *itf, uint8_t * buf, uint32_t len)
     rc = i2cn_master_read(itf->si_num, &data_struct, OS_TICKS_PER_SEC / 10,
                           1, MYNEWT_VAL(ICP101XX_I2C_RETRIES));
     if (rc) {
-        ICP101XX_LOG_ERROR("Failed to read %d bytes from 0x%x\n", 
+        ICP101XX_LOG_ERROR("Failed to read %u bytes from 0x%x\n", len,
                      data_struct.address);
     }
 

--- a/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
+++ b/hw/drivers/sensors/lis2ds12/src/lis2ds12.c
@@ -195,7 +195,7 @@ lis2ds12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DS12_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+            LIS2DS12_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2ds12stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12.c
@@ -296,7 +296,7 @@ lis2dw12_spi_writelen(struct sensor_itf *itf, uint8_t addr, uint8_t *payload,
         rc = hal_spi_tx_val(itf->si_num, payload[i]);
         if (rc == 0xFFFF) {
             rc = SYS_EINVAL;
-            LIS2DW12_LOG_ERROR("SPI_%u write failed addr:0x%02X:0x%02X\n",
+            LIS2DW12_LOG_ERROR("SPI_%u write failed addr:0x%02X\n",
                          itf->si_num, addr);
             STATS_INC(g_lis2dw12stats, write_errors);
             goto err;

--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -2095,7 +2095,7 @@ int lsm6dso_get_ag_data(struct sensor_itf *itf, sensor_type_t type, void *data,
             sensitivity = cfg->acc_sensitivity;
            break;
         default:
-            LSM6DSO_LOG_ERROR("Invalid sensor type: %d\n", type);
+            LSM6DSO_LOG_ERROR("Invalid sensor type: %d\n", (int)type);
             return SYS_EINVAL;
     }
 


### PR DESCRIPTION
Some drivers had incompatible with format specifier argument
list in logging statements.

Those were found by static code analyzing tool.