### PR TITLE
hw/mcu/stm/stm32_common: Add include for os_cputime.h

### DIFF
--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -52,6 +52,9 @@
 #include "stm32f4xx_hal_adc.h"
 #include "adc_stm32f4/adc_stm32f4.h"
 #endif
+#if MYNEWT_VAL(OS_CPUTIME_TIMER_NUM) >= 0
+#include "os/os_cputime.h"
+#endif
 
 #include "mcu/stm32_hal.h"
 


### PR DESCRIPTION
The stm32_periph.c file may not include os_cputime.h if certain
syscfg values are not set. This explicitly include os_cputime.h
if OS_CPUTIME_TIMER_NUM is >= 0.