### PR TITLE
stm32: Disable WFI when OS_SYSVIEW is defined

### DIFF
--- a/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
+++ b/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
@@ -27,6 +27,16 @@
 /* RTC tick only if LSE is enabled and OS_TICKS_PER_SEC can work with 32768 oscillator */
 #if MYNEWT_VAL(STM32_CLOCK_LSE) && (((32768 / OS_TICKS_PER_SEC) * OS_TICKS_PER_SEC) == 32768)
 
+/*
+ * ST's MCUs seems to have problem with accessing AHB interface from SWD during SLEEP.
+ * This makes it almost impossible to use with SEGGER SystemView, therefore when OS_SYSVIEW
+ * is defined __WFI will become a loop waiting for pending interrupts.
+ */
+#if MYNEWT_VAL(OS_SYSVIEW)
+#undef __WFI
+#define __WFI() do { } while ((SCB->ICSR & (SCB_ICSR_ISRPENDING_Msk | SCB_ICSR_PENDSTSET_Msk)) == 0)
+#endif
+
 struct hal_os_tick {
     uint32_t rtc_cnt;
 };


### PR DESCRIPTION
Reading RAM or FLASH from Debugger on STM32 MCUs in SLEEP (WFI)
returns wrong values.
If makes it almost impossible to use with SystemView when application
runs at high clock speed and spend a lot of time in SLEEP mode.
SystemView is often not able to correctly read header for RTT
virtually preventing tool to detect instrumentation.

This change replaces WFI with busy loop waiting for interrupts when
OS_SYSVIEW is defined.