### PR TITLE
fix issue 2001

### DIFF
--- a/encoding/tinycbor/include/tinycbor/cbor.h
+++ b/encoding/tinycbor/include/tinycbor/cbor.h
@@ -197,7 +197,7 @@ CBOR_API CborError cbor_encode_byte_iovec(CborEncoder *encoder,
                                           const struct cbor_iovec iov[],
                                           int iov_len);
 CBOR_API CborError cbor_encode_floating_point(CborEncoder *encoder, CborType fpType, const void *value);
-CBOR_INLINE_API CborError cbor_encode_bytes_written(CborEncoder *encoder)
+CBOR_INLINE_API int cbor_encode_bytes_written(CborEncoder *encoder)
 {   return encoder->writer->bytes_written; }
 CBOR_INLINE_API CborError cbor_encode_boolean(CborEncoder *encoder, bool value)
 { return cbor_encode_simple_value(encoder, (int)value - 1 + (CborBooleanType & 0x1f)); }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -844,7 +844,7 @@ sensor_set_type_mask(struct sensor *sensor, sensor_type_t mask)
 static inline sensor_type_t
 sensor_check_type(struct sensor *sensor, sensor_type_t type)
 {
-    return (sensor->s_types & sensor->s_mask & type);
+    return (sensor_type_t)(sensor->s_types & sensor->s_mask & type);
 }
 
 /**


### PR DESCRIPTION
C++ build failed due to more restrictive type checking in c++ over c.
- cbor had wrong return type
- sensor had inline function that with expression dealing with enum types is slightly more strict in c++.