### PR TITLE
da1469x_charger: Fix deps to included modules

### DIFF
--- a/hw/drivers/chg_ctrl/da1469x_charger/pkg.yml
+++ b/hw/drivers/chg_ctrl/da1469x_charger/pkg.yml
@@ -26,5 +26,11 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
+pkg.deps.DA1469X_CHARGER_CLI:
+    - "@apache-mynewt-core/util/parse"
+pkg.deps.GPADC_BATTERY:
+    - '@apache-mynewt-core/hw/drivers/adc/gpadc_da1469x'
+pkg.deps.SDADC_BATTERY:
+    - '@apache-mynewt-core/hw/drivers/adc/sdadc_da1469x'
 pkg.deps.DA1469X_CHARGER_USE_CHARGE_CONTROL:
     - '@apache-mynewt-core/hw/charge-control'


### PR DESCRIPTION
Charger shell code conditionally includes two modules.
Those two were not added to dependency list.

Missing modules were:
util/parse
hw/drivers/adc/gpadc_da1469x
hw/drivers/adc/sdadc_da1469x