### PR TITLE
hw/mcu/dialog: Remove preprocessor error

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -208,8 +208,6 @@ da1469x_delay_us(uint32_t delay_us)
 #ifndef CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_SEL_MIN_CUR_INT_Msk
 #define CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_SEL_MIN_CUR_INT_Pos (14UL)   /*!< PLL_SEL_MIN_CUR_INT (Bit 14)                          */
 #define CRG_XTAL_PLL_SYS_CTRL1_REG_PLL_SEL_MIN_CUR_INT_Msk (0x4000UL) /*!< PLL_SEL_MIN_CUR_INT (Bitfield-Mask: 0x01)           */
-#else
-#error Please remove above definition. It looks like it is not needed any more.
 #endif
 
 /**


### PR DESCRIPTION
There was intentional preprocessor generated error that
was supposed to detect when register definition file is updated.
It turned out that there are some custom register files that already
has this definition present yet normal DA1469xAB.h file still does
not have it.
Preprocessor error is now removed to avid build errors.