### PR TITLE
[STM32F0] Fix stm32_hal_timer_get_freq

### DIFF
--- a/hw/mcu/stm/stm32f0xx/src/hal_timer_freq.c
+++ b/hw/mcu/stm/stm32f0xx/src/hal_timer_freq.c
@@ -47,6 +47,9 @@ stm32_hal_timer_get_freq(void *timx)
 #ifdef TIM1
     case (uintptr_t)TIM1:
 #endif
+#ifdef TIM2
+    case (uintptr_t)TIM2:
+#endif
 #ifdef TIM3
     case (uintptr_t)TIM3:
 #endif


### PR DESCRIPTION
Case for TIM2 was missing, rendering this
timer unusable.