### PR TITLE
Add support for all UARTS on STM32

### DIFF
--- a/hw/mcu/stm/stm32_common/include/stm32_common/stm32_hal.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/stm32_hal.h
@@ -32,7 +32,9 @@ extern "C" {
                   ((uint8_t)(MYNEWT_VAL(UART_4) != 0)) + \
                   ((uint8_t)(MYNEWT_VAL(UART_5) != 0)) + \
                   ((uint8_t)(MYNEWT_VAL(UART_6) != 0)) + \
-                  ((uint8_t)(MYNEWT_VAL(UART_7) != 0)))
+                  ((uint8_t)(MYNEWT_VAL(UART_7) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_8) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_9) != 0)))
 
 #define PWM_CNT (((uint8_t)(MYNEWT_VAL(PWM_0) != 0)) + \
                  ((uint8_t)(MYNEWT_VAL(PWM_1) != 0)) + \

--- a/hw/mcu/stm/stm32_common/include/stm32_common/stm32_hal.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/stm32_hal.h
@@ -27,7 +27,12 @@ extern "C" {
 
 #define UART_CNT (((uint8_t)(MYNEWT_VAL(UART_0) != 0)) + \
                   ((uint8_t)(MYNEWT_VAL(UART_1) != 0)) + \
-                  ((uint8_t)(MYNEWT_VAL(UART_2) != 0)))
+                  ((uint8_t)(MYNEWT_VAL(UART_2) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_3) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_4) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_5) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_6) != 0)) + \
+                  ((uint8_t)(MYNEWT_VAL(UART_7) != 0)))
 
 #define PWM_CNT (((uint8_t)(MYNEWT_VAL(PWM_0) != 0)) + \
                  ((uint8_t)(MYNEWT_VAL(PWM_1) != 0)) + \

--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -63,6 +63,37 @@ uart_by_port(int port)
     if (port == 2) {
         return &uarts[index];
     }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_3)
+    if (port == 3) {
+        return &uarts[index];
+    }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_4)
+    if (port == 4) {
+        return &uarts[index];
+    }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_5)
+    if (port == 5) {
+        return &uarts[index];
+    }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_6)
+    if (port == 6) {
+        return &uarts[index];
+    }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_7)
+    if (port == 7) {
+        return &uarts[index];
+    }
+    index++;
 #endif
     return NULL;
 };

--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -95,6 +95,17 @@ uart_by_port(int port)
     }
     index++;
 #endif
+#if MYNEWT_VAL(UART_8)
+    if (port == 8) {
+        return &uarts[index];
+    }
+    index++;
+#endif
+#if MYNEWT_VAL(UART_9)
+    if (port == 9) {
+        return &uarts[index];
+    }
+#endif
     return NULL;
 };
 
@@ -103,7 +114,11 @@ struct hal_uart_irq {
     volatile uint32_t ui_cnt;
 };
 
-#if defined(UART8_BASE)
+#if defined(UART10_BASE)
+static struct hal_uart_irq uart_irqs[10];
+#elif defined(UART9_BASE)
+static struct hal_uart_irq uart_irqs[9];
+#elif defined(UART8_BASE)
 static struct hal_uart_irq uart_irqs[8];
 #elif defined(UART7_BASE)
 static struct hal_uart_irq uart_irqs[7];

--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -37,7 +37,7 @@
 #include "hash_stm32/hash_stm32.h"
 #endif
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || \
-    MYNEWT_VAL(UART_5) || MYNEWT_VAL(UART_6) || MYNEWT_VAL(UART_7)
+    MYNEWT_VAL(UART_5) || MYNEWT_VAL(UART_6) || MYNEWT_VAL(UART_7) || MYNEWT_VAL(UART_8) || MYNEWT_VAL(UART_9)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #endif
@@ -114,6 +114,14 @@ extern const struct stm32_uart_cfg os_bsp_uart6_cfg;
 #endif
 #if MYNEWT_VAL(UART_7)
 static struct uart_dev os_bsp_uart7;
