### PR TITLE
hw/bsp/pinetime: Make drivers optional and disable for bootloader

### DIFF
--- a/hw/bsp/pinetime/pkg.yml
+++ b/hw/bsp/pinetime/pkg.yml
@@ -35,6 +35,10 @@ pkg.deps:
     - '@apache-mynewt-core/hw/mcu/nordic/nrf52xxx'
     - '@apache-mynewt-core/kernel/os'
     - '@apache-mynewt-core/libc/baselibc'
+
+pkg.deps.BSP_CHARGER:
     - '@apache-mynewt-core/hw/drivers/chg_ctrl/sgm4056'
+
+pkg.deps.BSP_BATTERY:
     - '@apache-mynewt-core/hw/battery'
     - '@apache-mynewt-core/hw/drivers/adc'

--- a/hw/bsp/pinetime/syscfg.yml
+++ b/hw/bsp/pinetime/syscfg.yml
@@ -22,6 +22,16 @@ syscfg.defs:
     BSP_NRF52:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
+    BSP_BATTERY:
+        description: 'Setup battery driver in the BSP'
+        value: 1
+    BSP_CHARGER:
+        description: 'Setup charger driver in the BSP'
+        value: 1
+
+syscfg.vals.BOOT_LOADER:
+    BSP_BATTERY: 0
+    BSP_CHARGER: 0
 
 # Settings this BSP overrides.
 syscfg.vals:
@@ -56,14 +66,15 @@ syscfg.vals:
     # Configure NFC pins as GPIO P0.09, P0.10
     NFC_PINS_AS_GPIO: 1
 
-    # ADC needed for battery voltage
-    ADC_0: 1
-
     # Define flash areas
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+
+syscfg.vals.BSP_BATTERY:
+    # ADC needed for battery voltage
+    ADC_0: 1
 
 syscfg.vals.BLE_CONTROLLER:
     TIMER_0: 0


### PR DESCRIPTION
This adds a syscfg for the battery and charger drivers. These options
are not available for bootloader builds. This reduces the size of the
bootloader significantly. The build failed before and now fits easily.

$ newt size boot-pinetime
Size of Application Image: app
  FLASH     RAM
     28     222 *fill*
   1152       0 @apache-mynewt-core_crypto_mbedtls.a
    382     444 @apache-mynewt-core_hw_bsp_pinetime.a
     40       0 @apache-mynewt-core_hw_cmsis-core.a
    594       1 @apache-mynewt-core_hw_hal.a
   2112      32 @apache-mynewt-core_hw_mcu_nordic_nrf52xxx.a
    310      24 @apache-mynewt-core_kernel_os.a
    168       0 @apache-mynewt-core_libc_baselibc.a
    654     128 @apache-mynewt-core_sys_flash_map.a
    518      29 @apache-mynewt-core_sys_mfg.a
      6       4 @apache-mynewt-core_sys_sysinit.a
   4398    5996 @mcuboot_boot_bootutil.a
     62       0 @mcuboot_boot_mynewt.a
     16       0 @mcuboot_boot_mynewt_flash_map_backend.a
     72       0 boot-pinetime-sysinit-app.a

objsize
   text    data     bss     dec     hex filename
  10512      28    6420   16960    4240 bin/targets/boot-pinetime/app/@mcuboot/boot/mynewt/mynewt.elf