### PR TITLE
Add syscfg option to select HFCLK source for NRF52 devices

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_timer.c
@@ -650,6 +650,7 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
     /* disable interrupts */
     __HAL_DISABLE_INTERRUPTS(ctx);
 
+#if MYNEWT_VAL_CHOICE(MCU_HFCLK_SOURCE, HFXO)
     /* Make sure HFXO is started */
     if ((NRF_CLOCK->HFCLKSTAT &
          (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) !=
@@ -662,6 +663,7 @@ hal_timer_config(int timer_num, uint32_t freq_hz)
             }
         }
     }
+#endif
     hwtimer = bsptimer->tmr_reg;
 
     /* Stop the timer first */

--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_clock.c
@@ -35,6 +35,11 @@ nrf52_clock_hfxo_request(void)
     int started;
     uint32_t ctx;
 
+#if MYNEWT_VAL_CHOICE(MCU_HFCLK_SOURCE, HFINT)
+    /* Cannot enable/disable hfxo if it is not present */
+    assert(0);
+#endif
+
     started = 0;
     __HAL_DISABLE_INTERRUPTS(ctx);
     assert(nrf52_clock_hfxo_refcnt < 0xff);
@@ -62,6 +67,11 @@ nrf52_clock_hfxo_release(void)
 {
     int stopped;
     uint32_t ctx;
+
+#if MYNEWT_VAL_CHOICE(MCU_HFCLK_SOURCE, HFINT)
+    /* Cannot enable/disable hfxo if it is not present */
+    assert(0);
+#endif
 
     stopped = 0;
     __HAL_DISABLE_INTERRUPTS(ctx);

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -42,6 +42,18 @@ syscfg.defs:
             expected to be overridden by the BSP.
         value: 0
 
+    MCU_HFCLK_SOURCE:
+        description: >
+            Selected source for high frequency clock (HFCLK).
+            Selecting HFXO will still mostly use the HFINT but will switch to HFXO when requested (BLE, certain timers, etc...)
+            Selecting HFINT should only be used in the case where an external 32MHz crystal oscillator is not present.
+        value: HFXO
+        choices:
+            - HFXO
+            - HFINT
+        restrictions:
+            - '(MCU_HFCLK_SOURCE == "HFXO") || (MCU_LFCLK_SOURCE != "LFSYNTH")'
+
     MCU_LFCLK_SOURCE:
         description: >
             Selected source for low frequency clock (LFCLK).


### PR DESCRIPTION
This is needed to be able to run NRF52 devices without an external 32MHz crystal.
BLE will not work when set to HFINT, but everything else should.
The only restriction is that the LFCLK source cannot be LFSYNTH
In the rare case where MCU_HFCLK_SOURCE is set to HFINT and BLE is enabled, an assert(0) will be hit in nrf52_clock_hfxo_request/release
