### PR TITLE
stm32/hal_spi: Fix alternate function spec for SPI_4

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -648,7 +648,9 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 #if SPI_4_ENABLED
     case 4:
         __HAL_RCC_SPI5_CLK_ENABLE();
-#if !MYNEWT_VAL(MCU_STM32F1)
+#if defined(GPIO_AF6_SPI5)
+        gpio.Alternate = GPIO_AF6_SPI5;
+#elif defined(GPIO_AF5_SPI5)
         gpio.Alternate = GPIO_AF5_SPI5;
 #endif
         spi->handle.Instance = SPI5;


### PR DESCRIPTION
SPI_4 maps to STM SPI5.
Alternate function for this block is not always GPIO_AF5_SPI5.
For some MCUs (STM32F411) it should be GPIO_AF6_SPI5.
So now one that is defined by STM HAL will be used.