### PR TITLE
fix build error for LOG_VERSION < 3

### DIFF
--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -79,13 +79,15 @@ log_console_append_body(struct log *log, const struct log_entry_hdr *hdr,
         log_console_print_hdr(hdr);
     }
 
+#if MYNEWT_VAL(LOG_VERSION) < 3
+    console_write(body, body_len);
+#else
     if (hdr->ue_etype != LOG_ETYPE_CBOR) {
         console_write(body, body_len);
     } else {
-#if MYNEWT_VAL(LOG_VERSION) > 2
         log_console_dump_cbor_entry(body, body_len);
-#endif
     }
+#endif
     return (0);
 }
 


### PR DESCRIPTION
Code was not building for LOG_VERSION == 2
- LOG_ETYPE_CBOR was not defined but was used
- ue_etype was not defined but used

for log_reboot code from before cbor conversion was restored (with some modifications that allow it to build).