### PR TITLE
hw/mcu/dialog: Add system clock choice

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -38,6 +38,11 @@ void da1469x_clock_sys_xtal32m_init(void);
 void da1469x_clock_sys_xtal32m_enable(void);
 
 /**
+ * Wait for XTAL32M to settle
+ */
+void da1469x_clock_sys_xtal32m_wait_to_settle(void);
+
+/**
  * Switch sys_clk to XTAL32M
  *
  * Caller shall ensure that XTAL32M is already settled.
@@ -124,6 +129,46 @@ da1469x_clock_amba_disable(uint32_t mask)
     CRG_TOP->CLK_AMBA_REG &= ~mask;
     __HAL_ENABLE_INTERRUPTS(primask);
 }
+
+/**
+ * Enable PLL96
+ */
+static inline void
+da1469x_clock_sys_pll_enable(void)
+{
+    CRG_XTAL->PLL_SYS_CTRL1_REG |= CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_EN_Msk |
+                                   CRG_XTAL_PLL_SYS_CTRL1_REG_LDO_PLL_ENABLE_Msk;
+}
+
+/**
+ * Disable PLL96
+ *
+ * If PLL was used as SYS_CLOCK switches to XTAL32M.
+ */
+void da1469x_clock_sys_pll_disable(void);
+
+/**
+ * Checks whether PLL96 is locked and can be use as system clock or USB clock
+ *
+ * @return 0 if PLL is off, non-0 it its running
+ */
+static inline int
+da1469x_clock_is_pll_locked(void)
+{
+    return 0 != (CRG_XTAL->PLL_SYS_STATUS_REG & CRG_XTAL_PLL_SYS_STATUS_REG_PLL_LOCK_FINE_Msk);
+}
+
+/**
+ * Waits for PLL96 to lock.
+ */
+void da1469x_clock_pll_wait_to_lock(void);
+
+/**
+ * Switches system clock to PLL96
+ *
+ * Caller shall ensure that PLL is already locked.
+ */
+void da1469x_clock_sys_pll_switch(void);
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -97,8 +97,17 @@ da1469x_sleep(os_time_t ticks)
         g_mcu_wait_for_jtag_until = os_time_get() + os_time_ms_to_ticks32(100);
     }
 
-    /* XXX for now we always run on XTAL32M and assume PDC was configure to enable it */
+    /* XXX for now we always want XTAL32M and assume PDC was configure to enable it */
+#if MYNEWT_VAL(MCU_PLL_ENABLE)
+    da1469x_clock_sys_xtal32m_wait_to_settle();
+    da1469x_clock_sys_pll_enable();
+#if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, PLL96)
+    da1469x_clock_pll_wait_to_lock();
+    da1469x_clock_sys_pll_switch();
+#endif
+#else
     da1469x_clock_sys_xtal32m_switch_safe();
+#endif
 }
 
 #else

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -94,10 +94,19 @@ hal_system_clock_start(void)
 
     /* PD_TIM is already started in SystemInit */
 
-    /* Switch to XTAL32M and disable RC32M */
     da1469x_clock_sys_xtal32m_init();
     da1469x_clock_sys_xtal32m_enable();
+#if MYNEWT_VAL(MCU_PLL_ENABLE)
+    da1469x_clock_sys_pll_enable();
+#endif
+#if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, PLL96)
+    da1469x_clock_pll_wait_to_lock();
+    da1469x_clock_sys_pll_switch();
+#endif
+#if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, XTAL32M)
+    /* Switch to XTAL32M and disable RC32M */
     da1469x_clock_sys_xtal32m_switch_safe();
+#endif
     da1469x_clock_sys_rc32m_disable();
 
 #if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -66,6 +66,17 @@ syscfg.defs:
         description: >
             Specifies settling time [ms] of 32K crystal oscillator.
         value: 8000
+    MCU_SYSCLK_SOURCE:
+        description: >
+            Specifies system clock source
+        choices:
+            - XTAL32M
+            - PLL96
+        value: XTAL32M
+    MCU_PLL_ENABLE:
+        description: >
+            Enable 96MHz PLL
+        value: 0
 
     MCU_DEEP_SLEEP:
         description: >
@@ -381,6 +392,9 @@ syscfg.defs:
         restrictions:
             - '!GPADC_BATTERY'
 
+syscfg.vals.'MCU_SYSCLK_SOURCE == "PLL96"':
+    MCU_PLL_ENABLE: 1
+
 syscfg.restrictions:
     - "QSPI_FLASH_ADDRESS_LENGTH==24"
     - "!I2C_0 || (I2C_0_PIN_SCL && I2C_0_PIN_SDA)"
@@ -392,3 +406,4 @@ syscfg.restrictions:
     - "!SPI_1_MASTER || (SPI_1_MASTER_PIN_SCK && SPI_1_MASTER_PIN_MOSI && SPI_1_MASTER_PIN_MISO)"
     - "!SPI_0_SLAVE || (SPI_0_SLAVE_PIN_SCK && SPI_0_SLAVE_PIN_MOSI && SPI_0_SLAVE_PIN_MISO && SPI_0_SLAVE_PIN_SS)"
     - "!SPI_1_SLAVE || (SPI_1_SLAVE_PIN_SCK && SPI_1_SLAVE_PIN_MOSI && SPI_1_SLAVE_PIN_MISO && SPI_1_SLAVE_PIN_SS)"
+    - 'MCU_PLL_ENABLE || MCU_SYSCLK_SOURCE != "PLL96"'


### PR DESCRIPTION
System clock was always set to XTAL32M.

Now it can be also RC32M and PLL96
PLL96 can be turned on even if it is not used for system clock,
this is needed if USB is to be used.