### PR TITLE
Fix json decoding of empty array

### DIFF
--- a/encoding/json/src/json_decode.c
+++ b/encoding/json/src/json_decode.c
@@ -526,6 +526,7 @@ json_read_array(struct json_buffer *jb, const struct json_array_t *arr)
     json_skip_ws(jb);
 
     if (json_peek(jb) == ']') {
+        jb->jb_read_next(jb);
         goto breakout;
     }
 


### PR DESCRIPTION
Without the fix, decoding an empty array leads to JSON_ERR_BADTRAIL.
When peek is "positive", the read cursor needs to be forwarded to discard the closing "]".
