### PR TITLE
libs/baselibc: Fix double fflush definition problem (#2076)

### DIFF
--- a/libc/baselibc/include/stdio.h
+++ b/libc/baselibc/include/stdio.h
@@ -88,8 +88,12 @@ __extern_inline char *strerror(int errnum)
 	return (char*)"error_str";
 }
 
+__extern_inline int putchar(int c)
+{
+    return fputc(c, stdout);
+}
+
 #define putc(c,f)  fputc((c),(f))
-#define putchar(c) fputc((c),stdout)
 #define getc(f) fgetc(f)
 #define getchar() fgetc(stdin)
 


### PR DESCRIPTION
fflush double definition problem happens when baselibc version (B)
collides with tool chain provided one (A).
It can happen when other symbol located in (A) for example printf()
refers fflush().
(B) provides it's own version of printf() so it is not culprit
that pulls something form (A).

Function that actually pulls fflush() from (A) is putchar().
(B) provided definition of putchar() would work if it was not
for optimization done on simple printf's by gcc.
For one char prints like:
printf("a");
printf("%c", 1);

gcc chooses to change call to printf() with call to putchar(), but
at that time it just expects function putchar() to exists and
in (B) we have only macro that does not produces putchar symbol.

Simple solution is to conjure up symbol putchar in (B) so (A) version
is not needed.