### PR TITLE
hw/bsp/pinetime: Setup 7 second watchdog

### DIFF
--- a/hw/bsp/pinetime/syscfg.yml
+++ b/hw/bsp/pinetime/syscfg.yml
@@ -106,6 +106,10 @@ syscfg.vals:
     SPIFLASH_TCE_TYPICAL:   3000000 # Chip erase time (us)
     SPIFLASH_TCE_MAXIMUM:   10000000 # Maximum chip erase time (us)
 
+    # The default PineTime bootloader will setup a 7 second watchdog
+    SANITY_INTERVAL: 5000
+    WATCHDOG_INTERVAL: 7000
+
 syscfg.vals.BSP_BATTERY:
     # ADC needed for battery voltage
     ADC_0: 1


### PR DESCRIPTION
Change the watchdog settings, as the new version of the
default bootloader for the PineTime also setup a watchdog with a 7
second interval. Without this change the processor will be reset a few
seconds after the application was started.