### PR TITLE
hw/drivers/i2s: Use double buffering for STM32F4 family

### DIFF
--- a/hw/drivers/i2s/i2s_stm32f4/include/i2s_stm32f4/i2s_stm32f4.h
+++ b/hw/drivers/i2s/i2s_stm32f4/include/i2s_stm32f4/i2s_stm32f4.h
@@ -67,7 +67,8 @@ struct stm32_i2s {
     DMA_HandleTypeDef *hdma_i2sext;
 
     struct i2s *i2s;
-    struct i2s_sample_buffer *active_buffer;
+    struct i2s_sample_buffer *dma_buffers[2];
+    uint8_t dma_buffer_count;
 };
 
 #define DMA_CFG(dma, ch, st, name) &(name ## _stream ## st ## _channel ## ch)

--- a/hw/drivers/i2s/i2s_stm32f4/syscfg.yml
+++ b/hw/drivers/i2s/i2s_stm32f4/syscfg.yml
@@ -17,3 +17,9 @@
 #
 
 syscfg.defs:
+    I2S_FULLDUPLEX_ENABLE:
+        description: >
+            If set to 1 I2S full duplex is supported in code. This can be set to
+            0 to reduce code size when full duplex is not needed even when
+            hardware could support it.
+        value: 1


### PR DESCRIPTION
STM32F4 does not have FIFO for SPI/I2S devices.
Driver was swapping DMA buffers in interrupt.
In some cases (depending on sample rate), CPU clock and usage,
DMA could be started to late to handle I2S stream in
worst case odd number of samples could be lost resulting
in channel swapping. If only one channel was used it could
result in random audio disruption.

This change enables hardware double buffering for for DMA.
Hardware buffer swapping leaves more time for software to
handle buffers.

As side effect if driver has only one buffer (application did
not provided next one yet) this single buffer is reused till
new one arrives.  For microphone it just drops incoming data
for speaker it will play same samples again.

Same approach (keeping old buffer till new one arrives)
is used in NRF5x hardware.