### PR TITLE
hw/drivers/i2s: Fix no client crash

### DIFF
--- a/hw/drivers/i2s/src/i2s.c
+++ b/hw/drivers/i2s/src/i2s.c
@@ -252,7 +252,9 @@ i2s_start(struct i2s *i2s)
             rc = i2s_driver_start(i2s);
             if (rc == I2S_OK) {
                 i2s->state = I2S_STATE_RUNNING;
-                i2s->client->state_changed_cb(i2s, I2S_STATE_RUNNING);
+                if (i2s->client) {
+                    i2s->client->state_changed_cb(i2s, I2S_STATE_RUNNING);
+                }
             }
         }
     }


### PR DESCRIPTION
Function i2s_open() allows to pass NULL pointer for
client argument.
In one case this pointer was not checked for NULL value
before dereference.
This simply add missing NULL pointer check.