### PR TITLE
Remove restriction in syscfg to define bitbang RX pin

### DIFF
--- a/hw/drivers/uart/uart_bitbang/syscfg.yml
+++ b/hw/drivers/uart/uart_bitbang/syscfg.yml
@@ -28,5 +28,5 @@ syscfg.defs:
         value: -1
 
 syscfg.restrictions:
-    - UARTBB_0_PIN_TX >= 0 && UARTBB_0_PIN_RX >= 0
+    - UARTBB_0_PIN_TX >= 0
     - CONSOLE_UART_BAUD <= 19200


### PR DESCRIPTION
The bitbang driver code allows it to be used in tx only mode, so the syscfg.yml should not require an RX pin gpio. 