### PR TITLE
tinyusb: Add hardware initialization for DA1469x

### DIFF
--- a/hw/usb/tinyusb/da146xx/include/tusb_hw.h
+++ b/hw/usb/tinyusb/da146xx/include/tusb_hw.h
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TUSB_HW_H__
+#define __TUSB_HW_H__
+
+#define CFG_TUSB_MCU OPT_MCU_DA1469X
+
+#include <syscfg/syscfg.h>
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
+#define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)
+#else
+#define USBD_CDC_NOTIFY_EP      0x81
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP_SIZE)
+#define USBD_CDC_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_NOTIFY_EP_SIZE 0x08
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_OUT_EP)
+#define USBD_CDC_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_DATA_OUT_EP)
+#else
+#define USBD_CDC_DATA_OUT_EP    0x02
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_IN_EP)
+#define USBD_CDC_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_DATA_IN_EP)
+#else
+#define USBD_CDC_DATA_IN_EP     0x82
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_EP_SIZE)
+#define USBD_CDC_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_DATA_EP_SIZE)
+#else
+#define USBD_CDC_DATA_EP_SIZE   0x40
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP)
+#define USBD_HID_REPORT_EP      MYNEWT_VAL(USBD_HID_REPORT_EP)
+#else
+#define USBD_HID_REPORT_EP      0x83
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_SIZE)
+#define USBD_HID_REPORT_EP_SIZE MYNEWT_VAL(USBD_HID_REPORT_EP_SIZE)
+#else
+#define USBD_HID_REPORT_EP_SIZE 0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_INTERVAL)
+#define USBD_HID_REPORT_EP_INTERVAL MYNEWT_VAL(USBD_HID_REPORT_EP_INTERVAL)
+#else
+#define USBD_HID_REPORT_EP_INTERVAL 10
+#endif
+
+#endif

--- a/hw/usb/tinyusb/da146xx/pkg.yml
+++ b/hw/usb/tinyusb/da146xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,37 +17,17 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb
-pkg.description: >
-    Package provides task for TinyUSB.
-    This package requires API TINYUSB_HW_INIT that will
-    provide function tinyusb_hardware_init().
-
+pkg.name: hw/usb/tinyusb/da146xx
+pkg.description: Hardware initialization for Tinyusb
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - usb
     - tinyusb
 
+pkg.apis:
+    - TINYUSB_HW_INIT
+
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@tinyusb/tinyusb"
-
-pkg.init:
-    tinyusb_start: 'MYNEWT_VAL(USBD_SYSINIT_STAGE)'
-
-pkg.deps.USBD_STD_DESCRIPTORS:
-    - "@apache-mynewt-core/hw/usb/tinyusb/std_descriptors"
-pkg.deps.'MCU_TARGET == "nRF52840"':
-    - "@apache-mynewt-core/hw/usb/tinyusb/nrf5x"
-pkg.deps.MCU_STM32F4:
-    - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
-pkg.deps.MCU_STM32L4:
-    - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
-pkg.deps.MCU_STM32F1:
-    - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
-pkg.deps.'(MCU_TARGET == "DA14691" || MCU_TARGET == "DA14695" || MCU_TARGET == "DA14697" || MCU_TARGET == "DA14699")':
-    - "@apache-mynewt-core/hw/usb/tinyusb/da146xx"
-
-pkg.req_apis:
-    - TINYUSB_HW_INIT

--- a/hw/usb/tinyusb/da146xx/src/da1469x.c
+++ b/hw/usb/tinyusb/da146xx/src/da1469x.c
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <mcu/mcu.h>
+
+#include <device/usbd.h>
+#include <tusb.h>
+#include <hal/hal_gpio.h>
+
+static void
+USBD_IRQHandler(void)
+{
+    tud_int_handler(0);
+}
+
+void
+tinyusb_hardware_init(void)
+{
+    /* Setup USB IRQ */
+    NVIC_SetVector(USB_IRQn, (uint32_t)USBD_IRQHandler);
+    NVIC_SetPriority(USB_IRQn, 2);
+    NVIC_EnableIRQ(USB_IRQn);
+
+    /* Use PLL96 / 2 clock not HCLK */
+    CRG_TOP->CLK_CTRL_REG &= ~CRG_TOP_CLK_CTRL_REG_USB_CLK_SRC_Msk;
+
+    mcu_gpio_set_pin_function(14, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+    mcu_gpio_set_pin_function(15, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+}

--- a/hw/usb/tinyusb/da146xx/syscfg.yml
+++ b/hw/usb/tinyusb/da146xx/syscfg.yml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+
+syscfg.restrictions:
+    - USBD_EP0_SIZE == 8
+    - MCU_PLL_ENABLE


### PR DESCRIPTION
This provides code for hardware initialization: GPIO and clock.

This may be merged after TinyUSB part is merged.
https://github.com/hathach/tinyusb/pull/427