### PR TITLE
da1469x_sleep: Adding deep sleep pre/post callbacks, and QSPI configurability in deep sleep

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_sleep.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_sleep.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_SLEEP_H_
+#define __MCU_DA1469X_SLEEP_H_
+
+#include <stdbool.h>
+#include "os/os_time.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct da1469x_sleep_cb {
+    bool (* enter_sleep)(os_time_t ticks);
+    void (* exit_sleep)(bool slept);
+};
+
+void da1469x_sleep_cb_register(struct da1469x_sleep_cb *cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* __MCU_DA1469X_SLEEP_H_ */

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -208,8 +208,8 @@ da1469x_m33_wakeup:
     add     r1, r0, NVIC_IPR_OFFSET
     ldmia   r3!, {r4-r5}
     stmia   r0!, {r4-r5}
-    ldmia   r3, {r0, r2, r4-r12}
-    stmia   r1!, {r0, r2, r4-r12}
+    ldmia   r3!, {r0, r2, r4-r12}
+    stmia   r1, {r0, r2, r4-r12}
 
  /* Restore SCB state */
     ldmia   r3!, {r4-r10}

--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -39,7 +39,7 @@ da1469x_m33_sleep_state:
     .space 40   /* R4-R12, LR */
 .saved_nvic:
     .space 8    /* ISER[0..1] */
-    .space 40   /* IPR[0..39] */
+    .space 44   /* IPR[0..43] */
 .saved_scb:
     .space 28   /* SCR, CCR, SHPR[0..11], CPACR */
 #if MYNEWT_VAL(HARDFLOAT)
@@ -89,13 +89,13 @@ da1469x_m33_sleep:
     mrs     r2, CONTROL
     stmia   r3!, {r0-r2,r4-r12, lr}
 
-/* Save NVIC state (ISER[0..1] and IPR[0..39]) */
+/* Save NVIC state (ISER[0..1] and IPR[0..43]) */
     ldr     r0, =NVIC_BASE
     add     r1, r0, NVIC_IPR_OFFSET
     ldmia   r0!, {r4-r5}
     stmia   r3!, {r4-r5}
-    ldmia   r1!, {r2, r4-r12}
-    stmia   r3!, {r2, r4-r12}
+    ldmia   r1, {r0, r2, r4-r12}
+    stmia   r3!, {r0, r2, r4-r12}
 
 /* Save SCB state (SCR, CCR, SHPR and SHCSR) */
     ldr     r0, =(SCB_BASE + SCB_SCR_OFFSET)
@@ -118,6 +118,25 @@ da1469x_m33_sleep:
     ldr     r0, =RESET_STAT_REG
     movs    r3, #0
     str     r3, [r0, #0]
+
+#if MYNEWT_VAL(MCU_DEEP_SLEEP_QSPIC_QUAD_DISABLE)
+/*
+ * Disable QSPI continuous mode to achieve flash standby
+ */
+    ldr     r0, =QSPIC_BASE
+    ldr     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    bic     r1, r1, #1      /* Clear automode */
+    orr     r1, r1, #0x3c   /* Set IO2/IO3 DAT and OEN */
+    str     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    mov     r1, #1          /* Set single */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #8          /* Enable CS */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #0xff       /* Exit QPI mode */
+    strb    r1, [r0, #(QSPIC_WRITEDATA_OFFSET)]
+    mov     r1, #16         /* Disable CS */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+#endif
 
 /* Disable QSPI controller clock */
     ldr     r0, =CLK_AMBA_REG
@@ -149,6 +168,21 @@ da1469x_m33_sleep:
     orr     r1, r1, #0x1000
     str     r1, [r2, #0]
 
+#if MYNEWT_VAL(MCU_DEEP_SLEEP_QSPIC_QUAD_DISABLE)
+/*
+ * Put flash back into automode. We need to do this before we start executing code from flash
+ * again.
+ */
+    ldr     r0, =QSPIC_BASE
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    mov     r1, #4          /* Set quad */
+    str     r1, [r0, #(QSPIC_CTRLBUS_OFFSET)]
+    ldr     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+    bic     r1, r1, #0xc    /* Clear IO2/IO3 OEN */
+    orr     r1, r1, #1      /* Enable automode */
+    str     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
+#endif
+
     b       da1469x_m33_restore
 
     .section .text_ram
@@ -174,8 +208,8 @@ da1469x_m33_wakeup:
     add     r1, r0, NVIC_IPR_OFFSET
     ldmia   r3!, {r4-r5}
     stmia   r0!, {r4-r5}
-    ldmia   r3!, {r2, r4-r12}
-    stmia   r1!, {r2, r4-r12}
+    ldmia   r3, {r0, r2, r4-r12}
+    stmia   r1!, {r0, r2, r4-r12}
 
  /* Restore SCB state */
     ldmia   r3!, {r4-r10}

--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -22,6 +22,7 @@
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
+#include "mcu/da1469x_sleep.h"
 #include "mcu/mcu.h"
 #include "hal/hal_system.h"
 #include "da1469x_priv.h"
@@ -34,6 +35,8 @@ uint8_t g_mcu_pdc_combo_idx;
 
 static bool g_mcu_wait_for_jtag;
 static os_time_t g_mcu_wait_for_jtag_until;
+
+static struct da1469x_sleep_cb g_da1469x_sleep_cb;
 
 static inline bool
 da1469x_sleep_any_irq_pending(void)
@@ -66,13 +69,16 @@ da1469x_sleep(os_time_t ticks)
         return;
     }
 
+    /* Must enter mcu gpio sleep before releasing MCU_PD_DOMAIN_SYS */
+    mcu_gpio_enter_sleep();
+
     /* PD_SYS will not be disabled here until we enter deep sleep, so don't wait */
     da1469x_pd_release_nowait(MCU_PD_DOMAIN_SYS);
 
-    mcu_gpio_enter_sleep();
     ret = da1469x_m33_sleep();
     mcu_gpio_exit_sleep();
-    if (!ret) {
+
+    if (!slept) {
         /* We were not sleeping, no need to apply PD_SYS settings again */
         da1469x_pd_acquire_noconf(MCU_PD_DOMAIN_SYS);
         return;

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -160,6 +160,10 @@ syscfg.defs:
         value: ''
         restrictions:
         - (MCU_QSPIC_APP_CFG)
+    MCU_DEEP_SLEEP_QSPIC_QUAD_DISABLE:
+        description: >
+            Enable disabling quad mode when entering deep sleep
+        value: 0
 
 # MCU peripherals definitions
     I2C_0:


### PR DESCRIPTION
Adding configurability to da1469x_m33_sleep.S QSPI in deep sleep. MCU_DEEP_SLEEP_QSPIC_QUAD_DISABLE.
Adding retention for more IPRs.
Adding pre and post callbacks for dep_sleep

 @andrzej-kaczmarek 