### PR TITLE
uncrustify: disable var alignment inside structs

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -926,7 +926,7 @@ align_var_class_thresh          = 0        # number
 align_var_class_gap             = 0        # number
 
 # The span for aligning struct/union (0=don't align)
-align_var_struct_span           = 4        # number
+align_var_struct_span           = 0        # number
 
 # The threshold for aligning struct/union member definitions (0=no limit)
 align_var_struct_thresh         = 0        # number


### PR DESCRIPTION
Fix issue seen in #2161 