### PR TITLE
stm32f4: Add I2SPLL configuration

### DIFF
--- a/hw/mcu/stm/stm32f4xx/src/clock_stm32f4xx.c
+++ b/hw/mcu/stm/stm32f4xx/src/clock_stm32f4xx.c
@@ -42,6 +42,23 @@
 #error "At least one of HSE or HSI clock source must be enabled"
 #endif
 
+#if MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLM) && MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLN) && MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLR)
+static void
+config_i2s_pll(void)
+{
+    RCC_PeriphCLKInitTypeDef i2s_clock_init;
+
+    i2s_clock_init.PeriphClockSelection = RCC_PERIPHCLK_PLLI2S;
+    i2s_clock_init.PLLI2S.PLLI2SM = MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLM);
+    i2s_clock_init.PLLI2S.PLLI2SN = MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLN);
+    i2s_clock_init.PLLI2S.PLLI2SR = MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLR);
+    i2s_clock_init.TIMPresSelection = 0;
+    i2s_clock_init.RTCClockSelection = 0;
+
+    HAL_RCCEx_PeriphCLKConfig(&i2s_clock_init);
+}
+#endif
+
 void
 SystemClock_Config(void)
 {
@@ -249,6 +266,10 @@ SystemClock_Config(void)
     if (status != HAL_OK) {
         assert(0);
     }
+#endif
+
+#if MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLM) && MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLN) && MYNEWT_VAL(STM32_CLOCK_PLLI2S_PLLR)
+    config_i2s_pll();
 #endif
 
 #if PREFETCH_ENABLE

--- a/hw/mcu/stm/stm32f4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f4xx/syscfg.yml
@@ -79,6 +79,18 @@ syscfg.defs:
         description: PLL config R parameter
         value: 0
 
+    STM32_CLOCK_PLLI2S_PLLM:
+        description: I2SPLL config M parameter
+        value: 0
+
+    STM32_CLOCK_PLLI2S_PLLN:
+        description: I2SPLL config N parameter
+        value: 0
+
+    STM32_CLOCK_PLLI2S_PLLR:
+        description: I2SPLL config R parameter
+        value: 0
+
     STM32_CLOCK_ENABLE_OVERDRIVE:
         description: Turn on over-drive mode (reach higher clock rates)
         value: 0


### PR DESCRIPTION
I2SPLL clock configuration was missing so I2S peripheral
would not work without user code initialization.
Now I2SPLL configuration is added to syscfg, and PLL will be
configured when those values are set in BSP.