### PR TITLE
sys/config: read/write access config for mgmt cmd

### DIFF
--- a/sys/config/src/config_mgmt.c
+++ b/sys/config/src/config_mgmt.c
@@ -28,11 +28,29 @@
 #include "config/config.h"
 #include "config_priv.h"
 
+#define CONFIG_MGMT_READ    (MYNEWT_VAL(CONFIG_MGMT_RW) & 1)
+#define CONFIG_MGMT_WRITE   (MYNEWT_VAL(CONFIG_MGMT_RW) & 2)
+
+#if CONFIG_MGMT_READ
 static int conf_mgmt_read(struct mgmt_ctxt *);
+#endif
+#if CONFIG_MGMT_WRITE
 static int conf_mgmt_write(struct mgmt_ctxt *);
+#endif
 
 static const struct mgmt_handler conf_mgmt_handlers[] = {
-    [CONF_NMGR_OP] = { conf_mgmt_read, conf_mgmt_write}
+    [CONF_NMGR_OP] = {
+#if CONFIG_MGMT_READ
+        conf_mgmt_read,
+#else
+        NULL,
+#endif
+#if CONFIG_MGMT_WRITE
+        conf_mgmt_write,
+#else
+        NULL,
+#endif
+    }
 };
 
 static struct mgmt_group conf_mgmt_group = {
@@ -41,6 +59,7 @@ static struct mgmt_group conf_mgmt_group = {
     .mg_group_id = MGMT_GROUP_ID_CONFIG
 };
 
+#if CONFIG_MGMT_READ
 static int
 conf_mgmt_read(struct mgmt_ctxt *cb)
 {
@@ -80,7 +99,9 @@ conf_mgmt_read(struct mgmt_ctxt *cb)
     }
     return 0;
 }
+#endif
 
+#if CONFIG_MGMT_WRITE
 static int
 conf_mgmt_write(struct mgmt_ctxt *cb)
 {
@@ -141,6 +162,7 @@ conf_mgmt_write(struct mgmt_ctxt *cb)
     }
     return 0;
 }
+#endif
 
 int
 conf_mgmt_register(void)

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -41,6 +41,13 @@ syscfg.defs:
         description: 'SMP access to config'
         value: 0
 
+    CONFIG_MGMT_RW:
+        description: >
+            Config management access: 1=read-only, 2=write-only, 3=read/write
+            No effect if `CONFIG_MGMT` is 0.
+        value: 3
+        range: 1,2,3
+
     CONFIG_CLI:
         description: 'CLI commands for accessing config'
         value: 0


### PR DESCRIPTION
Before PR: the `CONFIG_MGMT` syscfg setting disabled or enabled the config newtmgr command in its entirety.  There was no way to enable only the read half of the command (for example).

After PR: there is a second syscfg setting: `CONFIG_MGMT_RW`.  The semantics mirror the `CONFIG_CLI_RW` setting.  That is:

* If `CONFIG_MGMT` is 0, the entire command is disabled.

Otherwise:

* If `CONFIG_MGMT_RW` is 1, only read commands are allowed.
* If `CONFIG_MGMT_RW` is 2, only write commands are allowed.
* If `CONFIG_MGMT_RW` is 3, both reads and writes are allowed.