### PR TITLE
da1469x load and debug fixes

### DIFF
--- a/compiler/gdbmacros/flash_loader.gdb
+++ b/compiler/gdbmacros/flash_loader.gdb
@@ -85,10 +85,9 @@ end
 # Load a file to a specific flash location
 #
 define fl_file_sz
-       shell echo -n set \$file_sz= > /tmp/foo.gdb
-       shell wc -c $arg0 | awk '{print $1}' >> /tmp/foo.gdb
-       source /tmp/foo.gdb
-       shell rm /tmp/foo.gdb
+       shell wc -c $arg0 | awk '{print "set \$file_sz="$1}' > foo.gdb
+       source foo.gdb
+       shell rm foo.gdb
 end
 
 define fl_program

--- a/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
@@ -22,10 +22,6 @@ bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m33"
 bsp.downloadscript:
     "hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.sh"
 bsp.debugscript: "hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_debug.sh"
-bsp.downloadscript.WINDOWS.OVERWRITE:
-    "hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_download.cmd"
-bsp.debugscript.WINDOWS.OVERWRITE:
-    "hw/bsp/dialog_da1469x-dk-pro/dialog_da1469x-dk-pro_debug.cmd"
 
 bsp.linkerscript:
     - "hw/bsp/dialog_da1469x-dk-pro/da1469x.ld"


### PR DESCRIPTION
There were two problems with this gdb script that prevent
it usage on Windows:
1. echo command from cmd.exe don't have -n option
  shell command that was creating foo.gdb script used echo which
  did not used /usb/bin/echo.exe from msys, but Windows build in
  echo that does not have -n option
2. /tmp folder is not valid for cmd.exe redirection

To fix this problems echo is not used, instead awk that is already
present is used to output whole line
foo.gdb is not created in /tmp folder (which would fail on Windows)
instead is created in current folder for a while. It was deleted
after source command so it's not that important to have it in /tmp
folder.

bsp.yml had load and debug overwrites for Windows, unfortunately
.cmd files were not created for this bsp.
Since newt can handle .sh files on Windows for a while
those overwrites are not needed anymore.