### PR TITLE
apps: Fix cbmem sizes

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -106,7 +106,6 @@ static int sensor_oic_gap_event(struct ble_gap_event *event, void *arg);
 /* Task 1 */
 #define TASK1_PRIO (8)
 #define TASK1_STACK_SIZE    OS_STACK_ALIGN(192)
-#define MAX_CBMEM_BUF 600
 static struct os_task task1;
 static volatile int g_task1_loops;
 

--- a/apps/slinky/src/main.c
+++ b/apps/slinky/src/main.c
@@ -79,7 +79,7 @@ static struct conf_handler test_conf_handler = {
 static uint8_t test8;
 static uint8_t test8_shadow;
 static char test_str[32];
-static uint32_t cbmem_buf[MAX_CBMEM_BUF];
+static uint8_t cbmem_buf[MAX_CBMEM_BUF];
 static struct cbmem cbmem;
 
 static char *

--- a/apps/slinky_oic/src/main.c
+++ b/apps/slinky_oic/src/main.c
@@ -89,7 +89,7 @@ static struct conf_handler test_conf_handler = {
 static uint8_t test8;
 static uint8_t test8_shadow;
 static char test_str[32];
-static uint32_t cbmem_buf[MAX_CBMEM_BUF];
+static uint8_t cbmem_buf[MAX_CBMEM_BUF];
 static struct cbmem cbmem;
 
 static char *

--- a/apps/splitty/src/main.c
+++ b/apps/splitty/src/main.c
@@ -73,7 +73,7 @@ STATS_NAME_START(gpio_stats)
 STATS_NAME(gpio_stats, toggles)
 STATS_NAME_END(gpio_stats)
 
-static uint32_t cbmem_buf[MAX_CBMEM_BUF];
+static uint8_t cbmem_buf[MAX_CBMEM_BUF];
 static struct cbmem cbmem;
 
 static void

--- a/docs/os/modules/logs/logs.rst
+++ b/docs/os/modules/logs/logs.rst
@@ -157,7 +157,8 @@ circular buffer.
 
     #include <log/log.h>
 
-    static uint32_t cbmem_buf[MAX_CBMEM_BUF];
+    #define MAX_CBMEM_BUF 300
+    static uint8_t cbmem_buf[MAX_CBMEM_BUF];
     static struct cbmem cbmem;
 
 


### PR DESCRIPTION
The size passed to cbmem_init is in bytes. Therefore the datatype of
cbmem_buf needs to be one byte long.