### PR TITLE
bme280 and sensor_creator fixes

### DIFF
--- a/hw/drivers/sensors/bme280/src/bme280_shell.c
+++ b/hw/drivers/sensors/bme280/src/bme280_shell.c
@@ -287,71 +287,57 @@ err:
     return rc;
 }
 
+static void
+bme280_shell_dump_reg(const char *name, uint8_t addr)
+{
+    uint8_t val = 0;
+    int rc;
+
+    rc = bme280_readlen(&g_sensor_itf, addr, &val, 1);
+    if (rc == 0) {
+        console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
+    } else {
+        console_printf("0x%02X (%s): failed (%d)\n", addr, name, rc);
+    }
+}
+
+#define DUMP_REG(name) bme280_shell_dump_reg(#name, BME280_REG_ADDR_ ## name)
+
 static int
 bme280_shell_cmd_dump(int argc, char **argv)
 {
-  uint8_t val;
-
   if (argc > 3) {
       return bme280_shell_err_too_many_args(argv[1]);
   }
 
   /* Dump all the register values for debug purposes */
-  val = 0;
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_T1, &val, 1));
-  console_printf("0x%02X (DIG_T1): 0x%02X\n", BME280_REG_ADDR_DIG_T1, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_T2, &val, 1));
-  console_printf("0x%02X (DIG_T2):  0x%02X\n", BME280_REG_ADDR_DIG_T2, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_T3, &val, 1));
-  console_printf("0x%02X (DIG_T3):   0x%02X\n", BME280_REG_ADDR_DIG_T3, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P1, &val, 1));
-  console_printf("0x%02X (DIG_P1): 0x%02X\n", BME280_REG_ADDR_DIG_P1, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P2, &val, 1));
-  console_printf("0x%02X (DIG_P2):  0x%02X\n", BME280_REG_ADDR_DIG_P2, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P3, &val, 1));
-  console_printf("0x%02X (DIG_P3):   0x%02X\n", BME280_REG_ADDR_DIG_P3, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P4, &val, 1));
-  console_printf("0x%02X (DIG_P4): 0x%02X\n", BME280_REG_ADDR_DIG_P4, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P5, &val, 1));
-  console_printf("0x%02X (DIG_P5):  0x%02X\n", BME280_REG_ADDR_DIG_P5, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P6, &val, 1));
-  console_printf("0x%02X (DIG_P6):   0x%02X\n", BME280_REG_ADDR_DIG_P6, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P7, &val, 1));
-  console_printf("0x%02X (DIG_P7): 0x%02X\n", BME280_REG_ADDR_DIG_P7, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P8, &val, 1));
-  console_printf("0x%02X (DIG_P8):  0x%02X\n", BME280_REG_ADDR_DIG_P8, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_P9, &val, 1));
-  console_printf("0x%02X (DIG_P9):   0x%02X\n", BME280_REG_ADDR_DIG_P9, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H1, &val, 1));
-  console_printf("0x%02X (DIG_H1): 0x%02X\n", BME280_REG_ADDR_DIG_H1, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H2, &val, 1));
-  console_printf("0x%02X (DIG_H2):  0x%02X\n", BME280_REG_ADDR_DIG_H2, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H3, &val, 1));
-  console_printf("0x%02X (DIG_H3):   0x%02X\n", BME280_REG_ADDR_DIG_H3, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H4, &val, 1));
-  console_printf("0x%02X (DIG_H4): 0x%02X\n", BME280_REG_ADDR_DIG_H4, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H5, &val, 1));
-  console_printf("0x%02X (DIG_H5):  0x%02X\n", BME280_REG_ADDR_DIG_H5, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_DIG_H6, &val, 1));
-  console_printf("0x%02X (DIG_H6):   0x%02X\n", BME280_REG_ADDR_DIG_H6, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_CHIPID, &val, 1));
-  console_printf("0x%02X (CHIPID):   0x%02X\n", BME280_REG_ADDR_CHIPID, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_VERSION, &val, 1));
-  console_printf("0x%02X (VER):   0x%02X\n", BME280_REG_ADDR_VERSION, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_CTRL_HUM, &val, 1));
-  console_printf("0x%02X (CTRL_HUM):   0x%02X\n", BME280_REG_ADDR_CTRL_HUM, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_STATUS, &val, 1));
-  console_printf("0x%02X (STATUS):   0x%02X\n", BME280_REG_ADDR_STATUS, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_CTRL_MEAS, &val, 1));
-  console_printf("0x%02X (CTRL_MEAS):   0x%02X\n", BME280_REG_ADDR_CTRL_MEAS, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_CONFIG, &val, 1));
-  console_printf("0x%02X (CONFIG):   0x%02X\n", BME280_REG_ADDR_CONFIG, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_PRESS, &val, 1));
-  console_printf("0x%02X (PRESS):   0x%02X\n", BME280_REG_ADDR_PRESS, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_TEMP, &val, 1));
-  console_printf("0x%02X (TEMP):   0x%02X\n", BME280_REG_ADDR_TEMP, val);
-  assert(0 == bme280_readlen(&g_sensor_itf, BME280_REG_ADDR_HUM, &val, 1));
-  console_printf("0x%02X (HUM):   0x%02X\n", BME280_REG_ADDR_HUM, val);
+  DUMP_REG(DIG_T1);
+  DUMP_REG(DIG_T2);
+  DUMP_REG(DIG_T3);
+  DUMP_REG(DIG_P1);
+  DUMP_REG(DIG_P2);
+  DUMP_REG(DIG_P3);
+  DUMP_REG(DIG_P4);
+  DUMP_REG(DIG_P5);
+  DUMP_REG(DIG_P6);
+  DUMP_REG(DIG_P7);
+  DUMP_REG(DIG_P8);
+  DUMP_REG(DIG_P9);
+  DUMP_REG(DIG_H1);
+  DUMP_REG(DIG_H2);
+  DUMP_REG(DIG_H3);
+  DUMP_REG(DIG_H4);
+  DUMP_REG(DIG_H5);
+  DUMP_REG(DIG_H6);
+  DUMP_REG(CHIPID);
+  DUMP_REG(VERSION);
+  DUMP_REG(CTRL_HUM);
+  DUMP_REG(STATUS);
+  DUMP_REG(CTRL_MEAS);
+  DUMP_REG(CONFIG);
+  DUMP_REG(PRESS);
+  DUMP_REG(TEMP);
+  DUMP_REG(HUM);
 
   return 0;
 }

