### PR TITLE
sensors/lis2dh12: Fix control flow in lis2dh12_set_tap_cfg()

### DIFF
--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -2981,22 +2981,22 @@ int lis2dh12_set_tap_cfg(struct sensor_itf *itf, struct lis2dh12_tap_settings *c
         return rc;
     }
 
-    lis2dh12_set_click_threshold(itf, cfg->click_ths);
+    rc = lis2dh12_set_click_threshold(itf, cfg->click_ths);
     if (rc) {
         return rc;
     }
 
-    lis2dh12_set_click_time_limit(itf, cfg->time_limit);
+    rc = lis2dh12_set_click_time_limit(itf, cfg->time_limit);
     if (rc) {
         return rc;
     }
 
-    lis2dh12_set_click_time_latency(itf, cfg->time_latency);
+    rc = lis2dh12_set_click_time_latency(itf, cfg->time_latency);
     if (rc) {
         return rc;
     }
 
-    lis2dh12_set_click_time_window(itf, cfg->time_window);
+    rc = lis2dh12_set_click_time_window(itf, cfg->time_window);
     if (rc) {
         return rc;
     }


### PR DESCRIPTION
Code was written with intention of checking return code after
each function call but setting rc variable is missing in obvious
places.

Error found by static code analyzer tool.