### PR TITLE
LWIP-UDP: pbuf_free on p as udp_sendto doesn't consume it

### DIFF
--- a/net/ip/src/lwip_socket.c
+++ b/net/ip/src/lwip_socket.c
@@ -538,6 +538,7 @@ lwip_sendto(struct mn_socket *ms, struct os_mbuf *m,
             return rc;
         }
         os_mbuf_free_chain(m);
+        pbuf_free(p);
         return 0;
 #endif
 #if LWIP_TCP


### PR DESCRIPTION
udp_sendto doesn't free the pbuf even though it succeeds in sending it as per comment at /net/ip/lwip_base/src/core/udp.c:854 causing a memory-leak and eventually you can't send udp-packets anymore as pbuf_alloc fails. 

Hence, lwip_sendto will need to free it both for successful and failed sends. 

The pbuf_free(p) should possibly happen before the check of rc even, removing the need to have it twice in the code. 
