### PR TITLE
hw/mcu/stm/stm32_common: Clear overrun error

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -152,6 +152,11 @@ uart_irq_handler(int num)
     if (isr & USART_ISR_ORE) {
         regs->ICR |= USART_ICR_ORECF;
     }
+#else
+    /* clear overrun */
+    if (isr & USART_SR_ORE) {
+        (void)RXDR(regs);
+    }
 #endif
 }
 


### PR DESCRIPTION
The uart irq handler for certain stm32 mcu's was not handling
the clearing of an rx overrun error. This code should handle it
properly.