### PR TITLE
base64,stats: add base64 fixedlen decode,fix stats

### DIFF
--- a/encoding/base64/include/base64/base64.h
+++ b/encoding/base64/include/base64/base64.h
@@ -30,6 +30,7 @@ int base64_encode(const void *, int, char *, uint8_t);
 int base64_decode(const char *, void *buf);
 int base64_pad(char *, int);
 int base64_decode_len(const char *str);
+int base64_decode_maxlen(const char *str, void *data, int len);
 
 #define BASE64_ENCODE_SIZE(__size) (((((__size) - 1) / 3) * 4) + 4)
 

--- a/encoding/base64/src/base64.c
+++ b/encoding/base64/src/base64.c
@@ -167,6 +167,29 @@ base64_decode(const char *str, void *data)
     return q - (unsigned char *) data;
 }
 
+int
+base64_decode_maxlen(const char *str, void *data, int len)
+{
+    const char *p;
+    unsigned char *q;
+
+    q = data;
+    for (p = str; *p && (*p == '=' || strchr(base64_chars, *p)); p += 4) {
+        if (q - (unsigned char *)data >= len) {
+            break;
+        }
+        unsigned int val = token_decode(p);
+        unsigned int marker = (val >> 24) & 0xff;
+        if (val == DECODE_ERROR)
+            return -1;
+        *q++ = (val >> 16) & 0xff;
+        if (marker < 2)
+            *q++ = (val >> 8) & 0xff;
+        if (marker < 1)
+            *q++ = val & 0xff;
+    }
+    return q - (unsigned char *) data;
+}
 
 int
 base64_decode_len(const char *str)

--- a/sys/stats/full/src/stats_conf.c
+++ b/sys/stats/full/src/stats_conf.c
@@ -101,12 +101,12 @@ stats_conf_set(int argc, char **argv, char *val)
 
             decode_len = base64_decode_len(val);
             if (decode_len > size) {
-                DEBUG_PANIC();
-                return OS_ENOMEM;
+                memset(data, 0, size);
+                base64_decode_maxlen(val, data, size);
+            } else {
+                memset(data, 0, size);
+                base64_decode(val, data);
             }
-
-            memset(data, 0, size);
-            base64_decode(val, data);
 
             return 0;
         }

--- a/sys/stats/full/src/stats_conf.c
+++ b/sys/stats/full/src/stats_conf.c
@@ -91,22 +91,15 @@ stats_conf_set(int argc, char **argv, char *val)
     struct stats_hdr *hdr;
     size_t size;
     void *data;
-    int decode_len;
 
     if (argc == 1) {
         hdr = stats_group_find(argv[0]);
         if (hdr != NULL) {
             size = stats_size(hdr);
             data = stats_data(hdr);
-
-            decode_len = base64_decode_len(val);
-            if (decode_len > size) {
-                memset(data, 0, size);
-                base64_decode_maxlen(val, data, size);
-            } else {
-                memset(data, 0, size);
-                base64_decode(val, data);
-            }
+            
+            memset(data, 0, size);
+            base64_decode_maxlen(val, data, size);
 
             return 0;
         }


### PR DESCRIPTION
- persistent stats were failing on a downgrade if more stats were added
- Fix is to read whatever stats we can based on the size of the buffer
  and only fail if the stats fail
- Adding API to base64 to decode by fixed length