### PR TITLE
fs/fatfs: Fix memory leaks for each open/opendir

### DIFF
--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -279,15 +279,15 @@ out:
 static int
 fatfs_close(struct fs_file *fs_file)
 {
-    FRESULT res;
+    FRESULT res = FR_OK;
     FIL *file = ((struct fatfs_file *) fs_file)->file;
 
-    if (file == NULL) {
-        return FS_EOK;
+    if (file != NULL) {
+        res = f_close(file);
+        free(file);
     }
 
-    res = f_close(file);
-    free(file);
+    free(fs_file);
     return fatfs_to_vfs_error(res);
 }
 
@@ -453,6 +453,7 @@ fatfs_closedir(struct fs_dir *fs_dir)
 
     res = f_closedir(dir);
     free(dir);
+    free(fs_dir);
     return fatfs_to_vfs_error(res);
 }
 


### PR DESCRIPTION
fatfs_opendir allocated struct fatfs_dir that was never freed
fatfs_open allocated struct fatfs_file that was never freed

Since there was no documentation that instructed caller that memory
returned by fs_open, fs_opendir should be freed it seems
reasonable to free memory in module that allocates it.