### PR TITLE
mcu/stm32: STM32F4x5/4x7 Errata fix

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -24,25 +24,32 @@
 /*
  * XXX implement tickless mode.
  */
+
+/*
+ * Errata for STM32F405, STM32F407, STM32F415, STM32F417.
+ * When WFI instruction is placed at address like 0x080xxxx4
+ * (also seen for addresses ending with xxx2). System may
+ * crash.
+ * __WFI function places WFI instruction at address ending with x0 or x8
+ * for affected MCUs.
+ */
+#if defined(STM32F405xx) || defined(STM32F407xx) || \
+    defined(STM32F415xx) || defined(STM32F417xx)
+#undef __WFI
+__attribute__((aligned(8), naked)) void static
+__WFI(void)
+{
+     __ASM volatile("wfi\n"
+                    "bx lr");
+}
+#endif
+
 void
 os_tick_idle(os_time_t ticks)
 {
     OS_ASSERT_CRITICAL();
     __DSB();
     __WFI();
-/*
- * Errata for STM32F405, STM32F407, STM32F415, STM32F417.
- * When WFI instruction is placed at address ending with xxx4
- * (also seen for addresses ending with xxx2). System may
- * crash.
- * Simplest workaround is to add 3 NOP instructions after WFI.
- */
-#if defined(STM32F405xx) || defined(STM32F407xx) || \
-    defined(STM32F415xx) || defined(STM32F417xx)
-    __NOP();
-    __NOP();
-    __NOP();
-#endif
 }
 
 void


### PR DESCRIPTION
Having 3 NOPs after WFI seems not always help for instruction
placed at 0x080xxxx4 addresses.
So now code makes sure that WFI is never placed at dangerous
address by placing it in function with know alignment.