### PR TITLE
bsp/sensorhub: Fix build

### DIFF
--- a/hw/bsp/sensorhub/syscfg.yml
+++ b/hw/bsp/sensorhub/syscfg.yml
@@ -38,3 +38,27 @@ syscfg.vals:
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     BOOT_SERIAL_DETECT_PIN: 16  # on Sensor Hub board BOOT0 is dedicated!
+    #
+    # WARNING !!!
+    #
+    # The following STM32_values are NOT tested and are most likely incorrect.
+    # They were copied over from stm32f429discovery bsp
+    # While they are not valid some of them are needed to at least build
+    # targets based on this board.
+    # TODO: Update settings to correct value for the board.
+    STM32_CLOCK_VOLTAGESCALING_CONFIG: 'PWR_REGULATOR_VOLTAGE_SCALE1'
+    STM32_CLOCK_HSI: 0
+    STM32_CLOCK_HSE: 1
+    STM32_CLOCK_HSE_BYPASS: 1
+    STM32_CLOCK_PLL_PLLM: 8
+    STM32_CLOCK_PLL_PLLN: 360
+    STM32_CLOCK_PLL_PLLP: 2
+    STM32_CLOCK_PLL_PLLQ: 7
+    STM32_CLOCK_ENABLE_OVERDRIVE: 0
+    STM32_CLOCK_AHB_DIVIDER: 'RCC_SYSCLK_DIV1'
+    STM32_CLOCK_APB1_DIVIDER: 'RCC_HCLK_DIV4'
+    STM32_CLOCK_APB2_DIVIDER: 'RCC_HCLK_DIV2'
+    STM32_FLASH_LATENCY: 'FLASH_LATENCY_5'
+    STM32_FLASH_PREFETCH_ENABLE: 1
+    STM32_INSTRUCTION_CACHE_ENABLE: 1
+    STM32_DATA_CACHE_ENABLE: 1


### PR DESCRIPTION
This fixes build for sensorhub bsp.
epos/apache-mynewt-core/hw/mcu/stm/stm32f4xx/src/clock_stm32f4xx.c:158:2: error: #error "PLLN value is invalid"
 #error "PLLN value is invalid"

Values provided in syscfg are most likely not valid and should be
updated.