### PR TITLE
da1469x, hal_uart: fix typo

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_uart.c
+++ b/hw/mcu/dialog/da1469x/src/hal_uart.c
@@ -233,7 +233,7 @@ da1469x_uart_common_isr(struct da1469x_uart *uart)
         }
     }
 
-    os_trace_isr_enter();
+    os_trace_isr_exit();
 }
 #endif
 


### PR DESCRIPTION
The trace api to be called at the end of the isr should be the exit one and not the entry one.