### PR TITLE
Detect connected programmer to download and debug firmware

### DIFF
--- a/hw/bsp/pinetime/pinetime_debug.sh
+++ b/hw/bsp/pinetime/pinetime_debug.sh
@@ -30,7 +30,23 @@
 . $CORE_PATH/hw/scripts/openocd.sh
 
 FILE_NAME=$BIN_BASENAME.elf
-CFG="-f interface/stlink.cfg -f target/nrf52.cfg"
+
+detect_programmer
+echo "Detected programmer: $DETECTED_PROGRAMMER"
+
+case $DETECTED_PROGRAMMER in
+	cmsis-dap)
+		OPENOCD_INTERFACE=cmsis-dap
+		;;
+	stlink-v2-1)
+		OPENOCD_INTERFACE=stlink-v2-1
+		;;
+	*) # default to stlink
+		OPENOCD_INTERFACE=stlink
+		;;
+esac
+
+CFG="-f interface/${OPENOCD_INTERFACE}.cfg -f target/nrf52.cfg"
 EXTRA_GDB_CMDS='monitor arm semihosting enable'
 # Exit openocd when gdb detaches.
 EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"

--- a/hw/bsp/pinetime/pinetime_debug.sh
+++ b/hw/bsp/pinetime/pinetime_debug.sh
@@ -31,22 +31,11 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 
-detect_programmer
-echo "Detected programmer: $DETECTED_PROGRAMMER"
-
-case $DETECTED_PROGRAMMER in
-	cmsis-dap)
-		OPENOCD_INTERFACE=cmsis-dap
-		;;
-	stlink-v2-1)
-		OPENOCD_INTERFACE=stlink-v2-1
-		;;
-	*) # default to stlink
-		OPENOCD_INTERFACE=stlink
-		;;
-esac
+# autodetect or default stlink
+openocd_detect_interface stlink
 
 CFG="-f interface/${OPENOCD_INTERFACE}.cfg -f target/nrf52.cfg"
+
 EXTRA_GDB_CMDS='monitor arm semihosting enable'
 # Exit openocd when gdb detaches.
 EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; nrf52.cpu configure -event gdb-detach {if {[nrf52.cpu curstate] eq \"halted\"} resume;shutdown}"

--- a/hw/bsp/pinetime/pinetime_download.sh
+++ b/hw/bsp/pinetime/pinetime_download.sh
@@ -31,7 +31,19 @@
 
 . $CORE_PATH/hw/scripts/openocd.sh
 
-CFG="-f interface/stlink.cfg -f target/nrf52.cfg"
+detect_programmer
+echo "Detected programmer: $DETECTED_PROGRAMMER"
+
+case $DETECTED_PROGRAMMER in
+	cmsis-dap)
+		OPENOCD_INTERFACE=cmsis-dap
+		;;
+	*) # default to stlink
+		OPENOCD_INTERFACE=stlink
+		;;
+esac
+
+CFG="-f interface/${OPENOCD_INTERFACE}.cfg -f target/nrf52.cfg"
 
 if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0

--- a/hw/bsp/pinetime/pinetime_download.sh
+++ b/hw/bsp/pinetime/pinetime_download.sh
@@ -38,6 +38,9 @@ case $DETECTED_PROGRAMMER in
 	cmsis-dap)
 		OPENOCD_INTERFACE=cmsis-dap
 		;;
+	stlink-v2-1)
+		OPENOCD_INTERFACE=stlink-v2-1
+		;;
 	*) # default to stlink
 		OPENOCD_INTERFACE=stlink
 		;;

--- a/hw/bsp/pinetime/pinetime_download.sh
+++ b/hw/bsp/pinetime/pinetime_download.sh
@@ -31,20 +31,8 @@
 
 . $CORE_PATH/hw/scripts/openocd.sh
 
-detect_programmer
-echo "Detected programmer: $DETECTED_PROGRAMMER"
-
-case $DETECTED_PROGRAMMER in
-	cmsis-dap)
-		OPENOCD_INTERFACE=cmsis-dap
-		;;
-	stlink-v2-1)
-		OPENOCD_INTERFACE=stlink-v2-1
-		;;
-	*) # default to stlink
-		OPENOCD_INTERFACE=stlink
-		;;
-esac
+# autodetect or default stlink
+openocd_detect_interface stlink
 
 CFG="-f interface/${OPENOCD_INTERFACE}.cfg -f target/nrf52.cfg"
 

