### PR TITLE
BSP de-initialization to be executed before boot loader start application

### DIFF
--- a/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_nrf52/src/hal_bsp.c
@@ -101,3 +101,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
+++ b/hw/bsp/ada_feather_stm32f405/src/hal_bsp.c
@@ -305,3 +305,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/apollo2_evb/src/hal_bsp.c
+++ b/hw/bsp/apollo2_evb/src/hal_bsp.c
@@ -181,6 +181,11 @@ hal_bsp_init(void)
 #endif
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 int
 hal_bsp_hw_id_len(void)
 {

--- a/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
+++ b/hw/bsp/arduino_primo_nrf52/src/hal_bsp.c
@@ -100,3 +100,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/b-l072z-lrwan1/src/hal_bsp.c
+++ b/hw/bsp/b-l072z-lrwan1/src/hal_bsp.c
@@ -133,6 +133,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/b-l475e-iot01a/src/hal_bsp.c
+++ b/hw/bsp/b-l475e-iot01a/src/hal_bsp.c
@@ -170,6 +170,11 @@ hal_bsp_init(void)
     sensor_dev_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/bbc_microbit/src/hal_bsp.c
+++ b/hw/bsp/bbc_microbit/src/hal_bsp.c
@@ -222,3 +222,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -347,3 +347,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -351,4 +351,19 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHB1ENR = RCC_AHB1ENR_CCMDATARAMEN;
+    RCC->AHB2ENR = 0x0;
+    RCC->AHB3ENR = 0x0;
+    RCC->APB1ENR = 0x0;
+    RCC->APB2ENR = 0x0;
+    RCC->AHB1RSTR = 0x22E017FF;
+    RCC->AHB2RSTR = 0x000000F1;
+    RCC->AHB3RSTR = 0x00000001;
+    RCC->APB1RSTR = 0xF6FEC9FF;
+    RCC->APB2RSTR = 0x04777933;
+    RCC->AHB1RSTR = 0x0;
+    RCC->AHB2RSTR = 0x0;
+    RCC->AHB3RSTR = 0x0;
+    RCC->APB1RSTR = 0x0;
+    RCC->APB2RSTR = 0x0;
 }

--- a/hw/bsp/ble400/src/hal_bsp.c
+++ b/hw/bsp/ble400/src/hal_bsp.c
@@ -224,3 +224,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/bluepill/src/hal_bsp.c
+++ b/hw/bsp/bluepill/src/hal_bsp.c
@@ -92,6 +92,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/bluepill/src/hal_bsp.c
+++ b/hw/bsp/bluepill/src/hal_bsp.c
@@ -95,6 +95,13 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHBENR = RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+    RCC->APB1RSTR = 0xFFFFFFFF;
+    RCC->APB2RSTR = 0x0038FFFD;
+    RCC->APB1RSTR = 0x0;
+    RCC->APB2RSTR = 0x0;
 }
 
 /**

--- a/hw/bsp/bmd200/src/hal_bsp.c
+++ b/hw/bsp/bmd200/src/hal_bsp.c
@@ -224,3 +224,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/bmd300eval/src/hal_bsp.c
+++ b/hw/bsp/bmd300eval/src/hal_bsp.c
@@ -101,3 +101,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/calliope_mini/src/hal_bsp.c
+++ b/hw/bsp/calliope_mini/src/hal_bsp.c
@@ -224,3 +224,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/ci40/src/hal_bsp.c
+++ b/hw/bsp/ci40/src/hal_bsp.c
@@ -62,3 +62,8 @@ hal_bsp_init(void)
 
     (void)rc;
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/dialog_cmac/src/hal_bsp.c
+++ b/hw/bsp/dialog_cmac/src/hal_bsp.c
@@ -37,3 +37,8 @@ hal_bsp_init(void)
     /* Create all available CMAC peripherals */
     cmac_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -91,3 +91,7 @@ hal_bsp_init(void)
     da1469x_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/dwm1001-dev/src/hal_bsp.c
