### PR TITLE
Documentation fixes

### DIFF
--- a/docs/os/modules/console/console.rst
+++ b/docs/os/modules/console/console.rst
@@ -216,7 +216,7 @@ is received. The two event queues are used as follows:
    available for the console to use for buffering input data.
 
    The caller must initialize the avail_queue and initialize and add an
-   :doc:`../../os/core_os/event_queue/event_queue` to the
+   :doc:`../../core_os/event_queue/event_queue` to the
    avail_queue before calling the :c:func:`console_set_queues()` function.
    The fields for the event should be set as follows:
 

--- a/docs/os/modules/fcb/fcb.rst
+++ b/docs/os/modules/fcb/fcb.rst
@@ -1,6 +1,20 @@
 Flash Circular Buffer (FCB)
 ===========================
 
+.. toctree::
+  :hidden:
+
+  fcb_append
+  fcb_append_finish
+  fcb_append_to_scratch
+  fcb_clear
+  fcb_getnext
+  fcb_init
+  fcb_is_empty
+  fcb_offset_last_n
+  fcb_rotate
+  fcb_walk
+
 Flash circular buffer provides an abstration through which you can treat
 flash like a FIFO. You append entries to the end, and read data from the
 beginning.

--- a/docs/os/modules/hal/hal.rst
+++ b/docs/os/modules/hal/hal.rst
@@ -10,9 +10,12 @@ Hardware Abstraction Layer
     hal_spi/hal_spi
     hal_i2c/hal_i2c
     hal_flash/hal_flash
-    hal_system/hal_system
+    hal_system/hal_sys
     hal_watchdog/hal_watchdog
     hal_bsp/hal_bsp
+    hal_os_tick/hal_os_tick
+    hal_creation
+    hal_in_libraries
 
 Description
 ~~~~~~~~~~~

--- a/docs/os/modules/hal/hal_flash/hal_flash.rst
+++ b/docs/os/modules/hal/hal_flash/hal_flash.rst
@@ -4,6 +4,11 @@ Flash
 The hardware independent interface to flash memory that is used by
 applications.
 
+.. toctree::
+    :hidden:
+
+    hal_flash_int
+
 Description
 ~~~~~~~~~~~
 

--- a/docs/os/modules/logs/logs.rst
+++ b/docs/os/modules/logs/logs.rst
@@ -80,7 +80,7 @@ required. The log package comes with three pre-built log handlers:
 -  cbmem -- writes/reads log events to a circular buffer. Supports
    walking and reading for access by newtmgr and shell commands.
 -  fcb -- writes/reads log events to a :doc:`flash circular
-   buffer <../../fcb/fcb>`. Supports walking and reading for
+   buffer <../fcb/fcb>`. Supports walking and reading for
    access by newtmgr and shell commands.
 
 In addition, it is possible to create custom log handlers for other

--- a/docs/os/modules/sensor_framework/sensor_api.rst
+++ b/docs/os/modules/sensor_framework/sensor_api.rst
@@ -43,14 +43,14 @@ object:
 **Notes**:
 
 -  See the :doc:`Sensor Device
-   Driver <../os/modules/sensor_framework/sensor_driver>` page for
+   Driver <sensor_driver>` page for
    the functions and data structures that a sensor driver package
    exports.
 
 -  The ``<sensorname>_init()`` function must also call the
    ``sensor_mgr_register()`` function to register the sensor with the
    sensor manager. See the :doc:`Sensor Manager
-   API <../os/modules/sensor_framework/sensor_mgr_api>` for
+   API <sensor_mgr_api>` for
    details.
 
 Setting the Configured Sensor Types
@@ -95,7 +95,7 @@ sensor at specified poll intervals. An application must call the
 in order for poller to poll the sensor.
 
 **Note:** An application needs to register a :doc:`sensor
-listener <../os/modules/sensor_framework/sensor_listener_api>` to
+listener <sensor_listener_api>` to
 receive the sensor data that the sensor manager poller reads from a
 sensor.
 
@@ -112,8 +112,8 @@ Sensor Object
 
 The ``struct sensor`` data structure represents the sensor device. The
 sensor API, the :doc:`sensor manager
-API <../os/modules/sensor_framework/sensor_mgr_api>`, and the :doc:`sensor
-listener API <../os/modules/sensor_framework/sensor_listener_api>`
+API <sensor_mgr_api>`, and the :doc:`sensor
+listener API <sensor_listener_api>`
 all operate on the ``sensor`` object abstraction. A sensor is maintained
 in the sensor manager global sensors list.
 

--- a/docs/os/modules/sensor_framework/sensor_create.rst
+++ b/docs/os/modules/sensor_framework/sensor_create.rst
@@ -37,7 +37,7 @@ application. For example:
 2. Include the "<sensorname>/<sensorname>.h" header file. The BSP uses
 the functions and data structures that a device driver package exports.
 See the :doc:`Sensor Device