--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -89,6 +89,9 @@ detect_programmer() {
     echo "$USB_DEV" | grep -q -i '0483:3748'
     [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2'
 
+    echo "$USB_DEV" | grep -q -i '0483:374b'
+    [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2-1'
+
     echo "$USB_DEV" | grep -q -i '1366:1015'
     [ $? -eq 0 ] && DETECTED_PROGRAMMER='jlink'
 

--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -76,3 +76,22 @@ parse_extra_jtag_cmd() {
     echo $NEW_EXTRA_JTAG_CMD
     EXTRA_JTAG_CMD=$NEW_EXTRA_JTAG_CMD
 }
+
+# Try to detect connnected programmers
+detect_programmer() {
+
+    # scan USB for well-known VID:PID
+    USB_DEV=$(ls /sys/bus/hid/devices)
+
+    echo "$USB_DEV" | grep -q -i 'c251:f001'
+    [ $? -eq 0 ] && DETECTED_PROGRAMMER='cmsis-dap'
+
+    echo "$USB_DEV" | grep -q -i '0483:3748'
+    [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2'
+
+    echo "$USB_DEV" | grep -q -i '1366:1015'
+    [ $? -eq 0 ] && DETECTED_PROGRAMMER='jlink'
+
+    # no programmers detected
+    [ -z "$DETECTED_PROGRAMMER" ] && DETECTED_PROGRAMMER='none'
+}

--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -77,26 +77,30 @@ parse_extra_jtag_cmd() {
     EXTRA_JTAG_CMD=$NEW_EXTRA_JTAG_CMD
 }
 
-# Try to detect connnected programmers
+# Try to detect connected programmers
 detect_programmer() {
 
-    # scan USB for well-known VID:PID
-    USB_DEV=$(ls /sys/bus/hid/devices)
+    DETECTED_PROGRAMMER='none'
+    
+    # check if lsusb command is available
+    if [ $(which lsusb) ] ; then
 
-    echo "$USB_DEV" | grep -q -i 'c251:f001'
-    [ $? -eq 0 ] && DETECTED_PROGRAMMER='cmsis-dap'
+        # extract the VID:PID list for connected USB devices
+        USB_DEV=$(lsusb | cut -f6 -d' ')
 
-    echo "$USB_DEV" | grep -q -i '0483:3748'
-    [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2'
+        echo "$USB_DEV" | grep -q -i 'c251:f001'
+        [ $? -eq 0 ] && DETECTED_PROGRAMMER='cmsis-dap'
 
-    echo "$USB_DEV" | grep -q -i '0483:374b'
-    [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2-1'
+        echo "$USB_DEV" | grep -q -i '0483:3748'
+        [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2'
 
-    echo "$USB_DEV" | grep -q -i '1366:1015'
-    [ $? -eq 0 ] && DETECTED_PROGRAMMER='jlink'
+        echo "$USB_DEV" | grep -q -i '0483:374b'
+        [ $? -eq 0 ] && DETECTED_PROGRAMMER='stlink-v2-1'
 
-    # no programmers detected
-    [ -z "$DETECTED_PROGRAMMER" ] && DETECTED_PROGRAMMER='none'
+        echo "$USB_DEV" | grep -q -i '1366:1015'
+        [ $? -eq 0 ] && DETECTED_PROGRAMMER='jlink'
+
+    fi
 
     echo "Detected programmer: $DETECTED_PROGRAMMER"
 }

--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -97,4 +97,6 @@ detect_programmer() {
 
     # no programmers detected
     [ -z "$DETECTED_PROGRAMMER" ] && DETECTED_PROGRAMMER='none'
+
+    echo "Detected programmer: $DETECTED_PROGRAMMER"
 }

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -149,3 +149,18 @@ openocd_reset_run () {
     openocd $CFG -c init -c "reset run" -c shutdown
     return $?
 }
+
+openocd_detect_interface () {
+    detect_programmer
+    case $DETECTED_PROGRAMMER in
+        cmsis-dap)
+            OPENOCD_INTERFACE='cmsis-dap'
+            ;;
+        stlink-v2-1)
+            OPENOCD_INTERFACE='stlink-v2-1'
+            ;;
+        *) # default is passed by argument or 'stlink'
+            OPENOCD_INTERFACE=${1:=stlink}
+            ;;
+    esac
+}


### PR DESCRIPTION
Here is a new bash funtion in _hw/scripts/common.sh_ to detect connected programmers. I've added detection by USB vendor:product IDs, but other methods could be implemented. At the moment I've tested with Segger's **jlink** nrf5x on-board, **cmsis-dap** on STM32 and **stlink-v2** and **stlink-v2.1**.

Detected programmer is put on **DETECTED_PROGRAMMER variable** so download or debug script for some board will be able to use the bash function. For example, scripts for pinetime BSP are using this feature.