### PR TITLE
console improvements

### DIFF
--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -132,6 +132,17 @@ extern void console_rx_restart(void);
 int console_lock(int timeout);
 int console_unlock(void);
 
+/**
+ * Set prompt and current input line.
+ *
+ * This shows prompt with current input editor, cursor is placed
+ * at the end of line.
+ *
+ * @param prompt non-editable part of user input line
+ * @param line  editable part
+ */
+void console_prompt_set(const char *prompt, const char *line);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -25,7 +25,7 @@
 #include "console/console.h"
 
 int
-console_out(int c)
+console_out_nolock(int c)
 {
     if (g_console_silence) {
         return c;
@@ -34,6 +34,15 @@ console_out(int c)
     console_is_midline = (c != '\n');
 
     return ble_monitor_out(c);
+}
+
+void
+console_rx_restart(void)
+{
+    /*
+     * Function required by console
+     * TODO: Check if actual body is needed.
+     */
 }
 
 int

--- a/sys/console/full/src/ble_monitor_console.c
+++ b/sys/console/full/src/ble_monitor_console.c
@@ -27,12 +27,6 @@
 int
 console_out_nolock(int c)
 {
-    if (g_console_silence) {
-        return c;
-    }
-
-    console_is_midline = (c != '\n');
-
     return ble_monitor_out(c);
 }
 

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -56,10 +56,10 @@
 #define CONSOLE_NLIP_DATA_START1 (4)
 #define CONSOLE_NLIP_DATA_START2 (20)
 
-#define NLIP_PKT_START1  (1 << 0)
-#define NLIP_PKT_START2  (1 << 1)
-#define NLIP_DATA_START1 (1 << 2)
-#define NLIP_DATA_START2 (1 << 3)
+#define NLIP_PKT_START1  (CONSOLE_NLIP_PKT_START1)
+#define NLIP_PKT_START2  (CONSOLE_NLIP_PKT_START2)
+#define NLIP_DATA_START1 (CONSOLE_NLIP_DATA_START1)
+#define NLIP_DATA_START2 (CONSOLE_NLIP_DATA_START2)
 
 /* Indicates whether the previous line of output was completed. */
 int console_is_midline;
@@ -663,21 +663,19 @@ ansi_cmd:
 static int
 handle_nlip(uint8_t byte)
 {
-    if (((nlip_state & NLIP_PKT_START1) &&
-         (nlip_state & NLIP_PKT_START2)) ||
-        ((nlip_state & NLIP_DATA_START1) &&
-         (nlip_state & NLIP_DATA_START2)))
+    if ((nlip_state == NLIP_PKT_START2) ||
+        (nlip_state == NLIP_DATA_START2))
     {
         return 1;
     }
 
-    if ((nlip_state & NLIP_PKT_START1) &&
+    if ((nlip_state == NLIP_PKT_START1) &&
         (byte == CONSOLE_NLIP_PKT_START2)) {
-        nlip_state |= NLIP_PKT_START2;
+        nlip_state == NLIP_PKT_START2;
         return 1;
-    } else if ((nlip_state & NLIP_DATA_START1) &&
+    } else if ((nlip_state == NLIP_DATA_START1) &&
                (byte == CONSOLE_NLIP_DATA_START2)) {
-        nlip_state |= NLIP_DATA_START2;
+        nlip_state == NLIP_DATA_START2;
         return 1;
     } else {
         nlip_state = 0;
@@ -798,10 +796,10 @@ console_handle_char(uint8_t byte)
         handle_ansi(byte, input->line);
         switch (byte) {
         case CONSOLE_NLIP_PKT_START1:
-            nlip_state |= NLIP_PKT_START1;
+            nlip_state == NLIP_PKT_START1;
             break;
         case CONSOLE_NLIP_DATA_START1:
-            nlip_state |= NLIP_DATA_START1;
+            nlip_state == NLIP_DATA_START1;
             break;
         case DEL:
         case BS:

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -641,9 +641,13 @@ ansi_cmd:
 #if MYNEWT_VAL(CONSOLE_HISTORY_SIZE) > 0
     case ANSI_UP:
     case ANSI_DOWN:
+#if MYNEWT_VAL(CONSOLE_UART_RX_BUF_SIZE) == 0
         console_blocking_mode();
+#endif
         console_hist_move(line, byte);
+#if MYNEWT_VAL(CONSOLE_UART_RX_BUF_SIZE) == 0
         console_non_blocking_mode();
+#endif
         break;
 #endif
     case ANSI_BACKWARD:

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -1184,6 +1184,14 @@ console_handle_char(uint8_t byte)
         case ETX:
             console_clear_line();
             break;
+        /* CTRL-L */
+        case VT:
+            if (MYNEWT_VAL(CONSOLE_STICKY_PROMPT)) {
+                request_terminal_size();
+            } else {
+                console_out_nolock(VT);
+            }
+            break;
         }
     } else {
         insert_char(&input->line[cur], byte);

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -826,10 +826,14 @@ console_handle_char(uint8_t byte)
         return 0;
     }
 
+    if (console_lock(1000)) {
+        return -1;
+    }
+
     /* Handle ANSI escape mode */
     if (esc_state & ESC_ANSI) {
         handle_ansi(byte, input->line);
-        return 0;
+        goto unlock;
     }
 
     /* Handle escape mode */
@@ -845,7 +849,7 @@ console_handle_char(uint8_t byte)
             break;
         }
 
-        return 0;
+        goto unlock;
     }
 
     /* Handle special control characters */
@@ -901,11 +905,11 @@ console_handle_char(uint8_t byte)
             console_clear_line();
             break;
         }
