### PR TITLE
Adding a version into newt compatilibilty map, for version: 0.0.1

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -60,6 +60,8 @@ repo.newt_compatibility:
     # present.
     0.0.0:
         0.0.0: good
+    0.0.1:
+        0.0.1: good
 
     # Core 1.1.0+ requires newt 1.1.0+ (feature: self-overrides).
     # Core 1.4.0+ requires newt 1.4.0+ (feature: sync repo deps).


### PR DESCRIPTION
This removes 'newt' warning when building JDP, since newt upgrade picks 0.0.1 for commit from master and keeps warning that 0.0.1 is not listed in compatibility map.