### PR TITLE
Full console: suppress new line when echo is disabled

### DIFF
--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -61,6 +61,12 @@ int console_read(char *str, int cnt, int *newline);
 #endif
 void console_blocking_mode(void);
 void console_non_blocking_mode(void);
+/**
+ * Switch console echo state for input data on (on != 0) or off ( on= 0) 
+ *
+ * @param on Let console know if it should echo the input (!= 0),
+ *        or disable the echo (= 0).
+ */
 void console_echo(int on);
 
 int console_vprintf(const char *fmt, va_list ap);

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -981,7 +981,7 @@ handle_nlip(uint8_t byte)
         insert_char(&input->line[cur], byte);
         if (byte == '\n') {
             input->line[cur] = '\0';
-            console_echo(1);
+            console_echo(echo);
             nlip_state = 0;
 
             console_handle_line();
@@ -1160,8 +1160,11 @@ console_handle_char(uint8_t byte)
                 console_switch_to_prompt();
                 console_clear_line();
             } else {
-                console_filter_out('\r');
-                console_filter_out('\n');
+                if (echo)
+                {
+                    console_filter_out('\r');
+                    console_filter_out('\n');
+                }
             }
             if (!MYNEWT_VAL_CHOICE(CONSOLE_HISTORY, none)) {
                 console_history_add(input->line);


### PR DESCRIPTION
When echo is switched off via console_echo(0), also new line should be suppressed.