### PR TITLE
Battery for PineTime BSP

### DIFF
--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+#if MYNEWT_VAL(BATTERY_SHELL)
+
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
@@ -539,3 +542,5 @@ battery_shell_register(void)
     rc = shell_cmd_register(&bat_cli_cmd);
     SYSINIT_PANIC_ASSERT_MSG(rc == 0, "Failed to register battery shell");
 }
+
+#endif

--- a/hw/bsp/pinetime/pkg.yml
+++ b/hw/bsp/pinetime/pkg.yml
@@ -36,3 +36,5 @@ pkg.deps:
     - '@apache-mynewt-core/kernel/os'
     - '@apache-mynewt-core/libc/baselibc'
     - '@apache-mynewt-core/hw/drivers/chg_ctrl/sgm4056'
+    - '@apache-mynewt-core/hw/battery'
+    - '@apache-mynewt-core/hw/drivers/adc'


### PR DESCRIPTION
This initializes the ADC for battery voltage measurement for PineTime BSP.
This also places a ifdef around the  battery shell code, as it doesn't compile when BATTERY_SHELL is disabled.