### PR TITLE
BSP for Adafruit Feather STM32F405 Express

### DIFF
--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405.ld
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F405 when running from flash and using the bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08020000, LENGTH = 256K /* First image slot. */
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.cmd
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.sh
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+#
+. $CORE_PATH/hw/scripts/jlink.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+
+JLINK_DEV="STM32F405RG"
+
+jlink_debug

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.sh
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.sh
@@ -27,10 +27,9 @@
 #  - RESET set if target should be reset when attaching
 #  - NO_GDB set if we should not start gdb to debug
 #
-. $CORE_PATH/hw/scripts/jlink.sh
+
+. $CORE_PATH/hw/scripts/stlink.sh
 
 FILE_NAME=$BIN_BASENAME.elf
 
-JLINK_DEV="STM32F405RG"
-
-jlink_debug
+stlink_debug

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.cmd
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.cmd
@@ -1,0 +1,22 @@
+@rem
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem  http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+@rem
+
+@rem Execute a shell with a script of the same name and .sh extension
+
+@bash "%~dp0%~n0.sh"

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.sh
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/jlink.sh
+
+if [ "$MFG_IMAGE" ]; then
+    FLASH_OFFSET=0x0
+fi
+
+JLINK_DEV="STM32F405RG"
+
+common_file_to_load
+jlink_load

--- a/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.sh
+++ b/hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.sh
@@ -57,13 +57,11 @@
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
 
-. $CORE_PATH/hw/scripts/jlink.sh
+. $CORE_PATH/hw/scripts/stlink.sh
 
 if [ "$MFG_IMAGE" ]; then
-    FLASH_OFFSET=0x0
+    FLASH_OFFSET=0x08000000
 fi
 
-JLINK_DEV="STM32F405RG"
-
 common_file_to_load
-jlink_load
+stlink_load

--- a/hw/bsp/ada_feather_stm32f405/boot-ada_feather_stm32f405.ld
+++ b/hw/bsp/ada_feather_stm32f405/boot-ada_feather_stm32f405.ld
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 32K
+  CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/ada_feather_stm32f405/bsp.yml
+++ b/hw/bsp/ada_feather_stm32f405/bsp.yml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.name: "Adafruit Feather STM32F405"
+bsp.url: https://www.adafruit.com/product/4382
+bsp.maker: "Adafruit"
+bsp.arch: cortex_m4
+bsp.compiler: compiler/arm-none-eabi-m4
+bsp.linkerscript:
+    - "hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/ada_feather_stm32f405/boot-ada_feather_stm32f405.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx/stm32f407.ld"
+bsp.downloadscript: "hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.sh"
+bsp.debugscript: "hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.sh"
+bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_download.cmd"
+bsp.debugscript.WINDOWS.OVERWRITE: "hw/bsp/ada_feather_stm32f405/ada_feather_stm32f405_debug.cmd"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x08000000
+            size: 32kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x08020000
+            size: 256kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x08060000
+            size: 256kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x080e0000
+            size: 128kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x08008000
+            size: 32kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x080a0000
+            size: 256kB

