### PR TITLE
TCP/IPv4 adaptor for CoAP

### DIFF
--- a/net/oic/include/oic/oc_api.h
+++ b/net/oic/include/oic/oc_api.h
@@ -127,11 +127,23 @@ int oc_notify_observers(oc_resource_t *resource);
 bool oc_do_ip_discovery(const char *rt, oc_discovery_cb_t handler);
 #endif
 
+/**
+ * Initializes a CoAP request.
+ */
+bool oc_init_req(oc_method_t method, const char *uri,
+                 oc_server_handle_t *server, const char *query,
+                 oc_response_handler_t handler, oc_qos_t qos);
+
 bool oc_do_get(const char *uri, oc_server_handle_t *server, const char *query,
                oc_response_handler_t handler, oc_qos_t qos);
 
 bool oc_do_delete(const char *uri, oc_server_handle_t *server,
                   oc_response_handler_t handler, oc_qos_t qos);
+
+/**
+ * Sends the most-recently initialized request.
+ */
+bool oc_do_req(void);
 
 bool oc_init_put(const char *uri, oc_server_handle_t *server, const char *query,
                  oc_response_handler_t handler, oc_qos_t qos);

--- a/net/oic/include/oic/port/mynewt/ip.h
+++ b/net/oic/include/oic/port/mynewt/ip.h
@@ -20,6 +20,8 @@
 #ifndef __OIC_MYNEWT_IP_H_
 #define __OIC_MYNEWT_IP_H_
 
+#include "oic/port/oc_connectivity.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/net/oic/include/oic/port/mynewt/stream.h
+++ b/net/oic/include/oic/port/mynewt/stream.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * stream.h: Utility code for adaptors that implement the CoAP-over-TCP
+ * protocol (Bluetooth, TCP/IP, etc.).
+ */
+
+#ifndef H_MYNEWT_TCP_
+#define H_MYNEWT_TCP_
+
+#include "os/mynewt.h"
+#include "oic/oc_ri.h"
+#include "oic/oc_ri_const.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Indicates whether a transport-specific endpoint matches the provided
+ * description.
+ */
+typedef bool oc_stream_ep_match(const void *ep, const void *ep_desc);
+
+/**
+ * Fills the given endpoint data structure according to the provided
+ * description.
+ */
+typedef void oc_stream_ep_fill(void *ep, const void *ep_desc);
+
+/**
+ * Used for reassembling CoAP-over-TCP packets.  A transport should only have
+ * one reassembler.
+ *
+ * The user must initialize ALL members.  After initialization, the user should
+ * not directly access any members.
+ */
+struct oc_stream_reassembler {
+    STAILQ_HEAD(, os_mbuf_pkthdr) pkt_q; /* Use STAILQ_HEAD_INITIALIZER() */
+    oc_stream_ep_match *ep_match;
+    oc_stream_ep_fill *ep_fill;
+    int endpoint_size;
+};
+
+/**
+ * Partially reassembles a CoAP-over-TCP packet from an incoming fragment.  If
+ * the fragment completes a packet, the reassembled packet is communicated back
+ * to the user via the `out_pkt` parameter.  Otherwise, the partial packet is
+ * recorded in the reassembler object.
+ *
+ * @param r                     The reassembler associated with this transport.
+ * @param frag                  The incoming fragment.
+ * @param ep_desc               Describes the endpoint of the incoming
+ *                                  fragment.  This gets passed to the
+ *                                  reassembler's callbacks.
+ * @param out_pkt               If the fragment completes a packet, the
+ *                                  completed packet is stored here.
+ *
+ * @return                      0 if the fragment was successfully processed;
+ *                              SYS_ENOMEM on mbuf allocation failure.
+ */
+int oc_stream_reass(struct oc_stream_reassembler *r, struct os_mbuf *frag,
+                    void *ep_desc, struct os_mbuf **out_pkt);
+
+/**
+ * Frees up resources associated with a given connection.  This should be
+ * called whenever a connection is closed.
+ *
+ * @param r                     The reassembler.
+ * @param ep                    Endpoint identifying the closed connection.
+ */
+void oc_stream_conn_del(struct oc_stream_reassembler *r, void *ep_desc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/net/oic/include/oic/port/mynewt/tcp4.h
+++ b/net/oic/include/oic/port/mynewt/tcp4.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Interface for the TCP/IPv4 CoAP transport.
+ *
+ * Unlike other transports, this one does not listen for new connections on its
+ * own.  Instead, the application needs to populate the transport with
+ * connections to be managed using oc_tcp4_add_conn().
+ */
+
+#ifndef H_MYNEWT_TCP4_
+#define H_MYNEWT_TCP4_
+
+#include "oic/port/mynewt/ip.h"
+
+struct oc_endpoint_tcp {
+    struct oc_endpoint_ip ep_ip;
+    struct mn_socket *sock;
+};
+
+extern uint8_t oc_tcp4_transport_id;
+
+typedef void oc_tcp4_err_fn(struct mn_socket *mn, int status, void *arg);
+
+/**
+ * Populates `ep` with the endpoint corresponding to the given socket.
+ */
+int oc_tcp4_ep_create(struct oc_endpoint_tcp *ep, struct mn_socket *sock);
+
+/**
+ * Adds the given socket to the list of managed CoAP TCP connections.  After
+ * adding a socket, the application should not directly read from or write to
+ * the socket.
+ *
+ * @param sock                  The socket to add.
+ * @param on_err                Callback that gets called when the connection
+ *                                  gets into a bad state.
+ * @param arg                   Optional argument to pass to the on_err callback.
+ *
+ * @return                      0 on success; SYS_E[...] code on error.
+ */
+int oc_tcp4_add_conn(struct mn_socket *sock, oc_tcp4_err_fn *on_err,
+                     void *arg);
+
+/**
+ * Removes the given socket to the list of managed CoAP TCP connections.
+ *
+ * @param sock                  The socket to remove.
+ *
+ * @return                      0 on success; SYS_E[...] code on error.
+ */
+int oc_tcp4_del_conn(struct mn_socket *sock);
+
+#endif

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -87,9 +87,7 @@ oc_endpoint_has_conn(struct oc_endpoint *oe)
     return oc_endpoint_use_tcp(oe);
 }
 
