### PR TITLE
hw/drivers/i2s: Add buffer overwrite check

### DIFF
--- a/hw/drivers/i2s/include/i2s/i2s.h
+++ b/hw/drivers/i2s/include/i2s/i2s.h
@@ -57,6 +57,8 @@ struct i2s_buffer_pool {
     struct i2s_sample_buffer *buffers;
 };
 
+#define I2S_BUFFER_GUARD MYNEWT_VAL(I2S_BUFFER_GUARD)
+
 /**
  * I2S buffer pool definition.
  * @param name   pool name to be used,
@@ -64,8 +66,8 @@ struct i2s_buffer_pool {
  * @param size   single buffer size in bytes
  */
 #define I2S_BUFFER_POOL_DEF(name, count, size) \
-    static uint8_t _Alignas(struct i2s_buffer_pool) name ## _buffers[(sizeof(struct i2s_sample_buffer) + size) * \
-                                                                     count]; \
+    static uint8_t _Alignas(struct i2s_buffer_pool) name ## _buffers[(sizeof(struct i2s_sample_buffer) + (size) + \
+                                                                      2 * (I2S_BUFFER_GUARD)) * (count)]; \
     struct i2s_buffer_pool name = { \
         .buffer_size = size, \
         .buffer_count = count, \

--- a/hw/drivers/i2s/syscfg.yml
+++ b/hw/drivers/i2s/syscfg.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    I2S_BUFFER_GUARD:
+        description: >
+            Size of extra memory for padding sample buffers.
+            It may be very helpful to trace memory overwrite problems.
+            When this is set to value > 0 extra checks are added to verify
+            that memory filled by user code does not write outside
+            sample buffer.
+        value: 0
+    I2S_BUFFER_GUARD_PATTERN:
+        description: >
+            Byte that will be used to fill reserved space before and after
+            data buffer.
+        value: 0xFD


### PR DESCRIPTION
It is easy to accidentally write past the sample buffer.
Such writes could lead to difficult to trace memory corruptions.

With this change most common errors will be detected early.
To have checking code working syscfg value I2S_BUFFER_GUARD
should specify how many bytes before and after actual data
is reserved and filled with pattern.