### PR TITLE
docs/os/bsp: Add board support section

### DIFF
--- a/docs/os/bsp/index.rst
+++ b/docs/os/bsp/index.rst
@@ -1,0 +1,28 @@
+..
+  #
+  # Copyright 2020 Casper Meijn <casper@meijn.net>
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  #
+
+Board support
+=============
+
+This section lists some of the supported boards, their current status and 
+links to tutorial specific to the board. A list of all supported boards can
+be found in `@apache-mynewt-core/hw/bsp <https://github.com/apache/mynewt-core/tree/master/hw/bsp>`__.
+
+.. toctree::
+    :maxdepth: 1
+
+    PineTime <pinetime>

--- a/docs/os/bsp/pinetime.rst
+++ b/docs/os/bsp/pinetime.rst
@@ -1,0 +1,41 @@
+..
+  #
+  # Copyright 2020 Casper Meijn <casper@meijn.net>
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  #
+
+PineTime smartwatch
+===================
+
+This page is about the board support package for the Pine64 PineTime smartwatch. 
+You can find some general documentation at the `device wiki <https://wiki.pine64.org/index.php/PineTime>`__. 
+You could buy a dev kit in the `store <https://store.pine64.org/?product=pinetime-dev-kit>`__.
+
+.. contents::
+  :local:
+  :depth: 2
+
+Status
+~~~~~~
+
+Currently the status is: incomplete.
+
+The board support package contains the code for booting the device and the pin 
+definitions. This means you can load an application like blinky, but no 
+pheriphirals can be used. New drivers will be added in the future.
+
+Tutorials
+~~~~~~~~~
+
+-  :doc:`../../tutorials/blinky/pinetime`

--- a/docs/os/os_user_guide.rst
+++ b/docs/os/os_user_guide.rst
@@ -22,6 +22,7 @@ OS User Guide
    Test Utilities <modules/testutil/testutil>
    JSON <modules/json/json>
    Manufacturing support <modules/mfg/mfg>
+   Board support <bsp/index>
 
 This guide provides comprehensive information about Mynewt OS, the
 real-time operating system for embedded systems. It is intended both for


### PR DESCRIPTION
Add a new section to the documentation which lists the status of BSPs.
The first page is the status of the PineTime BSP.

This is part of an effort to add PineTime support to mynewt. This documents the progress of that effort.