### PR TITLE
sensors: Fix LOG_MODULE conflicts

### DIFF
--- a/hw/drivers/sensors/ina219/syscfg.yml
+++ b/hw/drivers/sensors/ina219/syscfg.yml
@@ -48,7 +48,7 @@ syscfg.defs:
 
     INA219_LOG_MODULE:
         description: 'Numeric module ID to use for INA219 log messages.'
-        value: 86
+        value: 88
     INA219_LOG_LVL:
         description: 'Minimum level for the INA219 log.'
         value: 1

--- a/hw/drivers/sensors/ina226/syscfg.yml
+++ b/hw/drivers/sensors/ina226/syscfg.yml
@@ -34,7 +34,7 @@ syscfg.defs:
 
     INA226_LOG_MODULE:
         description: 'Numeric module ID to use for INA226 log messages.'
-        value: 86
+        value: 89
     INA226_LOG_LVL:
         description: 'Minimum level for the INA226 log.'
         value: 1


### PR DESCRIPTION
ina219 and ina226 had LOG_MODULE value copied from other driver.
To enable usage of those drivers together, LOG_MODULE are changed
to unique values.