### PR TITLE
const correctness log name

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -202,7 +202,7 @@ STATS_SECT_END
 #endif
 
 struct log {
-    char *l_name;
+    const char *l_name;
     const struct log_handler *l_log;
     void *l_arg;
     STAILQ_ENTRY(log) l_next;
@@ -248,7 +248,7 @@ uint8_t log_module_register(uint8_t id, const char *name);
 const char *log_module_get_name(uint8_t id);
 
 /* Log functions, manipulate a single log */
-int log_register(char *name, struct log *log, const struct log_handler *,
+int log_register(const char *name, struct log *log, const struct log_handler *,
                  void *arg, uint8_t level);
 
 /**

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -371,7 +371,7 @@ log_read_last_hdr(struct log *log, struct log_entry_hdr *out_hdr)
  * Associate an instantiation of a log with the logging infrastructure
  */
 int
-log_register(char *name, struct log *log, const struct log_handler *lh,
+log_register(const char *name, struct log *log, const struct log_handler *lh,
              void *arg, uint8_t level)
 {
     struct log_entry_hdr hdr;

--- a/sys/log/stub/include/log/log.h
+++ b/sys/log/stub/include/log/log.h
@@ -40,7 +40,7 @@ struct log_handler {
 };
 
 static inline int
-log_register(char *name, struct log *log, const struct log_handler *h,
+log_register(const char *name, struct log *log, const struct log_handler *h,
              void *arg, uint8_t level)
 {
     return 0;


### PR DESCRIPTION
`const` recently added to `struct os_dev:od_name` (which is great) but using that name with the log module currently gives a compile error.