### PR TITLE
watchdog: Fix places that ignore WATCHDOG_INTERVAL=0

### DIFF
--- a/apps/flash_loader/src/fl.c
+++ b/apps/flash_loader/src/fl.c
@@ -172,8 +172,10 @@ main(int argc, char **argv)
 
     hal_bsp_init();
     flash_map_init();
+#if MYNEWT_VAL(WATCHDOG_INTERVAL) > 0
     hal_watchdog_init(MYNEWT_VAL(WATCHDOG_INTERVAL));
     hal_watchdog_enable();
+#endif
 
     fl_data = malloc(MYNEWT_VAL(FLASH_LOADER_DL_SZ));
     assert(fl_data);
@@ -221,7 +223,9 @@ main(int argc, char **argv)
             rc = FL_RC_UNKNOWN_CMD_ERR;
             break;
         }
+#if MYNEWT_VAL(WATCHDOG_INTERVAL) > 0
         hal_watchdog_tickle();
+#endif
         if (fl_cmd_rc <= FL_RC_OK) {
             fl_cmd_rc = rc;
         }

--- a/hw/mcu/stm/stm32_common/src/hal_flash.c
+++ b/hw/mcu/stm/stm32_common/src/hal_flash.c
@@ -133,7 +133,7 @@ stm32_flash_write_linear(const struct hal_flash *dev, uint32_t address,
          * Long writes take excessive time, and stall the idle thread,
          * so tickling the watchdog here to avoid reset...
          */
-        if (!(i % 32)) {
+        if (MYNEWT_VAL(WATCHDOG_INTERVAL) > 0 && !(i % 32)) {
             hal_watchdog_tickle();
         }
     }


### PR DESCRIPTION
When WATCHDOG_INTERVAL is set to zero
- flash loader would try to initialize watchdog with 0 value
  that would most likely not work
- hal_flash for STM MCUs would try to tickle uninitialized
  watchdog and that would result in hard fault