### PR TITLE
[WIP - DO NOT MERGE] encoding/tinycbor: Break up cbor header

### DIFF
--- a/encoding/tinycbor/include/tinycbor/cbor.h
+++ b/encoding/tinycbor/include/tinycbor/cbor.h
@@ -32,6 +32,9 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "tinycbor/cbor_buf_writer.h"
+#include "tinycbor/cbor_buf_reader.h"
+
 #ifdef __cplusplus
 extern "C" {
 #else
@@ -157,15 +160,6 @@ typedef enum CborError {
 
 CBOR_API const char *cbor_error_string(CborError error);
 
-struct cbor_encoder_writer;
-
-typedef int (cbor_encoder_write)(struct cbor_encoder_writer *, const char *data, int len);
-
-typedef struct cbor_encoder_writer {
-    cbor_encoder_write *write;
-    int                 bytes_written;
-} cbor_encoder_writer;
-
 struct cbor_iovec {
     void   *iov_base;
     size_t iov_len;
@@ -173,7 +167,7 @@ struct cbor_iovec {
 
 /* Encoder API */
 struct CborEncoder {
-    cbor_encoder_writer *writer;
+    struct cbor_encoder_writer *writer;
     void *writer_arg;
     size_t added;
     int flags;
@@ -228,25 +222,6 @@ enum CborParserIteratorFlags
     CborIteratorFlag_NegativeInteger        = 0x02,
     CborIteratorFlag_UnknownLength          = 0x04,
     CborIteratorFlag_ContainerIsMap         = 0x20
-};
-
-struct cbor_decoder_reader;
-
-typedef uint8_t (cbor_reader_get8)(struct cbor_decoder_reader *d, int offset);
-typedef uint16_t (cbor_reader_get16)(struct cbor_decoder_reader *d, int offset);
-typedef uint32_t (cbor_reader_get32)(struct cbor_decoder_reader *d, int offset);
-typedef uint64_t (cbor_reader_get64)(struct cbor_decoder_reader *d, int offset);
-typedef uintptr_t (cbor_memcmp)(struct cbor_decoder_reader *d, char *buf, int offset, size_t len);
-typedef uintptr_t (cbor_memcpy)(struct cbor_decoder_reader *d, char *buf, int offset, size_t len);
-
-struct cbor_decoder_reader {
-    cbor_reader_get8  *get8;
-    cbor_reader_get16 *get16;
-    cbor_reader_get32 *get32;
-    cbor_reader_get64 *get64;
-    cbor_memcmp       *cmp;
-    cbor_memcpy       *cpy;
-    size_t             message_size;
 };
 
 struct CborParser

--- a/encoding/tinycbor/include/tinycbor/cbor_buf_reader.h
+++ b/encoding/tinycbor/include/tinycbor/cbor_buf_reader.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-#include <tinycbor/cbor.h>
+#include <tinycbor/cbor_decoder_reader.h>
 
 struct cbor_buf_reader {
     struct cbor_decoder_reader r;

--- a/encoding/tinycbor/include/tinycbor/cbor_decoder_reader.h
+++ b/encoding/tinycbor/include/tinycbor/cbor_decoder_reader.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CBOR_DECODER_READER_H
+#define CBOR_DECODER_READER_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct cbor_decoder_reader;
+
+typedef uint8_t (cbor_reader_get8)(struct cbor_decoder_reader *d, int offset);
+typedef uint16_t (cbor_reader_get16)(struct cbor_decoder_reader *d, int offset);
+typedef uint32_t (cbor_reader_get32)(struct cbor_decoder_reader *d, int offset);
+typedef uint64_t (cbor_reader_get64)(struct cbor_decoder_reader *d, int offset);
+typedef uintptr_t (cbor_memcmp)(struct cbor_decoder_reader *d, char *buf, int offset, size_t len);
+typedef uintptr_t (cbor_memcpy)(struct cbor_decoder_reader *d, char *buf, int offset, size_t len);
+
+struct cbor_decoder_reader {
+    cbor_reader_get8  *get8;
+    cbor_reader_get16 *get16;
+    cbor_reader_get32 *get32;
+    cbor_reader_get64 *get64;
+    cbor_memcmp       *cmp;
+    cbor_memcpy       *cpy;
+    size_t             message_size;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/encoding/tinycbor/include/tinycbor/cbor_encoder_writer.h
+++ b/encoding/tinycbor/include/tinycbor/cbor_encoder_writer.h
@@ -17,27 +17,24 @@
  * under the License.
  */
 
-#ifndef CBOR_BUF_WRITER_H
-#define CBOR_BUF_WRITER_H
-
-#include "tinycbor/cbor_encoder_writer.h"
+#ifndef CBOR_ENCODER_WRITER_H
+#define CBOR_ENCODER_WRITER_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct cbor_buf_writer {
-    cbor_encoder_writer enc;
-    uint8_t *ptr;
-    const uint8_t *end;
-};
+struct cbor_encoder_writer;
 
-void cbor_buf_writer_init(struct cbor_buf_writer *cb, uint8_t *buffer,
-                          size_t data);
-size_t cbor_buf_writer_buffer_size(struct cbor_buf_writer *cb,
-                                   const uint8_t *buffer);
+typedef int (cbor_encoder_write)(struct cbor_encoder_writer *, const char *data, int len);
+
+typedef struct cbor_encoder_writer {
+    cbor_encoder_write *write;
+    int                 bytes_written;
+} cbor_encoder_writer;
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* CBOR_BUF_WRITER_H */
+#endif /* CBOR_ENCODER_WRITER_H */


### PR DESCRIPTION
- Breaking up cbor header file to cbor_decoder_reader.h
  and cbor_encoder_writer.h

@sterlinghughes @mlaz @carlescufi @de-nordic

I have just made the change as a place holder and tested it out but I don't think this is necessary for Zephyr in anyway. Can we ask Dominik to take a look. If this is not required, I would like to not make this change at all in mynewt-core.