### PR TITLE
console history persistence

### DIFF
--- a/sys/console/full/history_log/pkg.yml
+++ b/sys/console/full/history_log/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-pkg.name: sys/console/full
-pkg.description: Text-based IO interface.
+pkg.name: sys/console/full/history_log
+pkg.description: Log-backed console history.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
@@ -26,15 +26,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
-pkg.deps.CONSOLE_UART:
-    - "@apache-mynewt-core/hw/drivers/uart"
-pkg.deps.CONSOLE_RTT:
-    - "@apache-mynewt-core/hw/drivers/rtt"
-pkg.deps.'CONSOLE_HISTORY == "ram"':
-    - "@apache-mynewt-core/sys/console/full/history_ram"
-pkg.deps.'CONSOLE_HISTORY == "log"':
-    - "@apache-mynewt-core/sys/console/full/history_log"
-pkg.apis: console
+    - "@apache-mynewt-core/sys/console/full"
 
 pkg.init:
-    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'
+    console_history_pkg_init: 'MYNEWT_VAL(SHELL_SYSINIT_STAGE)'

--- a/sys/console/full/history_log/src/history_log.c
+++ b/sys/console/full/history_log/src/history_log.c
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <ctype.h>
+#include <os/mynewt.h>
+#if MYNEWT_VAL(LOG_FCB)
+#include <fcb/fcb.h>
+#endif
+#if MYNEWT_VAL(LOG_FCB2)
+#include <fcb/fcb2.h>
+#endif
+#include <log/log.h>
+#include <console/history.h>
+
+#define HISTORY_CACHE_SIZE MYNEWT_VAL(CONSOLE_HISTORY_CACHE_SIZE)
+
+#if MYNEWT_VAL(LOG_FCB2) && defined(FLASH_AREA_CONSOLE_HISTORY) && !defined(MYNEWT_VAL_CONSOLE_HISTORY_LOG_NAME)
+static struct fcb2 history_fcb;
+static struct log history_fcb_log;
+#endif
+static struct log *history_log;
+
+/*
+ * Circular buffer for commands.
+ * Lines are separated by '\0'.
+ * history_ptr points to place where new command will be stored. It always
+ * points to '\0'.
+ * history_cache[history_ptr] == 0
+ * history_cache[(history_ptr - 1) MOD CONSOLE_HISTORY_CACHE_SIZE] == 0
+ *
+ * COM1.COM2 ARG.COM3 -t...COMn.COMn-1 ARG.
+ *                       ^--- history_ptr
+ */
+static char history_cache[HISTORY_CACHE_SIZE];
+
+static size_t history_ptr;
+/* Helper macros to move pointer in circular buffer */
+#define PREV_PTR(p) ((p > history_cache) ? p - 1 : (history_cache + HISTORY_CACHE_SIZE - 1))
+#define NEXT_PTR(p) ((p < history_cache + HISTORY_CACHE_SIZE - 1) ? p + 1 : history_cache)
+#define PTR_ADD(p, a) (((p) + (a) < history_cache + HISTORY_CACHE_SIZE) ? (p) + (a) : (p) + (a) - HISTORY_CACHE_SIZE)
+
+static int
+console_history_add_to_cache(const char *line)
+{
+    char *cache_end = history_cache + history_ptr;
+    /* Let p1 point to last null-terminator */
+    char *p1 = PREV_PTR(cache_end);
+    int len;
+    const char *p2;
+    int entry_num = 0;
+    int found_at = -1;
+
+    /* Trim from spaces */
+    while (isspace(*line)) {
+        line++;
+    };
+
+    len = strlen(line);
+    if (len == 0) {
+        return SYS_ENOENT;
+    }
+
+    /*
+     * Trim trailing spaces. It does not touch input buffer, it just
+     * corrects len variable.
+     */
+    while (isspace(line[len - 1])) {
+        len--;
+    }
+
+    assert(*cache_end == 0);
+    /* p1 should point to string terminator */
+    assert(*p1 == 0);
+    /* Now p1 point to last character of last command */
+    p1 = PREV_PTR(p1);
+
+    while (*p1) {
+        /* Compare entry in cache with line starting from the end */
+        for (p2 = line + len - 1; p2 >= line && *p1 == *p2; --p2, p1 = PREV_PTR(p1)) {
+        }
+        if (p2 < line && *p1 == '\0') {
+            /* Line was in history cache already */
+            if (entry_num == 0) {
+                /* Last entry matched no need to do anything */
+                return SYS_EALREADY;
+            }
+            found_at = entry_num;
+            break;
+        }
+        /* Line did no match entry_num line from cache, go to the start of
+         * entry */
+        while (*p1) {
+            p1 = PREV_PTR(p1);
+        }
+        /* Skip null terminator of previous entry */
+        p1 = PREV_PTR(p1);
+        entry_num++;
+    }
+
+    if (found_at < 0) {
+        /* p1 will be used to store new line in cache */
+        p1 = cache_end;
+    } else {
+        /*
+         * Line was in the cache, rotate old data.
+         * This will overwrite old copy of command.
+         * Line will be added a new.
+         */
+        p1 = NEXT_PTR(p1);
+        p2 = PTR_ADD(p1, len + 1);
+        while (p2 != cache_end) {
+            *p1 = *p2;
+            p1 = NEXT_PTR(p1);
+            p2 = NEXT_PTR(p2);
+        }
+    }
+    /* Copy current line to the end of cache (including null terminator) */
+    p2 = line;
+    for (; len > 0; --len) {
+        *p1 = *p2++;
+        p1 = NEXT_PTR(p1);
+    }
+    *p1 = '\0';
+    p1 = NEXT_PTR(p1);
+    history_ptr = p1 - history_cache;
+
+    /*
+     * History pointer should point to '\0', if it is not destroy oldest
+     * partial entry.
+     */
+    while (*p1) {
+        *p1 = '\0';
+        p1 = NEXT_PTR(p1);
+    }
+
+    return SYS_EOK;
+}
+
+static int
+history_cache_from_log(struct log *log, struct log_offset *log_offset,
+                       const struct log_entry_hdr *hdr,
+                       const void *dptr, uint16_t len)
+{
+    char line[MYNEWT_VAL_CONSOLE_MAX_INPUT_LEN];
+
+    if (len >= MYNEWT_VAL_CONSOLE_MAX_INPUT_LEN) {
+        len = MYNEWT_VAL_CONSOLE_MAX_INPUT_LEN - 1;
+    }
+    if (hdr->ue_module == MYNEWT_VAL(CONSOLE_HISTORY_LOG_MODULE)) {
+        log_read_body(log, dptr, line, 0, len);
+        line[len] = '\0';
+        (void)console_history_add_to_cache(line);
+    }
+
+    return 0;
+}
+
+void
+console_history_add(const char *line)
+{
+    if (console_history_add_to_cache(line) == SYS_EOK && history_log) {
+        log_printf(history_log, MYNEWT_VAL(CONSOLE_HISTORY_LOG_MODULE),
+                   LOG_LEVEL_MAX, line);
+    }
+}
+
+int
+console_history_get(int num, char *buf, size_t buf_size)
+{
+    char *cache_end = history_cache + history_ptr;
+    char *p1 = PREV_PTR(cache_end);
+    size_t len = 0;
+    size_t i;
+
+    if (num < 0) {
+        return SYS_EINVAL;
+    }
+
+    if (num == 0) {
+        *buf = '\0';
+        return 0;
+    }
+    assert(*cache_end == 0 && *p1 == 0);
+
+    i = num;
+    while (i) {
+        len = 0;
+        p1 = PREV_PTR(p1);
+        while (*p1) {
+            len++;
+            p1 = PREV_PTR(p1);
+        }
+        if (len) {
+            i--;
+        } else {
+            return SYS_EINVAL;
+        }
+    }
+    if (len >= buf_size) {
+        len = buf_size - 1;
+    }
+    for (i = 0; i <= len; ++i) {
+        p1 = NEXT_PTR((p1));
+        *buf++ = *p1;
+    }
+
+    return (int)num;
+}
+
+int
+console_history_pkg_init(void)
+{
+    struct log_offset off = { 0 };
+
+#if (MYNEWT_VAL(LOG_FCB) || MYNEWT_VAL(LOG_FCB2)) && defined(MYNEWT_VAL_CONSOLE_HISTORY_LOG_NAME)
+    history_log = log_find(MYNEWT_VAL(CONSOLE_HISTORY_LOG_NAME));
+#elif MYNEWT_VAL(LOG_FCB2) && defined(FLASH_AREA_CONSOLE_HISTORY)
+    /* If there is dedicated flash area for shell history and FCB2 is enabled */
+    fcb2_init_flash_area(&history_fcb, FLASH_AREA_CONSOLE_HISTORY, 0x12C9985, 1);
+    if (log_register("con_hist", &history_fcb_log, &log_fcb_handler,
+        &history_fcb, 0) == 0) {
+        history_log = &history_fcb_log;
+    }
+#endif
+    if (history_log) {
+        log_module_register(MYNEWT_VAL(CONSOLE_HISTORY_LOG_MODULE), "CON-HIST");
+        log_walk_body(history_log, history_cache_from_log, &off);
+    }
+
+    return 0;
+}

