### PR TITLE
hw/mcu/dialog: set reset values to SYS_CTRL_REG in hal_system_reset

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -70,6 +70,7 @@ hal_system_reset(void)
 
     while (1) {
         HAL_DEBUG_BREAK();
+        CRG_TOP->SYS_CTRL_REG = 0x20;
         NVIC_SystemReset();
     }
 }


### PR DESCRIPTION
When hal_system_reset() is called, a reset to execute from
Dialog's primary/ROM bootloader is required to ensure all the
checks in primary and secondary bootloader is performed and image
upgrade steps are performed when needed.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>