### PR TITLE
sys/log/cbmem: Fix return code for early break in log_cbmem_walk

### DIFF
--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -176,6 +176,7 @@ log_cbmem_walk(struct log *log, log_walk_func_t walk_func,
     struct cbmem_entry_hdr *hdr;
     struct cbmem_iter iter;
     int rc;
+    int walk_rc = 0;
 
     cbmem = (struct cbmem *) log->l_arg;
 
@@ -190,7 +191,7 @@ log_cbmem_walk(struct log *log, log_walk_func_t walk_func,
     if (log_offset->lo_ts < 0) {
         hdr = cbmem->c_entry_end;
         if (hdr != NULL) {
-            rc = walk_func(log, log_offset, (void *)hdr, hdr->ceh_len);
+            walk_rc = walk_func(log, log_offset, (void *)hdr, hdr->ceh_len);
         }
     } else {
         cbmem_iter_start(cbmem, &iter);
@@ -200,8 +201,8 @@ log_cbmem_walk(struct log *log, log_walk_func_t walk_func,
                 break;
             }
 
-            rc = walk_func(log, log_offset, (void *)hdr, hdr->ceh_len);
-            if (rc == 1) {
+            walk_rc = walk_func(log, log_offset, (void *)hdr, hdr->ceh_len);
+            if (walk_rc != 0) {
                 break;
             }
         }
@@ -212,7 +213,7 @@ log_cbmem_walk(struct log *log, log_walk_func_t walk_func,
         goto err;
     }
 
-    return (0);
+    return (walk_rc);
 err:
     return (rc);
 }


### PR DESCRIPTION
The return code of succesfull log_cbmem_walk was 0, even when the loop
ended early. In case of an early loop break, we want to return the rc of
the walked function.
This is needed to make `newtmgr log show --all` work, as the rc is
passed to the client to indicate more data available.

The return codes of the log_walk functions seem a bit of a mess, as they both indicate an error state as rc of the walk_func. To bad C doesn't support multiple return values.