### PR TITLE
da1469x: otp and serial script enhancements

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
@@ -26,7 +26,7 @@ from datetime import datetime
 
 @click.argument('infile')
 @click.option('-u', '--uart', required=True, help='uart port')
-@click.option('-r', '--reset_script', required=True, help='Custom reset script to switch to serial load')
+@click.option('-r', '--reset_script', required=False, help='Custom reset script to switch to serial load')
 @click.command(help='Load the provided file using serial load protocol')
 def load(infile, uart, reset_script):
     try:
@@ -59,12 +59,15 @@ def load(infile, uart, reset_script):
     prev = datetime.now()
     reset_delay_us = 250000
 
+    if reset_script is None:
+            print("Please reset board to enter ROM uart recovery")
+
     while True:
         elapsed = datetime.now() - prev
         if elapsed.seconds >= 15:
             raise SystemExit("Failed to receive SOM, aborting")
         if not som_detected and not reset_triggered:
-            if elapsed.microseconds >= reset_delay_us:
+            if reset_script and elapsed.microseconds >= reset_delay_us:
                 print("Triggering SWD reset...")
                 # Run in background
                 os.system(reset_script + " &")

--- a/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
@@ -35,6 +35,15 @@ def load(infile, uart, reset_script):
     except serial.SerialException:
         raise SystemExit("Failed to open serial port")
 
+    # drain serial port buffer
+    try:
+        while True:
+            data = ser.read(1)
+            if len(data) == 0:
+                break
+    except serial.SerialException:
+        raise SystemExit("Failed to open serial port")
+
     try:
         f = open(infile, "rb")
     except IOError:


### PR DESCRIPTION
This PR provides script enhancements to 

1. da146x_serial.py: Makes the reset script optional. Use manual reset method or script to enter serial load mode.
2. da1469x_serial.py: Provide a common function that flushes serial port when initially opened.
3. otp_tool.py: Provide a common function that flushes serial port when initially opened.