### PR TITLE
da1469x: use uint16 TLV tag

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_system_start.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system_start.c
@@ -86,7 +86,7 @@ boot_custom_start(uintptr_t flash_base, struct boot_rsp *rsp)
     const struct flash_area *fap;
     uint32_t off;
     uint16_t len;
-    uint8_t type;
+    uint16_t type;
     uint8_t buf[8];
     uint8_t key;
     uint32_t nonce[2];


### PR DESCRIPTION
`mcuboot: d13318a14f99a5a3947bedc980020ec73800aaeb`
updates the tag type to uint16_t. Use the same.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>