### PR TITLE
remove STATS_GET macro from stats/stub

### DIFF
--- a/sys/stats/stub/include/stats/stats.h
+++ b/sys/stats/stub/include/stats/stats.h
@@ -61,7 +61,6 @@ struct stats_hdr {
 
 #define STATS_SIZE_INIT_PARMS(__sectvarname, __size) 0, 0
 
-#define STATS_GET(__sectvarname, __var)
 #define STATS_INC(__sectvarname, __var)
 #define STATS_INCN(__sectvarname, __var, __n)
 #define STATS_CLEAR(__sectvarname, __var)


### PR DESCRIPTION
Macro STATS_GET don't make sense in stub (it do in full)