### PR TITLE
bsp/native: Don't use deprecated BASELIBC_ASSERT_FILE_LINE

### DIFF
--- a/hw/bsp/native-armv7/syscfg.yml
+++ b/hw/bsp/native-armv7/syscfg.yml
@@ -25,7 +25,7 @@ syscfg.defs:
 syscfg.vals:
     # Sim isn't flash constrained, so include filename, line number, and
     # message in asserts and sysinit panic messages.
-    BASELIBC_ASSERT_FILE_LINE: 1
+    OS_CRASH_FILE_LINE: 1
     SYSINIT_PANIC_FILE_LINE: 1
     SYSINIT_PANIC_MESSAGE: 1
 

--- a/hw/bsp/native-mips/syscfg.yml
+++ b/hw/bsp/native-mips/syscfg.yml
@@ -26,7 +26,7 @@ syscfg.vals:
     OS_IDLE_TICKLESS_MS_MIN: 1
     # Sim isn't flash constrained, so include filename, line number, and
     # message in asserts and sysinit panic messages.
-    BASELIBC_ASSERT_FILE_LINE: 1
+    OS_CRASH_FILE_LINE: 1
     SYSINIT_PANIC_FILE_LINE: 1
     SYSINIT_PANIC_MESSAGE: 1
 

--- a/hw/bsp/native/syscfg.yml
+++ b/hw/bsp/native/syscfg.yml
@@ -26,7 +26,7 @@ syscfg.vals:
     OS_IDLE_TICKLESS_MS_MIN: 1
     # Sim isn't flash constrained, so include filename, line number, and
     # message in asserts and sysinit panic messages.
-    BASELIBC_ASSERT_FILE_LINE: 1
+    OS_CRASH_FILE_LINE: 1
     SYSINIT_PANIC_FILE_LINE: 1
     SYSINIT_PANIC_MESSAGE: 1
 


### PR DESCRIPTION
Use OS_CRASH_FILE_LINE instead to avoid following message:

Override of defunct settings detected:
    BASELIBC_ASSERT_FILE_LINE: Use OS_CRASH_FILE_LINE instead

Setting history (newest -> oldest):
    BASELIBC_ASSERT_FILE_LINE: [@apache-mynewt-core/hw/bsp/native:1,
                                @apache-mynewt-core/libc/baselibc:0]