### PR TITLE
kernel/os: os_dev_add check to see if device is already present

### DIFF
--- a/kernel/os/src/os_dev.c
+++ b/kernel/os/src/os_dev.c
@@ -64,9 +64,12 @@ os_dev_add(struct os_dev *dev)
      */
     prev_dev = NULL;
     STAILQ_FOREACH(cur_dev, &g_os_dev_list, od_next) {
-        if (dev->od_stage < cur_dev->od_stage ||
-            ((dev->od_stage == cur_dev->od_stage) &&
-             (dev->od_priority < cur_dev->od_priority))) {
+        if (dev == cur_dev) {
+            /* Do nothing */
+            return 0;
+        } else if (dev->od_stage < cur_dev->od_stage ||
+                   ((dev->od_stage == cur_dev->od_stage) &&
+                    (dev->od_priority < cur_dev->od_priority))) {
             break;
         }
         prev_dev = cur_dev;


### PR DESCRIPTION
**Background:**
The flash loader application initializes the flash without
going through the os_dev APIs and by default OS_SCHEDULING
is set to 0. Hence no os initialization is done.

If the flash_loader needs to access other flash interfaces such as
encrypted flash, that is dependent on os features.

Turning OS_SCHEDULING can result in the hal_bsp_init being
invoked twice. Once through os_* and then from flash_loader.
Though this is should be avoided, in such scenario, it is seen
that the global device list gets incorrectly updated with entries
pointing to itself as next device, thus creating an infinite loop.

**Fix:**
If the device is already present in the global list,
calling os_dev_add() can potentially result in an incorrect
list. Fix this by checking for the device when the list
is traversed.


Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>