### PR TITLE
ARM semihosting console on pinetime

### DIFF
--- a/.style_ignored_dirs
+++ b/.style_ignored_dirs
@@ -5,6 +5,7 @@ apps/coremark
 crypto/mbedtls
 crypto/tinycrypt
 hw/drivers/rtt
+hw/drivers/semihosting
 libc/baselibc
 net/ip/lwip_base
 net/lora/node/src/mac

--- a/hw/bsp/pinetime/pinetime_debug.sh
+++ b/hw/bsp/pinetime/pinetime_debug.sh
@@ -31,6 +31,7 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f interface/stlink.cfg -f target/nrf52.cfg"
+EXTRA_GDB_CMDS='monitor arm semihosting enable'
 # Exit openocd when gdb detaches.
 EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"
 

--- a/hw/bsp/pinetime/syscfg.yml
+++ b/hw/bsp/pinetime/syscfg.yml
@@ -48,6 +48,10 @@ syscfg.vals:
 
     # UART port 0 is disabled
     UART_0: 0
+    CONSOLE_UART: 0
+
+    # Enable ARM semihosting console
+    CONSOLE_SEMIHOSTING: 1
 
     # Configure NFC pins as GPIO P0.09, P0.10
     NFC_PINS_AS_GPIO: 1

--- a/hw/drivers/semihosting/include/semihosting/mbed_semihost_api.h
+++ b/hw/drivers/semihosting/include/semihosting/mbed_semihost_api.h
@@ -1,0 +1,89 @@
+
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_SEMIHOST_H
+#define MBED_SEMIHOST_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(__ARMCC_VERSION)
+
+#if defined(__ICCARM__)
+static inline int __semihost(int reason, const void *arg)
+{
+    return __semihosting(reason, (void *)arg);
+}
+#else
+
+#ifdef __thumb__
+#   define AngelSWI            0xAB
+#   define AngelSWIInsn        "bkpt"
+#   define AngelSWIAsm          bkpt
+#else
+#   define AngelSWI            0x123456
+#   define AngelSWIInsn        "swi"
+#   define AngelSWIAsm          swi
+#endif
+
+static inline int __semihost(int reason, const void *arg)
+{
+    int value;
+
+    asm volatile(
+        "mov r0, %1"          "\n\t"
+        "mov r1, %2"          "\n\t"
+        AngelSWIInsn " %a3"   "\n\t"
+        "mov %0, r0"
+        : "=r"(value)                                          /* output operands             */
+        : "r"(reason), "r"(arg), "i"(AngelSWI)                 /* input operands              */
+        : "r0", "r1", "r2", "r3", "ip", "lr", "memory", "cc"   /* list of clobbered registers */
+    );
+
+    return value;
+}
+#endif
+#endif
+
+typedef uint32_t FILEHANDLE;
+
+FILEHANDLE semihost_open(const char *name, int openmode);
+int semihost_close(FILEHANDLE fh);
+int semihost_read(FILEHANDLE fh, unsigned char *buffer, unsigned int length, int mode);
+int semihost_write(FILEHANDLE fh, const unsigned char *buffer, unsigned int length, int mode);
+int semihost_ensure(FILEHANDLE fh);
+long semihost_flen(FILEHANDLE fh);
+int semihost_seek(FILEHANDLE fh, long position);
+int semihost_istty(FILEHANDLE fh);
+
+int semihost_remove(const char *name);
+int semihost_rename(const char *old_name, const char *new_name);
+
+int semihost_exit(void);
+
+int semihost_connected(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/hw/drivers/semihosting/pkg.yml
+++ b/hw/drivers/semihosting/pkg.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "hw/drivers/semihosting"
+pkg.description: "ARM semihosting implementation"
+pkg.author: "ARMmbed"
+pkg.homepage: "https://github.com/ARMmbed/mbed-os"
+pkg.keywords:
+  - ARM
+  - semihosting
+
+pkg.deps:
+  - "hw/cmsis-core"

--- a/hw/drivers/semihosting/src/mbed_semihost_api.c
+++ b/hw/drivers/semihosting/src/mbed_semihost_api.c
@@ -1,0 +1,122 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <os/mynewt.h>
+#include "semihosting/mbed_semihost_api.h"
+
+#include <stdint.h>
+#include <string.h>
+
+// ARM Semihosting Commands
+#define SYS_OPEN   (0x1)
+#define SYS_CLOSE  (0x2)
+#define SYS_WRITE  (0x5)
+#define SYS_READ   (0x6)
+#define SYS_ISTTY  (0x9)
+#define SYS_SEEK   (0xa)
+#define SYS_ENSURE (0xb)
+#define SYS_FLEN   (0xc)
+#define SYS_REMOVE (0xe)
+#define SYS_RENAME (0xf)
+#define SYS_EXIT   (0x18)
+
+FILEHANDLE semihost_open(const char *name, int openmode)
+{
+    uint32_t args[3];
+    args[0] = (uint32_t)name;
+    args[1] = (uint32_t)openmode;
+    args[2] = (uint32_t)strlen(name);
+    return __semihost(SYS_OPEN, args);
+}
+
+int semihost_close(FILEHANDLE fh)
+{
+    return __semihost(SYS_CLOSE, &fh);
+}
+
+int semihost_write(FILEHANDLE fh, const unsigned char *buffer, unsigned int length, int mode)
+{
+    if (length == 0) {
+        return 0;
+    }
+
+    uint32_t args[3];
+    args[0] = (uint32_t)fh;
+    args[1] = (uint32_t)buffer;
+    args[2] = (uint32_t)length;
+    return __semihost(SYS_WRITE, args);
+}
+
+int semihost_read(FILEHANDLE fh, unsigned char *buffer, unsigned int length, int mode)
+{
+    uint32_t args[3];
+    args[0] = (uint32_t)fh;
+    args[1] = (uint32_t)buffer;
+    args[2] = (uint32_t)length;
+    return __semihost(SYS_READ, args);
+}
+
+int semihost_istty(FILEHANDLE fh)
+{
+    return __semihost(SYS_ISTTY, &fh);
+}
+
+int semihost_seek(FILEHANDLE fh, long position)
+{
+    uint32_t args[2];
+    args[0] = (uint32_t)fh;
+    args[1] = (uint32_t)position;
+    return __semihost(SYS_SEEK, args);
+}
+
+int semihost_ensure(FILEHANDLE fh)
+{
+    return __semihost(SYS_ENSURE, &fh);
+}
+
+long semihost_flen(FILEHANDLE fh)
+{
+    return __semihost(SYS_FLEN, &fh);
+}
+
+int semihost_remove(const char *name)
+{
+    uint32_t args[2];
+    args[0] = (uint32_t)name;
+    args[1] = (uint32_t)strlen(name);
+    return __semihost(SYS_REMOVE, args);
+}
+
+int semihost_rename(const char *old_name, const char *new_name)
+{
+    uint32_t args[4];
+    args[0] = (uint32_t)old_name;
+    args[1] = (uint32_t)strlen(old_name);
+    args[0] = (uint32_t)new_name;
+    args[1] = (uint32_t)strlen(new_name);
+    return __semihost(SYS_RENAME, args);
+}
+
+int semihost_exit(void)
+{
+    uint32_t args[4];
+    return __semihost(SYS_EXIT, args);
+}
+
+int semihost_connected(void)
+{
+    return (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) ? 1 : 0;
+}

--- a/sys/console/full/pkg.yml
+++ b/sys/console/full/pkg.yml
@@ -30,6 +30,8 @@ pkg.deps.CONSOLE_UART:
     - "@apache-mynewt-core/hw/drivers/uart"
 pkg.deps.CONSOLE_RTT:
     - "@apache-mynewt-core/hw/drivers/rtt"
+pkg.deps.CONSOLE_SEMIHOSTING:
+    - "@apache-mynewt-core/hw/drivers/semihosting"
 pkg.deps.'CONSOLE_HISTORY == "ram"':
     - "@apache-mynewt-core/sys/console/full/history_ram"
 pkg.deps.'CONSOLE_HISTORY == "log"':

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -1220,6 +1220,9 @@ console_is_init(void)
 #if MYNEWT_VAL(CONSOLE_RTT)
     return rtt_console_is_init();
 #endif
+#if MYNEWT_VAL(CONSOLE_SEMIHOSTING)
+    return semihosting_console_is_init();
+#endif
 #if MYNEWT_VAL(CONSOLE_BLE_MONITOR)
     return ble_monitor_console_is_init();
 #endif

--- a/sys/console/full/src/console_priv.h
+++ b/sys/console/full/src/console_priv.h
@@ -31,6 +31,7 @@ void uart_console_blocking_mode(void);
 void uart_console_non_blocking_mode(void);
 int rtt_console_is_init(void);
 int rtt_console_init(void);
+int semihosting_console_is_init(void);
 int ble_monitor_console_is_init(void);
 
 #ifdef __cplusplus

--- a/sys/console/full/src/semihosting_console.c
+++ b/sys/console/full/src/semihosting_console.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os/mynewt.h"
+
+#if MYNEWT_VAL(CONSOLE_SEMIHOSTING)
+
+#include "semihosting/mbed_semihost_api.h"
+#include <unistd.h>
+#include "console_priv.h"
+
+static unsigned char semihosting_tx_buffer[MYNEWT_VAL(CONSOLE_SEMIHOSTING_TX_BUF_SIZE)];
+static unsigned char *semihosting_tx_buffer_pos = semihosting_tx_buffer;
+
+static void
+semihosting_console_flush(void)
+{
+    unsigned int size = semihosting_tx_buffer_pos - semihosting_tx_buffer;
+    semihost_write(STDOUT_FILENO, semihosting_tx_buffer, size, 0);
+    semihosting_tx_buffer_pos = semihosting_tx_buffer;
+}
+
+static void
+semihosting_console_flush_event(struct os_event *ev)
+{
+    semihosting_console_flush();
+}
+
+static void
+semihosting_console_write(unsigned char c)
+{
+    *semihosting_tx_buffer_pos = c;
+    semihosting_tx_buffer_pos++;
+    if (semihosting_tx_buffer_pos > semihosting_tx_buffer + sizeof(semihosting_tx_buffer)) {
+        semihosting_console_flush();
+    }
+}
+
+static struct os_event semihosting_console_flush_ev = {
+    .ev_cb = semihosting_console_flush_event,
+};
+
+int
+console_out_nolock(int character)
+{
+    unsigned char c = (char)character;
+
+    if (semihost_connected()) {
+        semihosting_console_write(c);
+
+        if (!OS_EVENT_QUEUED(&semihosting_console_flush_ev)) {
+            os_eventq_put(os_eventq_dflt_get(), &semihosting_console_flush_ev);
+        }
+    }
+
+    return character;
+}
+
+int
+semihosting_console_is_init(void)
+{
+    return 1;
+}
+
+#endif

--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -23,6 +23,9 @@ syscfg.defs:
     CONSOLE_RTT:
         description: 'Set console output to RTT'
         value: 0
+    CONSOLE_SEMIHOSTING:
+        description: 'Set console output to ARM semihosting'
+        value: 0
     CONSOLE_BLE_MONITOR:
         description: 'Set console output to BLE Monitor'
         value: 0
@@ -123,6 +126,10 @@ syscfg.defs:
             value may affect RTT console responsiveness, using small value may
             affect device performance due to more frequent polling.
         value: 250
+
+    CONSOLE_SEMIHOSTING_TX_BUF_SIZE:
+        description: 'ARM semihosting console transmit buffer size'
+        value: 128
 
     CONSOLE_DEFAULT_LOCK_TIMEOUT:
         description: 'Default timeout (in ms) for console_lock() function used in console_write.'


### PR DESCRIPTION
This adds ARM semihosting console support to mynewt. It is only the tx side. And it is enabled by default for PineTime BSP.

This first commits adds the actual semihosting driver. It originates from mbed-os, with some modification to make it compatible with mynewt.

The second commit adds semihosting to the full console implementation.

The third commit adds support for the CFG_POST_INIT variable in the openocd script. This was needed to enable semihosting during debug sessions.

The last commit edits the PineTime BSP to enable the semihosting console in syscfg and debug.sh.