### PR TITLE
sys/console: Fix NULL pointer dereference in log_find

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -297,12 +297,11 @@ log_find(const char *name)
     struct log *log;
 
     log = NULL;
-    do {
-        log = log_list_get_next(log);
+    while ((log = log_list_get_next(log)) != NULL) {
         if (strcmp(log->l_name, name) == 0) {
             break;
         }
-    } while (log != NULL);
+    }
 
     return log;
 }


### PR DESCRIPTION
When log_find() was called for non existing log after
checking all valid log pointers NULL pointer would be
used for checking name of the log.

Now strcmp() is called only if log pointer is not NULL.