+extern const struct stm32_uart_cfg os_bsp_uart7_cfg;
+#endif
+#if MYNEWT_VAL(UART_8)
+static struct uart_dev os_bsp_uart8;
+extern const struct stm32_uart_cfg os_bsp_uart7_cfg;
+#endif
+#if MYNEWT_VAL(UART_9)
+static struct uart_dev os_bsp_uart9;
 extern const struct stm32_uart_cfg os_bsp_uart7_cfg;
 #endif
 
@@ -358,6 +366,18 @@ stm32_periph_create_uart(void)
     rc = os_dev_create(&os_bsp_uart7.ud_dev, "uart7",
                        OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
                        (void *)&os_bsp_uart7_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_8)
+    rc = os_dev_create(&os_bsp_uart8.ud_dev, "uart8",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart8_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_9)
+    rc = os_dev_create(&os_bsp_uart9.ud_dev, "uart9",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart9_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -36,7 +36,7 @@
 #include "hash/hash.h"
 #include "hash_stm32/hash_stm32.h"
 #endif
-#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || MYNEWT_VAL(UART_5) || MYNEWT_VAL(UART_6) || MYNEWT_VAL(UART_7)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #endif
@@ -94,6 +94,26 @@ extern const struct stm32_uart_cfg os_bsp_uart1_cfg;
 #if MYNEWT_VAL(UART_2)
 static struct uart_dev os_bsp_uart2;
 extern const struct stm32_uart_cfg os_bsp_uart2_cfg;
+#endif
+#if MYNEWT_VAL(UART_3)
+static struct uart_dev os_bsp_uart3;
+extern const struct stm32_uart_cfg os_bsp_uart3_cfg;
+#endif
+#if MYNEWT_VAL(UART_4)
+static struct uart_dev os_bsp_uart4;
+extern const struct stm32_uart_cfg os_bsp_uart4_cfg;
+#endif
+#if MYNEWT_VAL(UART_5)
+static struct uart_dev os_bsp_uart5;
+extern const struct stm32_uart_cfg os_bsp_uart5_cfg;
+#endif
+#if MYNEWT_VAL(UART_6)
+static struct uart_dev os_bsp_uart6;
+extern const struct stm32_uart_cfg os_bsp_uart6_cfg;
+#endif
+#if MYNEWT_VAL(UART_7)
+static struct uart_dev os_bsp_uart7;
+extern const struct stm32_uart_cfg os_bsp_uart7_cfg;
 #endif
 
 #if MYNEWT_VAL(ADC_0)
@@ -307,6 +327,36 @@ stm32_periph_create_uart(void)
     rc = os_dev_create(&os_bsp_uart2.ud_dev, "uart2",
                        OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
                        (void *)&os_bsp_uart2_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_3)
+    rc = os_dev_create(&os_bsp_uart3.ud_dev, "uart3",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart3_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_4)
+    rc = os_dev_create(&os_bsp_uart4.ud_dev, "uart4",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart4_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_5)
+    rc = os_dev_create(&os_bsp_uart5.ud_dev, "uart5",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart5_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_6)
+    rc = os_dev_create(&os_bsp_uart6.ud_dev, "uart6",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart6_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(UART_7)
+    rc = os_dev_create(&os_bsp_uart7.ud_dev, "uart7",
+                       OS_DEV_INIT_PRIMARY, 1, uart_hal_init,
+                       (void *)&os_bsp_uart7_cfg);
     assert(rc == 0);
 #endif
 }

--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -36,7 +36,8 @@
 #include "hash/hash.h"
 #include "hash_stm32/hash_stm32.h"
 #endif
-#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || MYNEWT_VAL(UART_5) || MYNEWT_VAL(UART_6) || MYNEWT_VAL(UART_7)
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2) || MYNEWT_VAL(UART_3) || MYNEWT_VAL(UART_4) || \
+    MYNEWT_VAL(UART_5) || MYNEWT_VAL(UART_6) || MYNEWT_VAL(UART_7)
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #endif

