### PR TITLE
dialog/da1469x: Fix array pointer de-referencing bug

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_pd.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_pd.c
@@ -96,7 +96,7 @@ da1469x_pd_apply_trimv(uint8_t pd)
     }
 
     for (idx = 0; idx < pdd->trimv_count; idx++) {
-        reg = &pdd->trimv_words[idx * 2];
+        reg = (uint32_t *) pdd->trimv_words[idx * 2];
         val = pdd->trimv_words[idx * 2 + 1];
         *reg = val;
     }


### PR DESCRIPTION
Register trim values from OTP were not being applied. Upon inspection it
was found that da1469x_pd_apply_trimv() was improperly assigning 'reg' to the
address of 'trimv_words[idx *2]'.

With this fix the OTP register values appear to be properly applied.