--- a/sys/console/full/history_log/syscfg.yml
+++ b/sys/console/full/history_log/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,24 +17,19 @@
 # under the License.
 #
 
-pkg.name: sys/console/full
-pkg.description: Text-based IO interface.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/kernel/os"
-pkg.deps.CONSOLE_UART:
-    - "@apache-mynewt-core/hw/drivers/uart"
-pkg.deps.CONSOLE_RTT:
-    - "@apache-mynewt-core/hw/drivers/rtt"
-pkg.deps.'CONSOLE_HISTORY == "ram"':
-    - "@apache-mynewt-core/sys/console/full/history_ram"
-pkg.deps.'CONSOLE_HISTORY == "log"':
-    - "@apache-mynewt-core/sys/console/full/history_log"
-pkg.apis: console
-
-pkg.init:
-    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'
+syscfg.defs:
+    CONSOLE_HISTORY_CACHE_SIZE:
+        description: >
+            Number of RAM bytes used for caching history.
+        value: 256
+    CONSOLE_HISTORY_LOG_NAME:
+        description: >
+            Log name to use for storing console history.
+            When there is no flash area that can be used for storing
+            console history, any existing log can be utilized to
+            store console history.
+        value:
+    CONSOLE_HISTORY_LOG_MODULE:
+        description: >
+            Numeric module ID to use for console history log messages.
+        value: 9

