### PR TITLE
hw/bsp/pinetime: Setup I2C

### DIFF
--- a/hw/bsp/pinetime/syscfg.yml
+++ b/hw/bsp/pinetime/syscfg.yml
@@ -47,7 +47,7 @@ syscfg.vals:
     MCU_TARGET: nRF52832
 
     # 32.768 kHz crystal oscillator
-    MCU_LFCLK_SOURCE: LFXO      
+    MCU_LFCLK_SOURCE: LFXO
 
     # Enable DC/DC regulator
     MCU_DCDC_ENABLED: 1
@@ -61,7 +61,9 @@ syscfg.vals:
     SPI_0_MASTER_PIN_MOSI: 3  # P0.03: SPI-MOSI, LCD_SDI
     SPI_0_MASTER_PIN_MISO: 4  # P0.04: SPI-MISO
 
-    # I2C port 1 connected to CST816S touch controller, BMA421 accelerometer, HRS3300 heart rate sensor 
+    # I2C port 1 connected to CST816S touch controller, BMA421 accelerometer, HRS3300 heart rate sensor
+    I2C_1: 1
+    I2C_1_FREQ_KHZ: 400 # BMA421=1000 HRS3300=800 CST816S=400
     I2C_1_PIN_SCL: 7  # P0.07: BMA421-SCL, HRS3300-SCL, TP-SCLOUT
     I2C_1_PIN_SDA: 6  # P0.06: BMA421-SDA, HRS3300-SDA, TP-SDAI/O
 


### PR DESCRIPTION
Enable the I2C port 1 for the Pinetime. Maximum speed of 400 KHz is set since connected I2C slave devices are >= 400 KHz.