### PR TITLE
hw/drivers/crypto: Add crypto_in_use flag.

### DIFF
--- a/hw/drivers/crypto/crypto_nrf52/src/crypto_nrf52.c
+++ b/hw/drivers/crypto/crypto_nrf52/src/crypto_nrf52.c
@@ -34,27 +34,34 @@ struct aes_128_data {
 static bool
 nrf52_crypto_ecb_start(const struct aes_128_data *crypto_data)
 {
-    int ctr = 0x100000;
-    bool rc = true;
+    bool rc;
+    uint32_t end;
+    uint32_t err;
 
+    /* Just to be sure, always stop ECB and clear END/ERROR registers */
+    NRF_ECB->TASKS_STOPECB = 1;
+    NRF_ECB->EVENTS_ENDECB = 0;
+    NRF_ECB->EVENTS_ERRORECB = 0;
+
+    /* Set the data pointer and start ECB */
     NRF_ECB->ECBDATAPTR = (uint32_t)crypto_data;
     NRF_ECB->TASKS_STARTECB = 1;
 
-    while (ctr-- > 0) {
-        if (NRF_ECB->EVENTS_ENDECB) {
-            break;
-        }
-        if (NRF_ECB->EVENTS_ERRORECB) {
-            NRF_ECB->TASKS_STOPECB = 1;
-            rc = false;
+    while (1) {
+        end = NRF_ECB->EVENTS_ENDECB;
+        err = NRF_ECB->EVENTS_ERRORECB;
+        if (end || err) {
+            if (err) {
+                rc = false;
+            } else {
+                rc = true;
+            }
             break;
         }
     }
-    if (ctr == 0) {
-        NRF_ECB->TASKS_STOPECB = 1;
-    }
-    NRF_ECB->EVENTS_ENDECB = 0;
-    NRF_ECB->EVENTS_ERRORECB = 0;
+
+    /* While not necessary in all cases, stop ECB just as a precaution */
+    NRF_ECB->TASKS_STOPECB = 1;
 
     return rc;
 }
@@ -69,6 +76,8 @@ nrf52_crypto_encrypt_ecb(struct crypto_dev *crypto, const uint8_t *key,
 
     os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
 
+    crypto->in_use = 1;
+
     memcpy(crypto_data.key, key, AES_128_KEY_LEN);
 
     i = 0;
@@ -80,9 +89,13 @@ nrf52_crypto_encrypt_ecb(struct crypto_dev *crypto, const uint8_t *key,
 
         memcpy(crypto_data.plain, &inbuf[i], len);
 
-        /* XXX might sleep for a tick and try again? */
-        if (nrf52_crypto_ecb_start(&crypto_data) == false) {
-            break;
+        while (nrf52_crypto_ecb_start(&crypto_data) == false) {
+            /*
+             * If this fails it means that the AES engine was used causing the
+             * operation to abort. Just try again as the upper layer code does
+             * not seem to handle errors well. This condition should be
+             * temporary.
+             */
         }
 
         memcpy(&outbuf[i], crypto_data.cipher, len);
@@ -91,6 +104,8 @@ nrf52_crypto_encrypt_ecb(struct crypto_dev *crypto, const uint8_t *key,
         remain -= len;
         len = remain;
     }
+
+    crypto->in_use = 0;
 
     os_mutex_release(&gmtx);
 

--- a/hw/drivers/crypto/crypto_nrf52/src/crypto_nrf52.c
+++ b/hw/drivers/crypto/crypto_nrf52/src/crypto_nrf52.c
@@ -76,7 +76,7 @@ nrf52_crypto_encrypt_ecb(struct crypto_dev *crypto, const uint8_t *key,
 
     os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
 
-    crypto->in_use = 1;
+    crypto->in_use = true;
 
     memcpy(crypto_data.key, key, AES_128_KEY_LEN);
 
@@ -105,7 +105,7 @@ nrf52_crypto_encrypt_ecb(struct crypto_dev *crypto, const uint8_t *key,
         len = remain;
     }
 
-    crypto->in_use = 0;
+    crypto->in_use = false;
 
     os_mutex_release(&gmtx);
 

--- a/hw/drivers/crypto/include/crypto/crypto.h
+++ b/hw/drivers/crypto/include/crypto/crypto.h
@@ -91,7 +91,7 @@ struct crypto_interface {
 struct crypto_dev {
     struct os_dev dev;
     struct crypto_interface interface;
-    int in_use;
+    bool in_use;
 };
 
 struct crypto_iovec {
@@ -204,10 +204,10 @@ bool crypto_has_support(struct crypto_dev *crypto, uint8_t op, uint16_t algo,
  *
  * @param crypto   OS device
  *
- * @return 0: crypto not in use 1: crypto in use
+ * @return true: crypto not in use, false otherwise
  *
  */
-int crypto_in_use(struct crypto_dev *crypto);
+bool crypto_in_use(struct crypto_dev *crypto);
 
 /*
  * AES helpers

--- a/hw/drivers/crypto/include/crypto/crypto.h
+++ b/hw/drivers/crypto/include/crypto/crypto.h
@@ -91,6 +91,7 @@ struct crypto_interface {
 struct crypto_dev {
     struct os_dev dev;
     struct crypto_interface interface;
+    int in_use;
 };
 
 struct crypto_iovec {
@@ -197,6 +198,16 @@ uint32_t crypto_decryptv_custom(struct crypto_dev *crypto, uint16_t algo,
  */
 bool crypto_has_support(struct crypto_dev *crypto, uint8_t op, uint16_t algo,
         uint16_t mode, uint16_t keylen);
+
+/*
+ * Query Crypto in use
+ *
+ * @param crypto   OS device
+ *
+ * @return 0: crypto not in use 1: crypto in use
+ *
+ */
+int crypto_in_use(struct crypto_dev *crypto);
 
 /*
  * AES helpers

--- a/hw/drivers/crypto/src/crypto.c
+++ b/hw/drivers/crypto/src/crypto.c
@@ -415,7 +415,7 @@ crypto_has_support(struct crypto_dev *crypto, uint8_t op, uint16_t algo,
     return crypto->interface.has_support(crypto, op, algo, mode, keylen);
 }
 
-int
+bool
 crypto_in_use(struct crypto_dev *crypto)
 {
     return crypto->in_use;

--- a/hw/drivers/crypto/src/crypto.c
+++ b/hw/drivers/crypto/src/crypto.c
@@ -414,3 +414,9 @@ crypto_has_support(struct crypto_dev *crypto, uint8_t op, uint16_t algo,
     assert(crypto->interface.has_support);
     return crypto->interface.has_support(crypto, op, algo, mode, keylen);
 }
+
+int
+crypto_in_use(struct crypto_dev *crypto)
+{
+    return crypto->in_use;
+}

--- a/hw/drivers/flash/enc_flash/ef_crypto/pkg.yml
+++ b/hw/drivers/flash/enc_flash/ef_crypto/pkg.yml
@@ -29,3 +29,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/drivers/flash/enc_flash"
     - "@apache-mynewt-core/hw/drivers/crypto"
+
+pkg.restrictions:
+    - "CRYPTO"


### PR DESCRIPTION
This commit adds a flag to the crypto driver called "in_use".
This flag, and associated API, is intended for use by ISR's to
perform a quick check to see if an underlying crypto hw peripheral
is being used so that the HW peripheral can be used in the ISR
or the use of an associated piece may impact an ongoing crypto
operation.

Currently, this is only implemented for the nrf52. Some changes
were made to the nrf52 crypto code. Some reasoning behind some
of the changes: 1) do not think a counter to bail out of the
loop waiting for the crypto to end or an error to occur is needed.
Either one of the two will occur. 2) Not quite sure if it is
possible but if both EVENTS_ENDECB and EVENTS_ERRORECB can be set
at the same time, the previous could assume success when there was
an error. 3) If EVENTS_ERRORECB is generated we simply try the
operation again.

Note that a somewhat un-related change was made to the encrypted
flash ef_crypto driver to add a restriction such that CRYPTO is
required to be defined when using this package.