### PR TITLE
adc_nrf52: Fix out-of-bound array access

### DIFF
--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -295,7 +295,7 @@ nrf52_adc_configure_channel(struct adc_dev *dev, uint8_t cnum, void *cfgdata)
     uint16_t refmv;
     nrf_saadc_resolution_t res;
 
-    if (cnum > SAADC_CH_NUM) {
+    if (cnum >= SAADC_CH_NUM) {
         return OS_EINVAL;
     }
 


### PR DESCRIPTION
SAADC_CH_NUM defines maximum number of channels and is used as index
for accessing varous arrays of SAADC_CH_NUM elements.