### PR TITLE
LIS2DH12 Sem Time

### DIFF
--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -51,7 +51,7 @@
 /*
  * Max time to wait for interrupt.
  */
-#define LIS2DH12_MAX_INT_WAIT (4 * OS_TICKS_PER_SEC)
+#define LIS2DH12_MAX_INT_WAIT (1 * OS_TICKS_PER_SEC)
 
 static const struct lis2dh12_notif_cfg dflt_notif_cfg[] = {
     {


### PR DESCRIPTION
A LIS2DH12 semaphore on an interrupt has a max wait time of 4 seconds. This could cause unintended issues as 4 seconds may block the system from completing its other tasks. This also seems slightly excessive.

Reducing the wait time on a semaphore from 4 seconds to 1 second.