--- a/hw/bsp/ada_feather_stm32f405/include/bsp/bsp.h
+++ b/hw/bsp/ada_feather_stm32f405/include/bsp/bsp.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+#include <mcu/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stackos sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+#define sec_bss_nz_core __attribute__((section(".bss.core.nz")))
+
+/* More convenient section placement macros. */
+#define bssnz_t         sec_bss_nz_core
+
+extern uint8_t _ram_start;
+extern uint8_t _ccram_start;
+
+#define RAM_SIZE        (128 * 1024)
+#define CCRAM_SIZE      (64 * 1024)
+
+/* LED pins */
+#define LED_BLINK_PIN   MCU_GPIO_PORTC(1)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
@@ -1,0 +1,434 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.2.4
+  * @date    06-May-2016
+  * @brief   HAL configuration file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_HAL_CONF_H
+#define __STM32F4xx_HAL_CONF_H
+
+#include <syscfg/syscfg.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+#if 0
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_CAN_MODULE_ENABLED
+#define HAL_CRC_MODULE_ENABLED
+#define HAL_CRYP_MODULE_ENABLED
+#define HAL_DAC_MODULE_ENABLED
+#define HAL_DCMI_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+/* #define HAL_DMA2D_MODULE_ENABLED */
+#define HAL_ETH_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_NAND_MODULE_ENABLED
+#define HAL_NOR_MODULE_ENABLED
+#define HAL_PCCARD_MODULE_ENABLED
+#define HAL_SRAM_MODULE_ENABLED
+/* #define HAL_SDRAM_MODULE_ENABLED */
+#define HAL_HASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_LTDC_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RTC_MODULE_ENABLED
+/* #define HAL_SAI_MODULE_ENABLED */
+#define HAL_SD_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+#define HAL_IRDA_MODULE_ENABLED
+#define HAL_SMARTCARD_MODULE_ENABLED
+#define HAL_WWDG_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
+#define HAL_HCD_MODULE_ENABLED
+#else
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RNG_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#endif
+
+/* ########################## HSE/HSI Values adaptation ##################### */
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE    ((uint32_t)12000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE  ((uint32_t)32000)
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  */
+#if !defined  (LSE_VALUE)
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
+#endif /* LSE_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for I2S peripheral
+  *        This value is used by the I2S HAL module to compute the I2S clock source
+  *        frequency, this source is inserted directly through I2S_CKIN pad.
+  */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)12288000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0x0F) /*!< tick interrupt priority */
+#define  USE_RTOS                     0
+#define  PREFETCH_ENABLE              MYNEWT_VAL(STM32_FLASH_PREFETCH_ENABLE)
+#define  INSTRUCTION_CACHE_ENABLE     MYNEWT_VAL(STM32_INSTRUCTION_CACHE_ENABLE)
+#define  DATA_CACHE_ENABLE            MYNEWT_VAL(STM32_DATA_CACHE_ENABLE)
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+/* ################## Ethernet peripheral configuration ##################### */
+
+/* Section 1 : Ethernet peripheral configuration */
+
+/* MAC ADDRESS: MAC_ADDR0:MAC_ADDR1:MAC_ADDR2:MAC_ADDR3:MAC_ADDR4:MAC_ADDR5 */
+#define MAC_ADDR0   2
+#define MAC_ADDR1   0
+#define MAC_ADDR2   0
+#define MAC_ADDR3   0
+#define MAC_ADDR4   0
+#define MAC_ADDR5   0
+
+/* Definition of the Ethernet driver buffers size and count */
+#define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
+#define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
+#define ETH_RXBUFNB                    ((uint32_t)4)       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
+#define ETH_TXBUFNB                    ((uint32_t)4)       /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+/* Section 2: PHY configuration section */
+
+/* DP83848 PHY Address*/
+#define DP83848_PHY_ADDRESS             0x01
+/* PHY Reset delay these values are based on a 1 ms Systick interrupt*/
+#define PHY_RESET_DELAY                 ((uint32_t)0x000000FF)
+/* PHY Configuration delay */
+#define PHY_CONFIG_DELAY                ((uint32_t)0x00000FFF)
+
+#define PHY_READ_TO                     ((uint32_t)0x0000FFFF)
+#define PHY_WRITE_TO                    ((uint32_t)0x0000FFFF)
+
+/* Section 3: Common PHY Registers */
+
+#define PHY_BCR                         ((uint16_t)0x00)    /*!< Transceiver Basic Control Register   */
+#define PHY_BSR                         ((uint16_t)0x01)    /*!< Transceiver Basic Status Register    */
+
+#define PHY_RESET                       ((uint16_t)0x8000)  /*!< PHY Reset */
+#define PHY_LOOPBACK                    ((uint16_t)0x4000)  /*!< Select loop-back mode */
+#define PHY_FULLDUPLEX_100M             ((uint16_t)0x2100)  /*!< Set the full-duplex mode at 100 Mb/s */
+#define PHY_HALFDUPLEX_100M             ((uint16_t)0x2000)  /*!< Set the half-duplex mode at 100 Mb/s */
+#define PHY_FULLDUPLEX_10M              ((uint16_t)0x0100)  /*!< Set the full-duplex mode at 10 Mb/s  */
+#define PHY_HALFDUPLEX_10M              ((uint16_t)0x0000)  /*!< Set the half-duplex mode at 10 Mb/s  */
+#define PHY_AUTONEGOTIATION             ((uint16_t)0x1000)  /*!< Enable auto-negotiation function     */
+#define PHY_RESTART_AUTONEGOTIATION     ((uint16_t)0x0200)  /*!< Restart auto-negotiation function    */
+#define PHY_POWERDOWN                   ((uint16_t)0x0800)  /*!< Select the power down mode           */
+#define PHY_ISOLATE                     ((uint16_t)0x0400)  /*!< Isolate PHY from MII                 */
+
+#define PHY_AUTONEGO_COMPLETE           ((uint16_t)0x0020)  /*!< Auto-Negotiation process completed   */
+#define PHY_LINKED_STATUS               ((uint16_t)0x0004)  /*!< Valid link established               */
+#define PHY_JABBER_DETECTION            ((uint16_t)0x0002)  /*!< Jabber condition detected            */
+
+/* Section 4: Extended PHY Registers */
+
+#define PHY_SR                          ((uint16_t)0x10)    /*!< PHY status register Offset                      */
+#define PHY_MICR                        ((uint16_t)0x11)    /*!< MII Interrupt Control Register                  */
+#define PHY_MISR                        ((uint16_t)0x12)    /*!< MII Interrupt Status and Misc. Control Register */
+
+#define PHY_LINK_STATUS                 ((uint16_t)0x0001)  /*!< PHY Link mask                                   */
+#define PHY_SPEED_STATUS                ((uint16_t)0x0002)  /*!< PHY Speed mask                                  */
+#define PHY_DUPLEX_STATUS               ((uint16_t)0x0004)  /*!< PHY Duplex mask                                 */
+
+#define PHY_MICR_INT_EN                 ((uint16_t)0x0002)  /*!< PHY Enable interrupts                           */
+#define PHY_MICR_INT_OE                 ((uint16_t)0x0001)  /*!< PHY Enable output interrupt events              */
+
+#define PHY_MISR_LINK_INT_EN            ((uint16_t)0x0020U)  /*!< Enable Interrupt on change of link status       */
+#define PHY_LINK_INTERRUPT              ((uint16_t)0x2000U)  /*!< PHY link status interrupt mask                  */
+
+/* ################## SPI peripheral configuration ########################## */
+
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+* Activated: CRC code is present inside driver
+* Deactivated: CRC code cleaned from driver
+*/
+
+#define USE_SPI_CRC                     0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32f4xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32f4xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32f4xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32f4xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32f4xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_CAN_MODULE_ENABLED
+  #include "stm32f4xx_hal_can.h"
+#endif /* HAL_CAN_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32f4xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32f4xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DMA2D_MODULE_ENABLED
+  #include "stm32f4xx_hal_dma2d.h"
+#endif /* HAL_DMA2D_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32f4xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_DCMI_MODULE_ENABLED
+  #include "stm32f4xx_hal_dcmi.h"
+#endif /* HAL_DCMI_MODULE_ENABLED */
+
+#ifdef HAL_ETH_MODULE_ENABLED
+  #include "stm32f4xx_hal_eth.h"
+#endif /* HAL_ETH_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32f4xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_SRAM_MODULE_ENABLED
+  #include "stm32f4xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+  #include "stm32f4xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+  #include "stm32f4xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_PCCARD_MODULE_ENABLED
+  #include "stm32f4xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */
+
+#ifdef HAL_SDRAM_MODULE_ENABLED
+  #include "stm32f4xx_hal_sdram.h"
+#endif /* HAL_SDRAM_MODULE_ENABLED */
+
+#ifdef HAL_HASH_MODULE_ENABLED
+ #include "stm32f4xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32f4xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32f4xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32f4xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LTDC_MODULE_ENABLED
+ #include "stm32f4xx_hal_ltdc.h"
+#endif /* HAL_LTDC_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32f4xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32f4xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32f4xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+ #include "stm32f4xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+ #include "stm32f4xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32f4xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32f4xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32f4xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32f4xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32f4xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32f4xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32f4xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32f4xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+ #include "stm32f4xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F4xx_HAL_CONF_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
@@ -102,6 +102,8 @@
 #define HAL_RNG_MODULE_ENABLED
 #define HAL_SPI_MODULE_ENABLED
 #define HAL_TIM_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
 #define HAL_CORTEX_MODULE_ENABLED
 #endif
 
