### PR TITLE
Fix stm32 cputimer initialization

### DIFF
--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -200,6 +200,10 @@ stm32_periph_create_timers(void)
     rc = hal_timer_init(5, MYNEWT_VAL(TIMER_5_TIM));
     assert(rc == 0);
 #endif
+#if (MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0)
+    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
+    assert(rc == 0);
+#endif
 }
 
 static void


### PR DESCRIPTION
Peripheral initialization unification cut out cpu timer initialization.
So all STM32 BSP are not working correctly.
Code:
    rc = os_cputime_init(MYNEWT_VAL(OS_CPUTIME_FREQ));
    assert(rc == 0);
was removed from all BSPs but it was not added to stm32_periph.c