### PR TITLE
util/parse; include strings.h to compile on native.

### DIFF
--- a/util/parse/src/parse.c
+++ b/util/parse/src/parse.c
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #include <errno.h>
 #include <assert.h>
+#include <strings.h>
 #include "os/mynewt.h"
 #include "mn_socket/mn_socket.h"
 #include "parse/parse.h"


### PR DESCRIPTION
This is needed as that package sets std=c99, and strcasecmp() is then not visible from string.h.