### PR TITLE
mcu/dialog/da1469x: configurability for explicitly disabling dcdc

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
@@ -44,6 +44,11 @@ void da1469x_prail_dcdc_restore(void);
 
 #endif
 
+/**
+ * Disable DCDC
+ */
+void da1469x_prail_dcdc_disable(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -153,6 +153,12 @@ da1469x_prail_dcdc_restore(void)
 #endif
 
 void
+da1469x_prail_dcdc_disable(void)
+{
+    DCDC->DCDC_CTRL1_REG &= ~DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
+}
+
+void
 da1469x_prail_initialize(void)
 {
     da1469x_prail_configure_3v0();


### PR DESCRIPTION
Explicitly disable DCDC converter.