### PR TITLE
Revert "Revert "Prepare for Apache Mynewt 1.8.0 release""

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -36,6 +36,7 @@ repo.versions:
     "1.5.0": "mynewt_1_5_0_tag"
     "1.6.0": "mynewt_1_6_0_tag"
     "1.7.0": "mynewt_1_7_0_tag"
+    "1.8.0": "mynewt_1_8_0_tag"
 
     "0-latest": "1.7.0"
     "1-latest": "1.7.0"
@@ -51,6 +52,7 @@ repo.versions:
     "1.5-latest": "1.5.0"
     "1.6-latest": "1.6.0"
     "1.7-latest": "1.7.0"
+    "1.8-latest": "1.8.0"
 
 repo.newt_compatibility:
     # Allow all versions for 0.0.0.  This is a workaround to prevent a warning
@@ -64,6 +66,9 @@ repo.newt_compatibility:
     # Core 1.5.0+ requires newt 1.5.0+ (feature: transient packages)
     # Core 1.6.0+ requires newt 1.6.0+ (feature: choice)
     # Core 1.7.0+ requires newt 1.7.0+ (feature: range)
+    # Core 1.8.0+ requires newt 1.8.0+ (feature: version.yml not needed)
+    1.8.0:
+        1.8.0: good
     1.7.0:
         1.7.0: good
     1.6.0:
@@ -93,6 +98,7 @@ repo.deps:
             mynewt_1_5_0_tag: 1.0.0
             mynewt_1_6_0_tag: 1.1.0
             mynewt_1_7_0_tag: 1.2.0
+            mynewt_1_8_0_tag: 1.3.0
 
     mcuboot:
         type: github
@@ -101,6 +107,7 @@ repo.deps:
         vers:
             master: 0-dev
             mynewt_1_7_0_tag: 1.3.1
+            mynewt_1_8_0_tag: 1.5.0
 
     apache-mynewt-mcumgr:
         type: github
@@ -108,3 +115,4 @@ repo.deps:
         repo: mynewt-mcumgr
         vers:
             master: 0-dev
+            mynewt_1_8_0_tag: 0.1.0


### PR DESCRIPTION
Reverts apache/mynewt-core#2243

Tags on core should be fixed now (added non-rc tag as workaround) so we can revert this revert.