+++ b/hw/bsp/dwm1001-dev/src/hal_bsp.c
@@ -102,3 +102,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/embarc_emsk/src/hal_bsp.c
+++ b/hw/bsp/embarc_emsk/src/hal_bsp.c
@@ -104,3 +104,8 @@ hal_bsp_init(void)
 #endif
 
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/fanstel-ev-bt840/src/hal_bsp.c
+++ b/hw/bsp/fanstel-ev-bt840/src/hal_bsp.c
@@ -86,3 +86,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/frdm-k64f/src/hal_bsp.c
+++ b/hw/bsp/frdm-k64f/src/hal_bsp.c
@@ -257,3 +257,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/hifive1/src/hal_bsp.c
+++ b/hw/bsp/hifive1/src/hal_bsp.c
@@ -97,6 +97,11 @@ hal_bsp_init(void)
 #endif
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 int
 hal_bsp_hw_id(uint8_t *id, int max_len)
 {

--- a/hw/bsp/native-armv7/src/hal_bsp.c
+++ b/hw/bsp/native-armv7/src/hal_bsp.c
@@ -83,3 +83,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/native-mips/src/hal_bsp.c
+++ b/hw/bsp/native-mips/src/hal_bsp.c
@@ -83,3 +83,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/native/src/hal_bsp.c
+++ b/hw/bsp/native/src/hal_bsp.c
@@ -121,6 +121,11 @@ hal_bsp_init(void)
 }
 
 void
