### PR TITLE
bsp/black_vet6: Fix build with no UART_0

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -29,7 +29,7 @@
 #include "trng/trng.h"
 #include "trng_stm32/trng_stm32.h"
 #endif
-#if MYNEWT_VAL(UART_0)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #endif


### PR DESCRIPTION
Includes for uart related header only depended on UART_0 being
used.
When UART_0 is not used but UART_1 or UART_2 are, build failed
due to lack of include files.