--- a/hw/drivers/sensors/bme280/syscfg.yml
+++ b/hw/drivers/sensors/bme280/syscfg.yml
@@ -25,11 +25,17 @@ syscfg.defs:
         description: 'Shell interface number for the BME280'
         value: 0
     BME280_SHELL_ITF_TYPE:
-        description: 'Shell interface type for the BME280'
+        description: 'Shell interface type for the BME280 (0 - SPI, 1 - I2C)'
         value: 0
+    BME280_SHELL_ITF_BUS:
+        description: 'Shell interface bus for the BME280 when bus driver is used'
+        value: '"spi0"'
     BME280_SHELL_CSPIN:
         description: 'CS pin for BME280'
         value : 3
+    BME280_SHELL_ITF_ADDR:
+        description: 'Slave address for BME280 (0x76 or 0x77)'
+        value : 0x77
     BME280_CLI:
         description: 'Enable shell support for the BME280'
         value: 0

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <string.h>
 #include "os/mynewt.h"
+#include "bsp/bsp.h"
 
 #if MYNEWT_VAL(DRV2605_OFB)
 #include "hal/hal_gpio.h"

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -253,7 +253,7 @@ static const struct bus_i2c_node_cfg bmp280_node_cfg = {
 #endif
 #if MYNEWT_VAL(BMP280_OFB_SPI_NUM) >= 0
 struct bus_spi_node_cfg bmp280_node_cfg = {
-    .node_cfg.bus_name = MYNEWT_VAL(BME280_OFB_SPI_BUS),
+    .node_cfg.bus_name = MYNEWT_VAL(BMP280_OFB_SPI_BUS),
     .pin_cs = MYNEWT_VAL(BMP280_OFB_CS),
     .mode = BUS_SPI_MODE_0,
     .data_order = HAL_SPI_MSB_FIRST,


### PR DESCRIPTION
- bme280 shell now works with bus driver
- fixed typo in sensor creator
- added include bsp.h to sensor_creator
- assert on read registers in bme280 removed