### PR TITLE
sys/stats: Fix build with GCC 9.2.1

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -347,7 +347,7 @@ char *conf_str_from_value(enum conf_type type, void *vp, char *buf,
  *
  * @return 0 on success, non-zero on failure.
  */
-char *conf_str_from_bytes(void *vp, int vp_len, char *buf, int buf_len);
+char *conf_str_from_bytes(const void *vp, int vp_len, char *buf, int buf_len);
 
 /**
  * Convert a string into a value of type

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -258,7 +258,7 @@ conf_str_from_value(enum conf_type type, void *vp, char *buf, int buf_len)
 }
 
 char *
-conf_str_from_bytes(void *vp, int vp_len, char *buf, int buf_len)
+conf_str_from_bytes(const void *vp, int vp_len, char *buf, int buf_len)
 {
     if (BASE64_ENCODE_SIZE(vp_len) > buf_len) {
         return NULL;

--- a/sys/stats/full/include/stats/stats.h
+++ b/sys/stats/full/include/stats/stats.h
@@ -48,6 +48,7 @@ struct stats_hdr {
     int s_map_cnt;
 #endif
     STAILQ_ENTRY(stats_hdr) s_next;
+    uint8_t data[0];
 };
 
 /**
@@ -59,6 +60,7 @@ struct stats_persisted_hdr {
     struct stats_hdr sp_hdr;
     struct os_callout sp_persist_timer;
     os_time_t sp_persist_delay;
+    uint8_t data[0];
 };
 
 #define STATS_SECT_DECL(__name)             \

--- a/sys/stats/full/src/stats_conf.c
+++ b/sys/stats/full/src/stats_conf.c
@@ -61,10 +61,10 @@ static void
 stats_conf_serialize(const struct stats_hdr *hdr, void *buf)
 {
     size_t rawlen;
-    void *data;
+    const void *data;
 
     rawlen = stats_size(hdr);
-    data = stats_data(hdr);
+    data = stats_data_ro(hdr);
 
     conf_str_from_bytes(data, rawlen, buf, MYNEWT_VAL(STATS_PERSIST_BUF_SIZE));
 }
@@ -96,8 +96,8 @@ stats_conf_set(int argc, char **argv, char *val)
         hdr = stats_group_find(argv[0]);
         if (hdr != NULL) {
             size = stats_size(hdr);
-            data = stats_data(hdr);
-            
+            data = stats_data_rw(hdr);
+
             memset(data, 0, size);
             base64_decode_maxlen(val, data, size);
 

--- a/sys/stats/full/src/stats_priv.h
+++ b/sys/stats/full/src/stats_priv.h
@@ -47,7 +47,17 @@ size_t stats_size(const struct stats_hdr *hdr);
  *
  * @param hdr                   The stat group to pull data from.
  */
-void *stats_data(const struct stats_hdr *hdr);
+const void *stats_data_ro(const struct stats_hdr *hdr);
+
+/**
+ * @brief Retrieves the address of the first stat in the specified group.
+ *
+ * This is the same as stats_data_ro() except it returns non-const pointer
+ * so parameter specifying stat group is also non-const.
+ *
+ * @param hdr                   The stat group to pull data from.
+ */
+void *stats_data_rw(struct stats_hdr *hdr);
 
 /**
  * @brief Writes the specified stat group to sys/config.


### PR DESCRIPTION
This fixes following build error:

Compiling repos/apache-mynewt-core/sys/stats/full/src/stats.c
Error: In function 'stats_init',
    inlined from 'stats_module_init_internal' at repos/apache-mynewt-core/sys/stats/full/src/stats.c:148:10:
repos/apache-mynewt-core/sys/stats/full/src/stats.c:298:5: error: 'memset' offset [13, 16] from the object
at 'g_stats_stats' is out of the bounds of referenced subobject 's_hdr' with type 'struct stats_hdr'
at offset 0 [-Werror=array-bounds]
  298 |     memset((uint8_t *)shdr + offset, 0, size * cnt);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

I do not really like that we have separate macros for retrieving const
and non-const data pointer, but I do not see any easy way to workaround
this except for removing consts explicitly which basically original
private API did by casting to uint8_t*.