### PR TITLE
FIx: advance_internal should return error instead of using assert

### DIFF
--- a/encoding/tinycbor/src/cborparser.c
+++ b/encoding/tinycbor/src/cborparser.c
@@ -279,7 +279,9 @@ static CborError advance_internal(CborValue *it)
 {
     uint64_t length;
     CborError err = extract_number(it->parser, &it->offset,  &length);
-    assert(err == CborNoError);
+    if (err == CborNoError) {
+        return err;
+    }
 
     if (it->type == CborByteStringType || it->type == CborTextStringType) {
         assert(length == (size_t)length);


### PR DESCRIPTION
Assert may evaluate to empty expression which means that an error removed
from call to extract_number may get missed. It is better to return it,
and let it be processed further.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>