### PR TITLE
fs/fatfs: Fix file size reading

### DIFF
--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -349,11 +349,11 @@ fatfs_getpos(const struct fs_file *fs_file)
 static int
 fatfs_file_len(const struct fs_file *fs_file, uint32_t *out_len)
 {
-    uint32_t offset;
     FIL *file = ((struct fatfs_file *) fs_file)->file;
 
-    offset = (uint32_t) f_size(file);
-    return offset;
+    *out_len = (uint32_t) f_size(file);
+
+    return FS_EOK;
 }
 
 static int


### PR DESCRIPTION
fatfs_file_len() function was returning file size instead
of error code while actual buffer for file size was not touched.