### PR TITLE
sys/console: Hide cursor in log area

### DIFF
--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -387,6 +387,9 @@ console_switch_to_prompt(void)
             console_write_str(CSI "0m");
             console_out_nolock(c);
             console_out_nolock('\b');
+            if (MYNEWT_VAL(CONSOLE_HIDE_CURSOR_IN_LOG_AREA)) {
+                console_write_str(CSI "?25h");
+            }
         }
     }
 }
@@ -417,6 +420,9 @@ console_switch_to_logs(void)
                 c = ' ';
             }
             console_out_nolock(c);
+            if (MYNEWT_VAL(CONSOLE_HIDE_CURSOR_IN_LOG_AREA)) {
+                console_write_str(CSI "?25l");
+            }
             console_write_str(CSI "0m\b");
         }
         cursor_restore();

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -65,6 +65,10 @@ syscfg.defs:
             For black and white (minicom) use "7m" - inverse
             For color (putty) use "30;42m" - black/green
         value: '"7m"'
+    CONSOLE_HIDE_CURSOR_IN_LOG_AREA:
+        description: >
+            Hide cursor in log area.
+        value: 1
 
     CONSOLE_UART_BAUD:
         description: 'Console UART baud rate.'


### PR DESCRIPTION
Code hides cursor in log area to improve console usage experience.