### PR TITLE
sensors/adxl345: Fix adxl345_get_tap_settings bit filed handling

### DIFF
--- a/hw/drivers/sensors/adxl345/src/adxl345.c
+++ b/hw/drivers/sensors/adxl345/src/adxl345.c
@@ -843,8 +843,8 @@ adxl345_get_tap_settings(struct sensor_itf *itf, struct adxl345_tap_settings *se
     }
 
     settings->x_enable = (enables & (1 << 2)) != 0;
-    settings->x_enable = (enables & (1 << 1)) != 0;
-    settings->x_enable = (enables & (1 << 0)) != 0;
+    settings->y_enable = (enables & (1 << 1)) != 0;
+    settings->z_enable = (enables & (1 << 0)) != 0;
     settings->suppress = (enables & (1 << 3)) != 0;
 
     return 0;


### PR DESCRIPTION
Obvious copy/paster error where x_enable field was used
in places where y_enable and z_enable should have been.