### PR TITLE
kernel/os: added package dependency

### DIFF
--- a/kernel/os/pkg.yml
+++ b/kernel/os/pkg.yml
@@ -29,6 +29,9 @@ pkg.deps:
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/util/mem"
 
+pkg.deps.CONSOLE_RTT:
+    - "@apache-mynewt-core/hw/drivers/rtt"
+
 pkg.req_apis:
     - console
 


### PR DESCRIPTION
If RTT was enabled, rtt/SEGGER_RTT.h was being  included
in os.c, but that package was lacking, causing build error.