### PR TITLE
util/scfg: Support for unsigned integer types

### DIFF
--- a/util/scfg/src/scfg.c
+++ b/util/scfg/src/scfg.c
@@ -229,6 +229,10 @@ scfg_register(struct scfg_group *group, char *name)
         case CONF_INT16:
         case CONF_INT32:
         case CONF_INT64:
+        case CONF_UINT8:
+        case CONF_UINT16:
+        case CONF_UINT32:
+        case CONF_UINT64:
         case CONF_STRING:
         case CONF_BOOL:
             break;


### PR DESCRIPTION
When scfg was implemented, sys/config did not support unsigned integer
types.  Support has since been added to sys/config, but scfg still
rejects them.

This commit makes scfg not reject settings with unsigned integer types.