### PR TITLE
base64: check for buffer overflow and cleanup

### DIFF
--- a/encoding/base64/src/base64.c
+++ b/encoding/base64/src/base64.c
@@ -156,13 +156,16 @@ base64_decode(const char *str, void *data)
     for (p = str; *p && (*p == '=' || strchr(base64_chars, *p)); p += 4) {
         unsigned int val = token_decode(p);
         unsigned int marker = (val >> 24) & 0xff;
-        if (val == DECODE_ERROR)
+        if (val == DECODE_ERROR) {
             return -1;
+        }
         *q++ = (val >> 16) & 0xff;
-        if (marker < 2)
+        if (marker < 2) {
             *q++ = (val >> 8) & 0xff;
-        if (marker < 1)
+        }
+        if (marker < 1) {
             *q++ = val & 0xff;
+        }
     }
     return q - (unsigned char *) data;
 }
@@ -175,19 +178,33 @@ base64_decode_maxlen(const char *str, void *data, int len)
 
     q = data;
     for (p = str; *p && (*p == '=' || strchr(base64_chars, *p)); p += 4) {
+        unsigned int val = token_decode(p);
+        unsigned int marker = (val >> 24) & 0xff;
+
+        if (val == DECODE_ERROR) {
+            return -1;
+        }
+
+        *q++ = (val >> 16) & 0xff;
         if (q - (unsigned char *)data >= len) {
             break;
         }
-        unsigned int val = token_decode(p);
-        unsigned int marker = (val >> 24) & 0xff;
-        if (val == DECODE_ERROR)
-            return -1;
-        *q++ = (val >> 16) & 0xff;
-        if (marker < 2)
+
+        if (marker < 2) {
             *q++ = (val >> 8) & 0xff;
-        if (marker < 1)
+            if (q - (unsigned char *)data >= len) {
+                break;
+            }
+        }
+
+        if (marker < 1) {
             *q++ = val & 0xff;
+            if (q - (unsigned char *)data >= len) {
+                break;
+            }
+        }
     }
+
     return q - (unsigned char *) data;
 }
 


### PR DESCRIPTION
- Check for buffer overflow after each pointer increment
  since 0 is a valid marker