-
-        return 0;
+    } else {
+        insert_char(&input->line[cur], byte);
     }
-
-    insert_char(&input->line[cur], byte);
+unlock:
+    (void)console_unlock();
 
     return 0;
 }

--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -106,15 +106,8 @@ console_out_nolock(int character)
 {
     char c = (char)character;
 
-    if (g_console_silence) {
-        return c;
-    }
-
     if ('\n' == c) {
         rtt_console_write_ch('\r');
-        console_is_midline = 0;
-    } else {
-        console_is_midline = 1;
     }
 
     rtt_console_write_ch(c);

--- a/sys/console/full/src/uart_console.c
+++ b/sys/console/full/src/uart_console.c
@@ -156,10 +156,6 @@ uart_console_non_blocking_mode(void)
 int
 console_out_nolock(int c)
 {
-    if (g_console_silence) {
-        return c;
-    }
-
     /* Assure that there is a write cb installed; this enables to debug
      * code that is faulting before the console was initialized.
      */
@@ -169,9 +165,6 @@ console_out_nolock(int c)
 
     if ('\n' == c) {
         write_char_cb(uart_dev, '\r');
-        console_is_midline = 0;
-    } else {
-        console_is_midline = 1;
     }
     write_char_cb(uart_dev, c);
     uart_start_tx(uart_dev);

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -46,6 +46,9 @@ syscfg.defs:
             Number of lines to be stored in console history.
             Set to "0" to disable console history.
         value: 0
+    CONSOLE_MAX_PROMPT_LEN:
+        description: 'Maximum number of characters for prompt'
+        value: 16
 
     CONSOLE_UART_BAUD:
         description: 'Console UART baud rate.'

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -49,6 +49,11 @@ syscfg.defs:
     CONSOLE_MAX_PROMPT_LEN:
         description: 'Maximum number of characters for prompt'
         value: 16
+    CONSOLE_STICKY_PROMPT:
+        description: >
+            If set to 1 prompt will be visble all the time at the
+            bottom of terminal if terminal was detected.
+        value: 0
 
     CONSOLE_UART_BAUD:
         description: 'Console UART baud rate.'

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -54,6 +54,17 @@ syscfg.defs:
             If set to 1 prompt will be visble all the time at the
             bottom of terminal if terminal was detected.
         value: 0
+    CONSOLE_PROMPT_SOFT_CURSOR:
+        description: >
+            Set this to 1 for VT102 like terminals in case of volume of
+            log prints makes it difficult to see cursor in prompt line.
+        value: 0
+    CONSOLE_PROMPT_SOFT_CURSOR_ATTR:
+        description: >
+            Terminal escape sequence for cursor graphics mode.
+            For black and white (minicom) use "7m" - inverse
+            For color (putty) use "30;42m" - black/green
+        value: '"7m"'
 
     CONSOLE_UART_BAUD:
         description: 'Console UART baud rate.'

--- a/sys/console/minimal/include/console/console.h
+++ b/sys/console/minimal/include/console/console.h
@@ -128,6 +128,8 @@ extern int console_out(int character);
 int console_lock(int timeout);
 int console_unlock(void);
 
+void console_prompt_set(const char *prompt, const char *line);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -130,6 +130,15 @@ console_out(int c)
 }
 
 void
+console_prompt_set(const char *prompt, const char *line)
+{
+    console_write(promot, strlen(prompt));
+    if (line) {
+        console_write(line, strlen(line));
+    }
+}
+
+void
 console_write(const char *str, int cnt)
 {
     int i;

--- a/sys/console/stub/include/console/console.h
+++ b/sys/console/stub/include/console/console.h
@@ -129,6 +129,11 @@ console_out(int character)
     return 0;
 }
 
+static inline void
+console_prompt_set(const char *prompt, const char *line)
+{
+}
+
 static void inline
 console_silence(bool silent)
 {

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -73,16 +73,19 @@ get_prompt(void)
 }
 
 static void
-print_prompt(void)
+print_prompt(const char *line)
 {
-    console_printf("%s%s", get_prompt(), MYNEWT_VAL(SHELL_PROMPT_SUFFIX));
+    char full_prompt[30];
+    strcpy(full_prompt, get_prompt());
+    strcat(full_prompt, MYNEWT_VAL(SHELL_PROMPT_SUFFIX));
+    console_prompt_set(full_prompt, line);
 }
 
 static void
 print_prompt_if_console(struct streamer *streamer)
 {
     if (streamer == streamer_console_get()) {
-        print_prompt();
+        print_prompt(NULL);
     }
 }
 
@@ -482,13 +485,13 @@ shell(struct os_event *ev)
     struct streamer *streamer;
 
     if (!ev) {
-        print_prompt();
+        print_prompt(NULL);
         return;
     }
 
     cmd = ev->ev_arg;
     if (!cmd) {
-        print_prompt();
+        print_prompt(NULL);
         return;
     }
 
@@ -615,8 +618,7 @@ complete_param(char *line, const char *param_prefix,
 
     if (common_chars >= 0) {
         /* multiple match, restore prompt */
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
     } else {
         common_chars = strlen(first_match);
     }
@@ -704,8 +706,7 @@ complete_command(char *line, char *command_prefix,
         }
     }
     /* restore prompt */
-    print_prompt();
-    console_printf("%s", line);
+    print_prompt(line);
 }
 
 static void