@@ -116,7 +118,7 @@
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for HSE start up, in ms */
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**

--- a/hw/bsp/ada_feather_stm32f405/pkg.yml
+++ b/hw/bsp/ada_feather_stm32f405/pkg.yml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bsp/ada_feather_stm32f405
+pkg.type: bsp
+pkg.description: BSP definition for the Adafruit Feather STM32F405 board.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - Adafruit
+    - Feather
+    - stm32
+    - f405
+
+pkg.cflags:
+    # STM SDK files require these defines.
+    - '-DSTM32F405xx'
+
+pkg.cflags.HARDFLOAT:
+    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
+    - "@apache-mynewt-core/libc/baselibc"

--- a/hw/bsp/ada_feather_stm32f405/run_from_flash.ld
+++ b/hw/bsp/ada_feather_stm32f405/run_from_flash.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F405 when running from flash without bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08000000, LENGTH = 1024K
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* No image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/ada_feather_stm32f405/run_from_loader.ld
+++ b/hw/bsp/ada_feather_stm32f405/run_from_loader.ld
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F405 when running from flash and using the bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) :  ORIGIN = 0x08020000, LENGTH = 256K /* First image slot. */
+  CCM (rwx) :   ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) :   ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/ada_feather_stm32f405/run_from_sram.ld
+++ b/hw/bsp/ada_feather_stm32f405/run_from_sram.ld
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32F405 when running code from SRAM */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+  CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __coredata_start__
+ *   __coredata_end__
+ *   __corebss_start__
+ *   __corebss_end__
+ *   __ecoredata
+ *   __ecorebss
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    __text = .;
+
+    .text :
+    {
+        __vector_tbl_reloc__ = .;
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > RAM
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > RAM
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > RAM
+
+    __exidx_end = .;
+
+    . = ALIGN(8);
+    __etext = .;
+
+    .coredata : AT (__etext)
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(8);
+        __coredata_end__ = .;
+    } > CCM
+
+    __ecoredata = __etext + SIZEOF(.coredata);
+
+    /* This section is here so that the start of .data has the same VMA and LMA */
+    .ram_coredata (NOLOAD):
+    {
+        . = . + SIZEOF(.coredata);
+    } > RAM
+
+    .data : AT (__ecoredata)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        *(.corebss*)
+        *(.bss.core.nz)
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > CCM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    . = ALIGN(8);
+    __HeapBase = .;
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > CCM
+
+    /* Set stack top to end of CCM; stack limit is bottom of stack */
+    __StackTop = ORIGIN(CCM) + LENGTH(CCM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check for CCM overflow */
+    ASSERT(__StackLimit >= __ecorebss, "CCM overflow!")
+}
+

