### PR TITLE
FCB Rotate Notification

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -60,6 +60,7 @@ struct fcb {
     /* Flash circular buffer internal state */
     struct os_mutex f_mtx;	/* Locking for accessing the FCB data */
     struct flash_area *f_oldest;
+    struct flash_area *f_scratch;
     struct fcb_entry f_active;
     uint16_t f_active_id;
     uint8_t f_align;		/* writes to flash have to aligned to this */
@@ -68,15 +69,16 @@ struct fcb {
 /**
  * Error codes.
  */
-#define FCB_OK		0
-#define FCB_ERR_ARGS	-1
-#define FCB_ERR_FLASH	-2
-#define FCB_ERR_NOVAR   -3
-#define FCB_ERR_NOSPACE	-4
-#define FCB_ERR_NOMEM	-5
-#define FCB_ERR_CRC	-6
-#define FCB_ERR_MAGIC   -7
-#define FCB_ERR_VERSION -8
+#define FCB_OK             0
+#define FCB_ERR_ARGS      -1
+#define FCB_ERR_FLASH     -2
+#define FCB_ERR_NOVAR     -3
+#define FCB_ERR_NOSPACE   -4
+#define FCB_ERR_NOMEM     -5
+#define FCB_ERR_CRC       -6
+#define FCB_ERR_MAGIC     -7
+#define FCB_ERR_VERSION   -8
+#define FCB_ERR_NEXT_SECT -9
 
 int fcb_init(struct fcb *fcb);
 
@@ -100,6 +102,7 @@ int fcb_append_finish(struct fcb *, struct fcb_entry *append_loc);
 typedef int (*fcb_walk_cb)(struct fcb_entry *loc, void *arg);
 int fcb_walk(struct fcb *, struct flash_area *, fcb_walk_cb cb, void *cb_arg);
 int fcb_getnext(struct fcb *, struct fcb_entry *loc);
+int fcb_getnext_sector(struct fcb *fcb, struct fcb_entry *loc);
 
 /**
  * Erases the data from oldest sector.

--- a/fs/fcb/selftest/src/fcb_test.c
+++ b/fs/fcb/selftest/src/fcb_test.c
@@ -127,6 +127,7 @@ fcb_tc_pretest(uint8_t sector_count)
     memset(fcb, 0, sizeof(*fcb));
     fcb->f_sector_cnt = sector_count;
     fcb->f_sectors = test_fcb_area; /* XXX */
+    fcb->f_scratch = NULL;
 
     rc = 0;
     rc = fcb_init(fcb);

--- a/fs/fcb/selftest/src/testcases/fcb_test_multiple_scratch.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_multiple_scratch.c
@@ -35,7 +35,7 @@ TEST_CASE_SELF(fcb_test_multiple_scratch)
 
     fcb = &test_fcb;
     fcb->f_scratch_cnt = 1;
-
+    fcb->f_scratch = NULL;
     /*
      * Now fill up everything. We should be able to get 3 of the sectors
      * full.

--- a/fs/fcb/selftest/src/testcases/fcb_test_rotate.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_rotate.c
@@ -34,6 +34,7 @@ TEST_CASE_SELF(fcb_test_rotate)
     fcb_tc_pretest(2);
 
     fcb = &test_fcb;
+    fcb->f_scratch = NULL;
 
     old_id = fcb->f_active_id;
     rc = fcb_rotate(fcb);

--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -36,7 +36,7 @@ fcb_new_area(struct fcb *fcb, int cnt)
         if (!rfa) {
             rfa = fa;
         }
-        if (fcb->f_scratch) {
+        if (fcb->f_scratch != NULL) {
             if (fa == fcb->f_scratch) {
                 return NULL;
             }

--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -36,8 +36,14 @@ fcb_new_area(struct fcb *fcb, int cnt)
         if (!rfa) {
             rfa = fa;
         }
-        if (fa == fcb->f_oldest) {
-            return NULL;
+        if (fcb->f_scratch) {
+            if (fa == fcb->f_scratch) {
+                return NULL;
+            }
+        } else {
+            if (fa == fcb->f_oldest) {
+                return NULL;
+            }
         }
     } while (i++ < cnt);
     return rfa;

--- a/fs/fcb/src/fcb_rotate.c
+++ b/fs/fcb/src/fcb_rotate.c
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 #include "fcb/fcb.h"
 #include "fcb_priv.h"
 
@@ -49,6 +48,8 @@ fcb_rotate(struct fcb *fcb)
         fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
         fcb->f_active_id++;
     }
+    fcb->f_scratch = fcb->f_oldest;
+
     fcb->f_oldest = fcb_getnext_area(fcb, fcb->f_oldest);
 out:
     os_mutex_release(&fcb->f_mtx);

--- a/sys/config/selftest-fcb/src/testcases/config_test_custom_compress.c
+++ b/sys/config/selftest-fcb/src/testcases/config_test_custom_compress.c
@@ -50,6 +50,7 @@ TEST_CASE_SELF(config_test_custom_compress)
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
     cf.cf_fcb.f_sectors = fcb_areas;
     cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_scratch = NULL;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/config/selftest-fcb/src/testcases/config_test_save_2_fcb.c
+++ b/sys/config/selftest-fcb/src/testcases/config_test_save_2_fcb.c
@@ -30,6 +30,7 @@ TEST_CASE_SELF(config_test_save_2_fcb)
     cf.cf_fcb.f_magic = MYNEWT_VAL(CONFIG_FCB_MAGIC);
     cf.cf_fcb.f_sectors = fcb_areas;
     cf.cf_fcb.f_sector_cnt = sizeof(fcb_areas) / sizeof(fcb_areas[0]);
+    cf.cf_fcb.f_scratch = NULL;
 
     rc = conf_fcb_src(&cf);
     TEST_ASSERT(rc == 0);

--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -132,6 +132,13 @@ extern struct log_info g_log_info;
  */
 typedef void log_append_cb(struct log *log, uint32_t idx);
 
+/** @typdef log_notify_rotate_cb
+ * @brief Callback that is executed each time we are about to rotate a log.
+ * 
+ * @param log                   The log that is about to rotate 
+ */
+typedef void log_notify_rotate_cb(struct log *log);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -214,7 +214,7 @@ struct log {
     void *l_arg;
     STAILQ_ENTRY(log) l_next;
     log_append_cb *l_append_cb;
-    log_notify_rotate_cb *l_notify_erase_done_cb;
+    log_notify_rotate_cb *l_rotate_notify_cb;
     uint8_t l_level;
     uint16_t l_max_entry_len;   /* Log body length; if 0 disables check. */
 #if MYNEWT_VAL(LOG_STATS)
@@ -703,7 +703,7 @@ int log_storage_info(struct log *log, struct log_storage_info *info);
  * @param cb    The callback function to be executed.
  */
 void
-log_set_rotate_done_cb(struct log *log, log_notify_rotate_cb *cb);
+log_set_rotate_notify_cb(struct log *log, log_notify_rotate_cb *cb);
 
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
 /**

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -449,9 +449,9 @@ log_hdr_len(const struct log_entry_hdr *hdr)
 }
 
 void
-log_set_rotate_done_cb(struct log *log, log_notify_rotate_cb *cb)
+log_set_rotate_notify_cb(struct log *log, log_notify_rotate_cb *cb)
 {
-    log->l_notify_erase_done_cb = cb;
+    log->l_rotate_notify_cb = cb;
 }
 
 static int

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -448,6 +448,11 @@ log_hdr_len(const struct log_entry_hdr *hdr)
     return LOG_BASE_ENTRY_HDR_SIZE;
 }
 
+void
+log_set_rotate_done_cb(struct log *log, log_notify_rotate_cb *cb)
+{
+    log->l_notify_erase_done_cb = cb;
+}
 
 static int
 log_chk_type(uint8_t etype)
@@ -897,6 +902,23 @@ log_walk_body(struct log *log, log_walk_body_func_t walk_body_func,
 
     log_offset->lo_arg = &lwba;
     rc = log->l_log->log_walk(log, log_walk_body_fn, log_offset);
+    log_offset->lo_arg = lwba.arg;
+
+    return rc;
+}
+
+int
+log_walk_body_section(struct log *log, log_walk_body_func_t walk_body_func,
+              struct log_offset *log_offset)
+{
+    struct log_walk_body_arg lwba = {
+        .fn = walk_body_func,
+        .arg = log_offset->lo_arg,
+    };
+    int rc;
+
+    log_offset->lo_arg = &lwba;
+    rc = log->l_log->log_walk_sector(log, log_walk_body_fn, log_offset);
     log_offset->lo_arg = lwba.arg;
 
     return rc;

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -160,8 +160,8 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
 #endif
 
         /* Check to see if the active region is in the scratch region */
-        if (log->l_notify_erase_done_cb != NULL) {
-            log->l_notify_erase_done_cb(log);
+        if (log->l_rotate_notify_cb != NULL) {
+            log->l_rotate_notify_cb(log);
         }
 
 #if MYNEWT_VAL(LOG_FCB_BOOKMARKS)

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -555,7 +555,7 @@ log_fcb_walk_sector(struct log *log, log_walk_func_t walk_func,
      * last entry), add a bookmark pointing to this walk's start location.
      */
     if (log_offset->lo_ts >= 0) {
-        fcb_log_add_bmark(fcb_log, &loc, log_offset->lo_index);
+        log_fcb_add_bmark(fcb_log, &loc, log_offset->lo_index);
     }
 #endif
     do {


### PR DESCRIPTION
This PR allows the main application to be notified when a fcb sector is about to be rotated and take action if desired.

- Created a pointer to an empty slot called `f_scratch`. This is used as an early notification when the log will rotate soon.
- The main application will be notified when a section will be erased with a callback.
- Added function to walk through the oldest sector.