-Driver <../os/modules/sensor_framework/sensor_driver>` page for
+Driver <sensor_driver>` page for
 details.
 
 3. Declare a variable named ``sensorname`` of type

--- a/docs/os/modules/sensor_framework/sensor_driver.rst
+++ b/docs/os/modules/sensor_framework/sensor_driver.rst
@@ -10,7 +10,7 @@ device.
 This guide describes what a sensor device driver must implement to
 enable a sensor device within the sensor framework. For information on
 using the HAL API to communicate with a sensor device, see the :doc:`Hardware
-Layer Abstraction Guide <../os/modules/hal/hal>`.
+Layer Abstraction Guide <../hal/hal>`.
 
 The ``hw/drivers/sensors/<sensorname>`` package implements the device
 driver for the sensor named ``SENSORNAME``.
@@ -82,7 +82,7 @@ configure a device:
       interface the driver uses to communicate with the sensor device.
 
    See the :doc:`Creating Sensor
-   Devices <../os/modules/sensor_framework/sensor_create>` page for
+   Devices <sensor_create>` page for
    more details.
 
    The ``os_dev_create()`` function calls the ``<sensorname>_init()``
@@ -154,8 +154,8 @@ Registering the Sensor in the Sensor Framework
 
 The device driver must initialize and register a ``struct sensor``
 object with the sensor manager. See the :doc:`Sensor
-API <../os/modules/sensor_framework/sensor_api>` and the :doc:`Sensor
-Manager API <../os/modules/sensor_framework/sensor_mgr_api>`
+API <sensor_api>` and the :doc:`Sensor
+Manager API <sensor_mgr_api>`
 pages for more details.
 
 The device driver ``<sensorname>_init()`` function initializes and
@@ -329,7 +329,7 @@ Implementing a Sensor Device Shell Command
 A sensor device driver package may optionally implement a sensor device
 shell command that retrieves and sets sensor device information to aid
 in testing and debugging. While the sensor framework :doc:`sensor shell
-command <../os/modules/sensor_framework/sensor_shell>` reads sensor
+command <sensor_shell>` reads sensor
 data for configured sensor types and is useful for testing an
 application, it does not access low level device information, such as
 reading register values and setting hardware configurations, that might
@@ -363,7 +363,7 @@ Defining Logs
 ~~~~~~~~~~~~~
 
 A sensor device driver should define logs for testing purposes. See the
-:doc:`Log OS Guide <../os/modules/logs/logs>` for more details on how to
+:doc:`Log OS Guide <../logs/logs>` for more details on how to
 add logs. The driver should define a ``<SENSORNAME>_LOG`` syscfg setting
 to specify whether logging is enabled and disable the setting by
 default.
@@ -413,7 +413,7 @@ Defining Stats
 
 
 A sensor device driver may also define stats for the sensor. See the
-:doc:`Stats OS Guide <../os/modules/stats/stats>` for more details on how
+:doc:`Stats OS Guide <../stats/stats>` for more details on how
 to add stats. The driver should define a ``<SENSORNAME>_STATS`` syscfg
 setting to specify whether stats is enabled and disable the setting by
 default.

--- a/docs/os/modules/sensor_framework/sensor_listener_api.rst
+++ b/docs/os/modules/sensor_framework/sensor_listener_api.rst
@@ -8,7 +8,7 @@ function to register a listener that specifies the callback function and
 the types of sensor data to listen for from a sensor device.
 
 When the ``sensor_read()`` function defined in the :doc:`sensor
-API <../os/modules/sensor_framework/sensor_api>` is called to read
+API <sensor_api>` is called to read
 the sensor data for the specified sensor types from a sensor, the
 ``sensor_read()`` function calls the listener callback, passing it the
 sensor data that is read from the sensor.

--- a/docs/os/modules/shell/shell.rst
+++ b/docs/os/modules/shell/shell.rst
@@ -4,7 +4,7 @@ Shell
 The shell runs above the console and provides two functionalities:
 
 -  Processes console input. See the :doc:`Enabling the Console and Shell
-   tutorial <../../../tutorials/blinky_console>` for example of the
+   tutorial <../../../tutorials/blinky/blinky_console>` for example of the
    shell.
 -  Implements the :doc:`newtmgr <../../../newtmgr/index>` line
    protocol over serial transport.