--- a/hw/bsp/ada_feather_stm32f405/src/arch/cortex_m4/startup_STM32F40x.s
+++ b/hw/bsp/ada_feather_stm32f405/src/arch/cortex_m4/startup_STM32F40x.s
@@ -1,0 +1,353 @@
+/* File: startup_STM32F40x.S
+ * Purpose: startup file for Cortex-M4 devices. Should use with
+ *   GCC for ARM Embedded Processors
+ * Version: V1.4
+ * Date: 09 July 2012
+ *
+ * Copyright (c) 2011, 2012, ARM Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the ARM Limited nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ARM LIMITED BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+    .syntax unified
+    .arch armv7-m
+
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 0xc00
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long    Reset_Handler         /* Reset Handler */
+    .long    NMI_Handler           /* NMI Handler */
+    .long    HardFault_Handler     /* Hard Fault Handler */
+    .long    MemManage_Handler     /* MPU Fault Handler */
+    .long    BusFault_Handler      /* Bus Fault Handler */
+    .long    UsageFault_Handler    /* Usage Fault Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    SVC_Handler           /* SVCall Handler */
+    .long    DebugMon_Handler      /* Debug Monitor Handler */
+    .long    0                     /* Reserved */
+    .long    PendSV_Handler        /* PendSV Handler */
+    .long    SysTick_Handler       /* SysTick Handler */
+
+    /* External interrupts */
+    .long     WWDG_IRQHandler               /* Window WatchDog */
+    .long     PVD_IRQHandler                /* PVD through EXTI Line detection */
+    .long     TAMP_STAMP_IRQHandler         /* Tamper and TimeStamps through the EXTI line */
+    .long     RTC_WKUP_IRQHandler           /* RTC Wakeup through the EXTI line */
+    .long     FLASH_IRQHandler              /* FLASH */
+    .long     RCC_IRQHandler                /* RCC */
+    .long     EXTI0_IRQHandler              /* EXTI Line0 */
+    .long     EXTI1_IRQHandler              /* EXTI Line1 */
+    .long     EXTI2_IRQHandler              /* EXTI Line2 */
+    .long     EXTI3_IRQHandler              /* EXTI Line3 */
+    .long     EXTI4_IRQHandler              /* EXTI Line4 */
+    .long     DMA1_Stream0_IRQHandler       /* DMA1 Stream 0 */
+    .long     DMA1_Stream1_IRQHandler       /* DMA1 Stream 1 */
+    .long     DMA1_Stream2_IRQHandler       /* DMA1 Stream 2 */
+    .long     DMA1_Stream3_IRQHandler       /* DMA1 Stream 3 */
+    .long     DMA1_Stream4_IRQHandler       /* DMA1 Stream 4 */
+    .long     DMA1_Stream5_IRQHandler       /* DMA1 Stream 5 */
+    .long     DMA1_Stream6_IRQHandler       /* DMA1 Stream 6 */
+    .long     ADC_IRQHandler                /* ADC1, ADC2 and ADC3s */
+    .long     CAN1_TX_IRQHandler            /* CAN1 TX */
+    .long     CAN1_RX0_IRQHandler           /* CAN1 RX0 */
+    .long     CAN1_RX1_IRQHandler           /* CAN1 RX1 */
+    .long     CAN1_SCE_IRQHandler           /* CAN1 SCE */
+    .long     EXTI9_5_IRQHandler            /* External Line[9:5]s */
+    .long     TIM1_BRK_TIM9_IRQHandler      /* TIM1 Break and TIM9 */
+    .long     TIM1_UP_TIM10_IRQHandler      /* TIM1 Update and TIM10 */
+    .long     TIM1_TRG_COM_TIM11_IRQHandler /* TIM1 Trigger and Commutation and TIM11 */
+    .long     TIM1_CC_IRQHandler            /* TIM1 Capture Compare */
+    .long     TIM2_IRQHandler               /* TIM2 */
+    .long     TIM3_IRQHandler               /* TIM3 */
+    .long     TIM4_IRQHandler               /* TIM4 */
+    .long     I2C1_EV_IRQHandler            /* I2C1 Event */
+    .long     I2C1_ER_IRQHandler            /* I2C1 Error */
+    .long     I2C2_EV_IRQHandler            /* I2C2 Event */
+    .long     I2C2_ER_IRQHandler            /* I2C2 Error */
+    .long     SPI1_IRQHandler               /* SPI1 */
+    .long     SPI2_IRQHandler               /* SPI2 */
+    .long     USART1_IRQHandler             /* USART1 */
+    .long     USART2_IRQHandler             /* USART2 */
+    .long     USART3_IRQHandler             /* USART3 */
+    .long     EXTI15_10_IRQHandler          /* External Line[15:10]s */
+    .long     RTC_Alarm_IRQHandler          /* RTC Alarm (A and B) through EXTI Line */
+    .long     OTG_FS_WKUP_IRQHandler        /* USB OTG FS Wakeup through EXTI line */
+    .long     TIM8_BRK_TIM12_IRQHandler     /* TIM8 Break and TIM12 */
+    .long     TIM8_UP_TIM13_IRQHandler      /* TIM8 Update and TIM13 */
+    .long     TIM8_TRG_COM_TIM14_IRQHandler /* TIM8 Trigger and Commutation and TIM14 */
+    .long     TIM8_CC_IRQHandler            /* TIM8 Capture Compare */
+    .long     DMA1_Stream7_IRQHandler       /* DMA1 Stream7 */
+    .long     FSMC_IRQHandler               /* FSMC */
+    .long     SDIO_IRQHandler               /* SDIO */
+    .long     TIM5_IRQHandler               /* TIM5 */
+    .long     SPI3_IRQHandler               /* SPI3 */
+    .long     UART4_IRQHandler              /* UART4 */
+    .long     UART5_IRQHandler              /* UART5 */
+    .long     TIM6_DAC_IRQHandler           /* TIM6 and DAC1&2 underrun errors */
+    .long     TIM7_IRQHandler               /* TIM7 */
+    .long     DMA2_Stream0_IRQHandler       /* DMA2 Stream 0 */
+    .long     DMA2_Stream1_IRQHandler       /* DMA2 Stream 1 */
+    .long     DMA2_Stream2_IRQHandler       /* DMA2 Stream 2 */
+    .long     DMA2_Stream3_IRQHandler       /* DMA2 Stream 3 */
+    .long     DMA2_Stream4_IRQHandler       /* DMA2 Stream 4 */
+    .long     ETH_IRQHandler                /* Ethernet */
+    .long     ETH_WKUP_IRQHandler           /* Ethernet Wakeup through EXTI line */
+    .long     CAN2_TX_IRQHandler            /* CAN2 TX */
+    .long     CAN2_RX0_IRQHandler           /* CAN2 RX0 */
+    .long     CAN2_RX1_IRQHandler           /* CAN2 RX1 */
+    .long     CAN2_SCE_IRQHandler           /* CAN2 SCE */
+    .long     OTG_FS_IRQHandler             /* USB OTG FS */
+    .long     DMA2_Stream5_IRQHandler       /* DMA2 Stream 5 */
+    .long     DMA2_Stream6_IRQHandler       /* DMA2 Stream 6 */
+    .long     DMA2_Stream7_IRQHandler       /* DMA2 Stream 7 */
+    .long     USART6_IRQHandler             /* USART6 */
+    .long     I2C3_EV_IRQHandler            /* I2C3 event */
+    .long     I2C3_ER_IRQHandler            /* I2C3 error */
+    .long     OTG_HS_EP1_OUT_IRQHandler     /* USB OTG HS End Point 1 Out */
+    .long     OTG_HS_EP1_IN_IRQHandler      /* USB OTG HS End Point 1 In */
+    .long     OTG_HS_WKUP_IRQHandler        /* USB OTG HS Wakeup through EXTI */
+    .long     OTG_HS_IRQHandler             /* USB OTG HS */
+    .long     DCMI_IRQHandler               /* DCMI */
+    .long     CRYP_IRQHandler               /* CRYP crypto */
+    .long     HASH_RNG_IRQHandler           /* Hash and Rng */
+    .long     FPU_IRQHandler                /* FPU */
+
+    .size    __isr_vector, . - __isr_vector
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+/* Copy data core section from flash to RAM */
+    ldr    r1, =__etext
+    ldr    r2, =__coredata_start__
+    ldr    r3, =__coredata_end__
+
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
+
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+    ldr    r1, =__ecoredata
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+.LC1:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC1
+
+/* Set the bss core section to zero */
+    mov     r0, #0
+    ldr     r1, =__corebss_start__
+    ldr     r2, =__corebss_end__
+
+.LC2:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt    .LC2
+
+    /* Set the other bss section to zero as well*/
+    ldr     r1, =__bss_start__
+    ldr     r2, =__bss_end__
+
+.LC3:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt    .LC3
+
+/* Call system initialization and startup routines */
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx     r0
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .text
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro    def_default_handler    handler_name
+    .align 1
+    .thumb_func
+    .weak    \handler_name
+    .type    \handler_name, %function
+\handler_name :
+    b    .
+    .size    \handler_name, . - \handler_name
+    .endm
+
+    def_default_handler    NMI_Handler
+    def_default_handler    HardFault_Handler
+    def_default_handler    MemManage_Handler
+    def_default_handler    BusFault_Handler
+    def_default_handler    UsageFault_Handler
+    def_default_handler    SVC_Handler
+    def_default_handler    DebugMon_Handler
+    def_default_handler    PendSV_Handler
+    def_default_handler    SysTick_Handler
+    def_default_handler    Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+
+    def_irq_default_handler     WWDG_IRQHandler
+    def_irq_default_handler     PVD_IRQHandler
+    def_irq_default_handler     TAMP_STAMP_IRQHandler
+    def_irq_default_handler     RTC_WKUP_IRQHandler
+    def_irq_default_handler     FLASH_IRQHandler
+    def_irq_default_handler     RCC_IRQHandler
+    def_irq_default_handler     EXTI0_IRQHandler
+    def_irq_default_handler     EXTI1_IRQHandler
+    def_irq_default_handler     EXTI2_IRQHandler
+    def_irq_default_handler     EXTI3_IRQHandler
+    def_irq_default_handler     EXTI4_IRQHandler
+    def_irq_default_handler     DMA1_Stream0_IRQHandler
+    def_irq_default_handler     DMA1_Stream1_IRQHandler
+    def_irq_default_handler     DMA1_Stream2_IRQHandler
+    def_irq_default_handler     DMA1_Stream3_IRQHandler
+    def_irq_default_handler     DMA1_Stream4_IRQHandler
+    def_irq_default_handler     DMA1_Stream5_IRQHandler
+    def_irq_default_handler     DMA1_Stream6_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     CAN1_TX_IRQHandler
+    def_irq_default_handler     CAN1_RX0_IRQHandler
+    def_irq_default_handler     CAN1_RX1_IRQHandler
+    def_irq_default_handler     CAN1_SCE_IRQHandler
+    def_irq_default_handler     EXTI9_5_IRQHandler
+    def_irq_default_handler     TIM1_BRK_TIM9_IRQHandler
+    def_irq_default_handler     TIM1_UP_TIM10_IRQHandler
+    def_irq_default_handler     TIM1_TRG_COM_TIM11_IRQHandler
+    def_irq_default_handler     TIM1_CC_IRQHandler
+    def_irq_default_handler     TIM2_IRQHandler
+    def_irq_default_handler     TIM3_IRQHandler
+    def_irq_default_handler     TIM4_IRQHandler
+    def_irq_default_handler     I2C1_EV_IRQHandler
+    def_irq_default_handler     I2C1_ER_IRQHandler
+    def_irq_default_handler     I2C2_EV_IRQHandler
+    def_irq_default_handler     I2C2_ER_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     SPI2_IRQHandler
+    def_irq_default_handler     USART1_IRQHandler
+    def_irq_default_handler     USART2_IRQHandler
+    def_irq_default_handler     USART3_IRQHandler
+    def_irq_default_handler     EXTI15_10_IRQHandler
+    def_irq_default_handler     RTC_Alarm_IRQHandler
+    def_irq_default_handler     OTG_FS_WKUP_IRQHandler
+    def_irq_default_handler     TIM8_BRK_TIM12_IRQHandler
+    def_irq_default_handler     TIM8_UP_TIM13_IRQHandler
+    def_irq_default_handler     TIM8_TRG_COM_TIM14_IRQHandler
+    def_irq_default_handler     TIM8_CC_IRQHandler
+    def_irq_default_handler     DMA1_Stream7_IRQHandler
+    def_irq_default_handler     FSMC_IRQHandler
+    def_irq_default_handler     SDIO_IRQHandler
+    def_irq_default_handler     TIM5_IRQHandler
+    def_irq_default_handler     SPI3_IRQHandler
+    def_irq_default_handler     UART4_IRQHandler
+    def_irq_default_handler     UART5_IRQHandler
+    def_irq_default_handler     TIM6_DAC_IRQHandler
+    def_irq_default_handler     TIM7_IRQHandler
+    def_irq_default_handler     DMA2_Stream0_IRQHandler
+    def_irq_default_handler     DMA2_Stream1_IRQHandler
+    def_irq_default_handler     DMA2_Stream2_IRQHandler
+    def_irq_default_handler     DMA2_Stream3_IRQHandler
+    def_irq_default_handler     DMA2_Stream4_IRQHandler
+    def_irq_default_handler     ETH_IRQHandler
+    def_irq_default_handler     ETH_WKUP_IRQHandler
+    def_irq_default_handler     CAN2_TX_IRQHandler
+    def_irq_default_handler     CAN2_RX0_IRQHandler
+    def_irq_default_handler     CAN2_RX1_IRQHandler
+    def_irq_default_handler     CAN2_SCE_IRQHandler
+    def_irq_default_handler     OTG_FS_IRQHandler
+    def_irq_default_handler     DMA2_Stream5_IRQHandler
+    def_irq_default_handler     DMA2_Stream6_IRQHandler
+    def_irq_default_handler     DMA2_Stream7_IRQHandler
+    def_irq_default_handler     USART6_IRQHandler
+    def_irq_default_handler     I2C3_EV_IRQHandler
+    def_irq_default_handler     I2C3_ER_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_OUT_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_IN_IRQHandler
+    def_irq_default_handler     OTG_HS_WKUP_IRQHandler
+    def_irq_default_handler     OTG_HS_IRQHandler
+    def_irq_default_handler     DCMI_IRQHandler
+    def_irq_default_handler     CRYP_IRQHandler
+    def_irq_default_handler     HASH_RNG_IRQHandler
+    def_irq_default_handler     FPU_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
+
+    .end

