### PR TITLE
Make OS_TICKS_PER_SEC configurable for the nRF52 family.

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
+#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
 
 static inline void
 hal_debug_break(void)

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -80,6 +80,12 @@ syscfg.defs:
             the breakpoint wherever it gets called, For example, reset and crash
        value: 0
 
+    OS_TICKS_PER_SEC:
+        description: >
+            Desired ticks frequency in Hz. Note: Value must be a power of 2.
+        value: 128
+        range: 128,256,512,1024
+
 # MCU peripherals definitions
     I2C_0:
         description: 'Enable nRF52xxx I2C (TWI) 0'


### PR DESCRIPTION
Added a syscfg for the nRF52 family to make it so that OS_TICKS_PER_SEC can be customized on a case by case basis. This is particularly useful for cases where the OS event loop needs to respond more quickly, or with more granularity than at 128 ticks per second.

Should only be increased if necessary, as increasing OS_TICKS_PER_SEC increases system power consumption. Note that OS_TICKS_PER_SEC must be a power of 2 on the nRF52. The range values in the syscfg have all been tested working (blinky works) on the nRF52840 dev kit.

Resolves issue #1785.