### PR TITLE
da1469x_pd: add function to get power domain reference counts

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_pd.h
@@ -44,6 +44,7 @@ extern "C" {
 #define MCU_PD_DOMAIN_RAD           5
 
 int da1469x_pd_init(void);
+int da1469x_pd_get_ref_cnt(uint8_t pd);
 int da1469x_pd_acquire(uint8_t pd);
 int da1469x_pd_acquire_noconf(uint8_t pd);
 int da1469x_pd_release(uint8_t pd);

--- a/hw/mcu/dialog/da1469x/src/da1469x_pd.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_pd.c
@@ -119,6 +119,18 @@ da1469x_pd_init(void)
     return 0;
 }
 
+int
+da1469x_pd_get_ref_cnt(uint8_t pd)
+{
+    struct da1469x_pd_data *pdd;
+
+    assert(pd < PD_COUNT);
+
+    pdd = &g_da1469x_pd_data[pd];
+
+    return pdd->refcnt;
+}
+
 static int
 da1469x_pd_acquire_internal(uint8_t pd, bool load)
 {

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -89,6 +89,7 @@ static struct hal_gpio_irq hal_gpio_irqs[HAL_GPIO_MAX_IRQ];
 
 #if MYNEWT_VAL(MCU_GPIO_RETAINABLE_NUM) >= 0
 static uint32_t g_mcu_gpio_latch_state[2];
+static uint32_t g_mcu_gpio_data_latch_state[2];
 static uint8_t g_mcu_gpio_retained_num;
 static struct da1469x_retreg g_mcu_gpio_retained[MYNEWT_VAL(MCU_GPIO_RETAINABLE_NUM)];
 #endif
@@ -473,6 +474,10 @@ mcu_gpio_enter_sleep(void)
         return;
     }
 
+    /* Save pins states and their latched values */
+    g_mcu_gpio_data_latch_state[0] = GPIO->P0_DATA_REG;
+    g_mcu_gpio_data_latch_state[1] = GPIO->P1_DATA_REG;
+
     g_mcu_gpio_latch_state[0] = CRG_TOP->P0_PAD_LATCH_REG;
     g_mcu_gpio_latch_state[1] = CRG_TOP->P1_PAD_LATCH_REG;
 
@@ -498,8 +503,8 @@ mcu_gpio_exit_sleep(void)
     da1469x_retreg_restore(g_mcu_gpio_retained, g_mcu_gpio_retained_num);
 
     /* Set pins states to their latched values */
-    GPIO->P0_DATA_REG = GPIO->P0_DATA_REG;
-    GPIO->P1_DATA_REG = GPIO->P1_DATA_REG;
+    GPIO->P0_DATA_REG = g_mcu_gpio_data_latch_state[0];
+    GPIO->P1_DATA_REG = g_mcu_gpio_data_latch_state[1];
 
     CRG_TOP->P0_PAD_LATCH_REG = g_mcu_gpio_latch_state[0];
     CRG_TOP->P1_PAD_LATCH_REG = g_mcu_gpio_latch_state[1];


### PR DESCRIPTION
da1469x_pd.c: Add function to get power domain reference counts.
hal_gpio.c: Restore Px_DATA_REG from retained values. Seeing issues/hangs when attempting to restore it from itself, when it is possibly not retained when PD_COM is down.
