### PR TITLE
removed SUCCESS and FAIL #defines since not used in net/lora, but con…

### DIFF
--- a/net/lora/node/include/node/utilities.h
+++ b/net/lora/node/include/node/utilities.h
@@ -29,17 +29,6 @@
 #define TimerTime_t uint32_t
 
 /*!
- * Generic definition
- */
-#ifndef SUCCESS
-#define SUCCESS                                     1
-#endif
-
-#ifndef FAIL
-#define FAIL                                        0
-#endif
-
-/*!
  * \brief Returns the minimum value between a and b
  *
  * \param [IN] a 1st value


### PR DESCRIPTION
…flicting with CMSIS ErrorStatus enum typedefs of several STM32 mcus