### PR TITLE
hw/mcu/dialog: Add helper to enable/disable AMBA clocks

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -21,6 +21,7 @@
 #define __MCU_DA1469X_CLOCK_H_
 
 #include <stdint.h>
+#include "mcu/da1469x_hal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,6 +94,36 @@ uint32_t da1469x_clock_lp_rcx_freq_get(void);
  * Disable RCX
  */
 void da1469x_clock_lp_rcx_disable(void);
+
+/**
+ * Enable an AMBA clock
+ *
+ * @param idx
+ */
+static inline void
+da1469x_clock_amba_enable(uint32_t mask)
+{
+    uint32_t primask;
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+    CRG_TOP->CLK_AMBA_REG |= mask;
+    __HAL_ENABLE_INTERRUPTS(primask);
+}
+
+/**
+ * Disable AMBA clock(s)
+ *
+ * @param uint32_t mask
+ */
+static inline void
+da1469x_clock_amba_disable(uint32_t mask)
+{
+    uint32_t primask;
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+    CRG_TOP->CLK_AMBA_REG &= ~mask;
+    __HAL_ENABLE_INTERRUPTS(primask);
+}
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -96,9 +96,9 @@ uint32_t da1469x_clock_lp_rcx_freq_get(void);
 void da1469x_clock_lp_rcx_disable(void);
 
 /**
- * Enable an AMBA clock
+ * Enable AMBA clock(s)
  *
- * @param idx
+ * @param mask
  */
 static inline void
 da1469x_clock_amba_enable(uint32_t mask)

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -21,7 +21,7 @@
 #define __MCU_DA1469X_HAL_H_
 
 #include <assert.h>
-#include "mcu/cmsis_nvic.h"
+#include "mcu/mcu.h"
 #include "hal/hal_flash.h"
 
 #ifdef __cplusplus

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -21,6 +21,7 @@
 #define __MCU_DA1469X_HAL_H_
 
 #include <assert.h>
+#include "mcu/cmsis_nvic.h"
 #include "hal/hal_flash.h"
 
 #ifdef __cplusplus

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -21,6 +21,7 @@
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
+#include "mcu/da1469x_clock.h"
 #include "mcu/mcu.h"
 #include "da1469x_priv.h"
 
@@ -101,13 +102,14 @@ void SystemInit(void)
     CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_RETAIN_CACHE_Msk;
 #endif
 
+
     /* Switch OTPC to deep standby (DSTBY) mode */
-    CRG_TOP->CLK_AMBA_REG |= CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+    da1469x_clock_amba_enable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
     OTPC->OTPC_MODE_REG = (OTPC->OTPC_MODE_REG &
                            ~OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Msk) |
                           (1 << OTPC_OTPC_MODE_REG_OTPC_MODE_MODE_Pos);
     while (!(OTPC->OTPC_STAT_REG & OTPC_OTPC_STAT_REG_OTPC_STAT_MRDY_Msk));
-    CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk;
+    da1469x_clock_amba_disable(CRG_TOP_CLK_AMBA_REG_OTP_ENABLE_Msk);
 
     /* Initialize and configure power rails */
     da1469x_prail_initialize();


### PR DESCRIPTION
Add a helper to enable/disable AMBA clocks in CRG_TOP->CLK_AMBA_REG.
The code was doing an un-protected read-modify-write and if the clock is modified inside ISR's this could cause unpredictable behavior.

The helper will enable/disable interrupts around the setting/clearing of bits in that register. The helpers added are:
da1469x_clock_amba_enable(mask)
da1469x_clock_amba_disable(mask)
