### PR TITLE
sys/log: Add persistent log index

### DIFF
--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -119,6 +119,10 @@ struct log;
 struct log_info {
 #if MYNEWT_VAL(LOG_GLOBAL_IDX)
     uint32_t li_next_index;
+#if MYNEWT_VAL(LOG_PERSIST_INDEX)
+    uint32_t li_persistent_index;
+    struct os_event li_persist_store_event;
+#endif
 #endif
     uint8_t li_version;
 };

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -219,6 +219,10 @@ struct log {
     uint16_t l_max_entry_len;   /* Log body length; if 0 disables check. */
 #if !MYNEWT_VAL(LOG_GLOBAL_IDX)
     uint32_t l_idx;
+#if MYNEWT_VAL(LOG_PERSIST_INDEX)
+    uint32_t l_persistent_index;
+    struct os_event l_persist_store_event;
+#endif
 #endif
 #if MYNEWT_VAL(LOG_STATS)
     STATS_SECT_DECL(logs) l_stats;

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -55,6 +55,9 @@ pkg.deps.LOG_MGMT:
 pkg.deps.LOG_FLAGS_IMAGE_HASH:
     - "@apache-mynewt-core/mgmt/imgmgr"
 
+pkg.deps.LOG_PERSIST_INDEX:
+    - sys/config
+
 pkg.deps.LOG_STORAGE_WATERMARK:
     - sys/config
 

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -135,6 +135,12 @@ syscfg.defs:
         value: 0
         restrictions: LOG_STORAGE_WATERMARK
 
+    LOG_PERSIST_INDEX:
+        description: >
+            Log index will be periodically saved to config area. This allows will
+            allow to have unique log indices even after factory reset.
+        value: 0
+
     LOG_SYSINIT_STAGE_MAIN:
         description: >
             Primary sysinit stage for logging functionality.


### PR DESCRIPTION
It may be useful to keep log index even if after factory reset.

On startup:
A. (As usual) Firmware scans all persistent logs to determine the next available index.
B. Firmware reads the persistent_index value from flash, if available.
C. The next_index RAM variable is set to the greater of these two values.

On each log write:
1. Compare the next_index variable to persistent_index.
2. If the difference is less than 500, schedule an event to write a new persistent_index to flash.
3. The new persistent_index is equal to: next_index + 1000.

Note 1: the numbers 500 and 1000 were chosen arbitrarily.
Note 2: In step 2, the new persistent_index is written asynchronously because the logging task might not tolerate the time required to write to flash (e.g., ble_ll task).