### PR TITLE
Fix 2 bytes I2C read on stm32f1

### DIFF
--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v1.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_i2c_v1.c
@@ -695,14 +695,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_Custom(I2C_HandleTypeDef *hi2c,
     }
     else if(hi2c->XferSize == 2U)
     {
-      /* Disable Acknowledge */
-      hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
-
       /* Enable Pos */
       hi2c->Instance->CR1 |= I2C_CR1_POS;
 
       /* Clear ADDR flag */
       __HAL_I2C_CLEAR_ADDRFLAG(hi2c);
+
+      /* Disable Acknowledge */
+      hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
     }
     else
     {


### PR DESCRIPTION
2 byte read receive wrong data for seconde byte.
First byte read is NAKed and seconde is trash.
Register access sequecnce is wrong for 2 byte read.
Better sequence stolen from HAL_I2C_Master_Receive from hw/mcu/stm/stm32f1xx/src/ext/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_i2c.c
Now NAK is send on seconde byte not first.