### PR TITLE
mcu/dialog: Fix gpio irq init with deep sleep enabled

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -370,24 +370,6 @@ hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
         return -1;
     }
 
-#if MYNEWT_VAL(MCU_DEEP_SLEEP)
-    /*
-     * There should be no PDC entry, but let's check it just in case to avoid
-     * creating duplicated entry. We assume that someone either uses hal_gpio
-     * to control pins so we "own" PDC entries, or does this manually so this
-     * is never called for given pin.
-     */
-    i = da1469x_pdc_find(pin, MCU_PDC_MASTER_M33, 0);
-    if (i < 0) {
-        i = da1469x_pdc_add(pin, MCU_PDC_MASTER_M33, MCU_PDC_EN_XTAL);
-        if (i < 0) {
-            return -1;
-        }
-        da1469x_pdc_set(i);
-        da1469x_pdc_ack(i);
-    }
-#endif
-
     hal_gpio_init_in(pin, pull);
 
     switch (trig) {
@@ -406,6 +388,24 @@ hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
     hal_gpio_irqs[i].pin = pin;
     hal_gpio_irqs[i].func = handler;
     hal_gpio_irqs[i].arg = arg;
+
+#if MYNEWT_VAL(MCU_DEEP_SLEEP)
+    /*
+     * There should be no PDC entry, but let's check it just in case to avoid
+     * creating duplicated entry. We assume that someone either uses hal_gpio
+     * to control pins so we "own" PDC entries, or does this manually so this
+     * is never called for given pin.
+     */
+    i = da1469x_pdc_find(pin, MCU_PDC_MASTER_M33, 0);
+    if (i < 0) {
+        i = da1469x_pdc_add(pin, MCU_PDC_MASTER_M33, MCU_PDC_EN_XTAL);
+        if (i < 0) {
+            return -1;
+        }
+        da1469x_pdc_set(i);
+        da1469x_pdc_ack(i);
+    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Routine which adds PCC entry overwrites 'i' value so needs to be done
after interrupt struct is initialized, otherwise things will not work
as expected.