### PR TITLE
bsp/nucleo-f411re: Fix linker script

### DIFF
--- a/hw/bsp/nucleo-f411re/boot-nucleo-f411re.ld
+++ b/hw/bsp/nucleo-f411re/boot-nucleo-f411re.ld
@@ -20,7 +20,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 32K
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 16K
   RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 128K
 }
 


### PR DESCRIPTION
Flash area size for bootloader was different in bsp.yml and
in bootloader linker script.
When FLASH_AREA_REBOOT_LOG flash area was used bootloader area was
corrupted.