### PR TITLE
Add new syscfg to set MAC addr for STM32

### DIFF
--- a/apps/iptest/src/main.c
+++ b/apps/iptest/src/main.c
@@ -396,18 +396,6 @@ main(int argc, char **argv)
     mcu_sim_parse_args(argc, argv);
 #endif
 
-#ifndef ARCH_sim
-    {
-        /*
-         * XXX set mac address when using STM32 ethernet XXX
-         * XXX move this somewhere else XXX
-         */
-        static uint8_t mac[6]= { 0, 1, 1, 2, 2, 3 };
-        int stm32_eth_set_hwaddr(uint8_t *addr);
-        stm32_eth_set_hwaddr(mac);
-    }
-#endif
-
     sysinit();
 
     console_printf("iptest\n");

--- a/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
+++ b/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
@@ -510,12 +510,8 @@ stm32_eth_open(void)
          */
         return -1;
     }
-    if (ses->st_eth.Init.MACAddr == NULL) {
-        /*
-         * MAC address not set
-         */
-        return -1;
-    }
+
+    stm32_eth_set_hwaddr(MYNEWT_VAL(STM32_MAC_ADDR));
 
     if (ses->cfg->sec_phy_irq >= 0) {
         rc = hal_gpio_irq_init(ses->cfg->sec_phy_irq, stm32_phy_isr, ses,

--- a/hw/drivers/lwip/stm32_eth/syscfg.yml
+++ b/hw/drivers/lwip/stm32_eth/syscfg.yml
@@ -22,3 +22,7 @@ syscfg.defs:
         description: >
             Sysinit stage for the stm32 eth driver.
         value: 240
+
+    STM32_MAC_ADDR:
+        description: "Use given array of 6 bytes for MAC address."
+        value: ((uint8_t[6]){0x00, 0x01, 0x01, 0x02, 0x02, 0x03})


### PR DESCRIPTION
Remove hardcoded MAC address from `apps/iptest` and add it as a syscfg in the STM32 eth driver.