### PR TITLE
hw/mcu/dialog: Split DCDC startup into 2 phases

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_prail.h
@@ -31,6 +31,11 @@ void da1469x_prail_initialize(void);
 #if MYNEWT_VAL(MCU_DCDC_ENABLE)
 
 /**
+ * Initialize DCDC
+ */
+void da1469x_prail_dcdc_initialize(void);
+
+/**
  * Enable DCDC
  */
 void da1469x_prail_dcdc_enable(void);

--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -108,7 +108,7 @@ da1469x_prail_configure_1v4(void)
 
 #if MYNEWT_VAL(MCU_DCDC_ENABLE)
 void
-da1469x_prail_dcdc_enable(void)
+da1469x_prail_dcdc_initialize(void)
 {
     DCDC->DCDC_V18_REG |= DCDC_DCDC_V18_REG_DCDC_V18_ENABLE_HV_Msk;
     DCDC->DCDC_V18_REG &= ~DCDC_DCDC_V18_REG_DCDC_V18_ENABLE_LV_Msk;
@@ -121,7 +121,12 @@ da1469x_prail_dcdc_enable(void)
 
     DCDC->DCDC_V14_REG |= DCDC_DCDC_VDD_REG_DCDC_VDD_ENABLE_HV_Msk;
     DCDC->DCDC_V14_REG |= DCDC_DCDC_VDD_REG_DCDC_VDD_ENABLE_LV_Msk;
+}
 
+void
+da1469x_prail_dcdc_enable(void)
+{
+    /* Retain current DCDC configuration, it needs to be restored after wakeup */
     da1469x_retreg_init(g_mcu_dcdc_config, ARRAY_SIZE(g_mcu_dcdc_config));
     da1469x_retreg_assign(&g_mcu_dcdc_config[0], &DCDC->DCDC_V18_REG);
     da1469x_retreg_assign(&g_mcu_dcdc_config[1], &DCDC->DCDC_V18P_REG);

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -23,6 +23,7 @@
 #include "mcu/da1469x_lpclk.h"
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
+#include "mcu/da1469x_prail.h"
 #include "hal/hal_system.h"
 #include "os/os_cputime.h"
 
@@ -33,6 +34,10 @@ static enum hal_reset_reason g_hal_reset_reason;
 void
 hal_system_init(void)
 {
+#if MYNEWT_VAL(MCU_DCDC_ENABLE)
+    da1469x_prail_dcdc_enable();
+#endif
+
     /*
      * RESET_STAT_REG has to be cleared to allow HW set bits during next reset
      * so we should read it now and keep result for application to check at any

--- a/hw/mcu/dialog/da1469x/src/system_da1469x.c
+++ b/hw/mcu/dialog/da1469x/src/system_da1469x.c
@@ -127,7 +127,7 @@ SystemInit(void)
     /* Initialize and configure power rails */
     da1469x_prail_initialize();
 #if MYNEWT_VAL(MCU_DCDC_ENABLE)
-    da1469x_prail_dcdc_enable();
+    da1469x_prail_dcdc_initialize();
 #endif
 
     /* Latch all pins. We will unlatch them when initialized to do something. */


### PR DESCRIPTION
Currently DCDC configuration is hardcoded and it's not really possible
to change it in BSP. This patch makes it easier by splitting DCDC
startup into 2 phases: initialization and enabling.

Initialization is done in SystemInit and it only configures registers.
DCDC is then enabled in hal_system_init. This allows to inject extra
configuration in BSP startup code by modifying DCDC registers between
both calls and proper configuration will be retained on wakeup as
expected.