### PR TITLE
apps/rust_blinky: Add blinky app using Rust language

### DIFF
--- a/apps/rust_blinky/Cargo.toml
+++ b/apps/rust_blinky/Cargo.toml
@@ -1,0 +1,27 @@
+#
+# Copyright 2020 Casper Meijn <casper@meijn.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[package]
+name = "rust_blinky"
+version = "0.1.0"
+authors = ["Casper Meijn <casper@meijn.net>"]
+edition = "2018"
+
+[dependencies]
+panic-halt = "0.2.0"
+
+[lib]
+crate-type = ["staticlib"]

--- a/apps/rust_blinky/Cargo.toml
+++ b/apps/rust_blinky/Cargo.toml
@@ -22,6 +22,10 @@ edition = "2018"
 
 [dependencies]
 panic-halt = "0.2.0"
+cty = "0.2.1"
+
+[build-dependencies]
+bindgen = "0.54.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/apps/rust_blinky/build.rs
+++ b/apps/rust_blinky/build.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
+
+    let mut builder = bindgen::Builder::default()
+        .use_core()
+        .derive_default(true)
+        .ctypes_prefix("cty")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .header("wrapper.h");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    // If available, set the sysroot as mynewt would do
+    if let Ok(cc_path) = env::var("MYNEWT_CC_PATH") {
+        let cc_output = Command::new(cc_path)
+            .arg("-print-sysroot")
+            .output()
+            .expect("failed to execute gcc");
+        if !cc_output.status.success() {
+            panic!("Error: C-compiler failed to provide sysroot");
+        }
+        let sysroot_path = str::from_utf8(&cc_output.stdout).unwrap().trim();
+        builder = builder.clang_arg(format!("--sysroot={}", sysroot_path));
+    }
+
+    // If available, set the include directories as mynewt would do
+    if let Ok(include_path_list) = env::var("MYNEWT_INCLUDE_PATH") {
+        for include_path in include_path_list.split(":") {
+            builder = builder.clang_arg("--include-directory=".to_owned() + include_path);
+        }
+    }
+    // If available, set the CFLAGS as mynewt would do
+    if let Ok(cflag_list) = env::var("MYNEWT_CFLAGS") {
+        for cflag in cflag_list.split(" ") {
+            builder = builder.clang_arg(cflag);
+        }
+    }
+
+    builder
+        .generate()
+        .map_err(|_| "Failed to generate")
+        .unwrap()
+        .write_to_file(out_path)
+        .map_err(|e| format!("Failed to write output: {}", e))
+        .unwrap();
+}

--- a/apps/rust_blinky/cargo_build.sh
+++ b/apps/rust_blinky/cargo_build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eu
+
+#
+# Copyright 2020 Casper Meijn <casper@meijn.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ ${MYNEWT_VAL_ARCH_NAME} == '"cortex_m0"' ]]; then
+  TARGET="thumbv6m-none-eabi"
+elif [[ ${MYNEWT_VAL_ARCH_NAME} == '"cortex_m3"' ]]; then
+  TARGET="thumbv7m-none-eabi"
+elif [[ ${MYNEWT_VAL_ARCH_NAME} == '"cortex_m4"' || ${MYNEWT_VAL_ARCH_NAME} == '"cortex_m7"' ]]; then
+  if [[ $MYNEWT_VAL_HARDFLOAT -eq 1 ]]; then
+    TARGET="thumbv7em-none-eabihf"
+  else
+    TARGET="thumbv7em-none-eabi"
+  fi
+else
+  echo "The ARCH_NAME ${MYNEWT_VAL_ARCH_NAME} is not supported"
+  exit 1
+fi
+
+cargo build --target="${TARGET}" --target-dir="${MYNEWT_PKG_BIN_DIR}"
+cp "${MYNEWT_PKG_BIN_DIR}"/${TARGET}/debug/*.a "${MYNEWT_PKG_BIN_ARCHIVE}"

--- a/apps/rust_blinky/pkg.yml
+++ b/apps/rust_blinky/pkg.yml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "apps/rust_blinky"
+pkg.type: app
+pkg.description: "Example application which uses the Rust programming language"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.pre_build_cmds:
+    './cargo_build.sh': 1
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/stub"
+    - "@apache-mynewt-core/sys/stats/stub"

--- a/apps/rust_blinky/pkg.yml
+++ b/apps/rust_blinky/pkg.yml
@@ -29,6 +29,7 @@ pkg.pre_build_cmds:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/sys/stats/stub"

--- a/apps/rust_blinky/src/bindings.rs
+++ b/apps/rust_blinky/src/bindings.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/apps/rust_blinky/src/lib.rs
+++ b/apps/rust_blinky/src/lib.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_std]
+
+extern "C" {
+    fn sysinit_start();
+    fn sysinit_app();
+    fn sysinit_end();
+    fn hal_gpio_init_out(pin: i32, val: i32) -> i32;
+    fn hal_gpio_toggle(pin: i32);
+    fn os_time_delay(osticks: u32);
+}
+
+extern crate panic_halt;
+
+const OS_TICKS_PER_SEC: u32 = 128;
+
+const LED_BLINK_PIN: i32 = 23;
+
+
+#[no_mangle]
+pub extern "C" fn main() {
+    /* Initialize all packages. */
+    unsafe { sysinit_start(); }
+    unsafe { sysinit_app(); }
+    unsafe { sysinit_end(); }
+
+    unsafe { hal_gpio_init_out(LED_BLINK_PIN, 1); }
+
+    loop {
+        /* Wait one second */
+        unsafe { os_time_delay(OS_TICKS_PER_SEC); }
+
+        /* Toggle the LED */
+        unsafe { hal_gpio_toggle(LED_BLINK_PIN); }
+    }
+}

--- a/apps/rust_blinky/wrapper.h
+++ b/apps/rust_blinky/wrapper.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 Casper Meijn <casper@meijn.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <inttypes.h>
+#include "bsp/bsp.h"
+#include "os/os_time.h"
+#include "hal/hal_gpio.h"
+#include "sysinit/sysinit.h"


### PR DESCRIPTION
This added the Rust blinky application as explained in https://mynewt.apache.org/latest/tutorials/other/rust.html

Then it extends it by using bindgen to generate Rust code from the actual C-header as used for the C code. Then use the generated code in the Rust application to make it compatible with all BSP.