### PR TITLE
A few fixes to Lora example apps

### DIFF
--- a/apps/loraping/pkg.yml
+++ b/apps/loraping/pkg.yml
@@ -25,19 +25,13 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@mcuboot/boot/bootutil"
-    - "@apache-mynewt-core/boot/split"
     - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/mgmt/imgmgr"
-    - "@apache-mynewt-core/mgmt/smp"
-    - "@apache-mynewt-core/mgmt/smp/transport/smp_shell"
     - "@apache-mynewt-core/sys/config"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/id"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/shell"
     - "@apache-mynewt-core/sys/stats/full"
-    - "@apache-mynewt-core/test/flash_test"
 
 pkg.deps.CONFIG_NFFS:
     - "@apache-mynewt-core/fs/nffs"

--- a/apps/lorashell/syscfg.yml
+++ b/apps/lorashell/syscfg.yml
@@ -27,3 +27,4 @@ syscfg.vals:
     STATS_NAMES: 1
     SHELL_TASK: 1
     LORA_NODE_CLI: 1
+    SHELL_CMD_ARGC_MAX: 16


### PR DESCRIPTION
* lorashell: allow "lora rx_cfg" command to work by increasing the maximum number of parameters the shell is able to process.

* loraping: remove dependencies that don't seem necessary which allows for use in constrained devices (eg, b-l072z-lrwan1 with 72K slots).