--- a/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+
+#include "bsp/bsp.h"
+#include "os/mynewt.h"
+
+#include <hal/hal_bsp.h>
+#include <hal/hal_flash_int.h>
+#include <hal/hal_system.h>
+
+#include "stm32f405xx.h"
+#include <stm32_common/stm32_hal.h>
+
+#if MYNEWT_VAL(ETH_0)
+#include <stm32_eth/stm32_eth.h>
+#include <stm32_eth/stm32_eth_cfg.h>
+#endif
+
+#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
+#include <pwm_stm32/pwm_stm32.h>
+#endif
+
+#if MYNEWT_VAL(ADC_0) || MYNEWT_VAL(ADC_1) || MYNEWT_VAL(ADC_2)
+#include "stm32f4xx_hal_adc.h"
+#include "adc_stm32f4/adc_stm32f4.h"
+#endif
+
+const uint32_t stm32_flash_sectors[] = {
+    0x08000000,     /* 16kB */
+    0x08004000,     /* 16kB */
+    0x08008000,     /* 16kB */
+    0x0800c000,     /* 16kB */
+    0x08010000,     /* 64kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* End of flash */
+};
+
+#define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
+        "STM32_FLASH_NUM_AREAS does not match flash sectors");
+
+#if MYNEWT_VAL(ADC_0) || MYNEWT_VAL(ADC_1) || MYNEWT_VAL(ADC_2)
+/*
+ * Helper macros to build ADC data structures
+ */
+#define STM32F4_DEFAULT_DMA_HANDLE(instance, channel, parent) {           \
+        .Instance = (instance),                                           \
+        .Init.Channel = (channel),                                        \
+        .Init.Direction = DMA_PERIPH_TO_MEMORY,                           \
+        .Init.PeriphInc = DMA_PINC_DISABLE,                               \
+        .Init.MemInc = DMA_MINC_ENABLE,                                   \
+        .Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD,                  \
+        .Init.MemDataAlignment = DMA_MDATAALIGN_WORD,                     \
+        .Init.Mode = DMA_CIRCULAR,                                        \
+        .Init.Priority = DMA_PRIORITY_HIGH,                               \
+        .Init.FIFOMode = DMA_FIFOMODE_DISABLE,                            \
+        .Init.FIFOThreshold = DMA_FIFO_THRESHOLD_HALFFULL,                \
+        .Init.MemBurst = DMA_MBURST_SINGLE,                               \
+        .Init.PeriphBurst = DMA_PBURST_SINGLE,                            \
+        .Parent = (parent),                                               \
+}
+
+#define ADC_INIT_HANDLE(name, instance, dma_handle)                       \
+    ADC_HandleTypeDef (name) = {                                          \
+        .Init = {                                                         \
+            .ClockPrescaler = ADC_CLOCKPRESCALER_PCLK_DIV2,               \
+            .Resolution = ADC_RESOLUTION12b,                              \
+            .DataAlign = ADC_DATAALIGN_RIGHT,                             \
+            .ScanConvMode = DISABLE,                                      \
+            .EOCSelection = DISABLE,                                      \
+            .ContinuousConvMode = ENABLE,                                 \
+            .NbrOfConversion = 1,                                         \
+            .DiscontinuousConvMode = DISABLE,                             \
+            .NbrOfDiscConversion = 0,                                     \
+            .ExternalTrigConv = ADC_SOFTWARE_START,                       \
+            .ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE,        \
+            .DMAContinuousRequests = ENABLE,                              \
+        },                                                                \
+        .Instance = (instance),                                           \
+        .NbrOfCurrentConversionRank = 0,                                  \
+        .DMA_Handle = (dma_handle),                                       \
+        .Lock = HAL_UNLOCKED,                                             \
+        .State = 0,                                                       \
+        .ErrorCode = 0,                                                   \
+    }
+#endif
+
+#if MYNEWT_VAL(ADC_0)
+ADC_HandleTypeDef adc0_handle;
+
+DMA_HandleTypeDef adc0_dma00_handle = STM32F4_DEFAULT_DMA_HANDLE(
+    DMA2_Stream0, DMA_CHANNEL_0, &adc0_handle);
+
+ADC_INIT_HANDLE(adc0_handle, ADC1, &adc0_dma00_handle);
+
+struct stm32f4_adc_dev_cfg os_bsp_adc0_cfg = {
+    .sac_chan_count = 16,
+    .sac_chans = (struct adc_chan_config [16]) {
+        [0] = { 0 },
+        [1] = { 0 },
+        [2] = { 0 },
+        [3] = { 0 },
+        [4] = { 0 },
+        [5] = { 0 },
+        [6] = { 0 },
+        [7] = { 0 },
+        [8] = { 0 },
+        [9] = { 0 },
+        [10] = {
+            .c_refmv = 3300,
+            .c_res = 12,
+            .c_configured = 1,
+            .c_cnum = ADC_CHANNEL_10,
+        },
+    },
+    .sac_adc_handle = &adc0_handle,
+};
+#endif
+
+#if MYNEWT_VAL(ADC_1)
+ADC_HandleTypeDef adc1_handle;
+
+DMA_HandleTypeDef adc1_dma21_handle = STM32F4_DEFAULT_DMA_HANDLE(
+    DMA2_Stream2, DMA_CHANNEL_1, &adc1_handle);
+
+ADC_INIT_HANDLE(adc1_handle, ADC2, &adc1_dma21_handle);
+
+struct stm32f4_adc_dev_cfg os_bsp_adc1_cfg = {
+    .sac_chan_count = 16,
+    .sac_chans = (struct adc_chan_config [16]) {
+        [0] = { 0 },
+        [1] = {
+            .c_refmv = 3300,
+            .c_res = 12,
+            .c_configured = 1,
+            .c_cnum = ADC_CHANNEL_1,
+        },
+    },
+    .sac_adc_handle = &adc1_handle,
+};
+#endif
+
+#if MYNEWT_VAL(ADC_2)
+ADC_HandleTypeDef adc2_handle;
+
+DMA_HandleTypeDef adc2_dma12_handle = STM32F4_DEFAULT_DMA_HANDLE(
+    DMA2_Stream1, DMA_CHANNEL_2, &adc2_handle);
+
+ADC_INIT_HANDLE(adc2_handle, ADC3, &adc2_dma12_handle);
+
+struct stm32f4_adc_dev_cfg os_bsp_adc2_cfg = {
+    .sac_chan_count = 16,
+    .sac_chans = (struct adc_chan_config [16]) {
+        [0] = { 0 },
+        [1] = { 0 },
+        [2] = { 0 },
+        [3] = { 0 },
+        [4] = {
+            .c_refmv = 3300,
+            .c_res = 12,
+            .c_configured = 1,
+            .c_cnum = ADC_CHANNEL_4,
+        },
+    },
+    .sac_adc_handle = &adc2_handle,
+};
+#endif
+
+#if MYNEWT_VAL(UART_0)
+const struct stm32_uart_cfg os_bsp_uart0_cfg = {
+    .suc_uart = USART6,
+    .suc_rcc_reg = &RCC->APB2ENR,
+    .suc_rcc_dev = RCC_APB2ENR_USART6EN,
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+    .suc_pin_af = GPIO_AF8_USART6,
+    .suc_irqn = USART6_IRQn
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+const struct stm32_hal_i2c_cfg os_bsp_i2c0_cfg = {
+    .hic_i2c = I2C1,
+    .hic_rcc_reg = &RCC->APB1ENR,
+    .hic_rcc_dev = RCC_APB1ENR_I2C1EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C1,
+    .hic_10bit = 0,
+    .hic_speed = 100000,
+};
+#endif
+
+#if MYNEWT_VAL(ETH_0)
+const struct stm32_eth_cfg os_bsp_eth0_cfg = {
+    /*
+     * PORTA
+     *   PA1 - ETH_RMII_REF_CLK
+     *   PA2 - ETH_RMII_MDIO
+     *   PA3 - ETH_RMII_MDINT  (GPIO irq?)
+     *   PA7 - ETH_RMII_CRS_DV
+     */
+    .sec_port_mask[0] = (1 << 1) | (1 << 2) | (1 << 7),
+
+    /*
+     * PORTC
+     *   PC1 - ETH_RMII_MDC
+     *   PC4 - ETH_RMII_RXD0
+     *   PC5 - ETH_RMII_RXD1
+     */
+    .sec_port_mask[2] = (1 << 1) | (1 << 4) | (1 << 5),
+
+    /*
+     * PORTG
+     *   PG11 - ETH_RMII_TXEN
+     *   PG13 - ETH_RMII_TXD0
+     *   PG14 - ETH_RMII_TXD1
+     */
+    .sec_port_mask[6] = (1 << 11) | (1 << 13) | (1 << 14),
+    .sec_phy_type = SMSC_8710_RMII,
+    .sec_phy_irq = MCU_GPIO_PORTA(3)
+};
+#endif
+
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE
+    },
+    [1] = {
+        .hbmd_start = &_ccram_start,
+        .hbmd_size = CCRAM_SIZE
+    }
+};
+
+extern const struct hal_flash stm32_flash_dev;
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    /*
+     * Internal flash mapped to id 0.
+     */
+    if (id != 0) {
+        return NULL;
+    }
+    return &stm32_flash_dev;
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+int
+hal_bsp_power_state(int state)
+{
+    return (0);
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    /* Add any interrupt priorities configured by the bsp here */
+    return pri;
+}
+
+void
+hal_bsp_init(void)
+{
+    stm32_periph_create();
+}

