### PR TITLE
sys/config: Remove obsolete setting `CONFIG_NEWTMGR`

### DIFF
--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -41,10 +41,6 @@ syscfg.defs:
         description: 'SMP access to config'
         value: 0
 
-    CONFIG_NEWTMGR:
-        description: 'Newtmgr access to config'
-        value: 0
-
     CONFIG_CLI:
         description: 'CLI commands for accessing config'
         value: 0


### PR DESCRIPTION
This setting is no longer used.  It was replaced by `CONFIG_MGMT` a while back.