### PR TITLE
sys/id: Add optional id/serial_mfg field for storing manufacturer serial number

### DIFF
--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -32,6 +32,14 @@ extern "C" {
 extern char id_serial[];
 #endif
 
+#if MYNEWT_VAL(ID_SERIAL_MFG_PRESENT)
+/*
+ * Maximum expected serial_mfg number string length.
+ */
+#define ID_SERIAL_MFG_MAX_LEN       MYNEWT_VAL(ID_SERIAL_MFG_MAX_LEN)
+extern char id_serial_mfg[];
+#endif
+
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
 /*
  * Maximum expected manufacturer string length.

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -51,6 +51,9 @@ const char *id_app_str = "";
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
 char id_serial[ID_SERIAL_MAX_LEN];
 #endif
+#if MYNEWT_VAL(ID_SERIAL_MFG_PRESENT)
+char id_serial_mfg[ID_SERIAL_MFG_MAX_LEN];
+#endif
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
 char id_manufacturer[ID_MANUFACTURER_MAX_LEN];
 #endif
@@ -88,6 +91,10 @@ id_conf_get(int argc, char **argv, char *val, int val_len_max)
         } else if (!strcmp(argv[0], "serial")) {
             return (char *)id_serial;
 #endif
+#if MYNEWT_VAL(ID_SERIAL_MFG_PRESENT)
+        } else if (!strcmp(argv[0], "serial_mfg")) {
+            return (char *)id_serial_mfg;
+#endif
 #if MYNEWT_VAL(ID_MANUFACTURER_PRESENT)
         } else if (!strcmp(argv[0], "mfger")) {
             return (char *)id_manufacturer;
@@ -114,6 +121,11 @@ id_conf_set(int argc, char **argv, char *val)
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
         if (!strcmp(argv[0], "serial")) {
             return CONF_VALUE_SET(val, CONF_STRING, id_serial);
+        }
+#endif
+#if MYNEWT_VAL(ID_SERIAL_MFG_PRESENT)
+        if (!strcmp(argv[0], "serial_mfg")) {
+            return CONF_VALUE_SET(val, CONF_STRING, id_serial_mfg);
         }
 #endif
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
@@ -154,6 +166,9 @@ id_conf_export(void (*export_func)(char *name, char *val),
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
     export_func("id/serial", id_serial);
 #endif /* ID_SERIAL_PRESENT */
+#if MYNEWT_VAL(ID_SERIAL_MFG_PRESENT)
+    export_func("id/serial_mfg", id_serial_mfg);
+#endif /* ID_SERIAL_MFG_PRESENT */
 #if MYNEWT_VAL(ID_MANUFACTURER_PRESENT)
 #if MYNEWT_VAL(ID_MANUFACTURER_LOCAL)
     export_func("id/mfger", id_manufacturer);

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -24,6 +24,13 @@ syscfg.defs:
         description: Maximum length of id/serial value
         value: 64
 
+    ID_SERIAL_MFG_PRESENT:
+        description: 'Device manufacturing serial number exported as sys/id/serial_mfg.'
+        value: 0
+    ID_SERIAL_MFG_MAX_LEN:
+        description: Maximum length of id/serial_mfg value
+        value: 32
+
     ID_MANUFACTURER_PRESENT:
         description: 'Device manufacturer string exported as sys/id/mfger.'
         value: 0


### PR DESCRIPTION
This PR adds a new optional field, id/serial_mfg to be used for alternate serial numbers on devices during the manufacturing process.

The syscfg ID_SERIAL_MFG_PRESENT is disabled by default.