### PR TITLE
bsp/black_vet6: Fix UART2/3 RCC register address

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -343,7 +343,7 @@ static const struct stm32_uart_cfg uart_cfg0 = {
 #if MYNEWT_VAL(UART_1)
 static const struct stm32_uart_cfg uart_cfg1 = {
     .suc_uart = USART2,
-    .suc_rcc_reg = &RCC->APB2ENR,
+    .suc_rcc_reg = &RCC->APB1ENR,
     .suc_rcc_dev = RCC_APB1ENR_USART2EN,
     .suc_pin_tx = MYNEWT_VAL(UART_1_TX),
     .suc_pin_rx = MYNEWT_VAL(UART_1_RX),
@@ -356,7 +356,7 @@ static const struct stm32_uart_cfg uart_cfg1 = {
 #if MYNEWT_VAL(UART_2)
 static const struct stm32_uart_cfg uart_cfg2 = {
     .suc_uart = USART3,
-    .suc_rcc_reg = &RCC->APB2ENR,
+    .suc_rcc_reg = &RCC->APB1ENR,
     .suc_rcc_dev = RCC_APB1ENR_USART3EN,
     .suc_pin_tx = MYNEWT_VAL(UART_2_TX),
     .suc_pin_rx = MYNEWT_VAL(UART_2_RX),


### PR DESCRIPTION
RCC register for UART2 and UART3 were pointing to APB2ENR
register instead of APB1ENR which is only valid for UART1.
Correct bit-filed was used though so there is no need to
checked datasheet.
Obvious copy/paste error.
Now UART3 was verified to work.