@@ -259,7 +259,7 @@ structures hold help texts for a shell command.
     struct shell_param {
         const char *param_name;
         const char *help;
-    };`
+    };
 
 +------------------+--------------------------------------------------------+
 | Element          | Description                                            |

--- a/docs/os/modules/split/split.rst
+++ b/docs/os/modules/split/split.rst
@@ -90,7 +90,7 @@ Tutorial
 --------
 
 Building a Split Image
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 We will be referring to the Nordic PCA10028 (nRF51 DK) for examples in
 this document. Let's take a look at this board's flash map (defined in
@@ -291,7 +291,7 @@ via either the ``newt load`` or ``newt run`` command.
     Loading loader image into slot 1
 
 Image Management
-~~~~~~~~~~~~~~~~
+----------------
 
 Retrieve Current State (image list)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/os/modules/system_modules.rst
+++ b/docs/os/modules/system_modules.rst
@@ -1,5 +1,5 @@
 System Modules
-=============
+==============
 
 .. toctree::
    :hidden:

--- a/encoding/json/include/json/json.h
+++ b/encoding/json/include/json/json.h
@@ -248,9 +248,3 @@ int json_read_array(struct json_buffer *, const struct json_array_t *);
 #endif
 
 #endif /* _JSON_H_ */
-
-/**
- *   @} OSEncoding
- * @} OSJSON
- */
-

--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -151,3 +151,7 @@ int fcb_area_info(struct fcb *fcb, struct flash_area *fa, int *elemsp,
 #endif
 
 #endif /* __SYS_FLASHVAR_H_ */
+
+/**
+ * @} FCB
+ */

--- a/fs/fcb2/include/fcb/fcb2.h
+++ b/fs/fcb2/include/fcb/fcb2.h
@@ -314,3 +314,7 @@ int fcb2_area_info(struct fcb2 *fcb, int sector, int *elemsp, int *bytesp);
 #endif
 
 #endif /* __SYS_FLASHVAR_H_ */
+
+/**
+ * @} FCB2
+ */

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -35,8 +35,8 @@
 extern "C" {
 #endif
 
-/**  
- * @defgroup SensorAPI 
+/**
+ * @defgroup SensorAPI Sensor API
  * @{
  */
 
@@ -702,7 +702,7 @@ void sensor_unlock(struct sensor *sensor);
  */
 
 /**
- * @defgroup SensorListenerAPI
+ * @defgroup SensorListenerAPI Sensor listener API
  * @{
  */
 
@@ -749,7 +749,7 @@ int sensor_register_err_func(struct sensor *sensor,
  */
 
 /**
- * @defgroup SensorNotifierAPI
+ * @defgroup SensorNotifierAPI Sensor notifier API
  * @{
  */
 
@@ -781,7 +781,7 @@ int sensor_unregister_notifier(struct sensor *sensor, struct sensor_notifier *no
  */
 
 /**
- * @defgroup SensorAPI
+ * @defgroup SensorAPI Sensor API
  * @{
  */
 
@@ -887,7 +887,7 @@ sensor_get_config(struct sensor *sensor, sensor_type_t type,
 
 
 /**
- *   @defgroup SensorManagerAPI
+ *   @defgroup SensorManagerAPI Sensor manager API
      @{
  */
 

--- a/kernel/os/include/os/os_callout.h
+++ b/kernel/os/include/os/os_callout.h
@@ -22,7 +22,7 @@
 /**
  * @addtogroup OSKernel
  * @{
- *   @defgroup OSCallouts 
+ *   @defgroup OSCallouts  OS Callouts
  *   @{
  */
 

--- a/kernel/os/include/os/os_heap.h
+++ b/kernel/os/include/os/os_heap.h
@@ -21,7 +21,7 @@
 /**
  * @addtogroup OSKernel
  * @{
- *   @defgroup OSMalloc
+ *   @defgroup OSMalloc OS malloc
  *   @{
  */
 

--- a/kernel/os/include/os/os_mutex.h
+++ b/kernel/os/include/os/os_mutex.h
@@ -127,3 +127,8 @@ static inline uint16_t os_mutex_get_level(struct os_mutex *mu)
 #endif
 
 #endif  /* _OS_MUTEX_H_ */
+
+/**
+ *   @} OSMutex
+ * @} OSKernel
+ */


### PR DESCRIPTION
This fixes some of the warning when generating the mynewt documentation. It fixes broken links, syntax warnings and doxygen warnings.