### PR TITLE
fs: Add file flush functionality

### DIFF
--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -38,6 +38,7 @@ static int fatfs_close(struct fs_file *fs_file);
 static int fatfs_read(struct fs_file *fs_file, uint32_t len, void *out_data,
   uint32_t *out_len);
 static int fatfs_write(struct fs_file *fs_file, const void *data, int len);
+static int fatfs_flush(struct fs_file *fs_file);
 static int fatfs_seek(struct fs_file *fs_file, uint32_t offset);
 static uint32_t fatfs_getpos(const struct fs_file *fs_file);
 static int fatfs_file_len(const struct fs_file *fs_file, uint32_t *out_len);
@@ -79,6 +80,7 @@ static struct fs_ops fatfs_ops = {
     .f_close = fatfs_close,
     .f_read = fatfs_read,
     .f_write = fatfs_write,
+    .f_flush = fatfs_flush,
 
     .f_seek = fatfs_seek,
     .f_getpos = fatfs_getpos,
@@ -380,6 +382,17 @@ fatfs_write(struct fs_file *fs_file, const void *data, int len)
     if (len != out_len) {
         return FS_EFULL;
     }
+    return fatfs_to_vfs_error(res);
+}
+
+static int
+fatfs_flush(struct fs_file *fs_file)
+{
+    FRESULT res;
+    FIL *file = ((struct fatfs_file *)fs_file)->file;
+
+    res = f_sync(file);
+
     return fatfs_to_vfs_error(res);
 }
 

--- a/fs/fs/include/fs/fs.h
+++ b/fs/fs/include/fs/fs.h
@@ -52,6 +52,7 @@ int fs_closedir(struct fs_dir *);
 int fs_dirent_name(const struct fs_dirent *, size_t max_len,
   char *out_name, uint8_t *out_name_len);
 int fs_dirent_is_dir(const struct fs_dirent *);
+int fs_flush(struct fs_file *);
 
 /**
  * File access flags.

--- a/fs/fs/include/fs/fs_if.h
+++ b/fs/fs/include/fs/fs_if.h
@@ -36,6 +36,7 @@ struct fs_ops {
     int (*f_read)(struct fs_file *file, uint32_t len, void *out_data,
       uint32_t *out_len);
     int (*f_write)(struct fs_file *file, const void *data, int len);
+    int (*f_flush)(struct fs_file *file);
 
     int (*f_seek)(struct fs_file *file, uint32_t offset);
     uint32_t (*f_getpos)(const struct fs_file *file);

--- a/fs/fs/src/fs_file.c
+++ b/fs/fs/src/fs_file.c
@@ -52,6 +52,12 @@ fake_write(struct fs_file *file, const void *data, int len)
 }
 
 static int
+fake_flush(struct fs_file *file)
+{
+    return FS_EUNINIT;
+}
+
+static int
 fake_seek(struct fs_file *file, uint32_t offset)
 {
     return FS_EUNINIT;
@@ -122,6 +128,7 @@ struct fs_ops not_initialized_ops = {
     .f_close         = &fake_close,
     .f_read          = &fake_read,
     .f_write         = &fake_write,
+    .f_flush         = &fake_flush,
     .f_seek          = &fake_seek,
     .f_getpos        = &fake_getpos,
     .f_filelen       = &fake_filelen,
@@ -233,4 +240,11 @@ fs_unlink(const char *filename)
 {
     struct fs_ops *fops = fops_from_filename(filename);
     return fops->f_unlink(filename);
+}
+
+int
+fs_flush(struct fs_file *file)
+{
+    struct fs_ops *fops = fops_from_file(file);
+    return fops->f_flush(file);
 }

--- a/fs/nffs/src/nffs.c
+++ b/fs/nffs/src/nffs.c
@@ -63,6 +63,7 @@ static int nffs_close(struct fs_file *fs_file);
 static int nffs_read(struct fs_file *fs_file, uint32_t len, void *out_data,
   uint32_t *out_len);
 static int nffs_write(struct fs_file *fs_file, const void *data, int len);
+static int nffs_flush(struct fs_file *fs_file);
 static int nffs_seek(struct fs_file *fs_file, uint32_t offset);
 static uint32_t nffs_getpos(const struct fs_file *fs_file);
 static int nffs_file_len(const struct fs_file *fs_file, uint32_t *out_len);
@@ -81,6 +82,7 @@ struct fs_ops nffs_ops = {
     .f_close = nffs_close,
     .f_read = nffs_read,
     .f_write = nffs_write,
+    .f_flush = nffs_flush,
 
     .f_seek = nffs_seek,
     .f_getpos = nffs_getpos,
@@ -239,6 +241,23 @@ nffs_close(struct fs_file *fs_file)
     nffs_unlock();
 
     return rc;
+}
+
+/**
+ * NFFS flushes file content to flash
+ *
+ * @param file              The file handle to flush.
+ *
+ * @return                  0
+ */
+static int
+nffs_flush(struct fs_file *fs_file)
+{
+    /*
+     * TODO: Check if file flush implementation is needed.
+     * For now just return success.
+     */
+    return 0;
 }
 
 /**


### PR DESCRIPTION
This adds possibility to flush file content to storage
if file system can do this.

This is specially needed in case FAT is used that as such has this functionality.

When logging to file system will be implemented and used with FAT is would be nice to be able to write logs to storage without closing file.