### PR TITLE
bsp: stm32f3discovery: enable LSM303DLHC sensor

### DIFF
--- a/apps/sensors_test/pkg.yml
+++ b/apps/sensors_test/pkg.yml
@@ -34,7 +34,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/hw/sensor/creator"
     - "@apache-mynewt-core/sys/reboot"
-    - "@apache-mynewt-core/mgmt/smp/transport/ble"
     - "@apache-mynewt-core/sys/id"
     - "@apache-mynewt-core/mgmt/imgmgr"
     - "@apache-mynewt-core/test/flash_test"
@@ -44,6 +43,7 @@ pkg.deps.SENSOR_OIC:
    #- mgmt/oicmgr
 
 pkg.deps.SENSOR_BLE:
+    - "@apache-mynewt-core/mgmt/smp/transport/ble"
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"

--- a/hw/bsp/stm32f3discovery/pkg.yml
+++ b/hw/bsp/stm32f3discovery/pkg.yml
@@ -41,3 +41,9 @@ pkg.deps.UART_0:
 
 pkg.deps.UART_1:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+
+pkg.deps.LSM303DLHC_ONB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lsm303dlhc"
+
+pkg.init:
+    config_lsm303dlhc_sensor: 'MYNEWT_VAL(STM32F3DISCOVERY_SYSINIT_STAGE)'

--- a/hw/bsp/stm32f3discovery/syscfg.yml
+++ b/hw/bsp/stm32f3discovery/syscfg.yml
@@ -19,7 +19,7 @@
 
 syscfg.defs:
     STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
+        description: 'Total flash size in KB'
         value: 256
 
     UART_0:
@@ -40,6 +40,15 @@ syscfg.defs:
         description: 'Support for timer 2'
         value: 0
 
+    LSM303DLHC_ONB:
+        description: 'Onboard lsm303dlhc sensor'
+        value:  0
+
+    STM32F3DISCOVERY_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the STM32F3-Discovery BSP
+        value: 400
+
 syscfg.vals:
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
@@ -59,3 +68,6 @@ syscfg.vals:
     STM32_CLOCK_APB2_DIVIDER: 'RCC_HCLK_DIV1'
     STM32_FLASH_LATENCY: 'FLASH_LATENCY_2'
     STM32_FLASH_PREFETCH_ENABLE: 1
+
+syscfg.restrictions:
+    - "!LSM303DLHC_ONB || I2C_0"


### PR DESCRIPTION
Plus commit https://github.com/apache/mynewt-core/commit/6d10c795e3dea57c0d64e17b5a07c2fd8748ccb1 applies a small change to `sensors_test` to allow it to work on non-BLE HW.