### PR TITLE
Keep V18 in normal mode during active, not retention mode

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -60,9 +60,9 @@ da1469x_prail_configure_1v8(void)
     /* XXX make rail configurable */
 
     POWER_CTRL_REG_SET(V18_LEVEL, 1);                   /* 1.800 V */
-    POWER_CTRL_REG_SET(LDO_1V8_RET_ENABLE_ACTIVE, 1);
+    POWER_CTRL_REG_SET(LDO_1V8_RET_ENABLE_ACTIVE, 0);
     POWER_CTRL_REG_SET(LDO_1V8_RET_ENABLE_SLEEP, 1);
-    POWER_CTRL_REG_SET(LDO_1V8_ENABLE, 0);
+    POWER_CTRL_REG_SET(LDO_1V8_ENABLE, 1);
 }
 
 static void


### PR DESCRIPTION
The 1V8 rail was being configured to use the retention LDO by default, which is not correct. It should use the normal LDO in ACTIVE mode, the same as for the 1V8P and 3V0 rails. 


