### PR TITLE
NRF52, Re-added TASKS_RESUME in hal_i2c_master_write

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_i2c.c
@@ -514,6 +514,7 @@ hal_i2c_master_write(uint8_t i2c_num, struct hal_i2c_master_data *pdata,
     regs->SHORTS = 0;
 
     hal_i2c_trigger_start(regs, &regs->TASKS_STARTTX);
+    regs->TASKS_RESUME = 1;
 
     start = os_time_get();
     for (i = 0; i < pdata->len; i++) {


### PR DESCRIPTION
In mynewt_1_5 setting regs->TASKS_STARTTX was followed by setting regs->TASKS_RESUME in hal_i2c_master_write. This was removed in mynewt_1_6 resulting in rare but persistent hangs in the i2c master. I.e. once the hang was triggered no future i2c transactions could be performed. Not even disabling and reenabling the driver helped.

This change adds setting regs->TASKS_RESUME back. No hangs have been observed after this change.