### PR TITLE
mcu/danube: Fix build errors

### DIFF
--- a/hw/mcu/mips/danube/src/hal_system.c
+++ b/hw/mcu/mips/danube/src/hal_system.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "os/mynewt.h"
 #include "hal/hal_system.h"
 
 #include <stdint.h>

--- a/kernel/os/src/arch/mips/os_arch_mips.c
+++ b/kernel/os/src/arch/mips/os_arch_mips.c
@@ -38,6 +38,8 @@ uint32_t os_flags = OS_RUN_PRIV;
 
 extern struct os_task g_idle_task;
 
+void timer_handler(void);
+
 /* core timer interrupt */
 void __attribute__((interrupt, keep_interrupts_masked))
 _mips_isr_hw5(void)


### PR DESCRIPTION
MYNEWT_VAL definition was missing due to lack on os/mynewt.h

timer_handler() was used before it was defined without
forward declaration.