-#define OC_MBUF_ENDPOINT(m)                                            \
-    ((struct oc_endpoint *)((uint8_t *)m + sizeof(struct os_mbuf) +    \
-                            sizeof(struct os_mbuf_pkthdr)))
+#define OC_MBUF_ENDPOINT(m) ((struct oc_endpoint *) OS_MBUF_USRHDR(m))
 
 #ifdef OC_SECURITY
 uint16_t oc_connectivity_get_dtls_port(void);

--- a/net/oic/include/oic/port/oc_connectivity.h
+++ b/net/oic/include/oic/port/oc_connectivity.h
@@ -44,7 +44,7 @@ struct oc_ep_hdr {
  */
 typedef struct oc_endpoint {
     struct oc_ep_hdr ep;
-    uint8_t _res[23];          /* based on size of oc_endpoint_ip6 */
+    uint8_t _res[29];          /* based on size of oc_endpoint_tcp */
 } oc_endpoint_t;
 
 /*

--- a/net/oic/pkg.yml
+++ b/net/oic/pkg.yml
@@ -60,3 +60,4 @@ pkg.init:
     oc_register_serial: 'MYNEWT_VAL(OC_SYSINIT_STAGE_SERIAL)'
     oc_register_gatt: 'MYNEWT_VAL(OC_SYSINIT_STAGE_GATT)'
     oc_register_lora: 'MYNEWT_VAL(OC_SYSINIT_STAGE_LORA)'
+    oc_register_tcp4: 'MYNEWT_VAL(OC_SYSINIT_STAGE_TCP4)'

--- a/net/oic/src/api/oc_client_api.c
+++ b/net/oic/src/api/oc_client_api.c
@@ -265,6 +265,7 @@ oc_stop_observe(const char *uri, oc_server_handle_t *server)
 
 #if MYNEWT_VAL(OC_CLIENT_DISCOVERY_ENABLE)
 #if MYNEWT_VAL(OC_TRANSPORT_IP)
+#if MYNEWT_VAL(OC_TRANSPORT_IPV4) || MYNEWT_VAL(OC_TRANSPORT_IPV6)
 static bool
 oc_send_ip_discovery(oc_server_handle_t *handle, const char *rt,
                      oc_discovery_cb_t handler)
@@ -292,6 +293,7 @@ oc_send_ip_discovery(oc_server_handle_t *handle, const char *rt,
     }
     return status;
 }
+#endif
 
 #if MYNEWT_VAL(OC_TRANSPORT_IPV6)
 bool

--- a/net/oic/src/api/oc_ri.c
+++ b/net/oic/src/api/oc_ri.c
@@ -896,7 +896,8 @@ oc_ri_alloc_client_cb(const char *uri, oc_server_handle_t *server,
     cb->discovery = false;
     cb->timestamp = oc_clock_time();
     cb->observe_seq = -1;
-    memcpy(&cb->server, server, sizeof(oc_server_handle_t));
+
+    memcpy(&cb->server, server, oc_endpoint_size(&server->endpoint));
 
     os_callout_init(&cb->callout, oc_evq_get(), oc_ri_remove_cb, cb);
 

--- a/net/oic/src/messaging/coap/engine.c
+++ b/net/oic/src/messaging/coap/engine.c
@@ -231,17 +231,19 @@ coap_receive(struct os_mbuf **mp)
             }
             transaction->type = response->type;
         }
-    } else { // Fix this
-        /* handle responses */
-        if (message->type == COAP_TYPE_CON) {
-            erbium_status_code = EMPTY_ACK_RESPONSE;
-        } else if (message->type == COAP_TYPE_ACK) {
-            /* transactions are closed through lookup below */
-        } else if (message->type == COAP_TYPE_RST) {
+    } else {
+        if (!oc_endpoint_use_tcp(&endpoint)) {
+            /* handle responses */
+            if (message->type == COAP_TYPE_CON) {
+                erbium_status_code = EMPTY_ACK_RESPONSE;
+            } else if (message->type == COAP_TYPE_ACK) {
+                /* transactions are closed through lookup below */
+            } else if (message->type == COAP_TYPE_RST) {
 #ifdef OC_SERVER
-            /* cancel possible subscriptions */
-            coap_remove_observer_by_mid(OC_MBUF_ENDPOINT(m), message->mid);
+                /* cancel possible subscriptions */
+                coap_remove_observer_by_mid(OC_MBUF_ENDPOINT(m), message->mid);
 #endif
+            }
         }
 
         /* Open transaction now cleared for ACK since mid matches */

--- a/net/oic/src/port/mynewt/ip4_adaptor.c
+++ b/net/oic/src/port/mynewt/ip4_adaptor.c
@@ -60,9 +60,11 @@ static struct os_event oc_sock4_read_event = {
 #define COAP_PORT_UNSECURED (5683)
 
 /* 224.0.1.187 */
+#if MYNEWT_VAL(OC_SERVER)
 static const struct mn_in_addr coap_all_nodes_v4 = {
     .s_addr = htonl(0xe00001bb)
 };
+#endif
 
 STATS_SECT_START(oc_ip4_stats)
     STATS_SECT_ENTRY(iframe)

--- a/net/oic/src/port/mynewt/stream.c
+++ b/net/oic/src/port/mynewt/stream.c
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * stream.c: Utility code for adaptors that implement the CoAP-over-TCP
+ * protocol (Bluetooth, TCP/IP, etc.).
+ */
+
+#include "os/mynewt.h"
+#include "oic/port/mynewt/stream.h"
+#include "oic/messaging/coap/coap.h"
+
+int
+oc_stream_reass(struct oc_stream_reassembler *r, struct os_mbuf *om1,
+                void *ep_desc, struct os_mbuf **out_pkt)
+{
+    struct os_mbuf_pkthdr *pkt1;
+    struct os_mbuf_pkthdr *pkt2;
+    struct os_mbuf *om2;
+    uint8_t hdr[sizeof(struct coap_tcp_hdr32)];
+
+    *out_pkt = NULL;
+
+    pkt1 = OS_MBUF_PKTHDR(om1);
+    assert(pkt1);
+
+    /* Find the packet that this fragment belongs to, if any. */
+    STAILQ_FOREACH(pkt2, &r->pkt_q, omp_next) {
+        om2 = OS_MBUF_PKTHDR_TO_MBUF(pkt2);
+        if (r->ep_match(OS_MBUF_USRHDR(om2), ep_desc)) {
+            /* Data from same connection.  Append. */
+            os_mbuf_concat(om2, om1);
+            os_mbuf_copydata(om2, 0, sizeof(hdr), hdr);
+
+            if (coap_tcp_msg_size(hdr, sizeof(hdr)) <= pkt2->omp_len) {
+                /* Packet complete. */
+                STAILQ_REMOVE(&r->pkt_q, pkt2, os_mbuf_pkthdr, omp_next);
+                *out_pkt = om2;
+            }
+
+            return 0;
+        }
+    }
+
+    /* New frame, need to add endpoint to the front.  Check if there is enough
+     * space available. If not, allocate a new pkthdr.
+     */
+    if (OS_MBUF_USRHDR_LEN(om1) < r->endpoint_size) {
+        om2 = os_msys_get_pkthdr(0, r->endpoint_size);
+        if (!om2) {
+            os_mbuf_free_chain(om1);
+            return SYS_ENOMEM;
+        }
+        OS_MBUF_PKTHDR(om2)->omp_len = pkt1->omp_len;
+        SLIST_NEXT(om2, om_next) = om1;
+    } else {
+        om2 = om1;
+    }
+
+    r->ep_fill(OS_MBUF_USRHDR(om2), ep_desc);
+    pkt2 = OS_MBUF_PKTHDR(om2);
+
+    os_mbuf_copydata(om2, 0, sizeof(hdr), hdr);
+    if (coap_tcp_msg_size(hdr, sizeof(hdr)) > pkt2->omp_len) {
+        STAILQ_INSERT_TAIL(&r->pkt_q, pkt2, omp_next);
+    } else {
+        *out_pkt = om2;
+    }
+    return 0;
+}
+
+void
+oc_stream_conn_del(struct oc_stream_reassembler *r, void *ep_desc)
+{
+    struct os_mbuf_pkthdr *pkt;
+    struct os_mbuf *m;
+    struct oc_conn_ev *oce;
+
+    STAILQ_FOREACH(pkt, &r->pkt_q, omp_next) {
+        m = OS_MBUF_PKTHDR_TO_MBUF(pkt);
+        if (r->ep_match(OS_MBUF_USRHDR(m), ep_desc)) {
+            STAILQ_REMOVE(&r->pkt_q, pkt, os_mbuf_pkthdr, omp_next);
+            os_mbuf_free_chain(m);
+            break;
+        }
+    }
+
+    /* Notify listeners that this connection is gone. */
+
+    oce = oc_conn_ev_alloc();
+    assert(oce);
+
+    memset(&oce->oce_oe, 0, sizeof(oce->oce_oe));
+    r->ep_fill(&oce->oce_oe, ep_desc);
+    oc_conn_removed(oce);
+}

--- a/net/oic/src/port/mynewt/tcp4_adaptor.c
+++ b/net/oic/src/port/mynewt/tcp4_adaptor.c
@@ -1,0 +1,425 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "os/mynewt.h"
+
+uint8_t oc_tcp4_transport_id = UINT8_MAX;
+
+#if MYNEWT_VAL(OC_TRANSPORT_TCP4)
+
+#include <log/log.h>
+#include <mn_socket/mn_socket.h>
+#include <stats/stats.h>
+
+#include "oic/oc_log.h"
+#include "oic/port/oc_connectivity.h"
+#include "oic/port/mynewt/adaptor.h"
+#include "oic/port/mynewt/transport.h"
+#include "oic/port/mynewt/ip.h"
+#include "oic/port/mynewt/stream.h"
+#include "oic/port/mynewt/tcp4.h"
+
+#ifdef OC_SECURITY
+#error This implementation does not yet support security
+#endif
+
+static void oc_send_buffer_tcp4(struct os_mbuf *m);
+static uint8_t oc_ep_tcp4_size(const struct oc_endpoint *oe);
+static char *oc_log_ep_tcp4(char *ptr, int maxlen, const struct oc_endpoint *);
+static int oc_connectivity_init_tcp4(void);
+static void oc_connectivity_shutdown_tcp4(void);
+static void oc_event_tcp4(struct os_event *ev);
+static void oc_tcp4_readable(void *cb_arg, int err);
+static void oc_tcp4_writable(void *cb_arg, int err);
+static struct oc_tcp4_conn *oc_tcp4_remove_conn(struct mn_socket *sock);
+static bool oc_tcp4_ep_match(const void *ep, const void *ep_desc);
+static void oc_tcp4_ep_fill(void *ep, const void *ep_desc);
+
+static const struct oc_transport oc_tcp4_transport = {
+    .ot_flags = OC_TRANSPORT_USE_TCP,
+    .ot_ep_size = oc_ep_tcp4_size,
+    .ot_tx_ucast = oc_send_buffer_tcp4,
+    .ot_tx_mcast = NULL,
+    .ot_get_trans_security = NULL,
+    .ot_ep_str = oc_log_ep_tcp4,
+    .ot_init = oc_connectivity_init_tcp4,
+    .ot_shutdown = oc_connectivity_shutdown_tcp4
+};
+
+static struct os_event oc_tcp4_read_event = {
+    .ev_cb = oc_event_tcp4,
+};
+
+#define COAP_PORT_UNSECURED (5683)
+
+STATS_SECT_START(oc_tcp4_stats)
+    STATS_SECT_ENTRY(iframe)
+    STATS_SECT_ENTRY(ibytes)
+    STATS_SECT_ENTRY(ierr)
+    STATS_SECT_ENTRY(oucast)
+    STATS_SECT_ENTRY(obytes)
+    STATS_SECT_ENTRY(oerr)
+STATS_SECT_END
+STATS_SECT_DECL(oc_tcp4_stats) oc_tcp4_stats;
+STATS_NAME_START(oc_tcp4_stats)
+    STATS_NAME(oc_tcp4_stats, iframe)
+    STATS_NAME(oc_tcp4_stats, ibytes)
+    STATS_NAME(oc_tcp4_stats, ierr)
+    STATS_NAME(oc_tcp4_stats, oucast)
+    STATS_NAME(oc_tcp4_stats, obytes)
+    STATS_NAME(oc_tcp4_stats, oerr)
+STATS_NAME_END(oc_tcp4_stats)
+
+/**
+ * Describes a tcp endpoint.  EP descriptors get passed to callbacks that need
+ * to operate on a specific managed connection.
+ */
+struct oc_tcp4_ep_desc {
+    struct mn_socket *sock;
+    oc_ipv4_addr_t addr;
+    uint16_t port;
+};
+
+static struct oc_stream_reassembler oc_tcp4_r = {
+    .pkt_q = STAILQ_HEAD_INITIALIZER(oc_tcp4_r.pkt_q),
+    .ep_match = oc_tcp4_ep_match,
+    .ep_fill = oc_tcp4_ep_fill,
+    .endpoint_size = sizeof(struct oc_endpoint_tcp),
+};
+
+struct oc_tcp4_conn {
+    struct mn_socket *sock;
+    oc_tcp4_err_fn *err_cb;
+    void *err_arg;
+    SLIST_ENTRY(oc_tcp4_conn) next;
+};
+
+struct os_mempool oc_tcp4_conn_pool;
+static os_membuf_t oc_tcp4_conn_buf[
+    OS_MEMPOOL_SIZE(MYNEWT_VAL(OC_TCP4_MAX_CONNS),
+                    sizeof(struct oc_tcp4_conn))
+];
+
+union mn_socket_cb oc_tcp4_cbs = {
+    .socket.readable = oc_tcp4_readable,
+    .socket.writable = oc_tcp4_writable,
+};
+
+static SLIST_HEAD(, oc_tcp4_conn) oc_tcp4_conn_list;
+
+/* sockets to use for coap unicast and multicast */
+static struct mn_socket *oc_ucast4;
+
+static char *
+oc_log_ep_tcp4(char *ptr, int maxlen, const struct oc_endpoint *oe)
+{
+    const struct oc_endpoint_tcp *ep_tcp = (const struct oc_endpoint_tcp *)oe;
+    int len;
+
+    mn_inet_ntop(MN_PF_INET, ep_tcp->ep_ip.v4.address, ptr, maxlen);
+    len = strlen(ptr);
+    snprintf(ptr + len, maxlen - len, "-%u", ep_tcp->ep_ip.port);
+
+    return ptr;
+}
+
+static uint8_t
+oc_ep_tcp4_size(const struct oc_endpoint *oe)
+{
+    return sizeof(struct oc_endpoint_tcp);
+}
+
+static void
+oc_send_buffer_tcp4(struct os_mbuf *m)
+{
+    struct oc_endpoint_tcp *ep_tcp;
+    int rc;
+
+    STATS_INC(oc_tcp4_stats, oucast);
+
+    assert(OS_MBUF_USRHDR_LEN(m) >= sizeof(struct oc_endpoint_tcp));
+    ep_tcp = OS_MBUF_USRHDR(m);
+
+    assert(ep_tcp->sock != NULL);
+
+    STATS_INCN(oc_tcp4_stats, obytes, OS_MBUF_PKTLEN(m));
+
+    rc = mn_sendto(ep_tcp->sock, m, NULL);
+    if (rc != 0) {
+        OC_LOG_ERROR("Failed to send buffer %u ucast\n",
+                     OS_MBUF_PKTHDR(m)->omp_len);
+        STATS_INC(oc_tcp4_stats, oerr);
+    }
+}
+
+static bool
+oc_tcp4_ep_match(const void *ep, const void *ep_desc)
+{
+    const struct oc_tcp4_ep_desc *tcp4_desc;
+    const struct oc_endpoint_tcp *ep_tcp;
+
+    ep_tcp = ep;
+    tcp4_desc = ep_desc;
+
+    return tcp4_desc->sock == ep_tcp->sock;
+}
+
+static void
+oc_tcp4_ep_fill(void *ep, const void *ep_desc)
+{
+    const struct oc_tcp4_ep_desc *tcp4_desc;
+    struct oc_endpoint_tcp *ep_tcp;
+
+    ep_tcp = ep;
+    tcp4_desc = ep_desc;
+
+    ep_tcp->ep_ip.ep.oe_type = oc_tcp4_transport_id;
+    ep_tcp->ep_ip.ep.oe_flags = 0;
+    ep_tcp->ep_ip.v4 = tcp4_desc->addr;
+    ep_tcp->ep_ip.port = tcp4_desc->port;
+    ep_tcp->sock = tcp4_desc->sock;
+}
+
+int
+oc_tcp4_ep_create(struct oc_endpoint_tcp *ep, struct mn_socket *sock)
+{
+    struct oc_tcp4_ep_desc desc;
+    struct mn_sockaddr_in msin;
+    int rc;
+
+    rc = mn_getpeername(sock, (struct mn_sockaddr *)&msin);
+    if (rc != 0) {
+        return rc;
+    }
+
+    desc.sock = sock;
+    memcpy(&desc.addr, &msin.msin_addr, sizeof desc.addr);
+    desc.port = ntohs(msin.msin_port);
+
+    oc_tcp4_ep_fill(ep, &desc);
+
+    return 0;
+}
+
+static int
+oc_tcp_rx_frag(struct mn_socket *sock, struct os_mbuf *frag,
+               const struct mn_sockaddr_in *from)
+{
+    struct oc_tcp4_ep_desc ep_desc;
+    struct os_mbuf *pkt;
+    int rc;
+
+    STATS_INC(oc_tcp4_stats, iframe);
+    STATS_INCN(oc_tcp4_stats, ibytes, OS_MBUF_PKTLEN(frag));
+
+    ep_desc.sock = sock;
+    memcpy(&ep_desc.addr, &from->msin_addr, sizeof ep_desc.addr);
+    ep_desc.port = ntohs(from->msin_port);
+
+    rc = oc_stream_reass(&oc_tcp4_r, frag, &ep_desc, &pkt);
+    if (rc != 0) {
+        if (rc == SYS_ENOMEM) {
+            OC_LOG_ERROR("oc_tcp4_rx: Could not allocate mbuf\n");
+        }
+        STATS_INC(oc_tcp4_stats, ierr);
+        return rc;
+    }
+
+    if (pkt != NULL) {
+        STATS_INC(oc_tcp4_stats, iframe);
+        oc_recv_message(pkt);
+    }
+
+    return 0;
+}
+
+static void
+oc_tcp4_err(struct mn_socket *sock, int err)
+{
+    struct oc_tcp4_conn *conn;
+
+    conn = oc_tcp4_remove_conn(sock);
+    assert(conn != NULL);
+
+    if (conn->err_cb != NULL) {
+        conn->err_cb(conn->sock, err, conn->err_arg);
+    }
+
+    os_memblock_put(&oc_tcp4_conn_pool, conn);
+}
+
+static void
+oc_tcp4_readable(void *cb_arg, int err)
+{
+    if (err != 0) {
+        oc_tcp4_err(cb_arg, err);
+    } else {
+        os_eventq_put(oc_evq_get(), &oc_tcp4_read_event);
+    }
+}
+
+static void
+oc_tcp4_writable(void *cb_arg, int err)
+{
+    if (err != 0) {
+        oc_tcp4_err(cb_arg, err);
+    }
+}
+
+static void
+oc_connectivity_shutdown_tcp4(void)
+{
+    if (oc_ucast4) {
+        mn_close(oc_ucast4);
+    }
+}
+
+static void
+oc_event_tcp4(struct os_event *ev)
+{
+    struct mn_sockaddr_in from;
+    struct oc_tcp4_conn *conn;
+    struct os_mbuf *frag;
+    int rc;
+
+    SLIST_FOREACH(conn, &oc_tcp4_conn_list, next) {
+        while (1) {
+            rc = mn_recvfrom(conn->sock, &frag, (struct mn_sockaddr *) &from);
+            if (rc != 0) {
+                if (rc != MN_EAGAIN) {
+                    oc_tcp4_err(conn->sock, rc);
+                }
+                os_eventq_put(oc_evq_get(), &oc_tcp4_read_event);
+                return;
+            }
+
+            assert(OS_MBUF_IS_PKTHDR(frag));
+            oc_tcp_rx_frag(conn->sock, frag, &from);
+        }
+    }
+}
+
+static int
+oc_connectivity_init_tcp4(void)
+{
+    return 0;
+}
+
+static struct oc_tcp4_conn *
+oc_tcp4_find_conn(const struct mn_socket *sock, struct oc_tcp4_conn **out_prev)
+{
+    struct oc_tcp4_conn *prev;
+    struct oc_tcp4_conn *conn;
+
+    prev = NULL;
+
+    SLIST_FOREACH(conn, &oc_tcp4_conn_list, next) {
+        if (conn->sock == sock) {
+            break;
+        }
+
+        prev = conn;
+    }
+
+    if (out_prev != NULL) {
+        *out_prev = prev;
+    }
+
+    return conn;
+}
+
+int
+oc_tcp4_add_conn(struct mn_socket *sock, oc_tcp4_err_fn *on_err, void *arg)
+{
+    struct oc_tcp4_conn *conn;
+
+    conn = os_memblock_get(&oc_tcp4_conn_pool);
+    if (conn == NULL) {
+        return SYS_ENOMEM;
+    }
+
+    *conn = (struct oc_tcp4_conn) {
+        .sock = sock,
+        .err_cb = on_err,
+        .err_arg = arg,
+    };
+    mn_socket_set_cbs(conn->sock, conn->sock, &oc_tcp4_cbs);
+
+    SLIST_INSERT_HEAD(&oc_tcp4_conn_list, conn, next);
+
+    return 0;
+}
+
+static struct oc_tcp4_conn *
+oc_tcp4_remove_conn(struct mn_socket *sock)
+{
+    struct oc_tcp4_conn *conn;
+    struct oc_tcp4_conn *prev;
+
+    conn = oc_tcp4_find_conn(sock, &prev);
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    if (prev == NULL) {
+        SLIST_REMOVE_HEAD(&oc_tcp4_conn_list, next);
+    } else {
+        SLIST_NEXT(prev, next) = SLIST_NEXT(conn, next);
+    }
+
+    return conn;
+}
+
+int
+oc_tcp4_del_conn(struct mn_socket *sock)
+{
+    struct oc_tcp4_conn *conn;
+
+    conn = oc_tcp4_remove_conn(sock);
+    if (conn == NULL) {
+        return SYS_ENOENT;
+    }
+
+    os_memblock_put(&oc_tcp4_conn_pool, conn);
+
+    return 0;
+}
+
+#endif /* MYNEWT_VAL(OC_TRANSPORT_TCP4) */
+
+void
+oc_register_tcp4(void)
+{
+#if MYNEWT_VAL(OC_TRANSPORT_TCP4)
+    int rc;
+
+    SLIST_INIT(&oc_tcp4_conn_list);
+
+    rc = os_mempool_init(&oc_tcp4_conn_pool, MYNEWT_VAL(OC_TCP4_MAX_CONNS),
+                         sizeof (struct oc_tcp4_conn), oc_tcp4_conn_buf,
+                         "oc_tcp4_conn_pool");
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
+    oc_tcp4_transport_id = oc_transport_register(&oc_tcp4_transport);
+#endif
+}

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -42,6 +42,12 @@ syscfg.defs:
         description: 'Support Lora'
         value: '0'
 
+    OC_TRANSPORT_TCP4:
+        description: 'Enables OIC transport over TCP/IPv4'
+        value: 0
+        restrictions:
+            - OC_TRANSPORT_IP
+
     OC_LORA_PORT:
         description: 'Which LORA port to use'
         value: 0xbb
@@ -129,6 +135,15 @@ syscfg.defs:
         description: >
             Sysinit stage for the LoRa OIC transport.
         value: 301
+    OC_SYSINIT_STAGE_TCP4:
+        description: >
+            Sysinit stage for the TCP4 OIC transport.
+        value: 301
+
+    OC_TCP4_MAX_CONNS:
+        description: >
+            Maximum CoAP-aware TCP connections.
+        value: 4
 
     ### Log settings.
 


### PR DESCRIPTION
This transport uses mn_sockets.

Unlike other transports, this one does not listen for new connections on its own.  Instead, the application needs to populate the transport with connections to be managed using oc_tcp4_add_conn().  There are a few too many parameters that need to be specified when listening for TCP connections.