--- a/hw/mcu/stm/stm32_common/syscfg.yml
+++ b/hw/mcu/stm/stm32_common/syscfg.yml
@@ -163,6 +163,38 @@ syscfg.defs:
         description: 'UART_7 CTS pin'
         value: -1
 
+    UART_8:
+        description: 'UART 8'
+        value:  0
+    UART_8_PIN_TX:
+        description: 'UART_8 TX pin'
+        value: -1
+    UART_8_PIN_RX:
+        description: 'UART_8 RX pin'
+        value: -1
+    UART_8_PIN_RTS:
+        description: 'UART_8 RTS pin'
+        value: -1
+    UART_8_PIN_CTS:
+        description: 'UART_8 CTS pin'
+        value: -1
+
+    UART_9:
+        description: 'UART 9'
+        value:  0
+    UART_9_PIN_TX:
+        description: 'UART_9 TX pin'
+        value: -1
+    UART_9_PIN_RX:
+        description: 'UART_9 RX pin'
+        value: -1
+    UART_9_PIN_RTS:
+        description: 'UART_9 RTS pin'
+        value: -1
+    UART_9_PIN_CTS:
+        description: 'UART_9 CTS pin'
+        value: -1
+
     SPI_0_MASTER:
         description: 'SPI 0 master'
         value:  0

--- a/hw/mcu/stm/stm32_common/syscfg.yml
+++ b/hw/mcu/stm/stm32_common/syscfg.yml
@@ -83,6 +83,86 @@ syscfg.defs:
         description: 'UART_2 CTS pin'
         value: -1
 
+    UART_3:
+        description: 'UART 3'
+        value:  0
+    UART_3_PIN_TX:
+        description: 'UART_3 TX pin'
+        value: -1
+    UART_3_PIN_RX:
+        description: 'UART_3 RX pin'
+        value: -1
+    UART_3_PIN_RTS:
+        description: 'UART_3 RTS pin'
+        value: -1
+    UART_3_PIN_CTS:
+        description: 'UART_3 CTS pin'
+        value: -1
+
+    UART_4:
+        description: 'UART 4'
+        value:  0
+    UART_4_PIN_TX:
+        description: 'UART_4 TX pin'
+        value: -1
+    UART_4_PIN_RX:
+        description: 'UART_4 RX pin'
+        value: -1
+    UART_4_PIN_RTS:
+        description: 'UART_4 RTS pin'
+        value: -1
+    UART_4_PIN_CTS:
+        description: 'UART_4 CTS pin'
+        value: -1
+
+    UART_5:
+        description: 'UART 5'
+        value:  0
+    UART_5_PIN_TX:
+        description: 'UART_5 TX pin'
+        value: -1
+    UART_5_PIN_RX:
+        description: 'UART_5 RX pin'
+        value: -1
+    UART_5_PIN_RTS:
+        description: 'UART_5 RTS pin'
+        value: -1
+    UART_5_PIN_CTS:
+        description: 'UART_5 CTS pin'
+        value: -1
+
+    UART_6:
+        description: 'UART 6'
+        value:  0
+    UART_6_PIN_TX:
+        description: 'UART_6 TX pin'
+        value: -1
+    UART_6_PIN_RX:
+        description: 'UART_6 RX pin'
+        value: -1
+    UART_6_PIN_RTS:
+        description: 'UART_6 RTS pin'
+        value: -1
+    UART_6_PIN_CTS:
+        description: 'UART_6 CTS pin'
+        value: -1
+
+    UART_7:
+        description: 'UART 7'
+        value:  0
+    UART_7_PIN_TX:
+        description: 'UART_7 TX pin'
+        value: -1
+    UART_7_PIN_RX:
+        description: 'UART_7 RX pin'
+        value: -1
+    UART_7_PIN_RTS:
+        description: 'UART_7 RTS pin'
+        value: -1
+    UART_7_PIN_CTS:
+        description: 'UART_7 CTS pin'
+        value: -1
+
     SPI_0_MASTER:
         description: 'SPI 0 master'
         value:  0


### PR DESCRIPTION
Adds support for configuring UART3-UART7, increasing the maximum number of configurable UARTs on STM32 from 3 to 8.