### PR TITLE
sys/log/full; when rotating FCB, only remove bookmarks pointing to

### DIFF
--- a/sys/log/full/include/log/log_fcb.h
+++ b/sys/log/full/include/log/log_fcb.h
@@ -125,6 +125,14 @@ void log_fcb_init_bmarks(struct fcb_log *fcb_log,
 void log_fcb_clear_bmarks(struct fcb_log *fcb_log);
 
 /**
+ * @brief Remove bookmarks which point to oldest FCB/FCB2 area. This is
+ * meant to get called just before the area is rotated out.
+ *
+ * @param fcb_log               The fcb_log to operate on.
+ */
+void log_fcb_rotate_bmarks(struct fcb_log *fcb_log);
+
+/**
  * @brief Searches an fcb_log for the closest bookmark that comes before or at
  * the specified index.
  *

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -166,8 +166,8 @@ log_fcb_start_append(struct log *log, int len, struct fcb_entry *loc)
         }
 
 #if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
-        /* The FCB needs to be rotated.  Invalidate all bookmarks. */
-        log_fcb_clear_bmarks(fcb_log);
+        /* The FCB needs to be rotated. */
+        log_fcb_rotate_bmarks(fcb_log);
 #endif
 
         rc = fcb_rotate(fcb);

--- a/sys/log/full/src/log_fcb2.c
+++ b/sys/log/full/src/log_fcb2.c
@@ -170,8 +170,8 @@ log_fcb2_start_append(struct log *log, int len, struct fcb2_entry *loc)
 #endif
 
 #if MYNEWT_VAL(LOG_FCB_BOOKMARKS)
-        /* The FCB needs to be rotated.  Invalidate all bookmarks. */
-        log_fcb_clear_bmarks(fcb_log);
+        /* The FCB needs to be rotated. */
+        log_fcb_rotate_bmarks(fcb_log);
 #endif
 
         rc = fcb2_rotate(fcb);

--- a/sys/log/full/src/log_fcb_bmark.c
+++ b/sys/log/full/src/log_fcb_bmark.c
@@ -36,6 +36,36 @@ log_fcb_init_bmarks(struct fcb_log *fcb_log,
 }
 
 void
+log_fcb_rotate_bmarks(struct fcb_log *fcb_log)
+{
+    int i;
+    struct log_fcb_bmark *bmark;
+    struct log_fcb_bset *bset;
+
+    bset = &fcb_log->fl_bset;
+
+    for (i = 0; i < bset->lfs_size; i++) {
+        bmark = &bset->lfs_bmarks[i];
+#if MYNEWT_VAL(LOG_FCB)
+        if (bmark->lfb_entry.fe_area != fcb_log->fl_fcb.f_oldest) {
+            continue;
+        }
+#endif
+#if MYNEWT_VAL(LOG_FCB2)
+        if (bmark->lfb_entry.fe_sector != fcb_log->fl_fcb.f_oldest_sec) {
+            continue;
+        }
+#endif
+        if (i != bset->lfs_size - 1) {
+            *bmark = bset->lfs_bmarks[bset->lfs_size - 1];
+            i--;
+        }
+        bset->lfs_size--;
+        bset->lfs_next = bset->lfs_size;
+    }
+}
+
+void
 log_fcb_clear_bmarks(struct fcb_log *fcb_log)
 {
     fcb_log->fl_bset.lfs_size = 0;


### PR DESCRIPTION
area being erased.