### PR TITLE
battery: Add missing syscfg definition

### DIFF
--- a/hw/battery/syscfg.yml
+++ b/hw/battery/syscfg.yml
@@ -36,3 +36,8 @@ syscfg.defs:
         description: >
             Sysinit stage for battery functionality.
         value: 501
+
+    BATTERY_DRIVERS_MAX:
+        description: >
+            Number of battery drivers that can be registered.
+        value: 2


### PR DESCRIPTION
BATTERY_DRIVERS_MAX was used in battery.h but it was never
defined, this fixes this inconsistency.

Thanks @5frank for spotting this.