### PR TITLE
Add SGM4056 charger driver to pinetime BSP

### DIFF
--- a/hw/bsp/pinetime/pkg.yml
+++ b/hw/bsp/pinetime/pkg.yml
@@ -35,3 +35,4 @@ pkg.deps:
     - '@apache-mynewt-core/hw/mcu/nordic/nrf52xxx'
     - '@apache-mynewt-core/kernel/os'
     - '@apache-mynewt-core/libc/baselibc'
+    - '@apache-mynewt-core/hw/drivers/chg_ctrl/sgm4056'

--- a/hw/bsp/pinetime/src/hal_bsp.c
+++ b/hw/bsp/pinetime/src/hal_bsp.c
@@ -29,6 +29,7 @@
 #include "bsp/bsp.h"
 #include "mcu/nrf52_hal.h"
 #include "mcu/nrf52_periph.h"
+#include "sgm4056/sgm4056.h"
 
 /** What memory to include in coredump. */
 static const struct hal_bsp_mem_dump dump_cfg[] = {
@@ -88,12 +89,26 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
     return cfg_pri;
 }
 
+static struct sgm4056_dev os_bsp_charger;
+static struct sgm4056_dev_config os_bsp_charger_config = {
+    .power_presence_pin = CHARGER_POWER_PRESENCE_PIN,
+    .charge_indicator_pin = CHARGER_CHARGE_PIN,
+};
+
 void
 hal_bsp_init(void)
 {
+    int rc;
+
     /* Make sure system clocks have started. */
     hal_system_clock_start();
 
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
+
+    /* Create charge controller */
+    rc = os_dev_create(&os_bsp_charger.dev, "charger",
+                       OS_DEV_INIT_KERNEL, OS_DEV_INIT_PRIO_DEFAULT,
+                       sgm4056_dev_init, &os_bsp_charger_config);
+    assert(rc == 0);
 }

--- a/hw/drivers/chg_ctrl/sgm4056/include/sgm4056/sgm4056.h
+++ b/hw/drivers/chg_ctrl/sgm4056/include/sgm4056/sgm4056.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _SGM4056_H
+#define _SGM4056_H
+
+#include <os/os_dev.h>
+#include <charge-control/charge_control.h>
+
+struct sgm4056_dev_config {
+    int power_presence_pin;
+    int charge_indicator_pin;
+};
+
+struct sgm4056_dev {
+    struct os_dev dev;
+    struct sgm4056_dev_config config;
+};
+
+/**
+ * Init function for SGM4056 charger
+ * @return 0 on success, non-zero on failure
+ */
+int sgm4056_dev_init(struct os_dev *dev, void *arg);
+
+/**
+ * Reads the state of the power presence indication. Value is 1 when the input
+ * voltage is above the POR threshold but below the OVP threshold and 0 otherwise.
+ *
+ * @param dev The sgm4056 device to read on
+ * @param power_present Power presence indication to be returned by the
+ *      function (0 if input voltage is not detected, 1 if it is detected)
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int sgm4056_get_power_presence(struct sgm4056_dev *dev, int *power_present);
+
+/**
+ * Reads the state of the charge indication. Value is 1 when a charge cycle
+ * started and will be 0 when the end-of-charge (EOC) condition is met.
+ *
+ * @param dev The sgm4056 device to read on
+ * @param charging Charge indication to be returned by the
+ *      function (0 if battery is not charging, 1 if it is charging)
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int sgm4056_get_charge_indicator(struct sgm4056_dev *dev, int *charging);
+
+/**
+ * Reads the state of the charger. This is a combination of the power presence
+ * and charge indications. Value is either:
+ * - CHARGE_CONTROL_STATUS_NO_SOURCE, when no power present
+ * - CHARGE_CONTROL_STATUS_CHARGING, when power present and charging
+ * - CHARGE_CONTROL_STATUS_CHARGE_COMPLETE, when power present and not charging
+ *
+ * @param dev The sgm4056 device to read on
+ * @param charger_status Charger status indication to be returned
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int sgm4056_get_charger_status(struct sgm4056_dev *dev, charge_control_status_t *charger_status);
+
+#endif /* _SGM4056_H */

