### PR TITLE
added __ text label to stm32f0xx linker script for OS_CRASH_STACKTRACE and alike

### DIFF
--- a/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
+++ b/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
@@ -62,6 +62,8 @@ SECTIONS
         . = . + _imghdr_size;
     } > FLASH
 
+    __text = .;
+
     .text :
     {
         . = ALIGN(4);


### PR DESCRIPTION
added __text symbol which is required for OS_CRASH_STACKTRACE