### PR TITLE
sys/console: Fix RTT input handling with massive output stream

### DIFF
--- a/sys/console/full/src/rtt_console.c
+++ b/sys/console/full/src/rtt_console.c
@@ -145,7 +145,7 @@ rtt_console_poll_func(void *arg)
         while (key >= 0) {
             ret = console_handle_char((char)key);
             if (ret < 0) {
-                return;
+                break;
             }
             key = SEGGER_RTT_GetKey();
         }


### PR DESCRIPTION
console_handle_char may return negative value in case console
can't be locked. It can happen when a lot of data is being
transmitted out.
If this happened on first negative value returned from
console_handle_char RTT input was disable by not starting
timer for polling again.

This change makes timer active on console_handle_char failure.