--- a/hw/drivers/chg_ctrl/sgm4056/include/sgm4056/sgm4056.h
+++ b/hw/drivers/chg_ctrl/sgm4056/include/sgm4056/sgm4056.h
@@ -27,6 +27,10 @@ struct sgm4056_dev_config {
 
 struct sgm4056_dev {
     struct os_dev dev;
+#if MYNEWT_VAL(SGM4056_USE_CHARGE_CONTROL)
+    struct charge_control chg_ctrl;
+    struct os_event interrupt_event;
+#endif
     struct sgm4056_dev_config config;
 };
 

--- a/hw/drivers/chg_ctrl/sgm4056/pkg.yml
+++ b/hw/drivers/chg_ctrl/sgm4056/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "hw/drivers/chg_ctrl/sgm4056"
+pkg.description: "Driver for the SGM4056 charger"
+pkg.keywords:
+    - charger
+    - gpio
+    - sgm4056
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/charge-control"

--- a/hw/drivers/chg_ctrl/sgm4056/src/sgm4056.c
+++ b/hw/drivers/chg_ctrl/sgm4056/src/sgm4056.c
@@ -17,6 +17,80 @@
 #include "sgm4056/sgm4056.h"
 #include "hal/hal_gpio.h"
 
+#if MYNEWT_VAL(SGM4056_USE_CHARGE_CONTROL)
+
+static int
+sgm4056_chg_ctrl_get_status(struct charge_control *chg_ctrl, int *status)
+{
+    struct sgm4056_dev *dev;
+    int rc;
+
+    dev = (struct sgm4056_dev *)CHARGE_CONTROL_GET_DEVICE(chg_ctrl);
+    if (dev == NULL) {
+        rc = SYS_ENODEV;
+        goto err;
+    }
+
+    rc = sgm4056_get_charger_status(dev, (charge_control_status_t *)status);
+
+err:
+    return rc;
+}
+
+static int
+sgm4056_chg_ctrl_read(struct charge_control *chg_ctrl,
+                      charge_control_type_t type,
+                      charge_control_data_func_t data_func,
+                      void *data_arg, uint32_t timeout)
+{
+    int rc = 0;
+    int status;
+
+    if (type & CHARGE_CONTROL_TYPE_STATUS) {
+        rc = sgm4056_chg_ctrl_get_status(chg_ctrl, &status);
+        if (rc) {
+            goto err;
+        }
+
+        if (data_func) {
+            data_func(chg_ctrl, data_arg, (void *)&status, CHARGE_CONTROL_TYPE_STATUS);
+        }
+    }
+
+err:
+    return rc;
+}
+
+static const struct charge_control_driver sgm4056_chg_ctrl_driver = {
+    .ccd_read = sgm4056_chg_ctrl_read,
+    .ccd_get_config = NULL,
+    .ccd_set_config = NULL,
+    .ccd_get_status = sgm4056_chg_ctrl_get_status,
+    .ccd_get_fault = NULL,
+    .ccd_enable = NULL,
+    .ccd_disable = NULL,
+};
+
+static void
+sgm4056_interrupt_event_handler(struct os_event *ev)
+{
+    struct sgm4056_dev *dev = (struct sgm4056_dev *)ev->ev_arg;
+    assert(dev);
+
+    charge_control_read(&dev->chg_ctrl, CHARGE_CONTROL_TYPE_STATUS,
+            NULL, NULL, OS_TIMEOUT_NEVER);
+}
+
+static void
+sgm4056_irq_handler(void *arg)
+{
+    struct sgm4056_dev *dev = (struct sgm4056_dev *)arg;
+    assert(dev);
+
+    os_eventq_put(os_eventq_dflt_get(), &dev->interrupt_event);
+}
+#endif
+
 int
 sgm4056_dev_init(struct os_dev *odev, void *arg)
 {
@@ -31,7 +105,16 @@ sgm4056_dev_init(struct os_dev *odev, void *arg)
 
     dev->config = *cfg;
 
+#if MYNEWT_VAL(SGM4056_USE_CHARGE_CONTROL)
+    dev->interrupt_event.ev_cb = sgm4056_interrupt_event_handler;
+    dev->interrupt_event.ev_arg = dev;
+
+    rc = hal_gpio_irq_init(dev->config.power_presence_pin, sgm4056_irq_handler, dev, HAL_GPIO_TRIG_BOTH,
+                           HAL_GPIO_PULL_NONE);
+    hal_gpio_irq_enable(dev->config.power_presence_pin);
+#else
     rc = hal_gpio_init_in(dev->config.power_presence_pin, HAL_GPIO_PULL_NONE);
+#endif
     if (rc) {
         goto err;
     }
@@ -40,6 +123,29 @@ sgm4056_dev_init(struct os_dev *odev, void *arg)
     if (rc) {
         goto err;
     }
+
+#if MYNEWT_VAL(SGM4056_USE_CHARGE_CONTROL)
+    rc = charge_control_init(&dev->chg_ctrl, odev);
+    if (rc) {
+        goto err;
+    }
+
+    rc = charge_control_set_driver(&dev->chg_ctrl, CHARGE_CONTROL_TYPE_STATUS,
+                                   (struct charge_control_driver *)&sgm4056_chg_ctrl_driver);
+    if (rc) {
+        goto err;
+    }
+
+    rc = charge_control_set_type_mask(&dev->chg_ctrl, CHARGE_CONTROL_TYPE_STATUS);
+    if (rc) {
+        goto err;
+    }
+
+    rc = charge_control_mgr_register(&dev->chg_ctrl);
+    if (rc) {
+        goto err;
+    }
+#endif
 
 err:
     return rc;

--- a/hw/drivers/chg_ctrl/sgm4056/src/sgm4056.c
+++ b/hw/drivers/chg_ctrl/sgm4056/src/sgm4056.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sgm4056/sgm4056.h"
+#include "hal/hal_gpio.h"
+
+int
+sgm4056_dev_init(struct os_dev *odev, void *arg)
+{
+    struct sgm4056_dev *dev = (struct sgm4056_dev *)odev;
+    const struct sgm4056_dev_config *cfg = arg;
+    int rc = 0;
+
+    if (!dev) {
+        rc = SYS_ENODEV;
+        goto err;
+    }
+
+    dev->config = *cfg;
+
+    rc = hal_gpio_init_in(dev->config.power_presence_pin, HAL_GPIO_PULL_NONE);
+    if (rc) {
+        goto err;
+    }
+
+    rc = hal_gpio_init_in(dev->config.charge_indicator_pin, HAL_GPIO_PULL_NONE);
+    if (rc) {
+        goto err;
+    }
+
+err:
+    return rc;
+}
+
+int
+sgm4056_get_power_presence(struct sgm4056_dev *dev, int *power_present)
+{
+    int gpio_value = hal_gpio_read(dev->config.power_presence_pin);
+
+    *power_present = (gpio_value == 0);
+    return 0;
+}
+
+int
+sgm4056_get_charge_indicator(struct sgm4056_dev *dev, int *charging)
+{
+    int gpio_value = hal_gpio_read(dev->config.charge_indicator_pin);
+
+    *charging = (gpio_value == 0);
+    return 0;
+}
+
+int
+sgm4056_get_charger_status(struct sgm4056_dev *dev,
+                           charge_control_status_t *charger_status)
+{
+    int power_present;
+    int charging;
+    int rc;
+
+    rc = sgm4056_get_power_presence(dev, &power_present);
+    if (rc) {
+        goto err;
+    }
+
+    rc = sgm4056_get_charge_indicator(dev, &charging);
+    if (rc) {
+        goto err;
+    }
+
+    if (!power_present) {
+        *charger_status = CHARGE_CONTROL_STATUS_NO_SOURCE;
+    } else {
+        if (charging) {
+            *charger_status = CHARGE_CONTROL_STATUS_CHARGING;
+        } else {
+            *charger_status = CHARGE_CONTROL_STATUS_CHARGE_COMPLETE;
+        }
+    }
+
+err:
+    return rc;
+}

--- a/hw/drivers/chg_ctrl/sgm4056/syscfg.yml
+++ b/hw/drivers/chg_ctrl/sgm4056/syscfg.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SGM4056_USE_CHARGE_CONTROL:
+        description: 'Enable charge control integration'
+        value: 1


### PR DESCRIPTION
This adds a driver for the SGM4056 driver. The first commit adds the base driver, second commit adds charge control integration to the base driver. The last commit adds driver initialization to the pinetime BSP.