### PR TITLE
console: Fix typo

### DIFF
--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -132,7 +132,7 @@ console_out(int c)
 void
 console_prompt_set(const char *prompt, const char *line)
 {
-    console_write(promot, strlen(prompt));
+    console_write(prompt, strlen(prompt));
     if (line) {
         console_write(line, strlen(line));
     }


### PR DESCRIPTION
Fix typo that led to the following error:

```
repos/apache-mynewt-core/sys/console/minimal/src/console.c:135:19:
error: 'promot' undeclared (first use in this function); did you mean 'prompt'?
     console_write(promot, strlen(prompt));
```

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>