### PR TITLE
kernel/arch: Add option to use BASEPRI for critical section

### DIFF
--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -128,26 +128,41 @@ os_arch_save_sr(void)
 {
     uint32_t isr_ctx;
 
-    isr_ctx = __get_PRIMASK();
+#if MCU_CRITICAL_BASEPRI
+    isr_ctx = __get_BASEPRI();
+    __set_BASEPRI((MCU_CRITICAL_BASEPRI) << (8 - __NVIC_PRIO_BITS));
+#else
+    isr_ctx = __get_PRIMASK() & 1;
     __disable_irq();
-    return (isr_ctx & 1);
+#endif
+
+    return isr_ctx;
 }
 
 void
 os_arch_restore_sr(os_sr_t isr_ctx)
 {
+#if MCU_CRITICAL_BASEPRI
+    __set_BASEPRI(isr_ctx);
+#else
     if (!isr_ctx) {
         __enable_irq();
     }
+#endif
 }
 
 int
 os_arch_in_critical(void)
 {
-    uint32_t isr_ctx;
+    int ret;
 
-    isr_ctx = __get_PRIMASK();
-    return (isr_ctx & 1);
+#if MCU_CRITICAL_BASEPRI
+    ret = __get_BASEPRI() > 0;
+#else
+    ret = __get_PRIMASK() & 1;
+#endif
+
+    return ret;
 }
 
 static void

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -128,26 +128,41 @@ os_arch_save_sr(void)
 {
     uint32_t isr_ctx;
 
-    isr_ctx = __get_PRIMASK();
+#if MCU_CRITICAL_BASEPRI
+    isr_ctx = __get_BASEPRI();
+    __set_BASEPRI((MCU_CRITICAL_BASEPRI) << (8 - __NVIC_PRIO_BITS));
+#else
+    isr_ctx = __get_PRIMASK() & 1;
     __disable_irq();
-    return (isr_ctx & 1);
+#endif
+
+    return isr_ctx;
 }
 
 void
 os_arch_restore_sr(os_sr_t isr_ctx)
 {
+#if MCU_CRITICAL_BASEPRI
+    __set_BASEPRI(isr_ctx);
+#else
     if (!isr_ctx) {
         __enable_irq();
     }
+#endif
 }
 
 int
 os_arch_in_critical(void)
 {
-    uint32_t isr_ctx;
+    int ret;
 
-    isr_ctx = __get_PRIMASK();
-    return (isr_ctx & 1);
+#if MCU_CRITICAL_BASEPRI
+    ret = __get_BASEPRI() > 0;
+#else
+    ret = __get_PRIMASK() & 1;
+#endif
+
+    return ret;
 }
 
 static void

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -128,26 +128,41 @@ os_arch_save_sr(void)
 {
     uint32_t isr_ctx;
 
-    isr_ctx = __get_PRIMASK();
+#if MCU_CRITICAL_BASEPRI
+    isr_ctx = __get_BASEPRI();
+    __set_BASEPRI((MCU_CRITICAL_BASEPRI) << (8 - __NVIC_PRIO_BITS));
+#else
+    isr_ctx = __get_PRIMASK() & 1;
     __disable_irq();
-    return (isr_ctx & 1);
+#endif
+
+    return isr_ctx;
 }
 
 void
 os_arch_restore_sr(os_sr_t isr_ctx)
 {
+#if MCU_CRITICAL_BASEPRI
+    __set_BASEPRI(isr_ctx);
+#else
     if (!isr_ctx) {
         __enable_irq();
     }
+#endif
 }
 
 int
 os_arch_in_critical(void)
 {
-    uint32_t isr_ctx;
+    int ret;
 
-    isr_ctx = __get_PRIMASK();
-    return (isr_ctx & 1);
+#if MCU_CRITICAL_BASEPRI
+    ret = __get_BASEPRI() > 0;
+#else
+    ret = __get_PRIMASK() & 1;
+#endif
+
+    return ret;
 }
 
 static void


### PR DESCRIPTION
Using BASEPRI instead of PRIMASK may be beneficial if there is some interrupt in MCU which requires low latency thus preferably it has highest priority and is always enabled. For example, MCU with integrated BLE Core may have interrupt(s) that we need to handle in almost real time to switch between different modes. If there is no need to interact with OS in interrupt handler (as this would break critical sections) it's safe to keep this interrupt always enabled and have minimal latency so MCU code can take advantage of BASEPRI here.