### PR TITLE
hw/bsp/da1469x: Fix help text in serial load script

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
@@ -24,7 +24,7 @@ import os
 
 @click.argument('infile')
 @click.option('-u', '--uart', required=True, help='uart port')
-@click.command(help='Close out OTP configuration script')
+@click.command(help='Load the provided file using serial load protocol')
 def load(infile, uart):
     try:
         ser = serial.Serial(port=uart, baudrate=115200, timeout=10,


### PR DESCRIPTION
Match the script help with the serial load functionality
provided.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>