### PR TITLE
Fix NLIP receives

### DIFF
--- a/encoding/base64/src/base64.c
+++ b/encoding/base64/src/base64.c
@@ -131,19 +131,26 @@ token_decode(const char *token, int len)
     int i;
     unsigned int val = 0;
     int marker = 0;
-    if (len < 4)
+
+    if (len < 4) {
         return DECODE_ERROR;
+    }
+
     for (i = 0; i < 4; i++) {
         val *= 64;
-        if (token[i] == '=')
+        if (token[i] == '=') {
             marker++;
-        else if (marker > 0)
+        } else if (marker > 0) {
             return DECODE_ERROR;
-        else
+        } else {
             val += pos(token[i]);
+        }
     }
-    if (marker > 2)
+
+    if (marker > 2) {
         return DECODE_ERROR;
+    }
+
     return (marker << 24) | val;
 }
 

--- a/encoding/base64/src/base64.c
+++ b/encoding/base64/src/base64.c
@@ -231,6 +231,10 @@ base64_decoder_go(struct base64_decoder *dec)
         /* Detect invalid input. */
         for (i = 0; i < read_len; i++) {
             sval = dec->src[src_off + i];
+            if (sval == '\0') {
+                /* Incomplete input. */
+                return -1;
+            }
             if (sval != '=' && strchr(base64_chars, sval) == NULL) {
                 /* Invalid base64 character. */
                 return -1;

--- a/encoding/base64/src/base64.c
+++ b/encoding/base64/src/base64.c
@@ -126,12 +126,12 @@ base64_pad(char *buf, int len)
 #define DECODE_ERROR -1
 
 static unsigned int
-token_decode(const char *token)
+token_decode(const char *token, int len)
 {
     int i;
     unsigned int val = 0;
     int marker = 0;
-    if (strlen(token) < 4)
+    if (len < 4)
         return DECODE_ERROR;
     for (i = 0; i < 4; i++) {
         val *= 64;
@@ -248,7 +248,7 @@ base64_decoder_go(struct base64_decoder *dec)
 
         /* Copy full token into buf and decode it. */
         memcpy(&dec->buf[dec->buf_len], &dec->src[src_off], read_len);
-        val = token_decode(dec->buf);
+        val = token_decode(dec->buf, read_len);
         if (val == DECODE_ERROR) {
             return -1;
         }

--- a/sys/shell/src/shell_nlip.c
+++ b/sys/shell/src/shell_nlip.c
@@ -58,6 +58,12 @@ shell_nlip_process(char *data, int len)
     struct os_mbuf *m;
     uint16_t crc;
 
+    /* Trim trailing newline. */
+    if (len >= 1 && data[len - 1] == '\n') {
+        data[len - 1] = '\0';
+        len--;
+    }
+
     rc = base64_decode(data, data);
     if (rc < 0) {
         goto err;


### PR DESCRIPTION
Incoming NLIP frames were not being properly decoded.  This bug has two causes:

1. The trailing '\n' character was not being stripped before passing input to `nlip_process()`.  The base64 decode functions were recently made more strict such that they reject invalid input.  The old behavior was to stop at the first invalid character and return the partially decoded string.

The fix here is to trim the trailing '\n'.

2. The base64 code contained a buffer overrun bug.  An internal function expected a string but was passed an unterminated character array.  When the internal function called `strlen()` on its input, the result was undefined behavior.  Consequently, base64 decoding would fail with some optimization levels.

The fix is to change the intermediate function (`process_token()`) to accept a length argument.  The first argument is now treated as a regular character array (not a string).

The base64 changes that broke this are from this PR: https://github.com/apache/mynewt-core/pull/2287