### PR TITLE
Fix SPI/TWI support for NRF52810 and NRF52811

### DIFF
--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -66,7 +66,15 @@ static void twim1_irq_handler(void);
 static const struct twim twims[TWIM_COUNT] = {
     {
         .nrf_twim = NRF_TWIM0,
+#if MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52832) || MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52840)
         .irqn = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn,
+#elif MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52810)
+        .irqn = TWIM0_TWIS0_TWI0_IRQn,
+#elif  MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52811)
+        .irqn = TWIM0_TWIS0_TWI0_SPIM1_SPIS1_SPI1_IRQn,
+#else
+#error Unsupported MCU_TARGET
+#endif
         .isr = twim0_irq_handler,
     },
     {

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -649,10 +649,19 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
     }
 
     irq_handler = NULL;
-    spi->spi_type  = spi_type;
+    spi->spi_type = spi_type;
     if (spi_num == 0) {
 #if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
+
+/* SPI IRQn name is different between MCU variants */
+#if MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52832) || MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52840)
         spi->irq_num = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn;
+#elif MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52810) || MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52811)
+        spi->irq_num = SPIM0_SPIS0_SPI0_IRQn;
+#else
+#error Unsupported MCU_TARGET
+#endif
+
         irq_handler = nrf52_spi0_irq_handler;
         if (spi_type == HAL_SPI_TYPE_MASTER) {
 #if MYNEWT_VAL(SPI_0_MASTER)
@@ -671,8 +680,17 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         goto err;
 #endif
     } else if (spi_num == 1) {
-#if MYNEWT_VAL(SPI_1_MASTER)  || MYNEWT_VAL(SPI_1_SLAVE)
+#if MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_1_SLAVE)
+
+        /* SPI IRQn name is different between MCU variants */
+#if MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52832) || MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52840)
         spi->irq_num = SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn;
+#elif MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52811)
+        spi->irq_num = TWIM0_TWIS0_TWI0_SPIM1_SPIS1_SPI1_IRQn;
+#else
+#error Unsupported MCU_TARGET
+#endif
+
         irq_handler = nrf52_spi1_irq_handler;
         if (spi_type == HAL_SPI_TYPE_MASTER) {
 #if MYNEWT_VAL(SPI_1_MASTER)

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -91,8 +91,10 @@ syscfg.defs:
         description: 'Enable nRF52xxx I2C (TWI) 0'
         value: 0
         restrictions:
-            - "!SPI_0_MASTER"
-            - "!SPI_0_SLAVE"
+            - '!(SPI_0_MASTER && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
+            - '!(SPI_0_SLAVE  && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
+            - '!(SPI_1_MASTER && (MCU_TARGET == "nrf52811"))'
+            - '!(SPI_1_SLAVE  && (MCU_TARGET == "nrf52811"))'
     I2C_0_PIN_SCL:
         description: 'SCL pin for I2C_0'
         value: ''
@@ -124,7 +126,7 @@ syscfg.defs:
         value: 0
         restrictions:
             - "!SPI_0_SLAVE"
-            - "!I2C_0"
+            - '!(I2C_0 && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
     SPI_0_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_0_MASTER'
         value: ''
@@ -140,7 +142,7 @@ syscfg.defs:
         value: 0
         restrictions:
             - "!SPI_0_MASTER"
-            - "!I2C_0"
+            - '!(I2C_0 && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
     SPI_0_SLAVE_PIN_SCK:
         description: 'SCK pin for SPI_0_SLAVE'
         value: ''
@@ -159,7 +161,8 @@ syscfg.defs:
         value: 0
         restrictions:
             - "!SPI_1_SLAVE"
-            - "!I2C_1"
+            - '!(I2C_1 && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
+            - '!(I2C_0 && ((MCU_TARGET == "nrf52811")))'
     SPI_1_MASTER_PIN_SCK:
         description: 'SCK pin for SPI_1_MASTER'
         value: ''
@@ -175,7 +178,8 @@ syscfg.defs:
         value: 0
         restrictions:
             - "!SPI_1_MASTER"
-            - "!I2C_1"
+            - '!(I2C_1 && ((MCU_TARGET == "nrf52832") || (MCU_TARGET == "nrf52840")))'
+            - '!(I2C_0 && ((MCU_TARGET == "nrf52811")))'
     SPI_1_SLAVE_PIN_SCK:
         description: 'SCK pin for SPI_1_SLAVE'
         value: ''


### PR DESCRIPTION
Various devices in the NRF52 family have different number of SPI/TWI peripherals.
The NRF52810 only has TWI0 and SPI0 where the NRF52811 also has SPI1.
Unfortunately, NRF52810 and NRF52811 don't have the same IRQn names (and values) for TWI and SPI peripherals.

The peripheral/irq table is as follows:

```
            SPI0    SPI1    TWI0    TWI1
NRF52810    IRQ4    N/A     IRQ3    N/A
NRF52811    IRQ4    IRQ3    IRQ3    N/A
NRF52832    IRQ3    IRQ4    IRQ3    IRQ4
NRF52840    IRQ3    IRQ4    IRQ3    IRQ4
```

This change updates the nrf52xxx syscfg.yml's peripheral restrictions as well as hal_spi.c and i2c_nrf52_twim.c

The IRQn names are as follows:
nrf52.h/nrf52840.h
```
  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn=   3,  /*!< 3  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0                                      */
  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn=   4,  /*!< 4  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1
```

nrf52811.h
```
  TWIM0_TWIS0_TWI0_SPIM1_SPIS1_SPI1_IRQn=   3,  /*!< 3  TWIM0_TWIS0_TWI0_SPIM1_SPIS1_SPI1                                      */
  SPIM0_SPIS0_SPI0_IRQn     =   4,              /*!< 4  SPIM0_SPIS0_SPI0
```

nrf52810.h
```
  TWIM0_TWIS0_TWI0_IRQn     =   3,              /*!< 3  TWIM0_TWIS0_TWI0                                                       */
  SPIM0_SPIS0_SPI0_IRQn     =   4,              /*!< 4  SPIM0_SPIS0_SPI0
```