--- a/sys/console/full/history_ram/pkg.yml
+++ b/sys/console/full/history_ram/pkg.yml
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-pkg.name: sys/console/full
-pkg.description: Text-based IO interface.
+pkg.name: sys/console/full/history_ram
+pkg.description: RAM only console history.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
@@ -26,13 +26,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
-pkg.deps.CONSOLE_UART:
-    - "@apache-mynewt-core/hw/drivers/uart"
-pkg.deps.CONSOLE_RTT:
-    - "@apache-mynewt-core/hw/drivers/rtt"
-pkg.deps.'CONSOLE_HISTORY == "ram"':
-    - "@apache-mynewt-core/sys/console/full/history_ram"
-pkg.apis: console
+    - "@apache-mynewt-core/sys/console/full"
 
 pkg.init:
-    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'
+    console_history_pkg_init: 'MYNEWT_VAL(SHELL_SYSINIT_STAGE)'

--- a/sys/console/full/history_ram/src/ram.c
+++ b/sys/console/full/history_ram/src/ram.c
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <ctype.h>
+#include <os/mynewt.h>
+
+#ifndef bssnz_t
+/* Just in case bsp.h does not define it, in this case console history will
+ * not be preserved across software resets
+ */
+#define bssnz_t
+#endif
+
+bssnz_t static char console_hist_lines[ MYNEWT_VAL(RAM_HISTORY_SIZE) ][ MYNEWT_VAL(CONSOLE_MAX_INPUT_LEN) ];
+
+bssnz_t static struct console_hist {
+    uint32_t magic;
+    uint8_t head;
+    uint8_t count;
+    char *lines[ MYNEWT_VAL(RAM_HISTORY_SIZE) ];
+} console_hist;
+
+static size_t
+trim_whitespace(const char *str, char *out, size_t out_size)
+{
+    const char *end;
+    size_t len;
+
+    if (out_size == 0) {
+        return 0;
+    }
+
+    /* Skip leading space */
+    while (isspace((unsigned char)*str)) {
+        str++;
+    }
+
+    if (*str == 0) { /* All spaces? */
+        *out = 0;
+        return 0;
+    }
+
+    /* Skip trailing space */
+    end = str + strlen(str) - 1;
+    while (isspace((unsigned char)*end)) {
+        end--;
+    }
+
+    end++;
+
+    /* Set output size to minimum of trimmed string length and buffer size minus 1 */
+    len = min(end - str, out_size - 1);
+
+    /* Copy trimmed string and add null terminator */
+    memcpy(out, str, len);
+    out[len] = 0;
+
+    return len;
+}
+
+static uint8_t
+ring_buf_next(uint8_t i)
+{
+    return (uint8_t) ((i + 1) % MYNEWT_VAL(RAM_HISTORY_SIZE));
+}
+
+static uint8_t
+ring_buf_prev(uint8_t i)
+{
+    return i == 0 ? i = MYNEWT_VAL(RAM_HISTORY_SIZE) - 1 : --i;
+}
+
+static bool
+console_hist_is_full(void)
+{
+    return console_hist.count == MYNEWT_VAL(RAM_HISTORY_SIZE);
+}
+
+static bool
+console_hist_move_to_head(char *line)
+{
+    struct console_hist *sh = &console_hist;
+    char *match = NULL;
+    uint8_t prev;
+    uint8_t curr;
+    uint8_t left;
+
+    left = sh->count;
+    curr = ring_buf_prev(sh->head);
+    while (left) {
+        if (strcmp(sh->lines[curr], line) == 0) {
+            match = sh->lines[curr];
+            break;
+        }
+        curr = ring_buf_next(curr);
+        left--;
+    }
+
+    if (!match) {
+        return false;
+    }
+
+    prev = curr;
+    curr = ring_buf_next(curr);
+    while (curr != sh->head) {
+        sh->lines[prev] = sh->lines[curr];
+        prev = curr;
+        curr = ring_buf_next(curr);
+    }
+
+    sh->lines[prev] = match;
+
+    return true;
+}
+
+void
+console_history_add(const char *line)
+{
+    struct console_hist *sh = &console_hist;
+    char buf[MYNEWT_VAL(CONSOLE_MAX_INPUT_LEN)];
+    size_t len;
+
+    len = trim_whitespace(line, buf, sizeof(buf));
+    if (len == 0) {
+        return;
+    }
+
+    if (console_hist_move_to_head(buf)) {
+        return;
+    }
+
+    strcpy(sh->lines[sh->head], buf);
+    sh->head = ring_buf_next(sh->head);
+    if (!console_hist_is_full()) {
+        sh->count++;
+    }
+}
+
+int
+console_history_get(int num, char *buf, size_t buf_size)
+{
+    const char *line;
+    size_t line_len;
+
+    if (num > console_hist.count || num < -console_hist.count) {
+        return SYS_EINVAL;
+    }
+
+    if (num == 0) {
+        line_len = 0;
+    } else {
+        if (num < 0) {
+            num = console_hist.count + num + 1;
+        }
+        if (num <= console_hist.head) {
+            line = console_hist.lines[console_hist.head - num];
+        } else {
+            line = console_hist.lines[console_hist.head +
+                                      MYNEWT_VAL(RAM_HISTORY_SIZE) - num];
+        }
+
+        line_len = strlen(line);
+        if (line_len >= buf_size) {
+            line_len = buf_size - 1;
+        }
+        memcpy(buf, line, line_len);
+    }
+    buf[line_len] = '\0';
+
+    return num;
+}
+
+int
+console_history_pkg_init(void)
+{
+    struct console_hist *sh = &console_hist;
+    int i;
+    int size;
+
+    if (sh->magic != 0xBABEFACE) {
+        memset(console_hist_lines, 0, sizeof(console_hist_lines));
+        memset(&console_hist, 0, sizeof(console_hist));
+
+        size = MYNEWT_VAL(RAM_HISTORY_SIZE) + 1;
+
+        for (i = 0; i < size - 1; i++) {
+            sh->lines[i] = console_hist_lines[i];
+        }
+        sh->magic = 0xBABEFACE;
+    }
+
+    return 0;
+}

