### PR TITLE
Allow oc gatt client as BLE central

### DIFF
--- a/net/oic/include/oic/oc_gatt.h
+++ b/net/oic/include/oic/oc_gatt.h
@@ -48,7 +48,7 @@ extern "C" {
 /* Secure CoAP rsp. characteristic: 0x1001 */
 #define OC_GATT_SEC_RSP_CHR_UUID    0x1001
 
-int oc_ble_coap_gatt_init(void);
+int oc_ble_coap_gatt_srv_init(void);
 void oc_ble_coap_conn_new(uint16_t conn_handle);
 void oc_ble_coap_conn_del(uint16_t conn_handle);
 

--- a/net/oic/include/oic/oc_gatt.h
+++ b/net/oic/include/oic/oc_gatt.h
@@ -48,9 +48,14 @@ extern "C" {
 /* Secure CoAP rsp. characteristic: 0x1001 */
 #define OC_GATT_SEC_RSP_CHR_UUID    0x1001
 
-int oc_ble_coap_gatt_srv_init(void);
+int oc_ble_coap_gatt_init(void);
 void oc_ble_coap_conn_new(uint16_t conn_handle);
 void oc_ble_coap_conn_del(uint16_t conn_handle);
+
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+void oc_ble_coap_gatt_notify_rx(uint16_t conn_handle, uint16_t att_handle,
+                                struct os_mbuf *om);
+#endif
 
 #ifdef __cplusplus
 }

--- a/net/oic/include/oic/port/mynewt/ble.h
+++ b/net/oic/include/oic/port/mynewt/ble.h
@@ -31,6 +31,9 @@ struct oc_endpoint_ble {
     struct oc_ep_hdr ep;
     uint8_t srv_idx;
     uint16_t conn_handle;
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+    uint16_t tx_att_handle;
+#endif
 };
 
 /**
@@ -53,6 +56,11 @@ int oc_endpoint_is_gatt(const struct oc_endpoint *oe);
  */
 int oc_endpoint_gatt_conn_eq(const struct oc_endpoint *oe1,
                              const struct oc_endpoint *oe2);
+
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+void oc_endpoint_gatt_create(struct oc_endpoint_ble *ep, uint16_t conn_handle,
+                             uint16_t attr_handle);
+#endif
 
 #ifdef __cplusplus
 }

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -192,6 +192,7 @@ static const struct ble_gatt_svc_def oc_gatt_svr_svcs[] = { {
     },
 };
 
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 0)
 /*
  * Look up service index based on characteristic handle from request.
  */
@@ -207,6 +208,8 @@ oc_ble_req_attr_to_idx(uint16_t attr_handle)
     }
     return -1;
 }
+#endif
+
 
 static uint8_t
 oc_ep_gatt_size(const struct oc_endpoint *oe)

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -192,7 +192,6 @@ static const struct ble_gatt_svc_def oc_gatt_svr_svcs[] = { {
     },
 };
 
-#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 0)
 /*
  * Look up service index based on characteristic handle from request.
  */
@@ -208,7 +207,6 @@ oc_ble_req_attr_to_idx(uint16_t attr_handle)
     }
     return -1;
 }
-#endif
 
 static uint8_t
 oc_ep_gatt_size(const struct oc_endpoint *oe)

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -345,7 +345,7 @@ oc_gatt_chr_access(uint16_t conn_handle, uint16_t attr_handle,
 #endif
 
 int
-oc_ble_coap_gatt_init(void)
+oc_ble_coap_gatt_srv_init(void)
 {
 #if (MYNEWT_VAL(OC_SERVER) == 1)
     int rc;

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -192,6 +192,7 @@ static const struct ble_gatt_svc_def oc_gatt_svr_svcs[] = { {
     },
 };
 
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 0)
 /*
  * Look up service index based on characteristic handle from request.
  */
@@ -207,6 +208,7 @@ oc_ble_req_attr_to_idx(uint16_t attr_handle)
     }
     return -1;
 }
+#endif
 
 static uint8_t
 oc_ep_gatt_size(const struct oc_endpoint *oe)
