### PR TITLE
sys/log: fix reboot log entries

### DIFF
--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -755,7 +755,7 @@ log_fcb_copy_entry(struct log *log, struct fcb_entry *entry,
                    struct fcb *dst_fcb)
 {
     struct log_entry_hdr ueh;
-    char data[LOG_PRINTF_MAX_ENTRY_LEN + LOG_BASE_ENTRY_HDR_SIZE +
+    char data[MYNEWT_VAL(LOG_FCB_COPY_MAX_ENTRY_LEN) + LOG_BASE_ENTRY_HDR_SIZE +
               LOG_IMG_HASHLEN];
     uint16_t hdr_len;
     int dlen;
@@ -770,7 +770,7 @@ log_fcb_copy_entry(struct log *log, struct fcb_entry *entry,
 
     hdr_len = log_hdr_len(&ueh);
 
-    dlen = min(entry->fe_data_len, LOG_PRINTF_MAX_ENTRY_LEN +
+    dlen = min(entry->fe_data_len, MYNEWT_VAL(LOG_FCB_COPY_MAX_ENTRY_LEN) +
                hdr_len);
 
     rc = log_fcb_read(log, entry, data, 0, dlen);

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -140,5 +140,10 @@ syscfg.defs:
             Primary sysinit stage for logging functionality.
         value: 100
 
+    LOG_FCB_COPY_MAX_ENTRY_LEN:
+        description: >
+            Max entry length that can be copied from one fcb log to another.
+        value: 256
+
 syscfg.vals.LOG_NEWTMGR:
     LOG_MGMT: MYNEWT_VAL(LOG_MGMT)


### PR DESCRIPTION
- reboot log entries were getting truncated on an fcb_rotate since
  by default we try to restore 10 entries. this change manifested after
  the reboot_log entry length increased greater than 128 which happened
  recently as part of the reboot_log transition to CBOR encoded one form a
  string log.