### PR TITLE
sensors/lsm6dso: Fix control flow error in lsm6dso_spi_fixup

### DIFF
--- a/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
+++ b/hw/drivers/sensors/lsm6dso/src/lsm6dso.c
@@ -515,8 +515,9 @@ static int lsm6dso_spi_fixup(struct sensor *sensor, struct sensor_itf *itf,
         rc = hal_spi_enable(sensor->s_itf.si_num);
         if (rc) {
             return rc;
+        }
 
-        if (init)
+        if (init) {
             return hal_gpio_init_out(sensor->s_itf.si_cs_pin, 1);
         }
     }


### PR DESCRIPTION
Two curly braces were missing resulting in dead code.
Final
 return hal_gpio_init_out(sensor->s_itf.si_cs_pin, 1);
would never be called, which could be a problem.