--- a/sys/console/full/history_ram/syscfg.yml
+++ b/sys/console/full/history_ram/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -6,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,22 +16,8 @@
 # under the License.
 #
 
-pkg.name: sys/console/full
-pkg.description: Text-based IO interface.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/kernel/os"
-pkg.deps.CONSOLE_UART:
-    - "@apache-mynewt-core/hw/drivers/uart"
-pkg.deps.CONSOLE_RTT:
-    - "@apache-mynewt-core/hw/drivers/rtt"
-pkg.deps.'CONSOLE_HISTORY == "ram"':
-    - "@apache-mynewt-core/sys/console/full/history_ram"
-pkg.apis: console
-
-pkg.init:
-    console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'
+syscfg.defs:
+    RAM_HISTORY_SIZE:
+        description: >
+            Number of lines to be stored in console history.
+        value: 10

--- a/sys/console/full/include/console/history.h
+++ b/sys/console/full/include/console/history.h
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef __SYS_CONSOLE_FULL_HISTORY_H__
+#define __SYS_CONSOLE_FULL_HISTORY_H__
+
+void console_history_add(const char *line);
+
+int console_history_get(int num, char *buf, size_t buf_size);
+
+#endif /* __SYS_CONSOLE_FULL_HISTORY_H__ */

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -56,6 +56,7 @@ syscfg.defs:
         choices:
             - none  # no history support
             - ram   # history kept in ram for current session only
+            - log   # history kept in log
     CONSOLE_MAX_PROMPT_LEN:
         description: 'Maximum number of characters for prompt'
         value: 16

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -43,9 +43,19 @@ syscfg.defs:
         value: 256
     CONSOLE_HISTORY_SIZE:
         description: >
-            Number of lines to be stored in console history.
-            Set to "0" to disable console history.
+            This is no longer used.
+            Equivalent settings:
+                CONSOLE_HISTORY: ram
+                RAM_HISTORY_SIZE: <n>   <- previous value of CONSOLE_HISTORY_SIZE
         value: 0
+        deprecated: 1
+    CONSOLE_HISTORY:
+        description: >
+            Select how console should handle command history.
+        value: none
+        choices:
+            - none  # no history support
+            - ram   # history kept in ram for current session only
     CONSOLE_MAX_PROMPT_LEN:
         description: 'Maximum number of characters for prompt'
         value: 16


### PR DESCRIPTION
This adds possibility to store commands typed in console in persistent stored log.
It may be useful when complicated commands are used.

In this PR code that was handling console history was moved to separate package.
Additional package that handles storage in logs is added.

CONSOLE_HISTORY_SIZE was deprecated.