### PR TITLE
bsp/pinetime - Change loading tool to J-Link

### DIFF
--- a/hw/bsp/pinetime/pinetime_debug.sh
+++ b/hw/bsp/pinetime/pinetime_debug.sh
@@ -27,13 +27,18 @@
 #  - RESET set if target should be reset when attaching
 #  - NO_GDB set if we should not start gdb to debug
 #
-. $CORE_PATH/hw/scripts/openocd.sh
+. $CORE_PATH/hw/scripts/jlink.sh
 
 FILE_NAME=$BIN_BASENAME.elf
-CFG="-f interface/stlink.cfg -f target/nrf52.cfg"
-EXTRA_GDB_CMDS='monitor arm semihosting enable'
-# Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"
 
-openocd_debug
+if [ $# -gt 2 ]; then
+    SPLIT_ELF_NAME=$3.elf
+    # TODO -- this magic number 0x42000 is the location of the second image
+    # slot. we should either get this from a flash map file or somehow learn
+    # this from the image itself
+    EXTRA_GDB_CMDS="add-symbol-file $SPLIT_ELF_NAME 0x8000 -readnow"
+fi
 
+JLINK_DEV="nRF52"
+
+jlink_debug

--- a/hw/bsp/pinetime/pinetime_download.sh
+++ b/hw/bsp/pinetime/pinetime_download.sh
@@ -29,22 +29,13 @@
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
 
-. $CORE_PATH/hw/scripts/openocd.sh
-
-CFG="-f interface/stlink.cfg -f target/nrf52.cfg"
+. $CORE_PATH/hw/scripts/jlink.sh
 
 if [ "$MFG_IMAGE" ]; then
-    FLASH_OFFSET=0
+    FLASH_OFFSET=0x0
 fi
 
-# We write the config registers for BPROT so that NVMC write
-# protection gets disabled for all blocks of the flash
-# We also write the DISABLEINDEBUG register so that, write
-# protection gets disabled in debug register by default
-CFG_POST_INIT="mww 0x40000600 0;mww 0x40000604 0;mww 0x40000608 1;\
-               mww 0x40000610 0;mww 0x40000614 0;
-              "
+JLINK_DEV="nRF52"
 
 common_file_to_load
-openocd_load
-openocd_reset_run
+jlink_load


### PR DESCRIPTION
Default tool to flash pinetime with Mynewt should be J-Link, not STLink.
This is consistent with other bsps using Nordic chips, and is easier to use.