### PR TITLE
log/common: Fix misleading comment.

### DIFF
--- a/sys/log/common/include/log_common/log_common.h
+++ b/sys/log/common/include/log_common/log_common.h
@@ -42,7 +42,7 @@ struct log;
 #define LOG_LEVEL_WARN     (2)
 #define LOG_LEVEL_ERROR    (3)
 #define LOG_LEVEL_CRITICAL (4)
-/* Up to 7 custom log levels. */
+/* Up to 10 custom log levels. */
 #define LOG_LEVEL_MAX      (15)
 
 #define LOG_LEVEL_STR(level) \


### PR DESCRIPTION
Currently `mcumgr log level_list` command isn't working because it expects LOG_LEVEL_IDX to return NULL instead of the string "UNKNOWN" when a non valid level index is provided.