### PR TITLE
encoding/base64: Support decode in chunks

### DIFF
--- a/encoding/base64/include/base64/base64.h
+++ b/encoding/base64/include/base64/base64.h
@@ -26,11 +26,32 @@
 extern "C" {
 #endif
 
+/**
+ * base64_decoder: used for decoding chunked data.  All public fields must be
+ * initialized before use.
+ */
+struct base64_decoder {
+    /*** public */
+    const char *src;
+    void *dst;
+    int src_len; /* <=0 if src ends with '\0' */
+    int dst_len; /* <=0 if dst unbounded */
+
+    /*** private */
+    char buf[4];
+    int buf_len;
+};
+
 int base64_encode(const void *, int, char *, uint8_t);
 int base64_decode(const char *, void *buf);
 int base64_pad(char *, int);
 int base64_decode_len(const char *str);
 int base64_decode_maxlen(const char *str, void *data, int len);
+
+/**
+ * Decodes base64 data using the provided decoder.
+ */
+int base64_decoder_go(struct base64_decoder *dec);
 
 #define BASE64_ENCODE_SIZE(__size) (((((__size) - 1) / 3) * 4) + 4)
 

--- a/encoding/base64/selftest/src/base64_test.c
+++ b/encoding/base64/selftest/src/base64_test.c
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "base64_test_priv.h"
+
+TEST_SUITE(base64_test_suite)
+{
+    hex2str();
+    str2hex();
+    decode_basic();
+    decode_maxlen();
+    decode_chunks();
+}
+
+int
+main(int argc, char **argv)
+{
+    base64_test_suite();
+    return tu_any_failed;
+}

--- a/encoding/base64/selftest/src/base64_test_priv.h
+++ b/encoding/base64/selftest/src/base64_test_priv.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BASE64_TEST_PRIV_
+#define H_BASE64_TEST_PRIV_
+
+#include "testutil/testutil.h"
+#include "base64/base64.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TEST_SUITE_DECL(hex_fmt_test_suite);
+
+TEST_CASE_DECL(hex2str);
+TEST_CASE_DECL(str2hex);
+TEST_CASE_DECL(decode_basic);
+TEST_CASE_DECL(decode_maxlen);
+TEST_CASE_DECL(decode_chunks);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/encoding/base64/selftest/src/testcases/decode_chunks.c
+++ b/encoding/base64/selftest/src/testcases/decode_chunks.c
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "base64_test_priv.h"
+
+static void
+pass(const char *src, const char *expected)
+{
+    struct base64_decoder dec;
+    struct os_mbuf_pkthdr *omp;
+    struct os_mbuf *cur;
+    struct os_mbuf *om;
+    int delta;
+    int len;
+    int rc;
+
+    /* Split source data among several buffers in an mbuf chain. */
+
+    om = os_msys_get_pkthdr(0, 0);
+    TEST_ASSERT_FATAL(om != NULL);
+
+    rc = os_mbuf_append(om, src, strlen(src));
+    TEST_ASSERT_FATAL(rc == 0);
+
+    /* Just make sure the source requires 2+ mbufs. */ 
+    TEST_ASSERT_FATAL(SLIST_NEXT(om, om_next) != NULL);
+
+    /* Decode source data in place. */
+
+    omp = OS_MBUF_PKTHDR(om);
+
+    memset(&dec, 0, sizeof dec);
+    for (cur = om; cur != NULL; cur = SLIST_NEXT(cur, om_next)) {
+        dec.src = (const char *)cur->om_data;
+        dec.src_len = cur->om_len;
+        dec.dst = cur->om_data;
+        dec.dst_len = -1;
+
+        len = base64_decoder_go(&dec);
+        if (len < 0) {
+            os_mbuf_free_chain(om);
+            return;
+        }
+
+        delta = cur->om_len - len;
+        cur->om_len = len;
+
+        omp->omp_len -= delta;
+    }
+
+    // Verify mbuf contents.
+    rc = os_mbuf_cmpf(om, 0, expected, strlen(expected));
+    TEST_ASSERT(rc == 0);
+}
+
+TEST_CASE_SELF(decode_chunks)
+{
+    pass(
+        "RnJvbSBteSBpbmZhbmN5IEkgd2FzIG5vdGVkIGZvciB0aGUgZG9jaWxpdHkgYW5kIGh1bWFuaXR5IG9mIG15IGRpc3Bvc2l0aW9uLiBNeSB0ZW5kZXJuZXNzIG9mIGhlYXJ0IHdhcyBldmVuIHNvIGNvbnNwaWN1b3VzIGFzIHRvIG1ha2UgbWUgdGhlIGplc3Qgb2YgbXkgY29tcGFuaW9ucy4gSSB3YXMgZXNwZWNpYWxseSBmb25kIG9mIGFuaW1hbHMsIGFuZCB3YXMgaW5kdWxnZWQgYnkgbXkgcGFyZW50cyB3aXRoIGEgZ3JlYXQgdmFyaWV0eSBvZiBwZXRzLiBXaXRoIHRoZXNlIEkgc3BlbnQgbW9zdCBvZiBteSB0aW1lLCBhbmQgbmV2ZXIgd2FzIHNvIGhhcHB5IGFzIHdoZW4gZmVlZGluZyBhbmQgY2FyZXNzaW5nIHRoZW0uIFRoaXMgcGVjdWxpYXJpdHkgb2YgY2hhcmFjdGVyIGdyZXcgd2l0aCBteSBncm93dGgsIGFuZCBpbiBteSBtYW5ob29kLCBJIGRlcml2ZWQgZnJvbSBpdCBvbmUgb2YgbXkgcHJpbmNpcGFsIHNvdXJjZXMgb2YgcGxlYXN1cmUuIFRvIHRob3NlIHdobyBoYXZlIGNoZXJpc2hlZCBhbiBhZmZlY3Rpb24gZm9yIGEgZmFpdGhmdWwgYW5kIHNhZ2FjaW91cyBkb2csIEkgbmVlZCBoYXJkbHkgYmUgYXQgdGhlIHRyb3VibGUgb2YgZXhwbGFpbmluZyB0aGUgbmF0dXJlIG9yIHRoZSBpbnRlbnNpdHkgb2YgdGhlIGdyYXRpZmljYXRpb24gdGh1cyBkZXJpdmFibGUuIFRoZXJlIGlzIHNvbWV0aGluZyBpbiB0aGUgdW5zZWxmaXNoIGFuZCBzZWxmLXNhY3JpZmljaW5nIGxvdmUgb2YgYSBicnV0ZSwgd2hpY2ggZ29lcyBkaXJlY3RseSB0byB0aGUgaGVhcnQgb2YgaGltIHdobyBoYXMgaGFkIGZyZXF1ZW50IG9jY2FzaW9uIHRvIHRlc3QgdGhlIHBhbHRyeSBmcmllbmRzaGlwIGFuZCBnb3NzYW1lciBmaWRlbGl0eSBvZiBtZXJlIE1hbi4K",
+        "From my infancy I was noted for the docility and humanity of my disposition. My tenderness of heart was even so conspicuous as to make me the jest of my companions. I was especially fond of animals, and was indulged by my parents with a great variety of pets. With these I spent most of my time, and never was so happy as when feeding and caressing them. This peculiarity of character grew with my growth, and in my manhood, I derived from it one of my principal sources of pleasure. To those who have cherished an affection for a faithful and sagacious dog, I need hardly be at the trouble of explaining the nature or the intensity of the gratification thus derivable. There is something in the unselfish and self-sacrificing love of a brute, which goes directly to the heart of him who has had frequent occasion to test the paltry friendship and gossamer fidelity of mere Man."
+    );
+}

--- a/encoding/base64/selftest/src/testcases/decode_maxlen.c
+++ b/encoding/base64/selftest/src/testcases/decode_maxlen.c
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "base64_test_priv.h"
+
+static void
+pass(const char *src, int max_len, const char *expected)
+{
+    char dst[1024];
+    int len;
+
+    len = base64_decode_maxlen(src, dst, max_len);
+    TEST_ASSERT_FATAL(len == strlen(expected));
+    TEST_ASSERT(memcmp(dst, expected, len) == 0);
+}
+
+TEST_CASE_SELF(decode_maxlen)
+{
+    pass("dGhlIGRpZSBpcyBjYXN0", 5, "the d");
+    pass("c29tZSB0ZXh0IHdpdGggcGFkZGluZw==", 10, "some text ");
+    pass("c29tZSB0ZXh0IHdpdGggcGFkZGluZw==", 1000, "some text with padding");
+}


### PR DESCRIPTION
Add support for chunked decoding.  This is done with a new struct which remembers the partial token it read from the previous (incomplete) chunk.

The main use case for this feature is: a large base64-encoded string split across several mbufs in a chain.  It was not possible to decode this using the old API.  Each buffer may have a length that is not a multiple of four, so a user could not decode each buffer separately.  Furthermore, the entire input may not be null-terminated and it is not always possible to add a terminator (that operation might require allocating another mbuf!).

This also fixes two bugs related to base64 decoding:

1. Never read past the end of the source string (even if its length is not a multiple of four).

2. Return error (-1) on all invalid inputs.  The decode functions used to return the number of bytes written before the problem was detected (i.e., partial decode).  This made it difficult to distinguish this kind of failure from success.