### PR TITLE
FAT filesystem fixes

### DIFF
--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -184,7 +184,7 @@ drivenumber_from_disk(char *disk_name)
     struct mounted_disk *new_disk;
     int disk_number;
     FATFS *fs;
-    char path[DRIVE_LEN];
+    char path[6];
 
     disk_number = 0;
     if (disk_name) {
@@ -198,7 +198,7 @@ drivenumber_from_disk(char *disk_name)
 
     /* XXX: check for errors? */
     fs = malloc(sizeof(FATFS));
-    sprintf(path, "%d:", disk_number);
+    sprintf(path, "%d:", (uint8_t)disk_number);
     f_mount(fs, path, 1);
 
     /* FIXME */

--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -423,7 +423,7 @@ out:
         if (dir) free(dir);
         if (out_dir) free(out_dir);
     }
-    return FS_EOK;
+    return rc;
 }
 
 static int


### PR DESCRIPTION
This fixes:
- opendir return code in case of failure
- unlink, rename, makedir were not working due to path handling problem
One warning silenced