### PR TITLE
bsp/bluepill: Use HSE instead of HSI for clock source

### DIFF
--- a/hw/bsp/bluepill/src/hal_bsp.c
+++ b/hw/bsp/bluepill/src/hal_bsp.c
@@ -136,20 +136,34 @@ clock_config(void)
     RCC_OscInitTypeDef oscinitstruct = { 0 };
 
     /* Configure PLL ------------------------------------------------------*/
-    /* PLL configuration: PLLCLK = (HSI / 2) * PLLMUL = (8 / 2) * 16 = 64 MHz */
-    /* PREDIV1 configuration: PREDIV1CLK = PLLCLK / HSEPredivValue = 64 / 1 = 64 MHz */
-    /* Enable HSI and activate PLL with HSi_DIV2 as source */
-    oscinitstruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    oscinitstruct.HSEState = RCC_HSE_OFF;
+    /*
+     * PLL configuration: PLLCLK = HSE * PLLMUL = 8 * 9 = 72 MHz
+     * PREDIV1 configuration: PREDIV1CLK = PLLCLK / HSEPredivValue = 72 / 1 = 72 MHz
+     */
+    oscinitstruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    oscinitstruct.HSEState = RCC_HSE_ON;
     oscinitstruct.LSEState = RCC_LSE_OFF;
-    oscinitstruct.HSIState = RCC_HSI_ON;
+    oscinitstruct.HSIState = RCC_HSI_OFF;
     oscinitstruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
     oscinitstruct.HSEPredivValue = RCC_HSE_PREDIV_DIV1;
     oscinitstruct.PLL.PLLState = RCC_PLL_ON;
-    oscinitstruct.PLL.PLLSource = RCC_PLLSOURCE_HSI_DIV2;
-    oscinitstruct.PLL.PLLMUL = RCC_PLL_MUL16;
+    oscinitstruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+    oscinitstruct.PLL.PLLMUL = RCC_PLL_MUL9;
     if (HAL_RCC_OscConfig(&oscinitstruct) != HAL_OK) {
-        assert(0);
+        /*
+         * Failed to set clock to HSE + PLL, try HSI + PLL before assert
+         * PLL configuration: PLLCLK = (HSI / 2) * PLLMUL = (8 / 2) * 16 = 64 MHz
+         * PREDIV1 configuration: PREDIV1CLK = PLLCLK / HSEPredivValue = 64 / 1 = 64 MHz
+         * Enable HSI and activate PLL with HSI_DIV2 as source.
+         */
+        oscinitstruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+        oscinitstruct.HSEState = RCC_HSE_OFF;
+        oscinitstruct.HSIState = RCC_HSI_ON;
+        oscinitstruct.PLL.PLLSource = RCC_PLLSOURCE_HSI_DIV2;
+        oscinitstruct.PLL.PLLMUL = RCC_PLL_MUL16;
+        if (HAL_RCC_OscConfig(&oscinitstruct) != HAL_OK) {
+            assert(0);
+        }
     }
 
     /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 
@@ -158,7 +172,7 @@ clock_config(void)
                                RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
     clkinitstruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
     clkinitstruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-    clkinitstruct.APB2CLKDivider = RCC_HCLK_DIV4;
+    clkinitstruct.APB2CLKDivider = RCC_HCLK_DIV1;
     clkinitstruct.APB1CLKDivider = RCC_HCLK_DIV2;
     if (HAL_RCC_ClockConfig(&clkinitstruct, FLASH_LATENCY_2) != HAL_OK) {
         assert(0);


### PR DESCRIPTION
Bluepill has 8MHz crystal oscillators on board.
Previously clock was configured to use internal HSI as source
resulting in clock frequency 64MHz.
Now external oscillator is configured instead increasing clock
to 72MHz.
Additionally HSI could not be reliably used as system clock
when USB peripheral is enabled.