### PR TITLE
muc/stm32: Add workaround for STM32F4x5/7 WFI error

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -30,6 +30,19 @@ os_tick_idle(os_time_t ticks)
     OS_ASSERT_CRITICAL();
     __DSB();
     __WFI();
+/*
+ * Errata for STM32F405, STM32F407, STM32F415, STM32F417.
+ * When WFI instruction is placed at address ending with xxx4
+ * (also seen for addresses ending with xxx2). System may
+ * crash.
+ * Simplest workaround is to add 3 NOP instructions after WFI.
+ */
+#if defined(STM32F405xx) || defined(STM32F407xx) || \
+    defined(STM32F415xx) || defined(STM32F417xx)
+    __NOP();
+    __NOP();
+    __NOP();
+#endif
 }
 
 void


### PR DESCRIPTION
MCUs from STM32F405, STM32F407, STM32F415, STM32F417 family
have documented error behaviour when exiting from sleep mode
when WFI instruction placed at address ending with xx4 was executed.

See en.DM00037591.pdf section 2.1.3 for details and conditions.

It is more cumbersome to make sure WFI is at safe location so
simplest workaround proposed by ST is implemented:
- Add 3 NOP instructions after WFI.