### PR TITLE
da1469x/hal_flash: Fix write boundaries

### DIFF
--- a/hw/mcu/dialog/da14699/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da14699/include/mcu/mcu.h
@@ -145,6 +145,7 @@ void mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func);
 void mcu_gpio_enter_sleep(void);
 void mcu_gpio_exit_sleep(void);
 
+#define MCU_MEM_QSPIF_M_END_REMAP_ADDRESS (0x800000)
 #define MCU_MEM_QSPIF_M_START_ADDRESS   (0x16000000)
 #define MCU_MEM_QSPIF_M_END_ADDRESS     (0x18000000)
 #define MCU_MEM_SYSRAM_START_ADDRESS    (0x20000000)

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -323,6 +323,22 @@ da1469x_hff_read(const struct hal_flash *dev, uint32_t address, void *dst,
     return 0;
 }
 
+static bool
+da1469x_hff_in_flash_addr_space(const void *src)
+{
+    /*
+     * Due to the remap specified in the datasheet, 0->0x80000 (8 MBytes) are
+     * remapped, hence that needs to be considered as well.
+     */
+    if ((((uint32_t)src < MCU_MEM_QSPIF_M_START_ADDRESS)       &&
+         ((uint32_t)src >= MCU_MEM_QSPIF_M_END_REMAP_ADDRESS)) ||
+         ((uint32_t)src >= MCU_MEM_QSPIF_M_END_ADDRESS)) {
+        return false;
+    }
+
+    return true;
+}
+
 static int
 da1469x_hff_write(const struct hal_flash *dev, uint32_t address,
                   const void *src, uint32_t num_bytes)
@@ -330,12 +346,10 @@ da1469x_hff_write(const struct hal_flash *dev, uint32_t address,
     uint8_t buf[ MYNEWT_VAL(QSPI_FLASH_READ_BUFFER_SIZE) ];
     uint32_t chunk_len;
 
-    /*
-     * We can write directly if 'src' is outside flash memory, otherwise we
+    /* We can write directly if 'src' is outside flash memory, otherwise we
      * need to read data to RAM first and then write to flash.
      */
-    if (((uint32_t)src < MCU_MEM_QSPIF_M_START_ADDRESS) ||
-        ((uint32_t)src >= MCU_MEM_QSPIF_M_END_ADDRESS)) {
+    if (da1469x_hff_in_flash_addr_space(src) == false) {
         return da1469x_qspi_write(dev, address, src, num_bytes);
     }
 


### PR DESCRIPTION
- Write boundaries in the hal flash write callback were partially
  correct, 0->0x80000 address remap also needs to be considered as per the datasheet.