+hal_bsp_deinit(void)
+{
+}
+
+void
 hal_bsp_init_trng(void)
 {
     int i;

--- a/hw/bsp/nina-b1/src/hal_bsp.c
+++ b/hw/bsp/nina-b1/src/hal_bsp.c
@@ -102,3 +102,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10028-16k/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10028-16k/src/hal_bsp.c
@@ -226,3 +226,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10028/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10028/src/hal_bsp.c
@@ -226,3 +226,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10040/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10040/src/hal_bsp.c
@@ -120,3 +120,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10056/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10056/src/hal_bsp.c
@@ -105,6 +105,11 @@ hal_bsp_init(void)
     nrf52_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 #if MYNEWT_VAL(BSP_USE_HAL_SPI)
 void
 bsp_spi_read_buf(uint8_t addr, uint8_t *buf, uint8_t size)

--- a/hw/bsp/nordic_pca10090/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10090/src/hal_bsp.c
@@ -95,3 +95,8 @@ hal_bsp_init(void)
     /* Create all available nRF9160 peripherals */
     nrf91_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10095/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10095/src/hal_bsp.c
@@ -75,3 +75,8 @@ hal_bsp_init(void)
     /* Create all available nRF5340 peripherals */
     nrf5340_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca10095_net/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10095_net/src/hal_bsp.c
@@ -75,3 +75,8 @@ hal_bsp_init(void)
     /* Create all available nRF5340 Net Core peripherals */
     nrf5340_net_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nordic_pca20020/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca20020/src/hal_bsp.c
@@ -161,3 +161,8 @@ hal_bsp_init(void)
 
     sensor_dev_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
+++ b/hw/bsp/nrf51-arduino_101/src/hal_bsp.c
@@ -224,3 +224,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nrf51-blenano/src/hal_bsp.c
+++ b/hw/bsp/nrf51-blenano/src/hal_bsp.c
@@ -225,3 +225,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nucleo-f030r8/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f030r8/src/hal_bsp.c
@@ -122,3 +122,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nucleo-f072rb/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f072rb/src/hal_bsp.c
@@ -129,3 +129,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nucleo-f103rb/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f103rb/src/hal_bsp.c
@@ -143,6 +143,13 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHBENR = RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+    RCC->APB1RSTR = 0xFFFFFFFF;
+    RCC->APB2RSTR = 0x0038FFFD;
+    RCC->APB1RSTR = 0x0;
+    RCC->APB2RSTR = 0x0;
 }
 
 /**

--- a/hw/bsp/nucleo-f103rb/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f103rb/src/hal_bsp.c
@@ -140,6 +140,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f303k8/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f303k8/src/hal_bsp.c
@@ -132,3 +132,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nucleo-f303re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f303re/src/hal_bsp.c
@@ -131,3 +131,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -117,6 +117,18 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHB1ENR = 0;
+    RCC->AHB2ENR = 0;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+    RCC->AHB1RSTR = 0x00C0109F;
+    RCC->AHB2RSTR = 0x00000080;
+    RCC->APB1RSTR = 0x10E2C80F;
+    RCC->APB2RSTR = 0x00077931;
+    RCC->AHB1RSTR = 0x00000000;
+    RCC->AHB2RSTR = 0x00000000;
+    RCC->APB1RSTR = 0x00000000;
+    RCC->APB2RSTR = 0x00000000;
 }
 
 /**

--- a/hw/bsp/nucleo-f401re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f401re/src/hal_bsp.c
@@ -114,6 +114,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f411re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f411re/src/hal_bsp.c
@@ -171,6 +171,18 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHB1ENR = 0;
+    RCC->AHB2ENR = 0;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+    RCC->AHB1RSTR = 0x00C0109F;
+    RCC->AHB2RSTR = 0x00000080;
+    RCC->APB1RSTR = 0x10E2C80F;
+    RCC->APB2RSTR = 0x00177931;
+    RCC->AHB1RSTR = 0x00000000;
+    RCC->AHB2RSTR = 0x00000000;
+    RCC->APB1RSTR = 0x00000000;
+    RCC->APB2RSTR = 0x00000000;
 }
 
 /**

--- a/hw/bsp/nucleo-f411re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f411re/src/hal_bsp.c
@@ -168,6 +168,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f413zh/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f413zh/src/hal_bsp.c
@@ -120,6 +120,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f439zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f439zi/src/hal_bsp.c
@@ -185,6 +185,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f746zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f746zg/src/hal_bsp.c
@@ -182,6 +182,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-f767zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f767zi/src/hal_bsp.c
@@ -187,6 +187,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/nucleo-l476rg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l476rg/src/hal_bsp.c
@@ -147,6 +147,24 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHB1ENR = RCC_AHB1ENR_FLASHEN;
+    RCC->AHB2ENR = 0;
+    RCC->AHB3ENR = 0;
+    RCC->APB1ENR1 = 0;
+    RCC->APB1ENR2 = 0;
+    RCC->APB2ENR = 0;
+    RCC->AHB1RSTR = 0x00031103;
+    RCC->AHB2RSTR = 0x000771FF;
+    RCC->AHB3RSTR = 0x00000101;
+    RCC->APB1RSTR1 = 0xF7FEC23F;
+    RCC->APB1RSTR2 = 0x00000027;
+    RCC->APB2RSTR = 0x01677C01;
+    RCC->APB1RSTR1 = 0x0;
+    RCC->APB1RSTR2 = 0x0;
+    RCC->APB2RSTR = 0x0;
+    RCC->AHB1RSTR = 0x0;
+    RCC->AHB2RSTR = 0x0;
+    RCC->AHB3RSTR = 0x0;
 }
 
 /**

--- a/hw/bsp/nucleo-l476rg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l476rg/src/hal_bsp.c
@@ -144,6 +144,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/olimex-p103/src/hal_bsp.c
+++ b/hw/bsp/olimex-p103/src/hal_bsp.c
@@ -92,6 +92,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
+++ b/hw/bsp/olimex_stm32-e407_devboard/src/hal_bsp.c
@@ -305,3 +305,8 @@ hal_bsp_init(void)
 {
     stm32_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/p-nucleo-wb55/src/hal_bsp.c
+++ b/hw/bsp/p-nucleo-wb55/src/hal_bsp.c
@@ -97,6 +97,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
+++ b/hw/bsp/pic32mx470_6lp_clicker/src/hal_bsp.c
@@ -195,3 +195,8 @@ hal_bsp_init(void)
 
     (void)rc;
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
+++ b/hw/bsp/pic32mz2048_wi-fire/src/hal_bsp.c
@@ -274,6 +274,11 @@ hal_bsp_init(void)
     (void)rc;
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 int
 hal_bsp_hw_id_len(void)
 {

--- a/hw/bsp/pinetime/src/hal_bsp.c
+++ b/hw/bsp/pinetime/src/hal_bsp.c
@@ -236,3 +236,8 @@ hal_bsp_init(void)
     hal_bsp_battery_init();
     #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/puckjs/src/hal_bsp.c
+++ b/hw/bsp/puckjs/src/hal_bsp.c
@@ -102,3 +102,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/rb-blend2/src/hal_bsp.c
+++ b/hw/bsp/rb-blend2/src/hal_bsp.c
@@ -101,3 +101,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/rb-nano2/src/hal_bsp.c
+++ b/hw/bsp/rb-nano2/src/hal_bsp.c
@@ -100,3 +100,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/reel_board/src/hal_bsp.c
+++ b/hw/bsp/reel_board/src/hal_bsp.c
@@ -94,3 +94,8 @@ hal_bsp_init(void)
         assert(rc == 0);
     }
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/ruuvitag_rev_b/src/hal_bsp.c
+++ b/hw/bsp/ruuvitag_rev_b/src/hal_bsp.c
@@ -210,3 +210,8 @@ hal_bsp_init(void)
 
     sensor_dev_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/stm32f3discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f3discovery/src/hal_bsp.c
@@ -173,3 +173,8 @@ hal_bsp_init(void)
     stm32_periph_create();
     sensor_dev_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/stm32f411discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f411discovery/src/hal_bsp.c
@@ -171,6 +171,18 @@ hal_bsp_init(void)
 void
 hal_bsp_deinit(void)
 {
+    RCC->AHB1ENR = 0;
+    RCC->AHB2ENR = 0;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+    RCC->AHB1RSTR = 0x00C0109F;
+    RCC->AHB2RSTR = 0x00000080;
+    RCC->APB1RSTR = 0x10E2C80F;
+    RCC->APB2RSTR = 0x00177931;
+    RCC->AHB1RSTR = 0x00000000;
+    RCC->AHB2RSTR = 0x00000000;
+    RCC->APB1RSTR = 0x00000000;
+    RCC->APB2RSTR = 0x00000000;
 }
 
 /**

--- a/hw/bsp/stm32f411discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f411discovery/src/hal_bsp.c
@@ -168,6 +168,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/stm32f429discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f429discovery/src/hal_bsp.c
@@ -123,6 +123,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/stm32f4discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f4discovery/src/hal_bsp.c
@@ -122,6 +122,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/stm32f7discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32f7discovery/src/hal_bsp.c
@@ -159,6 +159,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/stm32l152discovery/src/hal_bsp.c
+++ b/hw/bsp/stm32l152discovery/src/hal_bsp.c
@@ -92,6 +92,11 @@ hal_bsp_init(void)
     stm32_periph_create();
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 /**
  * Returns the configured priority for the given interrupt. If no priority
  * configured, return the priority passed in

--- a/hw/bsp/telee02/src/hal_bsp.c
+++ b/hw/bsp/telee02/src/hal_bsp.c
@@ -118,6 +118,11 @@ hal_bsp_init(void)
     assert(rc == 0);
 }
 
+void
+hal_bsp_deinit(void)
+{
+}
+
 #if MYNEWT_VAL(LORA_NODE)
 void lora_bsp_enable_mac_timer(void)
 {

--- a/hw/bsp/usbmkw41z/src/hal_bsp.c
+++ b/hw/bsp/usbmkw41z/src/hal_bsp.c
@@ -86,3 +86,8 @@ hal_bsp_init(void)
 {
     return;
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/vbluno51/src/hal_bsp.c
+++ b/hw/bsp/vbluno51/src/hal_bsp.c
@@ -224,3 +224,8 @@ hal_bsp_init(void)
     assert(rc == 0);
 #endif
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/bsp/vbluno52/src/hal_bsp.c
+++ b/hw/bsp/vbluno52/src/hal_bsp.c
@@ -102,3 +102,8 @@ hal_bsp_init(void)
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }
+
+void
+hal_bsp_deinit(void)
+{
+}

--- a/hw/hal/include/hal/hal_bsp.h
+++ b/hw/hal/include/hal/hal_bsp.h
@@ -40,6 +40,15 @@ extern "C" {
 void hal_bsp_init(void);
 
 /**
+ * De-initializes BSP. Intended to be called from bootloader
+ * before it call application reset handler.
+ * It should leave resources (timers/DMA/peripherals) in a state
+ * that nothing unexpected is active before application code
+ * is ready to handle it.
+ */
+void hal_bsp_deinit(void);
+
+/**
  * Return pointer to flash device structure, given BSP specific
  * flash id.
  */


### PR DESCRIPTION
This introduces empty hal_bsp_deinit() function
that is intended to be called by bootloader
before it calls application reset handler.

mcuboot calls hal_bsp_init() at start it can leave
various resources initialized before application
starts.
In can leave to situation when such resource (timer/uart)
is configured with interrupt enabled.
Then in bad case interrupt can be activated before resource
is reconfigured, or interrupt are remapped but often RAM (bss and data)
are already wiped out and interrupt (with handler still from
bootloader will try to execute with its data structures corrupted.

matching mcuboot pr: https://github.com/mcu-tools/mcuboot/pull/886