### PR TITLE
otp_tool: return the key read using otp_read_key

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/otp_tool.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/otp_tool.py
@@ -150,6 +150,7 @@ def otp_read_key(index, segment, uart):
     else:
         raise SystemExit("Error reading key with status %s" %
                          hex(response.status))
+    return key
 
 
 @click.argument('infile')
@@ -335,7 +336,7 @@ def flash_read(uart, length, outfile, offset):
               help='flash address offset, in hex')
 @click.option('-l', '--length', type=int, required=True, help='size to erase')
 @click.option('-u', '--uart', required=True, help='uart port')
-@click.command(help='Write to flash')
+@click.command(help='Erase flash')
 def flash_erase(uart, offset, length):
     try:
         ser = serial.Serial(port=uart, baudrate=1000000, timeout=60,


### PR DESCRIPTION
Return the read key for further processing and verification.
Fix comment for `flash_erase()`

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>