### PR TITLE
flash_loader: Fix awk script

### DIFF
--- a/compiler/gdbmacros/flash_loader.gdb
+++ b/compiler/gdbmacros/flash_loader.gdb
@@ -85,7 +85,7 @@ end
 # Load a file to a specific flash location
 #
 define fl_file_sz
-       shell wc -c $arg0 | awk '{print "set \$file_sz="$1}' > foo.gdb
+       shell wc -c $arg0 | awk '{print "set $file_sz="$1}' > foo.gdb
        source foo.gdb
        shell rm foo.gdb
 end


### PR DESCRIPTION
flash_loader.gdb generated script that was later sourced back
into gdb with file_sz variable computed in shell.

This script had extra backslash that was not really needed.
awk complained about this extra \
