### PR TITLE
Add support for load/debug to remote J-Link server

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -39,6 +39,7 @@ if [ "$MFG_IMAGE" ]; then
 fi
 
 parse_extra_jtag_cmd $EXTRA_JTAG_CMD
+jlink_target_cmd
 
 GDB_CMD_FILE=.gdb_load
 JLINK_LOG_FILE=.jlink_log
@@ -103,10 +104,14 @@ fi
 
 FILE_SIZE=$(file_size $FILE_NAME)
 
+if [ -z $JLINK_TARGET_HOST ]; then
+    JLINK_SERVER_CMD="shell sh -c \"trap '' 2; $JLINK_GDB_SERVER -device cortex-m33 -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD > $JLINK_LOG_FILE 2>&1 &\""
+fi
+
 cat > $GDB_CMD_FILE <<EOF
 set pagination off
-shell sh -c "trap '' 2; $JLINK_GDB_SERVER -device cortex-m33 -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD > $JLINK_LOG_FILE 2>&1 &"
-target remote localhost:$PORT
+$JLINK_SERVER_CMD
+$JLINK_TARGET_CMD
 mon reset
 mon halt
 restore $FLASH_LOADER.bin binary 0x20000000

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -27,7 +27,6 @@ JLINK_GDB_SERVER=JLinkGDBServer
 jlink_load () {
     GDB_CMD_FILE=.gdb_cmds
     GDB_OUT_FILE=.gdb_out
-    PORT=3333
 
     windows_detect
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -48,17 +48,17 @@ jlink_load () {
     jlink_target_cmd
 
     if [ $WINDOWS -eq 1 ]; then
-	JLINK_GDB_SERVER=JLinkGDBServerCL
+        JLINK_GDB_SERVER=JLinkGDBServerCL
     fi
     if [ -z $FILE_NAME ]; then
         echo "Missing filename"
         exit 1
     fi
     if [ ! -f "$FILE_NAME" ]; then
-	# tries stripping current path for readability
+        # tries stripping current path for readability
         FILE=${FILE_NAME##$(pwd)/}
-	echo "Cannot find file" $FILE
-	exit 1
+        echo "Cannot find file" $FILE
+        exit 1
     fi
     if [ -z $FLASH_OFFSET ]; then
         echo "Missing flash offset"
@@ -102,22 +102,22 @@ jlink_load () {
 
     error=`echo $msgs | grep error`
     if [ -n "$error" ]; then
-	exit 1
+        exit 1
     fi
 
     error=`echo $msgs | grep -i failed`
     if [ -n "$error" ]; then
-	exit 1
+        exit 1
     fi
 
     error=`echo $msgs | grep -i "unknown / supported"`
     if [ -n "$error" ]; then
-	exit 1
+        exit 1
     fi
 
     error=`echo $msgs | grep -i "not found"`
     if [ -n "$error" ]; then
-	exit 1
+        exit 1
     fi
 
     return 0
@@ -133,7 +133,7 @@ jlink_load () {
 jlink_debug() {
     windows_detect
     if [ $WINDOWS -eq 1 ]; then
-	JLINK_GDB_SERVER=JLinkGDBServerCL
+        JLINK_GDB_SERVER=JLinkGDBServerCL
     fi
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
     jlink_target_cmd
@@ -177,13 +177,13 @@ jlink_debug() {
         fi
         echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
 
-	if [ $WINDOWS -eq 1 ]; then
-	    FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
-	    $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
-	else
+        if [ $WINDOWS -eq 1 ]; then
+            FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
+            $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
+        else
             arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE
-	fi
+        fi
     else
         $JLINK_GDB_SERVER -device $JLINK_DEV -speed 4000 -if SWD -port $PORT -singlerun $EXTRA_JTAG_CMD
     fi


### PR DESCRIPTION
This adds support for `JLINK_REMOTE` option which, if set, will make `load` and `debug` commands try to connect to remote `JLinkGDBServer` instead of launching local one.