### PR TITLE
kernel/os: count t_run_time in cpu time ticks conditionally

### DIFF
--- a/kernel/os/src/os_sched.c
+++ b/kernel/os/src/os_sched.c
@@ -74,6 +74,8 @@ err:
 void
 os_sched_ctx_sw_hook(struct os_task *next_t)
 {
+    uint32_t ticks;
+
 #if MYNEWT_VAL(OS_CTX_SW_STACK_CHECK)
     os_stack_t *top;
     int i;
@@ -84,8 +86,13 @@ os_sched_ctx_sw_hook(struct os_task *next_t)
     }
 #endif
     next_t->t_ctx_sw_cnt++;
-    g_current_task->t_run_time += g_os_time - g_os_last_ctx_sw_time;
-    g_os_last_ctx_sw_time = g_os_time;
+#if MYNEWT_VAL(OS_TASK_RUN_TIME_CPUTIME)
+    ticks = os_cputime_get32();
+#else
+    ticks = g_os_time;
+#endif
+    g_current_task->t_run_time += ticks - g_os_last_ctx_sw_time;
+    g_os_last_ctx_sw_time = ticks;
 }
 
 struct os_task *

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -180,6 +180,11 @@ syscfg.defs:
             Interval for sanity check on main task. Setting a 0 will disable
             sanity check on main task. Value is in milliseconds.
         value: 0
+    OS_TASK_RUN_TIME_CPUTIME:
+        description: >
+            If set, run time is measured in cpu time ticks rather than OS time
+            ticks.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1


### PR DESCRIPTION
- task runtime - t_run_time variable can now be counted in cpu time
  ticks if OS_TASK_RUN_TIME_CPUTIME syscfg is set.