### PR TITLE
Define peripheral vectors number for STM32F401xC

### DIFF
--- a/hw/mcu/stm/stm32f4xx/include/mcu/cmsis_nvic.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/cmsis_nvic.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#if defined(STM32F401xE) || defined(STM32F407xx) || defined(STM32F405xx)
+#if defined(STM32F401xE) || defined(STM32F401xC) || defined(STM32F407xx) || defined(STM32F405xx)
  #define MCU_NUM_PERIPH_VECTORS 82
 #elif defined(STM32F411xE)
  #define MCU_NUM_PERIPH_VECTORS 86


### PR DESCRIPTION
Number of vector was not defined for STM32F401xC MCUs.