### PR TITLE
hw/mcu/dialog: Fix return value from da1469x_m33_sleep

### DIFF
--- a/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
+++ b/hw/mcu/dialog/da1469x/src/arch/cortex_m33/da1469x_m33_sleep.S
@@ -160,7 +160,6 @@ da1469x_m33_sleep:
  * did not sleep.
  */
     str     r1, [r0, #0]
-    mov     r0, #0
 
 /* Enable QSPI controller clock */
     ldr     r2, =CLK_AMBA_REG
@@ -183,6 +182,7 @@ da1469x_m33_sleep:
     str     r1, [r0, #(QSPIC_CTRLMOD_OFFSET)]
 #endif
 
+    mov     r0, #0
     b       da1469x_m33_restore
 
     .section .text_ram


### PR DESCRIPTION
QSPIC code changes r0 register which is set in the code before to
indicate that deep sleep did not happen. This means we will always
return non-zero which means "deep sleep *did* happen" in da1469x_sleep.
It likely is not not much of a problem except we will always take
longer path when exiting from da1469x_sleep.