### PR TITLE
sys/config: Extended callbacks

### DIFF
--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -51,9 +51,7 @@ conf_dump_running(void)
 
     conf_lock();
     SLIST_FOREACH(ch, &conf_handlers, ch_list) {
-        if (ch->ch_export) {
-            ch->ch_export(conf_running_one, CONF_EXPORT_SHOW);
-        }
+        conf_export_cb(ch, conf_running_one, CONF_EXPORT_SHOW);
     }
     conf_unlock();
 }

--- a/sys/config/src/config_priv.h
+++ b/sys/config/src/config_priv.h
@@ -34,6 +34,12 @@ int conf_line_make2(char *dst, int dlen, const char *name, const char *value);
 struct conf_handler *conf_parse_and_lookup(char *name, int *name_argc,
                                            char *name_argv[]);
 
+/**
+ * Executes a conf_handler's "export" callback and returns the result.
+ */
+int conf_export_cb(struct conf_handler *ch, conf_export_func_t export_func,
+                   conf_export_tgt_t tgt);
+
 SLIST_HEAD(conf_store_head, conf_store);
 extern struct conf_store_head conf_load_srcs;
 SLIST_HEAD(conf_handler_head, conf_handler);

--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -260,16 +260,15 @@ conf_save_tree(char *name)
     int rc;
 
     conf_lock();
+
     ch = conf_parse_and_lookup(name, &name_argc, name_argv);
     if (!ch) {
         rc = OS_INVALID_PARM;
         goto out;
     }
-    if (ch->ch_export) {
-        rc = ch->ch_export(conf_store_one, CONF_EXPORT_PERSIST);
-    } else {
-        rc = 0;
-    }
+
+    rc = conf_export_cb(ch, conf_store_one, CONF_EXPORT_PERSIST);
+
 out:
     conf_unlock();
     return rc;
@@ -300,11 +299,9 @@ conf_save(void)
     }
     rc = 0;
     SLIST_FOREACH(ch, &conf_handlers, ch_list) {
-        if (ch->ch_export) {
-            rc2 = ch->ch_export(conf_store_one, CONF_EXPORT_PERSIST);
-            if (!rc) {
-                rc = rc2;
-            }
+        rc2 = conf_export_cb(ch, conf_store_one, CONF_EXPORT_PERSIST);
+        if (!rc) {
+            rc = rc2;
         }
     }
     if (cs->cs_itf->csi_save_end) {


### PR DESCRIPTION
This PR is needed for the "scfg" feature: https://github.com/apache/mynewt-core/pull/2182.

The four conf_handler callbacks (get, set, commit, and export) do not accept a `void *arg` parameter.  This means every config group must define a dedicated set of callback functions, making it impossible wrap the config API in a generic way.

This PR allows config groups to be defined as "extended".  An extended config group uses slightly different callbacks.  These callbacks do take a `void *arg` parameter.

To define an extended config group, set its `ch_ext` member to 1.