### PR TITLE
add include of bsp_defs.h so that a BSP can override defines (for exa…

### DIFF
--- a/kernel/os/src/os.c
+++ b/kernel/os/src/os.c
@@ -31,6 +31,9 @@
 #include "rtt/SEGGER_RTT.h"
 #endif
 
+/* Include BSP header to allow it to override defines if required */
+#include "bsp/bsp_defs.h"
+
 /**
  * @defgroup OSKernel Operating System Kernel
  * @brief This section contains documentation for the core operating system kernel


### PR DESCRIPTION
The bsp_defs.h in a specific BSP can redefine the idle stack size without changing the core of mynewt
