### PR TITLE
[WIP] DA1469x UART rx pullup

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -54,6 +54,7 @@ struct da1469x_uart_cfg {
     int8_t pin_rx;
     int8_t pin_rts;
     int8_t pin_cts;
+    uint8_t rx_pullup;
 };
 
 struct da1469x_hal_i2c_cfg {

--- a/hw/mcu/dialog/da1469x/src/da1469x_periph.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_periph.c
@@ -86,6 +86,7 @@ static const struct da1469x_uart_cfg os_bsp_uart0_cfg = {
     .pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
     .pin_rts = -1,
     .pin_cts = -1,
+    .rx_pullup = MYNEWT_VAL(UART_0_RX_ENABLE_PULLUP)
 };
 #endif
 #if MYNEWT_VAL(UART_1)
@@ -95,6 +96,7 @@ static const struct da1469x_uart_cfg os_bsp_uart1_cfg = {
     .pin_rx = MYNEWT_VAL(UART_1_PIN_RX),
     .pin_rts = MYNEWT_VAL(UART_1_PIN_RTS),
     .pin_cts = MYNEWT_VAL(UART_1_PIN_CTS),
+    .rx_pullup = MYNEWT_VAL(UART_1_RX_ENABLE_PULLUP)
 };
 #endif
 #if MYNEWT_VAL(UART_2)
@@ -104,6 +106,7 @@ static const struct da1469x_uart_cfg os_bsp_uart2_cfg = {
     .pin_rx = MYNEWT_VAL(UART_2_PIN_RX),
     .pin_rts = MYNEWT_VAL(UART_2_PIN_RTS),
     .pin_cts = MYNEWT_VAL(UART_2_PIN_CTS),
+    .rx_pullup = MYNEWT_VAL(UART_2_RX_ENABLE_PULLUP)
 };
 #endif
 

--- a/hw/mcu/dialog/da1469x/src/hal_uart.c
+++ b/hw/mcu/dialog/da1469x/src/hal_uart.c
@@ -40,6 +40,11 @@ struct da1469x_uart {
     volatile uint8_t tx_started : 1;
     volatile uint8_t rx_data;
 
+    /* Stores rx pin func for use during open/close and if there is a pullup */
+    mcu_gpio_func rx_pin_func;
+    int8_t        rx_pin;
+    uint8_t       rx_pullup;
+
     hal_uart_rx_char rx_func;
     hal_uart_tx_char tx_func;
     hal_uart_tx_done tx_done;
@@ -214,6 +219,8 @@ da1469x_uart_common_isr(struct da1469x_uart *uart)
         case 0x06: /* receiver line status */
             break;
         case 0x07: /* busy detect */
+            /* Clear the flag so if assert not defined no infinite loop here */
+            (void)regs->UART2_USR_REG;
             assert(0);
             break;
         case 0x0c: /* character timeout */
@@ -351,11 +358,15 @@ hal_uart_init(int port, void *arg)
     IRQn_Type irqn;
     void (* isr)(void);
     mcu_gpio_func gpiofunc[4]; /* RX, TX, RTS, CTS */
+    uint8_t rx_pullup;
 
     uart = da1469x_uart_resolve(port);
     if (!uart) {
         return SYS_EINVAL;
     }
+
+    /* Assume no need for internal rx pullup */
+    rx_pullup = 0;
 
     switch (port) {
 #if MYNEWT_VAL(UART_0)
@@ -367,6 +378,9 @@ hal_uart_init(int port, void *arg)
         gpiofunc[1] = MCU_GPIO_FUNC_UART_RX;
         gpiofunc[2] = 0;
         gpiofunc[3] = 0;
+#if MYNEWT_VAL(UART_0_RX_ENABLE_PULLUP)
+        rx_pullup = 1;
+#endif
         break;
 #endif
 #if MYNEWT_VAL(UART_1)
@@ -378,6 +392,9 @@ hal_uart_init(int port, void *arg)
         gpiofunc[1] = MCU_GPIO_FUNC_UART2_RX;
         gpiofunc[2] = MCU_GPIO_FUNC_UART2_RTSN;
         gpiofunc[3] = MCU_GPIO_FUNC_UART2_CTSN;
+#if MYNEWT_VAL(UART_1_RX_ENABLE_PULLUP)
+        rx_pullup = 1;
+#endif
         break;
 #endif
 #if MYNEWT_VAL(UART_2)
@@ -389,6 +406,9 @@ hal_uart_init(int port, void *arg)
         gpiofunc[1] = MCU_GPIO_FUNC_UART3_RX;
         gpiofunc[2] = MCU_GPIO_FUNC_UART3_RTSN;
         gpiofunc[3] = MCU_GPIO_FUNC_UART3_CTSN;
+#if MYNEWT_VAL(UART_2_RX_ENABLE_PULLUP)
+        rx_pullup = 1;
+#endif
         break;
 #endif
     default:
@@ -402,6 +422,11 @@ hal_uart_init(int port, void *arg)
 
     uart->regs = regs;
     uart->irqn = irqn;
+
+    /* These are for uart open/close to enable a pullup on the rx line */
+    uart->rx_pin_func = gpiofunc[1];
+    uart->rx_pin = cfg->pin_rx;
+    uart->rx_pullup = rx_pullup;
 
     mcu_gpio_set_pin_function(cfg->pin_tx, MCU_GPIO_MODE_OUTPUT, gpiofunc[0]);
     mcu_gpio_set_pin_function(cfg->pin_rx, MCU_GPIO_MODE_INPUT, gpiofunc[1]);
@@ -463,6 +488,22 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
     if (!baudrate_cfg) {
         return SYS_ENOTSUP;
     }
+
+    /* Enable pullup if configured */
+    if (uart->rx_pullup) {
+        mcu_gpio_set_pin_function(uart->rx_pin, MCU_GPIO_MODE_INPUT_PULLUP,
+                                  uart->rx_pin_func);
+    }
+
+    /*
+     * If the UART is busy we are not allowed to write to the LCR register.
+     * Doing so results in the "busy detect" error. Note that if either the
+     * TX or RX lines are held low the uart will be considered busy.
+     */
+    if (regs->UART2_USR_REG & UART2_UART2_USR_REG_UART_BUSY_Msk) {
+        return SYS_EBUSY;
+    }
+
     regs->UART2_LCR_REG |= UART2_UART2_LCR_REG_UART_DLAB_Msk;
     regs->UART2_IER_DLH_REG = (baudrate_cfg >> 16) & 0xff;
     regs->UART2_RBR_THR_DLL_REG = (baudrate_cfg >> 8) & 0xff;
@@ -543,6 +584,12 @@ hal_uart_close(int port)
     default:
         assert(0);
         break;
+    }
+
+    /* Set back to input with no pullup if pullup enabled */
+    if (uart->rx_pullup) {
+        mcu_gpio_set_pin_function(uart->rx_pin, MCU_GPIO_MODE_INPUT,
+                                  uart->rx_pin_func);
     }
 
     return 0;

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -252,6 +252,9 @@ syscfg.defs:
     UART_0_PIN_RX:
         description: 'RX pin for UART0'
         value: ''
+    UART_0_RX_ENABLE_PULLUP:
+        description: 'Enable internal pullup on RX pin. 0:none 1:enable pullup'
+        value: 0
 
     UART_1:
         description: Enable DA1469x UART 1 (UART2 peripheral)
@@ -268,6 +271,9 @@ syscfg.defs:
     UART_1_PIN_CTS:
         description: 'CTS pin for UART1'
         value: -1
+    UART_1_RX_ENABLE_PULLUP:
+        description: 'Enable internal pullup on RX pin. 0:none 1:enable pullup'
+        value: 0
 
     UART_2:
         description: Enable DA1469x UART 2 (UART3 peripheral)
@@ -284,6 +290,9 @@ syscfg.defs:
     UART_2_PIN_CTS:
         description: 'CTS pin for UART2'
         value: -1
+    UART_2_RX_ENABLE_PULLUP:
+        description: 'Enable internal pullup on RX pin. 0:none 1:enable pullup'
+        value: 0
 
     TIMER_0:
         description: Enable DA1469x timer 0 (Timer peripheral)


### PR DESCRIPTION
This code will allow a user to configure an internal pullup on the UART rx pin. It is expected that a BSP would set UART_X_RX_ENABLE_PULLUP if there is no external pullup on the line.

<XXX: will add more here once we test this and see if it works>