### PR TITLE
sys/config: Support for unsigned integer types

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -66,6 +66,14 @@ typedef enum conf_type {
     CONF_DOUBLE,
     /** Boolean */
     CONF_BOOL,
+    /** 8-bit unsigned integer */
+    CONF_UINT8,
+    /** 16-bit unsigned integer */
+    CONF_UINT16,
+    /** 32-bit unsigned integer */
+    CONF_UINT32,
+    /** 64-bit unsigned integer */
+    CONF_UINT64,
 } __attribute__((__packed__)) conf_type_t;
 
 /**

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -152,21 +152,20 @@ conf_parse_and_lookup(char *name, int *name_argc, char *name_argv[])
 int
 conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
 {
-    int32_t val;
-    int64_t val64;
-    uint32_t uval;
-    uint64_t uval64;
+    int64_t val;
+    uint64_t uval;
     char *eptr;
 
     if (!val_str) {
         goto err;
     }
     switch (type) {
+    case CONF_BOOL:
     case CONF_INT8:
     case CONF_INT16:
     case CONF_INT32:
-    case CONF_BOOL:
-        val = strtol(val_str, &eptr, 0);
+    case CONF_INT64:
+        val = strtoll(val_str, &eptr, 0);
         if (*eptr != '\0') {
             goto err;
         }
@@ -176,30 +175,29 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
             }
             *(bool *)vp = val;
         } else if (type == CONF_INT8) {
-            if (val < INT8_MIN || val > UINT8_MAX) {
+            if (val < INT8_MIN || val > INT8_MAX) {
                 goto err;
             }
             *(int8_t *)vp = val;
         } else if (type == CONF_INT16) {
-            if (val < INT16_MIN || val > UINT16_MAX) {
+            if (val < INT16_MIN || val > INT16_MAX) {
                 goto err;
             }
             *(int16_t *)vp = val;
         } else if (type == CONF_INT32) {
+            if (val < INT32_MIN || val > INT32_MAX) {
+                goto err;
+            }
             *(int32_t *)vp = val;
+        } else {
+            *(int64_t *)vp = val;
         }
-        break;
-    case CONF_INT64:
-        val64 = strtoll(val_str, &eptr, 0);
-        if (*eptr != '\0') {
-            goto err;
-        }
-        *(int64_t *)vp = val64;
         break;
     case CONF_UINT8:
     case CONF_UINT16:
     case CONF_UINT32:
-        uval = strtoul(val_str, &eptr, 0);
+    case CONF_UINT64:
+        uval = strtoull(val_str, &eptr, 0);
         if (*eptr != '\0') {
             goto err;
         }
@@ -214,15 +212,13 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
             }
             *(uint16_t *)vp = uval;
         } else if (type == CONF_UINT32) {
+            if (uval > UINT32_MAX) {
+                goto err;
+            }
             *(uint32_t *)vp = uval;
+        } else {
+            *(uint64_t *)vp = uval;
         }
-        break;
-    case CONF_UINT64:
-        uval64 = strtoull(val_str, &eptr, 0);
-        if (*eptr != '\0') {
-            goto err;
-        }
-        *(uint64_t *)vp = uval64;
         break;
     case CONF_STRING:
         val = strlen(val_str);

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -258,45 +258,45 @@ conf_bytes_from_str(char *val_str, void *vp, int *len)
 char *
 conf_str_from_value(enum conf_type type, void *vp, char *buf, int buf_len)
 {
-    int32_t val;
-    uint32_t uval;
+    int64_t val;
+    uint64_t uval;
 
     if (type == CONF_STRING) {
         return vp;
     }
     switch (type) {
+    case CONF_BOOL:
     case CONF_INT8:
     case CONF_INT16:
     case CONF_INT32:
-    case CONF_BOOL:
+    case CONF_INT64:
         if (type == CONF_BOOL) {
             val = *(bool *)vp;
         } else if (type == CONF_INT8) {
             val = *(int8_t *)vp;
         } else if (type == CONF_INT16) {
             val = *(int16_t *)vp;
-        } else {
+        } else if (type == CONF_INT32) {
             val = *(int32_t *)vp;
+        } else {
+            val = *(int64_t *)vp;
         }
-        snprintf(buf, buf_len, "%ld", (long)val);
-        return buf;
-    case CONF_INT64:
-        snprintf(buf, buf_len, "%lld", *(long long *)vp);
+        snprintf(buf, buf_len, "%lld", val);
         return buf;
     case CONF_UINT8:
     case CONF_UINT16:
     case CONF_UINT32:
+    case CONF_UINT64:
         if (type == CONF_UINT8) {
             uval = *(uint8_t *)vp;
         } else if (type == CONF_UINT16) {
             uval = *(uint16_t *)vp;
-        } else {
+        } else if (type == CONF_UINT32) {
             uval = *(uint32_t *)vp;
+        } else {
+            uval = *(uint64_t *)vp;
         }
-        snprintf(buf, buf_len, "%lu", (unsigned long)uval);
-        return buf;
-    case CONF_UINT64:
-        snprintf(buf, buf_len, "%llu", *(unsigned long long *)vp);
+        snprintf(buf, buf_len, "%llu", uval);
         return buf;
     default:
         return NULL;

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -154,6 +154,8 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
 {
     int32_t val;
     int64_t val64;
+    uint32_t uval;
+    uint64_t uval64;
     char *eptr;
 
     if (!val_str) {
@@ -194,6 +196,34 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
         }
         *(int64_t *)vp = val64;
         break;
+    case CONF_UINT8:
+    case CONF_UINT16:
+    case CONF_UINT32:
+        uval = strtoul(val_str, &eptr, 0);
+        if (*eptr != '\0') {
+            goto err;
+        }
+        if (type == CONF_UINT8) {
+            if (uval > UINT8_MAX) {
+                goto err;
+            }
+            *(uint8_t *)vp = uval;
+        } else if (type == CONF_UINT16) {
+            if (uval > UINT16_MAX) {
+                goto err;
+            }
+            *(uint16_t *)vp = uval;
+        } else if (type == CONF_UINT32) {
+            *(uint32_t *)vp = uval;
+        }
+        break;
+    case CONF_UINT64:
+        uval64 = strtoull(val_str, &eptr, 0);
+        if (*eptr != '\0') {
+            goto err;
+        }
+        *(uint64_t *)vp = uval64;
+        break;
     case CONF_STRING:
         val = strlen(val_str);
         if (val + 1 > maxlen) {
@@ -229,6 +259,7 @@ char *
 conf_str_from_value(enum conf_type type, void *vp, char *buf, int buf_len)
 {
     int32_t val;
+    uint32_t uval;
 
     if (type == CONF_STRING) {
         return vp;
@@ -251,6 +282,21 @@ conf_str_from_value(enum conf_type type, void *vp, char *buf, int buf_len)
         return buf;
     case CONF_INT64:
         snprintf(buf, buf_len, "%lld", *(long long *)vp);
+        return buf;
+    case CONF_UINT8:
+    case CONF_UINT16:
+    case CONF_UINT32:
+        if (type == CONF_UINT8) {
+            uval = *(uint8_t *)vp;
+        } else if (type == CONF_UINT16) {
+            uval = *(uint16_t *)vp;
+        } else {
+            uval = *(uint32_t *)vp;
+        }
+        snprintf(buf, buf_len, "%lu", (unsigned long)uval);
+        return buf;
+    case CONF_UINT64:
+        snprintf(buf, buf_len, "%llu", *(unsigned long long *)vp);
         return buf;
     default:
         return NULL;


### PR DESCRIPTION
Prior to this commit, only signed integer types were supported for persisted settings.  This PR adds support for unsigned integer types.