### PR TITLE
STM32 Allow reboot to bootloader

### DIFF
--- a/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
@@ -106,6 +106,8 @@ extern "C" {
  */
 #define MCU_AFIO_PIN_NONE       (0xFFFF)
 
+void stm32_start_bootloader(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32_common/src/stm32_bootloader.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_bootloader.c
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <mcu/stm32_hal.h>
+#include <mcu/mcu.h>
+
+void
+stm32_start_bootloader(void)
+{
+    const uint32_t *system_memory = (const uint32_t *)STM32_SYSTEM_MEMORY;
+    void (*system_memory_reset_handler)(void);
+
+    HAL_RCC_DeInit();
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
+#ifdef __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH
+    __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
+#endif
+
+    __set_MSP(system_memory[0]);
+
+    system_memory_reset_handler = (void (*)(void))(system_memory[1]);
+    system_memory_reset_handler();
+}

--- a/hw/mcu/stm/stm32f0xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f0xx/include/mcu/mcu.h
@@ -28,6 +28,27 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVC_IRQn
 
+#if defined(STM32F030x6) || defined(STM32F030x8) || \
+    defined(STM32F031x6) || \
+    defined(STM32F038xx) || \
+    defined(STM32F051x8) || \
+    defined(STM32F058xx)
+#define STM32_SYSTEM_MEMORY     0x1FFFEC00
+#elif defined(STM32F030xC) || \
+    defined(STM32F091xC) || \
+    defined(STM32F098xx)
+#define STM32_SYSTEM_MEMORY     0x1FFFD800
+#elif defined(STM32F042x6) || \
+    defined(STM32F048xx) || \
+    defined(STM32F070x6)
+#define STM32_SYSTEM_MEMORY     0x1FFFC400
+#elif defined(STM32F070xB) || \
+    defined(STM32F071xB) || \
+    defined(STM32F072xB) || \
+    defined(STM32F078xx)
+#define STM32_SYSTEM_MEMORY     0x1FFFC800
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f1xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/mcu.h
@@ -28,6 +28,19 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVCall_IRQn
 
+#if defined(STM32F100xB) || defined(STM32F100xE) || \
+    defined(STM32F101x6) || defined(STM32F101xB) || defined(STM32F101xE) || \
+    defined(STM32F102x6) || defined(STM32F102xB) || \
+    defined(STM32F103x6) || defined(STM32F103xB) || defined(STM32F103xE)
+#define STM32_SYSTEM_MEMORY     0x1FFFF000
+#elif defined(STM32F105xC) || \
+    defined(STM32F107xC)
+#define STM32_SYSTEM_MEMORY     0x1FFFB000
+#elif defined(STM32F101xG) || \
+    defined(STM32F103xG)
+#define STM32_SYSTEM_MEMORY     0x1FFFE000
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f3xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/mcu.h
@@ -26,6 +26,19 @@
 extern "C" {
 #endif
 
+#if defined(STM32F301x8) || \
+    defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F302xE) || \
+    defined(STM32F303xC) || defined(STM32F303xE) || defined(STM32F303x8) || \
+    defined(STM32F318xx) || \
+    defined(STM32F328xx) || \
+    defined(STM32F334x8) || \
+    defined(STM32F358xx) || \
+    defined(STM32F373xC) || \
+    defined(STM32F378xx) || \
+    defined(STM32F398xx)
+#define STM32_SYSTEM_MEMORY     0x1FFFD800
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f4xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/mcu.h
@@ -26,6 +26,27 @@
 extern "C" {
 #endif
 
+#if defined(STM32F401xC) || defined(STM32F401xE) || \
+    defined(STM32F405xx) || \
+    defined(STM32F407xx) || \
+    defined(STM32F410Cx) || defined(STM32F410Rx) || defined(STM32F410Tx) || \
+    defined(STM32F411xE) || \
+    defined(STM32F412Cx) || defined(STM32F412Rx) || defined(STM32F412Vx) || defined(STM32F412Zx) || \
+    defined(STM32F415xx) || \
+    defined(STM32F417xx) || \
+    defined(STM32F427xx) || \
+    defined(STM32F429xx) || \
+    defined(STM32F437xx) || \
+    defined(STM32F439xx) || \
+    defined(STM32F446xx) || \
+    defined(STM32F469xx) || \
+    defined(STM32F479xx)
+#define STM32_SYSTEM_MEMORY     0x1FFF0000
+#elif defined(STM32F413xx) || \
+    defined(STM32F423xx)
+#define STM32_SYSTEM_MEMORY     0x1FF00000
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32f7xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32f7xx/include/mcu/mcu.h
@@ -26,6 +26,14 @@
 extern "C" {
 #endif
 
+#if defined(STM32F722xx) || defined(STM32F723xx) || \
+    defined(STM32F732xx) || defined(STM32F733xx) || \
+    defined(STM32F745xx) || defined(STM32F746xx) || \
+    defined(STM32F756xx) || \
+    defined(STM32F767xx) || defined(STM32F769xx) || \
+    defined(STM32F777xx) || defined(STM32F779xx)
+#define STM32_SYSTEM_MEMORY     0x1FF00000
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/stm/stm32l0xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32l0xx/include/mcu/mcu.h
@@ -26,6 +26,18 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVC_IRQn
 
+#if defined(STM32L010x4) || defined(STM32L010x6) || defined(STM32L010x8) || defined(STM32L010xB) || \
+    defined(STM32L011xx) || \
+    defined(STM32L021xx) || \
+    defined(STM32L031xx) || \
+    defined(STM32L041xx) || \
+    defined(STM32L051xx) || defined(STM32L052xx) || defined(STM32L053xx) || \
+    defined(STM32L061xx) || defined(STM32L062xx) || defined(STM32L063xx) || \
+    defined(STM32L071xx) || defined(STM32L072xx) || defined(STM32L073xx) || \
+    defined(STM32L081xx) || defined(STM32L082xx) || defined(STM32L083xx)
+#define STM32_SYSTEM_MEMORY     0x1FF00000
+#endif
+
 /*
  * Defines for naming GPIOs.
  */

--- a/hw/mcu/stm/stm32l1xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32l1xx/include/mcu/mcu.h
@@ -28,6 +28,16 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVC_IRQn
 
+#if defined(STM32L100xB) || defined(STM32L100xBA) || defined(STM32L100xC) || \
+    defined(STM32L151xB) || defined(STM32L151xBA) || defined(STM32L151xC) || defined(STM32L151xCA) || \
+    defined(STM32L151xD) || defined(STM32L151xDX) || defined(STM32L151xE) || \
+    defined(STM32L152xB) || defined(STM32L152xBA) || defined(STM32L152xC) || defined(STM32L152xCA) || \
+    defined(STM32L152xD) || defined(STM32L152xDX) || defined(STM32L152xE) || \
+    defined(STM32L162xC) || defined(STM32L162xCA) || defined(STM32L162xD) || defined(STM32L162xDX) || \
+    defined(STM32L162xE)
+#define STM32_SYSTEM_MEMORY     0x1FF00000
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32l4xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32l4xx/include/mcu/mcu.h
@@ -28,6 +28,21 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVC_IRQn
 
+#if defined(STM32L412xx) || \
+    defined(STM32L422xx) || \
+    defined(STM32L431xx) || defined(STM32L432xx) || defined(STM32L433xx) || \
+    defined(STM32L442xx) || defined(STM32L443xx) || \
+    defined(STM32L451xx) || defined(STM32L452xx) || \
+    defined(STM32L462xx) || \
+    defined(STM32L471xx) || defined(STM32L475xx) || defined(STM32L476xx) || \
+    defined(STM32L485xx) || defined(STM32L486xx) || \
+    defined(STM32L496xx) || \
+    defined(STM32L4A6xx) || \
+    defined(STM32L4R5xx) || defined(STM32L4R7xx) || defined(STM32L4R9xx) || \
+    defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
+#define STM32_SYSTEM_MEMORY     0x1FFF0000
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/stm/stm32wbxx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32wbxx/include/mcu/mcu.h
@@ -28,6 +28,11 @@ extern "C" {
 
 #define SVC_IRQ_NUMBER SVC_IRQn
 
+#if defined(STM32WB50xx) || \
+    defined(STM32WB55xx)
+#define STM32_SYSTEM_MEMORY     0x1FFF0000
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
STM32 MCUs have embedded bootloader that can be activated on reset when BOOT pin(s) are in certain state.
This change allows to start bootloader from application that is running from flash, so bootloader can be activated even if BOOT pins are soldered to boot system from flash.
