### PR TITLE
hw/mcu/dialog: Fix unitialized variable in hal_timer_stop

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_timer.c
+++ b/hw/mcu/dialog/da1469x/src/hal_timer.c
@@ -515,6 +515,7 @@ hal_timer_stop(struct hal_timer *timer)
         return 0;
     }
 
+    reset = 0;
     tmr = timer->bsp_timer;
 
     __HAL_DISABLE_INTERRUPTS(primask);


### PR DESCRIPTION
The local variable 'reset' was not initialized prior to use.