### PR TITLE
hw/mcu/fe310: Add fast reboot path

### DIFF
--- a/hw/mcu/sifive/fe310/src/hal_system.c
+++ b/hw/mcu/sifive/fe310/src/hal_system.c
@@ -24,13 +24,18 @@
 void
 hal_system_reset(void)
 {
-
+    extern void _reset_handler(void);
 #if MYNEWT_VAL(HAL_SYSTEM_RESET_CB)
     hal_system_reset_cb();
 #endif
 
     while (1) {
         HAL_DEBUG_BREAK();
+        if (MYNEWT_VAL(HAL_SYSTEM_RESET_FULL)) {
+            ((void (*)(void))SPI0_MEM_ADDR)();
+        } else {
+            _reset_handler();
+        }
     }
 }
 

--- a/hw/mcu/sifive/fe310/syscfg.yml
+++ b/hw/mcu/sifive/fe310/syscfg.yml
@@ -77,3 +77,11 @@ syscfg.defs:
     OS_TICKLESS_SLEEP:
         description: 'Enable tickless sleep'
         value: 1
+    HAL_SYSTEM_RESET_FULL:
+        description: >
+            When set to 1, hal_system_reset() reboots by jumping to start of flash.
+            When set to 0, hal_system_reset() jumps directly to _reset_handler of
+            application skipping bootloader code.
+            This maybe useful when .bssnz section is being used to store data across
+            software reboots.
+        value: 1


### PR DESCRIPTION
hal_reset_handler() for fe310 can now act in two ways
- (default) it will jump to the beginning of flash starting
  from bootloader _reset_handler.
- when HAL_SYSTEM_RESET_FULL is 0 hal_reset_handler will just
  jump to application _reset_handler.
  This functionality can be useful when .bssnz section is used,
  in this case bootloader will not overwrite it with it's own
  data.