### PR TITLE
hw/scripts: Add shortcut for accessing JLink via USB S/N

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -40,6 +40,7 @@ fi
 
 parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 jlink_target_cmd
+jlink_sn
 
 GDB_CMD_FILE=.gdb_load
 JLINK_LOG_FILE=.jlink_log

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -34,6 +34,12 @@ jlink_target_cmd () {
     fi
 }
 
+jlink_sn () {
+    if [ -n "$JLINK_SN" ]; then
+        EXTRA_JTAG_CMD="-select usb=$JLINK_SN " $EXTRA_JTAG_CMD
+    fi
+}
+
 #
 # FILE_NAME is the file to load
 # FLASH_OFFSET is location in the flash
@@ -46,6 +52,7 @@ jlink_load () {
     windows_detect
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
     jlink_target_cmd
+    jlink_sn
 
     if [ $WINDOWS -eq 1 ]; then
         JLINK_GDB_SERVER=JLinkGDBServerCL
@@ -137,6 +144,7 @@ jlink_debug() {
     fi
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
     jlink_target_cmd
+    jlink_sn
 
     if [ -z "$NO_GDB" ]; then
         GDB_CMD_FILE=.gdb_cmds


### PR DESCRIPTION
JLINK_USB=<serial> env allows to specify JLink USB S/N. This is
convenient shortcut for '--extrajtagcmd "-select usb=<serial>"'.