### PR TITLE
trng_test: fix compile time warnings

### DIFF
--- a/apps/trng_test/src/main.c
+++ b/apps/trng_test/src/main.c
@@ -218,10 +218,10 @@ main(void)
             }
 
             if (failed) {
-                console_printf("monobit: (%ld/%d) %f, block4: (%ld/%d) %f, block8: (%ld/%d) %f\n",
-                        blksz, monobit_fails, ((float)blksz - monobit_fails) / blksz,
-                        blksz, block4_fails, ((float)blksz - block4_fails) / blksz,
-                        blksz, block8_fails, ((float)blksz - block8_fails) / blksz);
+                console_printf("monobit: (%u/%u) %f, block4: (%u/%u) %f, block8: (%u/%u) %f\n",
+                        (unsigned int)blksz, (unsigned int)monobit_fails, ((float)blksz - monobit_fails) / blksz,
+                        (unsigned int)blksz, (unsigned int)block4_fails, ((float)blksz - block4_fails) / blksz,
+                        (unsigned int)blksz, (unsigned int)block8_fails, ((float)blksz - block8_fails) / blksz);
             }
 
             idx = 0;


### PR DESCRIPTION
While building for simulator on Linux, the following warnings were
observed.

```
error: format ‘%ld’ expects argument of type ‘long int’,
but argument 2 has type ‘uint32_t {aka unsigned int}’
[-Werror=format=] console_printf("monobit: (%ld/%d) %f,
block4: (%ld/%d) %f, block8: (%ld/%d) %f\n",
```

Cast blksz, monobit_fails, block4_fails and block8_fails variables
when using in console_printf().

This change builds makes the test compatible for the simulator as well
as da1469x-dk-pro.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>