### PR TITLE
oc_core: randomize uuid before use

### DIFF
--- a/net/oic/src/api/oc_uuid.c
+++ b/net/oic/src/api/oc_uuid.c
@@ -94,8 +94,21 @@ oc_uuid_to_str(const oc_uuid_t *uuid, char *buffer, int buflen)
 }
 
 void
+oc_gen_randomize_uuid(oc_uuid_t *uuid)
+{
+    int i;
+
+    for(i = 0; i < 16; i++) {
+            uuid->id[i] = (uint8_t)rand();
+    }
+}
+
+void
 oc_gen_uuid(oc_uuid_t *uuid)
 {
+  /* Set to Random values as per type 4 */
+  oc_gen_randomize_uuid(uuid);
+
   hal_bsp_hw_id(&uuid->id[0], sizeof(uuid->id));
 
   /*  From RFC 4122


### PR DESCRIPTION
Initialize the uuid buffer with random values before passing it to oc_gen_uuid().

This fixes the following warning generated from code coverage analysis.

```
CID 10028 (#1 of 1): Uninitialized scalar variable (UNINIT)10.
uninit_use_in_call: Using uninitialized element of array uuid.id when calling oc_gen_uuid.
```
Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>