### PR TITLE
hw/bsp/dialog: Update default path for flash loader

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -46,7 +46,7 @@ JLINK_LOG_FILE=.jlink_log
 # flash_loader build for this BSP
 if [ -z $FLASH_LOADER ]; then
     FL_TGT=da1469x_flash_loader
-    FLASH_LOADER=$BIN_ROOT/targets/$FL_TGT/app/apps/flash_loader/flash_loader.elf
+    FLASH_LOADER=$BIN_ROOT/targets/$FL_TGT/app/@apache-mynewt-core/apps/flash_loader/flash_loader.elf
 fi
 if [ ! -f $FLASH_LOADER ]; then
     FILE=${FLASH_LOADER##$(pwd)/}


### PR DESCRIPTION
Recent versions of newt include repository name in generated files path.