### PR TITLE
remove timer 4 initialisation from loraping

### DIFF
--- a/apps/loraping/src/main.c
+++ b/apps/loraping/src/main.c
@@ -223,8 +223,6 @@ main(void)
 
     sysinit();
 
-    hal_timer_config(4, 1000000);
-
     /* Radio initialization. */
     radio_events.TxDone = on_tx_done;
     radio_events.RxDone = on_rx_done;


### PR DESCRIPTION
Timer is inited and never used and some BSP dont have timer 4.