### PR TITLE
Dialog SPI HAL should not initialize SS pin in master mode

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_spi.c
+++ b/hw/mcu/dialog/da1469x/src/hal_spi.c
@@ -207,10 +207,6 @@ hal_spi_init_master(const struct da1469x_hal_spi *spi,
         mcu_gpio_set_pin_function(cfg->pin_di, MCU_GPIO_MODE_INPUT,
                                   spi->hw->spi_di_func);
     }
-    if (cfg->pin_ss >= 0) {
-        mcu_gpio_set_pin_function(cfg->pin_ss, MCU_GPIO_MODE_INPUT,
-                                  spi->hw->spi_ss_func);
-    }
 
     spi->hw->regs->SPI_CLEAR_INT_REG = 0;
     spi->hw->regs->SPI_CTRL_REG = 0;


### PR DESCRIPTION
Removes initialization of the SS pin from `hal_spi_init_master` in the mcu/dialog HAL. 

Explanation:
Currently `hal_spi_init_master` initializes the SS pin, which should only be done if the SPI is operating in slave mode. Since no syscfg exists to define the SS pin for master mode, it defaults to 0 and the following code will set port 0 pin 0 to MCU_GPIO_MODE_INPUT:
```
    if (cfg->pin_ss >= 0) {
        mcu_gpio_set_pin_function(cfg->pin_ss, MCU_GPIO_MODE_INPUT,
                                  spi->hw->spi_ss_func);
    }
```