### PR TITLE
hw/mcu/dialog: Fix size of flag variables when MCU_DMA_CHAN_MAX > 8

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_dma.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_dma.c
@@ -46,11 +46,11 @@ struct da1469x_dma_interrupt_cfg {
 };
 
 #if (MCU_DMA_CHAN_MAX) > 8
-static uint8_t g_da1469x_dma_acquired;
-static uint8_t g_da1469x_dma_isr_set;
-#else
 static uint16_t g_da1469x_dma_acquired;
 static uint16_t g_da1469x_dma_isr_set;
+#else
+static uint8_t g_da1469x_dma_acquired;
+static uint8_t g_da1469x_dma_isr_set;
 #endif
 
 static struct da1469x_dma_interrupt_cfg g_da1469x_dma_isr_cfg[MCU_DMA_CHAN_MAX];


### PR DESCRIPTION
These two variables need to be uint16_t when MCU_DMA_CHAN_MAX is > 8.

Currently the code is as follows, which results in not enough bit flags for DMA channel # 9 or higher:
```
#if (MCU_DMA_CHAN_MAX) > 8
static uint8_t g_da1469x_dma_acquired;
static uint8_t g_da1469x_dma_isr_set;
#else
static uint16_t g_da1469x_dma_acquired;
static uint16_t g_da1469x_dma_isr_set;
#endif
```