### PR TITLE
hw/mcu/dialog: Improve lpclk notifications

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_lpclk.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_lpclk.h
@@ -20,13 +20,19 @@
 #ifndef __MCU_DA1469X_LPCLK_H_
 #define __MCU_DA1469X_LPCLK_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef void (da1469x_lpclk_cb)(void);
+typedef void (da1469x_lpclk_cb)(uint32_t freq);
 
 void da1469x_lpclk_register_cmac_cb(da1469x_lpclk_cb *cb);
+/* Stable lp clock enabled (e.g. switched to XTAL after settling) */
+void da1469x_lpclk_enabled(void);
+/* Frequency of lp clock changed (e.g. after RCX recalibration) */
+void da1469x_lpclk_updated(void);
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_cmac.c
@@ -162,12 +162,12 @@ done:
 }
 
 static void
-da1469x_cmac_lpclk_cb(void)
+da1469x_cmac_lpclk_cb(uint32_t freq)
 {
     struct cmac_config_dynamic *cmac_config_dyn;
 
     cmac_config_dyn = CMAC_SYM_CONFIG_DYN;
-    cmac_config_dyn->enable_sleep = true;
+    cmac_config_dyn->enable_sleep = freq == 32768;
 }
 
 void

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -37,23 +37,42 @@ static void
 da1469x_lpclk_settle_tmr_cb(void *arg)
 {
     da1469x_clock_lp_xtal32k_switch();
-
-    g_mcu_lpclk_available = true;
-
-    if (g_da1469x_lpclk_cmac_cb) {
-        g_da1469x_lpclk_cmac_cb();
-    }
+    da1469x_lpclk_enabled();
 }
 #endif
+
+static void
+da1469x_lpclk_notify(void)
+{
+    if (!g_da1469x_lpclk_cmac_cb || !g_mcu_lpclk_available) {
+        return;
+    }
+
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
+    g_da1469x_lpclk_cmac_cb(32768);
+#elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
+    g_da1469x_lpclk_cmac_cb(da1469x_clock_lp_rcx_freq_get());
+#endif
+}
 
 void
 da1469x_lpclk_register_cmac_cb(da1469x_lpclk_cb *cb)
 {
     g_da1469x_lpclk_cmac_cb = cb;
+    da1469x_lpclk_notify();
+}
 
-    if (g_mcu_lpclk_available) {
-        cb();
-    }
+void
+da1469x_lpclk_enabled(void)
+{
+    g_mcu_lpclk_available = true;
+    da1469x_lpclk_notify();
+}
+
+void
+da1469x_lpclk_updated(void)
+{
+    da1469x_lpclk_notify();
 }
 
 void

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include "syscfg/syscfg.h"
 #include "mcu/da1469x_clock.h"
+#include "mcu/da1469x_lpclk.h"
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "hal/hal_system.h"
@@ -101,6 +102,7 @@ hal_system_clock_start(void)
     da1469x_clock_lp_rcx_enable();
     da1469x_clock_lp_rcx_switch();
     da1469x_clock_lp_rcx_calibrate();
+    da1469x_lpclk_enabled();
 #else
     /*
      * We cannot switch lp_clk to XTAL32K here since it needs some time to


### PR DESCRIPTION
lpclk notification is now triggered also for RCX and includes current
lpclk frequency. If at some point RCX is recalibrated, we can just sent
another notification with new frequency.