--- a/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
@@ -191,15 +191,15 @@ struct stm32f4_adc_dev_cfg os_bsp_adc2_cfg = {
 
 #if MYNEWT_VAL(UART_0)
 const struct stm32_uart_cfg os_bsp_uart0_cfg = {
-    .suc_uart = USART6,
-    .suc_rcc_reg = &RCC->APB2ENR,
-    .suc_rcc_dev = RCC_APB2ENR_USART6EN,
+    .suc_uart = USART3,
+    .suc_rcc_reg = &RCC->APB1ENR,
+    .suc_rcc_dev = RCC_APB1ENR_USART3EN,
     .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
     .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
     .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
     .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
-    .suc_pin_af = GPIO_AF8_USART6,
-    .suc_irqn = USART6_IRQn
+    .suc_pin_af = GPIO_AF7_USART3,
+    .suc_irqn = USART3_IRQn
 };
 #endif
 

--- a/hw/bsp/ada_feather_stm32f405/syscfg.yml
+++ b/hw/bsp/ada_feather_stm32f405/syscfg.yml
@@ -46,14 +46,22 @@ syscfg.vals:
     STM32_FLASH_PREFETCH_ENABLE: 1
     STM32_INSTRUCTION_CACHE_ENABLE: 1
     STM32_DATA_CACHE_ENABLE: 1
+    # UART0 is on the large breakout connector, pins TX and RX.
     UART_0_PIN_TX: 'MCU_GPIO_PORTB(10)'
     UART_0_PIN_RX: 'MCU_GPIO_PORTB(11)'
     UART_0_PIN_RTS: -1
     UART_0_PIN_CTS: -1
-    SPI_0_PIN_SS: 'MCU_GPIO_PORTC(5)'
-    SPI_0_PIN_SCK: 'MCU_GPIO_PORTB(5)'
-    SPI_0_PIN_MISO: 'MCU_GPIO_PORTB(14)'
-    SPI_0_PIN_MOSI: 'MCU_GPIO_PORTB(15)'
+    # SPI0 is connected to onboard SPI Flash
+    SPI_0_PIN_SS: 'MCU_GPIO_PORTA(15)'
+    SPI_0_PIN_SCK: 'MCU_GPIO_PORTB(3)'
+    SPI_0_PIN_MISO: 'MCU_GPIO_PORTB(4)'
+    SPI_0_PIN_MOSI: 'MCU_GPIO_PORTB(5)'
+    # SPI1 is on the large breakout connector, pins A5, SCK, MO, and MI.
+    SPI_1_PIN_SS: 'MCU_GPIO_PORTC(5)'
+    SPI_1_PIN_SCK: 'MCU_GPIO_PORTB(13)'
+    SPI_1_PIN_MISO: 'MCU_GPIO_PORTB(14)'
+    SPI_1_PIN_MOSI: 'MCU_GPIO_PORTB(15)'
+    # I2C0 is on the STEMMA connector, and the small breakout connector, pins SCL and SDA.
     I2C_0_PIN_SCL: 'MCU_GPIO_PORTB(6)'
     I2C_0_PIN_SDA: 'MCU_GPIO_PORTB(7)'
     TIMER_0_TIM: 'TIM9'

--- a/hw/bsp/ada_feather_stm32f405/syscfg.yml
+++ b/hw/bsp/ada_feather_stm32f405/syscfg.yml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB.'
+        value: 1024
+
+    STM32_FLASH_NUM_AREAS:
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 12
+
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    STM32_CLOCK_VOLTAGESCALING_CONFIG: 'PWR_REGULATOR_VOLTAGE_SCALE1'
+    STM32_CLOCK_HSI: 0
+    STM32_CLOCK_HSE: 1
+    STM32_CLOCK_HSE_BYPASS: 0
+    STM32_CLOCK_PLL_PLLM: 6
+    STM32_CLOCK_PLL_PLLN: 50
+    STM32_CLOCK_PLL_PLLP: 2
+    STM32_CLOCK_PLL_PLLQ: 4
+    STM32_CLOCK_ENABLE_OVERDRIVE: 0
+    STM32_CLOCK_AHB_DIVIDER: 'RCC_SYSCLK_DIV1'
+    STM32_CLOCK_APB1_DIVIDER: 'RCC_HCLK_DIV2'
+    STM32_CLOCK_APB2_DIVIDER: 'RCC_HCLK_DIV1'
+    STM32_FLASH_LATENCY: 'FLASH_LATENCY_5'
+    STM32_FLASH_PREFETCH_ENABLE: 1
+    STM32_INSTRUCTION_CACHE_ENABLE: 1
+    STM32_DATA_CACHE_ENABLE: 1
+    UART_0_PIN_TX: 'MCU_GPIO_PORTB(10)'
+    UART_0_PIN_RX: 'MCU_GPIO_PORTB(11)'
+    UART_0_PIN_RTS: -1
+    UART_0_PIN_CTS: -1
+    SPI_0_PIN_SS: 'MCU_GPIO_PORTC(5)'
+    SPI_0_PIN_SCK: 'MCU_GPIO_PORTB(5)'
+    SPI_0_PIN_MISO: 'MCU_GPIO_PORTB(14)'
+    SPI_0_PIN_MOSI: 'MCU_GPIO_PORTB(15)'
+    I2C_0_PIN_SCL: 'MCU_GPIO_PORTB(6)'
+    I2C_0_PIN_SDA: 'MCU_GPIO_PORTB(7)'
+    TIMER_0_TIM: 'TIM9'

--- a/hw/mcu/stm/stm32f4xx/include/mcu/cmsis_nvic.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/cmsis_nvic.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#if defined(STM32F401xE) || defined(STM32F407xx)
+#if defined(STM32F401xE) || defined(STM32F407xx) || defined(STM32F405xx)
  #define MCU_NUM_PERIPH_VECTORS 82
 #elif defined(STM32F411xE)
  #define MCU_NUM_PERIPH_VECTORS 86


### PR DESCRIPTION
This PR adds support for the [Adafruit Feather STM32F405 Express](https://www.adafruit.com/product/4382).

I have tested UART, SPI, and I2C interfaces.