### PR TITLE
hw/battery: Fix strncpy warning

### DIFF
--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -376,7 +376,8 @@ battery_prop_get_name(const struct battery_property *prop, char *buf,
     const struct battery_driver_property *driver_prop =
             &driver->bd_driver_properties[prop->bp_prop_num - driver->bd_first_property];
 
-    strncpy(buf, driver_prop->bdp_name, buf_size);
+    strncpy(buf, driver_prop->bdp_name, buf_size - 1);
+    buf[buf_size - 1] = '\0';
 
     return buf;
 }
@@ -389,7 +390,7 @@ battery_find_property_by_name(struct os_dev *battery, const char *name)
     int i;
 
     for (i = 0; i < bat->b_all_property_count; ++i) {
-        battery_prop_get_name(&bat->b_properties[i], buf, 20);
+        battery_prop_get_name(&bat->b_properties[i], buf, sizeof(buf));
         if (strcmp(buf, name) == 0) {
             return &bat->b_properties[i];
         }

--- a/hw/battery/src/battery.c
+++ b/hw/battery/src/battery.c
@@ -32,8 +32,7 @@
 /*
  * Structure holds information about listener and what is it listening for.
  */
-struct listener_data
-{
+struct listener_data {
     /* The properties to monitor for change */
     uint32_t ld_prop_change_mask[BATTERY_PROPERTY_MASK_SIZE];
     /* The properties to monitor for periodic read */
@@ -42,8 +41,7 @@ struct listener_data
     struct battery_prop_listener *ld_listener;
 };
 
-struct battery_manager
-{
+struct battery_manager {
     /* The lock for battery object */
     struct os_mutex bm_lock;
 
@@ -193,7 +191,7 @@ battery_get_num(struct battery *battery)
 
 struct battery_driver *
 battery_get_driver(struct os_dev *battery,
-        const char *dev_name)
+                   const char *dev_name)
 {
     int i;
     assert(battery);
@@ -224,22 +222,23 @@ clear_bit(uint32_t *mask, int bit)
 
 static struct battery_property *
 find_driver_property(struct battery *bat, struct battery_driver *driver,
-        battery_property_type_t type, battery_property_flags_t flags)
+                     battery_property_type_t type, battery_property_flags_t flags)
 {
     struct battery_property *prop = bat->b_properties + driver->bd_first_property;
     int i;
     assert(driver);
 
     for (i = 0; driver->bd_property_count; ++i, ++prop) {
-        if (prop->bp_type == type && prop->bp_flags == flags)
+        if (prop->bp_type == type && prop->bp_flags == flags) {
             return prop;
+        }
     }
     return NULL;
 }
 
 static struct battery_property *
 find_hardware_property(struct battery *battery, struct battery_driver *driver,
-        battery_property_type_t type, battery_property_flags_t flags)
+                       battery_property_type_t type, battery_property_flags_t flags)
 {
     struct battery_property *res = NULL;
     int i;
@@ -258,8 +257,8 @@ find_hardware_property(struct battery *battery, struct battery_driver *driver,
 
 struct battery_property *
 battery_find_property(struct os_dev *battery,
-        battery_property_type_t type, battery_property_flags_t flags,
-        const char *dev_name)
+                      battery_property_type_t type, battery_property_flags_t flags,
+                      const char *dev_name)
 {
     struct battery_property *res = NULL;
     struct battery_property *prop;
@@ -276,7 +275,7 @@ battery_find_property(struct os_dev *battery,
     if (!res) {
         /* Search battery manager created properties */
         for (i = 0; i < bat->b_all_property_count; ++i) {
-            prop =  &bat->b_properties[i];
+            prop = &bat->b_properties[i];
             if (prop->bp_type == type &&
                 prop->bp_flags == flags &&
                 (driver == NULL ||
@@ -324,7 +323,7 @@ battery_find_property(struct os_dev *battery,
 
 int
 battery_get_property_count(struct os_dev *battery,
-        struct battery_driver *driver)
+                           struct battery_driver *driver)
 {
     struct battery *bat = (struct battery *)battery;
     int i;
@@ -344,7 +343,7 @@ battery_get_property_count(struct os_dev *battery,
 
 struct battery_property *
 battery_enum_property(struct os_dev *battery, struct battery_driver *driver,
-        uint8_t prop_num)
+                      uint8_t prop_num)
 {
     struct battery *bat = (struct battery *)battery;
     struct battery_property *prop = NULL;
@@ -369,12 +368,12 @@ battery_enum_property(struct os_dev *battery, struct battery_driver *driver,
 
 char *
 battery_prop_get_name(const struct battery_property *prop, char *buf,
-        size_t buf_size)
+                      size_t buf_size)
 {
     struct battery *bat = battery_manager.bm_batteries[prop->bp_bat_num];
     struct battery_driver *driver = bat->b_drivers[prop->bp_drv_num];
     const struct battery_driver_property *driver_prop =
-            &driver->bd_driver_properties[prop->bp_prop_num - driver->bd_first_property];
+        &driver->bd_driver_properties[prop->bp_prop_num - driver->bd_first_property];
 
     strncpy(buf, driver_prop->bdp_name, buf_size - 1);
     buf[buf_size - 1] = '\0';
@@ -400,7 +399,7 @@ battery_find_property_by_name(struct os_dev *battery, const char *name)
 
 static void
 battery_mgr_poll_battery_driver(struct battery *bat,
-        struct battery_driver *drv, uint32_t changed[], uint32_t queried[])
+                                struct battery_driver *drv, uint32_t changed[], uint32_t queried[])
 {
     int i;
     battery_property_value_t old_val;
@@ -442,7 +441,7 @@ battery_mgr_poll_battery(struct battery *battery)
     int j;
 
     /* Poll battery drivers */
-    for(i = 0; i < BATTERY_DRIVERS_MAX; ++i) {
+    for (i = 0; i < BATTERY_DRIVERS_MAX; ++i) {
         driver = battery->b_drivers[i];
         if (driver) {
             battery_mgr_poll_battery_driver(battery, driver, changed, queried);
@@ -496,7 +495,7 @@ battery_set_poll_rate_ms(struct os_dev *battery, uint32_t poll_rate)
 
 int
 battery_set_poll_rate_ms_delay(struct os_dev *battery, uint32_t poll_rate,
-    uint32_t start_delay)
+                               uint32_t start_delay)
 {
     struct battery *bat = (struct battery *)battery;
 
@@ -575,7 +574,7 @@ battery_add_driver(struct os_dev *battery, struct battery_driver *driver)
 
 static int
 get_listener_index(struct battery *battery,
-        struct battery_prop_listener *listener)
+                   struct battery_prop_listener *listener)
 {
     int i;
 
@@ -630,7 +629,7 @@ battery_update_polled_properties(struct battery *battery)
 
 int
 battery_prop_change_subscribe(struct battery_prop_listener *listener,
-        struct battery_property *prop)
+                              struct battery_property *prop)
 {
     struct battery *battery;
     int listener_index;
@@ -651,7 +650,7 @@ battery_prop_change_subscribe(struct battery_prop_listener *listener,
 
 int
 battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
-        struct battery_property *prop)
+                                struct battery_property *prop)
 {
     struct battery *battery;
     int i;
@@ -674,7 +673,7 @@ battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
     } else {
         /* No property supplied, remove listener from all subscriptions */
         for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
-            battery =  battery_manager.bm_batteries[i];
+            battery = battery_manager.bm_batteries[i];
             for (j = 0; j < battery->b_listener_count; ++i) {
                 if (battery->b_listeners[j].ld_listener == listener) {
                     /* Reduce number of listeners */
@@ -683,7 +682,7 @@ battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
                         /* It was not last listener,
                          * move last to emptied space */
                         battery->b_listeners[j] =
-                                battery->b_listeners[battery->b_listener_count];
+                            battery->b_listeners[battery->b_listener_count];
                     }
                     battery->b_listeners =
                         realloc(battery->b_listeners,
@@ -702,7 +701,7 @@ battery_prop_change_unsubscribe(struct battery_prop_listener *listener,
 
 int
 battery_prop_poll_subscribe(struct battery_prop_listener *listener,
-        struct battery_property *prop)
+                            struct battery_property *prop)
 {
     struct battery *battery;
     int listener_index;
@@ -723,7 +722,7 @@ battery_prop_poll_subscribe(struct battery_prop_listener *listener,
 
 int
 battery_prop_poll_unsubscribe(struct battery_prop_listener *listener,
-        struct battery_property *prop)
+                              struct battery_property *prop)
 {
     struct battery *battery;
     int i;
@@ -744,13 +743,13 @@ battery_prop_poll_unsubscribe(struct battery_prop_listener *listener,
                   prop->bp_prop_num);
     } else {
         for (i = 0; i < BATTERY_MAX_COUNT; ++i) {
-            battery =  battery_manager.bm_batteries[i];
+            battery = battery_manager.bm_batteries[i];
             for (j = 0; j < battery->b_listener_count; ++i) {
                 if (battery->b_listeners[j].ld_listener == listener) {
                     battery->b_listener_count--;
                     if (j < battery->b_listener_count) {
                         battery->b_listeners[j] =
-                                battery->b_listeners[battery->b_listener_count];
+                            battery->b_listeners[battery->b_listener_count];
                     }
                     battery->b_listeners =
                         realloc(battery->b_listeners,

--- a/hw/battery/src/battery_adc.c
+++ b/hw/battery/src/battery_adc.c
@@ -61,8 +61,8 @@ battery_adc_property_get(struct battery_driver *driver,
              * and divider if external resistor divider is used for measurement.
              */
             property->bp_value.bpv_voltage =
-                    adc_result_mv(bat_adc->adc_dev, bat_adc->cfg.channel, val) *
-                    bat_adc->cfg.mul / bat_adc->cfg.div;
+                adc_result_mv(bat_adc->adc_dev, bat_adc->cfg.channel, val) *
+                bat_adc->cfg.mul / bat_adc->cfg.div;
         }
     } else {
         rc = -1;
@@ -94,11 +94,11 @@ battery_adc_disable(struct battery *battery)
 }
 
 static const struct battery_driver_functions battery_adc_drv_funcs = {
-    .bdf_property_get     = battery_adc_property_get,
-    .bdf_property_set     = battery_adc_property_set,
+    .bdf_property_get = battery_adc_property_get,
+    .bdf_property_set = battery_adc_property_set,
 
-    .bdf_enable           = battery_adc_enable,
-    .bdf_disable          = battery_adc_disable,
+    .bdf_enable = battery_adc_enable,
+    .bdf_disable = battery_adc_disable,
 };
 
 static const struct battery_driver_property battery_adc_properties[] = {
@@ -115,7 +115,7 @@ battery_adc_open(struct os_dev *dev, uint32_t timeout, void *arg)
 
     /* Open ADC with parameters specified in BSP */
     bat_adc->adc_dev = (struct adc_dev *)os_dev_open(
-            (char *)bat_adc->cfg.adc_dev_name, timeout, bat_adc->cfg.adc_open_arg);
+        (char *)bat_adc->cfg.adc_dev_name, timeout, bat_adc->cfg.adc_open_arg);
     if (bat_adc->adc_dev) {
         /* Setup channel configuration to use for battery voltage */
         adc_chan_config(bat_adc->adc_dev, bat_adc->cfg.channel,

--- a/hw/battery/src/battery_prop.c
+++ b/hw/battery/src/battery_prop.c
@@ -25,7 +25,8 @@
 #include <battery/battery_drv.h>
 #include <battery/battery.h>
 
-int battery_prop_get_value(struct battery_property *prop)
+int
+battery_prop_get_value(struct battery_property *prop)
 {
     struct battery_driver *drv;
     struct battery *bat = (struct battery *)battery_get_battery(prop->bp_bat_num);
@@ -39,7 +40,8 @@ int battery_prop_get_value(struct battery_property *prop)
 }
 
 int
-battery_prop_get_value_float(struct battery_property *prop, float *value) {
+battery_prop_get_value_float(struct battery_property *prop, float *value)
+{
     int rc = battery_prop_get_value(prop);
     if (rc == 0 && prop->bp_valid) {
         *value = prop->bp_value.bpv_flt;
@@ -117,7 +119,8 @@ get_property_driver(struct battery_property *prop)
 
 int
 battery_prop_set_value(struct battery_property *prop,
-        const battery_property_value_t *value) {
+                       const battery_property_value_t *value)
+{
     struct battery_driver *drv = get_property_driver(prop);
     int rc = 0;
     /* Driver provided property */
@@ -129,13 +132,14 @@ battery_prop_set_value(struct battery_property *prop,
         prop->bp_valid = 1;
     }
     if (prop->bp_base) {
-        // TODO: Search for complex properties
+        /* TODO: Search for complex properties */
     }
     return rc;
 }
 
 int
-battery_prop_set_value_float(struct battery_property *prop, float value) {
+battery_prop_set_value_float(struct battery_property *prop, float value)
+{
     battery_property_value_t v;
     v.bpv_flt = value;
     return battery_prop_set_value(prop, &v);

--- a/hw/battery/src/battery_shell.c
+++ b/hw/battery/src/battery_shell.c
@@ -35,58 +35,50 @@ static int bat_compat_cmd(int argc, char **argv);
 #if MYNEWT_VAL(SHELL_CMD_HELP)
 #define HELP(a) &(a)
 
-static const struct shell_param bat_read_params[] =
-{
-        { "all" },
-        { NULL }
+static const struct shell_param bat_read_params[] = {
+    { "all" },
+    { NULL }
 };
 
-static const struct shell_param bat_monitor_params[] =
-{
-        { NULL }
+static const struct shell_param bat_monitor_params[] = {
+    { NULL }
 };
 
-static const struct shell_cmd_help bat_read_help =
-{
-        .summary = "read battery properties",
-        .usage = "read <prop>",
-        .params = bat_read_params,
+static const struct shell_cmd_help bat_read_help = {
+    .summary = "read battery properties",
+    .usage = "read <prop>",
+    .params = bat_read_params,
 };
 
-static const struct shell_cmd_help bat_write_help =
-{
-        .summary = "write battery properties",
-        .usage = "read <prop> <value>",
-        .params = NULL,
+static const struct shell_cmd_help bat_write_help = {
+    .summary = "write battery properties",
+    .usage = "read <prop> <value>",
+    .params = NULL,
 };
 
-static const struct shell_cmd_help bat_list_help =
-{
-        .summary = "list battery properties",
-        .usage = "list",
-        .params = NULL,
+static const struct shell_cmd_help bat_list_help = {
+    .summary = "list battery properties",
+    .usage = "list",
+    .params = NULL,
 };
 
-static const struct shell_cmd_help bat_poll_rate_help =
-{
-        .summary = "set battery polling rate",
-        .usage = "pollrate <time_in_s>",
-        .params = NULL,
+static const struct shell_cmd_help bat_poll_rate_help = {
+    .summary = "set battery polling rate",
+    .usage = "pollrate <time_in_s>",
+    .params = NULL,
 };
 
-static const struct shell_cmd_help bat_monitor_help =
-{
-        .summary = "start battery property monitoring",
-        .usage = "monitor <prop> [off]",
-        .params = bat_monitor_params,
+static const struct shell_cmd_help bat_monitor_help = {
+    .summary = "start battery property monitoring",
+    .usage = "monitor <prop> [off]",
+    .params = bat_monitor_params,
 };
 
 #else
 #define HELP(a) NULL
 #endif
 
-static const struct shell_cmd bat_cli_cmd =
-{
+static const struct shell_cmd bat_cli_cmd = {
     .sc_cmd = "bat",
     .sc_cmd_func = bat_compat_cmd,
 };
@@ -97,7 +89,8 @@ static const struct shell_cmd bat_cli_cmd =
  * Help for the bat command.
  *
  */
-static void cmd_bat_help(void)
+static void
+cmd_bat_help(void)
 {
     console_printf("Usage: bat <cmd> [options]\n");
     console_printf("Available bat commands:\n");
@@ -117,23 +110,24 @@ static void cmd_bat_help(void)
 }
 
 static const char *bat_status[] = {
-        "???",
-        "charging",
-        "discharging",
-        "connected not charging",
-        "battery full",
+    "???",
+    "charging",
+    "discharging",
+    "connected not charging",
+    "battery full",
 };
 
 static const char *bat_level[] = {
-        "???",
-        "battery level critical",
-        "battery level low",
-        "battery level normal",
-        "battery level high",
-        "battery level full",
+    "???",
+    "battery level critical",
+    "battery level low",
+    "battery level normal",
+    "battery level high",
+    "battery level full",
 };
 
-static void print_property(const struct battery_property *prop)
+static void
+print_property(const struct battery_property *prop)
 {
     char name[20];
 
@@ -198,7 +192,8 @@ battery_shell_open_dev(void)
     return bat;
 }
 
-static int cmd_bat_read(int argc, char **argv)
+static int
+cmd_bat_read(int argc, char **argv)
 {
     int rc;
     int maxp;
@@ -321,10 +316,10 @@ cmd_bat_write(int argc, char ** argv)
     }
 
     if (prop->bp_type == BATTERY_PROP_VOLTAGE_NOW &&
-            (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
+        (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
         rc = battery_prop_set_value_uint32(prop, (uint32_t)val);
     } else if (prop->bp_type == BATTERY_PROP_TEMP_NOW &&
-            (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
+               (prop->bp_flags & BATTERY_PROPERTY_FLAGS_ALARM_THREASH) != 0) {
         rc = battery_prop_set_value_float(prop, val);
     } else {
         console_printf("Property %s can't be written!\n", argv[1]);
@@ -346,7 +341,8 @@ err:
     return rc;
 }
 
-static int cmd_bat_list(int argc, char **argv)
+static int
+cmd_bat_list(int argc, char **argv)
 {
     int i;
     int max;
@@ -380,7 +376,8 @@ err:
     return rc;
 }
 
-static int cmd_bat_poll_rate(int argc, char **argv)
+static int
+cmd_bat_poll_rate(int argc, char **argv)
 {
     int rc;
     uint32_t rate_in_s;
@@ -415,19 +412,21 @@ err:
     return rc;
 }
 
-static int bat_property(struct battery_prop_listener *listener,
-        const struct battery_property *prop)
+static int
+bat_property(struct battery_prop_listener *listener,
+             const struct battery_property *prop)
 {
     print_property(prop);
     return 0;
 }
 
 static struct battery_prop_listener listener = {
-        .bpl_prop_changed = bat_property,
-        .bpl_prop_read = bat_property,
+    .bpl_prop_changed = bat_property,
+    .bpl_prop_read = bat_property,
 };
 
-static int cmd_bat_monitor(int argc, char **argv)
+static int
+cmd_bat_monitor(int argc, char **argv)
 {
     int rc;
     struct battery_property *prop;
@@ -477,8 +476,7 @@ err:
     return rc;
 }
 
-static const struct shell_cmd bat_cli_commands[] =
-{
+static const struct shell_cmd bat_cli_commands[] = {
     SHELL_CMD("read", cmd_bat_read, &bat_read_help),
     SHELL_CMD("write", cmd_bat_write, &bat_write_help),
     SHELL_CMD("list", cmd_bat_list, &bat_list_help),
@@ -497,36 +495,30 @@ static const struct shell_cmd bat_cli_commands[] =
  *
  * @return int 0: success, -1 error
  */
-static int bat_compat_cmd(int argc, char **argv)
+static int
+bat_compat_cmd(int argc, char **argv)
 {
     int rc;
     int i;
 
-    if (argc < 2)
-    {
+    if (argc < 2) {
         rc = SYS_EINVAL;
-    }
-    else
-    {
-        for (i = 0; bat_cli_commands[i].sc_cmd; ++i)
-        {
-            if (strcmp(bat_cli_commands[i].sc_cmd, argv[1]) == 0)
-            {
+    } else {
+        for (i = 0; bat_cli_commands[i].sc_cmd; ++i) {
+            if (strcmp(bat_cli_commands[i].sc_cmd, argv[1]) == 0) {
                 rc = bat_cli_commands[i].sc_cmd_func(argc - 1, argv + 1);
                 break;
             }
         }
         /* No command found */
-        if (bat_cli_commands[i].sc_cmd == NULL)
-        {
+        if (bat_cli_commands[i].sc_cmd == NULL) {
             console_printf("Invalid command.\n");
             rc = -1;
         }
     }
 
     /* Print help in case of error */
-    if (rc)
-    {
+    if (rc) {
         cmd_bat_help();
     }
 


### PR DESCRIPTION
GCC complains about a strncpy call when building using build_profile speed.
This warning indicates a possible string truncation. The only proper
solution I could find was to decrease the buf_size and explicitly set a
zero byte.

Error: In function 'battery_prop_get_name',
    inlined from 'battery_find_property_by_name' at repos/apache-mynewt-core/hw/battery/src/battery.c:392:9:
repos/apache-mynewt-core/hw/battery/src/battery.c:379:5: error: 'strncpy' specified bound 20 equals destination size [-Werror=stringop-truncation]
  379 |     strncpy(buf, driver_prop->bdp_name, buf_size);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors