### PR TITLE
hw/mcu/dialog: Fix retaining SCB state in deep sleep

### DIFF
--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -128,9 +128,8 @@ da1469x_m33_sleep:
 /* Set SCB->SCR[SLEEPDEEP] so we can enter deep sleep */
     ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
     ldr     r1, [r0, #0]
-    mov     r2, r1
-    orr     r2, r1, #4      /* SLEEPDEEP */
-    str     r2, [r0, #0]
+    orr     r1, r1, #4      /* SLEEPDEEP */
+    str     r1, [r0, #0]
 
 /* Sleep! */
     dsb

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -99,9 +99,9 @@ da1469x_m33_sleep:
 
 /* Save SCB state (SCR, CCR, SHPR and SHCSR) */
     ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
-    ldmia   r0!, {r4-r9}
+    ldmia   r0, {r4-r9}
     and     r9, r9, #(SCB_SHCSR_MASK)
-    ldr     r10, [r1, #(SCB_CPACR_OFFSET - SCB_SCR_OFFSET)]
+    ldr     r10, [r0, #(SCB_CPACR_OFFSET - SCB_SCR_OFFSET)]
     and     r10, r10, #(SCB_CPACR_MASK)
     stmia   r3!, {r4-r10}
 


### PR DESCRIPTION
SCB->CPACR value is loaded using r1 register as a base address, but
there was no proper value set there.