@@ -721,8 +722,7 @@ complete_module(char *line, char *module_prefix,
         for (i = 0; i < num_of_shell_entities; i++) {
             console_printf("%s\n", shell_modules[i].name);
         }
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
         return;
     }
 
@@ -765,8 +765,7 @@ complete_module(char *line, char *module_prefix,
 
     if (common_chars >= 0) {
         /* multiple match, restore prompt */
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
     } else {
         common_chars = strlen(first_match);
         space = 1;
@@ -796,8 +795,7 @@ complete_select(char *line, char *cur,
     if (tok_len == 0) {
         console_printf("\n");
         print_modules(streamer_console_get());
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
         return;
     }
 
@@ -833,8 +831,7 @@ completion(char *line, console_append_char_cb append_char)
         } else {
             print_module_commands(default_module, streamer_console_get());
         }
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
         return;
     }
 
@@ -869,8 +866,7 @@ completion(char *line, console_append_char_cb append_char)
         if (tok_len == 0) {
             console_printf("\n");
             print_module_commands(module, streamer_console_get());
-            print_prompt();
-            console_printf("%s", line);
+            print_prompt(line);
             return;
         }
 
@@ -891,8 +887,7 @@ completion(char *line, console_append_char_cb append_char)
     if (tok_len == 0) {
         console_printf("\n");
         print_command_params(module, command, streamer_console_get());
-        print_prompt();
-        console_printf("%s", line);
+        print_prompt(line);
         return;
     }
     complete_param(line, cur, tok_len,
@@ -920,7 +915,7 @@ shell_register_default_module(const char *name)
 
     if (result != -1) {
         console_printf("\n");
-        print_prompt();
+        print_prompt(NULL);
     }
 }
 

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -698,7 +698,7 @@ complete_command(char *line, char *command_prefix,
      * More words match but there is nothing that could be appended
      * list all possible matches.
      */
-    console_printf("\n");
+    console_out('\n');
     console_printf("%s\n", commands[first_match].sc_cmd);
     for (i = first_match + 1; commands[i].sc_cmd; i++) {
         if (0 == strncmp(command_prefix, commands[i].sc_cmd, command_len)) {
@@ -718,7 +718,7 @@ complete_module(char *line, char *module_prefix,
     int common_chars = -1, space = 0;
 
     if (!module_len) {
-        console_printf("\n");
+        console_out('\n');
         for (i = 0; i < num_of_shell_entities; i++) {
             console_printf("%s\n", shell_modules[i].name);
         }
@@ -741,7 +741,7 @@ complete_module(char *line, char *module_prefix,
 
         /* more commands match, print first match */
         if (first_match && (common_chars < 0)) {
-            console_printf("\n");
+            console_out('\n');
             console_printf("%s\n", first_match);
             common_chars = strlen(first_match);
         }
@@ -793,7 +793,7 @@ complete_select(char *line, char *cur,
     cur += tok_len + 1;
     tok_len = get_token(&cur, &null_terminated);
     if (tok_len == 0) {
-        console_printf("\n");
+        console_out('\n');
         print_modules(streamer_console_get());
         print_prompt(line);
         return;
@@ -825,7 +825,7 @@ completion(char *line, console_append_char_cb append_char)
 
     /* empty token - print options */
     if (tok_len == 0) {
-        console_printf("\n");
+        console_out('\n');
         if (default_module == -1) {
             print_modules(streamer_console_get());
         } else {
@@ -864,7 +864,7 @@ completion(char *line, console_append_char_cb append_char)
         tok_len = get_token(&cur, &null_terminated);
 
         if (tok_len == 0) {
-            console_printf("\n");
+            console_out('\n');
             print_module_commands(module, streamer_console_get());
             print_prompt(line);
             return;
@@ -885,7 +885,7 @@ completion(char *line, console_append_char_cb append_char)
     cur += tok_len;
     tok_len = get_last_token(&cur);
     if (tok_len == 0) {
-        console_printf("\n");
+        console_out('\n');
         print_command_params(module, command, streamer_console_get());
         print_prompt(line);
         return;
@@ -914,7 +914,7 @@ shell_register_default_module(const char *name)
     int result = set_default_module(name);
 
     if (result != -1) {
-        console_printf("\n");
+        console_out('\n');
         print_prompt(NULL);
     }
 }

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -686,6 +686,10 @@ complete_command(char *line, char *command_prefix,
             append_char(line, ' ');
         }
         return;
+    } else if (match_count == 1) {
+        /* Whole word matched, append space */
+        append_char(line, ' ');
+        return;
     }
 
     /*

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -794,9 +794,6 @@ complete_select(char *line, char *cur,
     cur += tok_len + 1;
     tok_len = get_token(&cur, &null_terminated);
     if (tok_len == 0) {
-        if (default_module != -1) {
-            return;
-        }
         console_printf("\n");
         print_modules(streamer_console_get());
         print_prompt();
@@ -805,9 +802,7 @@ complete_select(char *line, char *cur,
     }
 
     if (null_terminated) {
-        if (default_module == -1) {
-            complete_module(line, cur, tok_len, append_char);
-        }
+        complete_module(line, cur, tok_len, append_char);
     }
 }
 


### PR DESCRIPTION
This allows to have editable prompt line visible at the bottom of the terminal window.
This can be useful when logs are flooding console and it would be hard to type
complicated commands.

Additionally:
- completion for `select` fixed
- fixed auto completion for complete word (space added when word was already full)
- CTRL-C clears input line
- CTRL-L resets console if something goes wrong
- HOME/END putty work now