### PR TITLE
sensors/tcs34725: Add bus driver support

### DIFF
--- a/hw/drivers/sensors/tcs34725/include/tcs34725/tcs34725.h
+++ b/hw/drivers/sensors/tcs34725/include/tcs34725/tcs34725.h
@@ -47,7 +47,11 @@ struct tcs34725_cfg {
 };
 
 struct tcs34725 {
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    struct bus_i2c_node i2c_node;
+#else
     struct os_dev dev;
+#endif
     struct sensor sensor;
     struct tcs34725_cfg cfg;
     os_time_t last_read_time;
@@ -212,6 +216,22 @@ tcs34725_get_rawdata(struct sensor_itf *itf, uint16_t *r, uint16_t *g,
 int
 tcs34725_get_int_limits(struct sensor_itf *itf, uint16_t *low, uint16_t *high);
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+
+/**
+ * Create I2C bus node for TCS34725 sensor
+ *
+ * @param node        Bus node
+ * @param name        Device name
+ * @param i2c_cfg     I2C node configuration
+ * @param sensor_itf  Sensors interface
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int tcs34725_create_i2c_sensor_dev(struct bus_i2c_node *node, const char *name,
+                                   const struct bus_i2c_node_cfg *i2c_cfg,
+                                   struct sensor_itf *sensor_itf);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/sensors/tcs34725/syscfg.yml
+++ b/hw/drivers/sensors/tcs34725/syscfg.yml
@@ -30,6 +30,9 @@ syscfg.defs:
     TCS34725_SHELL_ITF_ADDR:
         description: 'TCS34725 I2C address'
         value : 0x29
+    TCS34725_SHELL_ITF_BUS:
+        description: 'Shell interface bus for the TCS34725 when bus driver is used'
+        value: '"i2c0"'
     TCS34725_ITF_LOCK_TMO:
         description: 'TCS34725 interface lock timeout in milliseconds'
         value: 1000

--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -126,6 +126,12 @@ syscfg.defs:
     TCS34725_OFB:
         description: 'TCS34725 is present'
         value : 0
+    TCS34725_OFB_I2C_BUS:
+        description: 'I2C interface used for TCS34725'
+        value: '"i2c0"'
+    TCS34725_OFB_I2C_ADDR:
+        description: 'I2C address of TCS34725'
+        value: 0x29
     BMA253_OFB:
         description: 'BMA253 is present'
         value : 0


### PR DESCRIPTION
Now tcs34725 can be configured with I2C bus drivers.