@@ -321,8 +323,11 @@ oc_gatt_chr_access(uint16_t conn_handle, uint16_t attr_handle,
     switch (ctxt->op) {
     case BLE_GATT_ACCESS_OP_WRITE_CHR:
         m = ctxt->om;
-
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+        srv_idx = OC_BLE_SRV_NONE;
+#else
         srv_idx = oc_ble_req_attr_to_idx(attr_handle);
+#endif
         assert(srv_idx >= 0);
         rc = oc_ble_reass(m, conn_handle, srv_idx);
         if (rc) {
@@ -342,7 +347,7 @@ oc_gatt_chr_access(uint16_t conn_handle, uint16_t attr_handle,
 #endif
 
 int
-oc_ble_coap_gatt_srv_init(void)
+oc_ble_coap_gatt_init(void)
 {
 #if (MYNEWT_VAL(OC_SERVER) == 1)
     int rc;
@@ -390,6 +395,32 @@ oc_ble_coap_conn_del(uint16_t conn_handle)
 
     oc_stream_conn_del(&oc_ble_r, &ep_desc);
 }
+
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+void
+oc_endpoint_gatt_create(struct oc_endpoint_ble *ep, uint16_t conn_handle,
+                        uint16_t attr_handle)
+{
+    ep->ep.oe_type = oc_gatt_transport_id;
+    ep->conn_handle = conn_handle;
+    ep->tx_att_handle = attr_handle;
+    ep->srv_idx = OC_BLE_SRV_NONE;
+}
+#endif
+
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+void
+oc_ble_coap_gatt_notify_rx(uint16_t conn_handle, uint16_t att_handle,
+                           struct os_mbuf *om)
+{
+    struct ble_gatt_access_ctxt ctxt = {
+            .op = BLE_GATT_ACCESS_OP_WRITE_CHR,
+            .om = om,
+    };
+    oc_gatt_chr_access(conn_handle, att_handle, &ctxt, NULL);
+    om = NULL;
+}
+#endif
 
 /*
  * This runs in the context of task handling coap.
@@ -500,11 +531,14 @@ oc_send_buffer_gatt(struct os_mbuf *m)
     STATS_INC(oc_ble_stats, oframe);
     STATS_INCN(oc_ble_stats, obytes, OS_MBUF_PKTLEN(m));
 
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+    attr_handle = oe_ble->tx_att_handle;
+#else
     if (oe_ble->srv_idx >= OC_BLE_SRV_CNT) {
         goto err;
     }
-    attr_handle = oc_ble_srv_handles[oe_ble->srv_idx].rsp;
-
+    attr_handle = oc_ble_src_handles[oe_ble->srv_idx].rsp;
+#endif
     mtu = ble_att_mtu(conn_handle);
     if (mtu < 4) {
         oc_ble_coap_conn_del(conn_handle);
@@ -519,8 +553,11 @@ oc_send_buffer_gatt(struct os_mbuf *m)
     while (1) {
         STATS_INC(oc_ble_stats, oseg);
         pkt = STAILQ_NEXT(OS_MBUF_PKTHDR(m), omp_next);
-
+#if (MYNEWT_VAL(OC_BLE_CENTRAL) == 1)
+        ble_gattc_write_no_rsp(conn_handle, attr_handle, m);
+#else
         ble_gattc_notify_custom(conn_handle, attr_handle, m);
+#endif
         if (pkt) {
             m = OS_MBUF_PKTHDR_TO_MBUF(pkt);
         } else {

--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -535,7 +535,7 @@ oc_send_buffer_gatt(struct os_mbuf *m)
     if (oe_ble->srv_idx >= OC_BLE_SRV_CNT) {
         goto err;
     }
-    attr_handle = oc_ble_src_handles[oe_ble->srv_idx].rsp;
+    attr_handle = oc_ble_srv_handles[oe_ble->srv_idx].rsp;
 #endif
     mtu = ble_att_mtu(conn_handle);
     if (mtu < 4) {

--- a/net/oic/syscfg.yml
+++ b/net/oic/syscfg.yml
@@ -64,6 +64,10 @@ syscfg.defs:
         description: 'Enables OIC server support'
         value: '0'
 
+    OC_BLE_CENTRAL:
+        description: 'Send messages as characteristic writes'
+        value: '0'
+
     OC_DEBUG:
         description: 'Enables OIC debug logs'
         value: '0'


### PR DESCRIPTION
This PR enables an oc client to work with ble gatt transport adaptor in as a ble central (rather than a peripheral). This had never been done and therefore did not work. As a client and a central, we need to write to a the request characteristic and listen for notifications on the response characteristic. 

These changes add a new syscfg flag `OC_BLE_CENTRAL` to `net/oic/syscfg.yml` with a default value 0. Setting this value to 1 defines a function for receiving response characteristic notifications and enables characteristic write requests. 