### PR TITLE
sensor_creator: Fix bma2xx initialization

### DIFF
--- a/hw/drivers/sensors/bma2xx/include/bma2xx/bma2xx.h
+++ b/hw/drivers/sensors/bma2xx/include/bma2xx/bma2xx.h
@@ -33,6 +33,11 @@ extern "C" {
 /* XXX use some better defaults. For now it is min */
 #define BMA2XX_LOW_G_DELAY_MS_DEFAULT       2
 #define BMA2XX_HIGH_G_DELAY_MS_DEFAULT      2
+#define BMA2XX_LOW_G_THRESH_G_DEFAULT       0.375f
+#define BMA2XX_LOW_G_HYSTER_G_DEFAULT       0.125f
+#define BMA2XX_HIGH_G_THRESH_G_DEFAULT      1.5f
+#define BMA2XX_HIGH_G_HYSTER_G_DEFAULT      0.125f
+#define BMA2XX_ORIENT_HYSTER_G_DEFAULT      0.0625f
 
 /* Supported device models.  */
 enum bma2xx_model {

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -1485,7 +1485,11 @@ config_bma2xx_sensor(void)
 
     cfg.model = BMA2XX_BMA280;
     cfg.low_g_delay_ms = BMA2XX_LOW_G_DELAY_MS_DEFAULT;
+    cfg.low_g_thresh_g = BMA2XX_LOW_G_THRESH_G_DEFAULT;
+    cfg.low_g_hyster_g = BMA2XX_LOW_G_HYSTER_G_DEFAULT;
     cfg.high_g_delay_ms = BMA2XX_HIGH_G_DELAY_MS_DEFAULT;
+    cfg.high_g_thresh_g = BMA2XX_HIGH_G_THRESH_G_DEFAULT;
+    cfg.high_g_hyster_g = BMA2XX_HIGH_G_HYSTER_G_DEFAULT;
     cfg.g_range = BMA2XX_G_RANGE_2;
     cfg.filter_bandwidth = BMA2XX_FILTER_BANDWIDTH_500_HZ;
     cfg.use_unfiltered_data = false;
@@ -1497,6 +1501,7 @@ config_bma2xx_sensor(void)
     cfg.offset_x_g = 0.0;
     cfg.offset_y_g = 0.0;
     cfg.offset_z_g = 0.0;
+    cfg.orient_hyster_g = BMA2XX_ORIENT_HYSTER_G_DEFAULT;
     cfg.orient_blocking = BMA2XX_ORIENT_BLOCKING_NONE;
     cfg.orient_mode = BMA2XX_ORIENT_MODE_SYMMETRICAL;
     cfg.power_mode = BMA2XX_POWER_MODE_NORMAL;


### PR DESCRIPTION
5 fields from bma2xx sensor were left unset in sensor_creator,
it would result in unpredictable data since variable was on stack.
Now values that correspond to device reset values are defined
in driver and are used in sensor creator.