### PR TITLE
hw/mcu/dialog: Add syscfg to allow setting a custom DMA_IRQn priority.

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_dma.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_dma.c
@@ -110,6 +110,7 @@ da1469x_dma_init(void)
 {
     NVIC_DisableIRQ(DMA_IRQn);
     NVIC_SetVector(DMA_IRQn, (uint32_t)dma_handler);
+    NVIC_SetPriority(DMA_IRQn, MYNEWT_VAL(MCU_DMA_IRQ_PRIO));
 }
 
 struct da1469x_dma_regs *

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -92,6 +92,12 @@ syscfg.defs:
             Used internally by the newt tool.
         value: 1
 
+    MCU_DMA_IRQ_PRIO:
+        description: >
+            Specifies the NVIC interrupt priority to assign for the DMA_IRQn 
+            interrupt.
+        value: 15
+
     RAM_RESIDENT:
         description: 'Compile app to be loaded to RAM'
         value: 0


### PR DESCRIPTION
For hw/mcu/dialog/da1469x, adds a syscfg `MCU_DMA_IRQ_PRIO` to allow setting the interrupt priority of DMA_IRQn at system initialization time. 

