### PR TITLE
hw/bsp/dialog: Start flash loader with XTAL32M

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
+++ b/hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh
@@ -122,6 +122,8 @@ symbol-file $FLASH_LOADER
 # valid for Macronix flash found on Dialog development kits)
 set *(int *)0x3800000C = 0xa8a500eb
 set *(int *)0x38000010 = 0x00000066
+# Set XTAL as system clock
+set *(int *)0x50000014 = 0x00000040
 
 set *(int *)0x500000BC = 4
 set \$sp=*(int *)0x20000000


### PR DESCRIPTION
If application was running on 96MHz PLL flash loader seems
to have problem flashing board.
This switches system clock to XTAL32 before flash loader code
is executed.