### PR TITLE
nucleo: Add missing BUTTON_1 definitions

### DIFF
--- a/hw/bsp/nucleo-f030r8/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f030r8/include/bsp/bsp.h
@@ -44,6 +44,9 @@ extern uint8_t _ram_start;
 /* LED pins */
 #define LED_BLINK_PIN MCU_GPIO_PORTA(5)
 
+/* Button pin */
+#define BUTTON_1      MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(3)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(2)

--- a/hw/bsp/nucleo-f072rb/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f072rb/include/bsp/bsp.h
@@ -44,6 +44,9 @@ extern uint8_t _ram_start;
 /* LED pins */
 #define LED_BLINK_PIN MCU_GPIO_PORTA(5)
 
+/* Button pin */
+#define BUTTON_1      MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(3)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(2)

--- a/hw/bsp/nucleo-f103rb/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f103rb/include/bsp/bsp.h
@@ -42,6 +42,9 @@ extern uint8_t _ram_start;
 /* One led LED pin, two names */
 #define LED_BLINK_PIN   ARDUINO_PIN_D13
 
+/* Button pin */
+#define BUTTON_1        MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(3)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(2)

--- a/hw/bsp/nucleo-f303k8/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f303k8/include/bsp/bsp.h
@@ -49,6 +49,9 @@ extern uint8_t _ccram_start;
 
 #define LED_BLINK_PIN LED_BLINK_PIN_1
 
+/* Button pin */
+#define BUTTON_1            MCU_GPIO_PORTC(13)
+
 /* Arduino nano pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(10)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(9)

--- a/hw/bsp/nucleo-f303re/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f303re/include/bsp/bsp.h
@@ -52,6 +52,9 @@ extern uint8_t _ccram_start;
 /* Buttons */
 #define BTN_USER_1        MCU_GPIO_PORTC(13)
 
+/* Button pin */
+#define BUTTON_1          BTN_USER_1
+
 /* This defines the maximum NFFS areas (block) are in the BSPs NFS file 
  * system space.  This in conjunction with flash map determines how 
  * many NFS blocks there will be.  A minimum is the number of individually

--- a/hw/bsp/nucleo-f401re/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f401re/include/bsp/bsp.h
@@ -41,6 +41,9 @@ extern uint8_t _ram_start;
 /* LED pins */
 #define LED_BLINK_PIN   MCU_GPIO_PORTA(5)
 
+/* Button pin */
+#define BUTTON_1        MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(3)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(2)

--- a/hw/bsp/nucleo-f413zh/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f413zh/include/bsp/bsp.h
@@ -43,6 +43,9 @@ extern uint8_t _ccram_start;
 /* LED pins */
 #define LED_BLINK_PIN   MCU_GPIO_PORTB(7)
 
+/* Button pin */
+#define BUTTON_1        MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTG(9)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTG(14)

--- a/hw/bsp/nucleo-f439zi/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f439zi/include/bsp/bsp.h
@@ -43,6 +43,9 @@ extern uint8_t _ccram_start;
 /* LED pins */
 #define LED_BLINK_PIN   MCU_GPIO_PORTB(7)
 
+/* Button pin */
+#define BUTTON_1        MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTG(9)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTG(14)

--- a/hw/bsp/nucleo-f746zg/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f746zg/include/bsp/bsp.h
@@ -58,6 +58,9 @@ extern uint8_t _ram2_start;
 /* BUTTON pins */
 #define BTN_USER_1      MCU_GPIO_PORTC(13)
 
+/* Button pin */
+#define BUTTON_1        BTN_USER_1
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTG(9)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTG(14)

--- a/hw/bsp/nucleo-f767zi/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-f767zi/include/bsp/bsp.h
@@ -58,6 +58,9 @@ extern uint8_t _ram2_start;
 /* BUTTON pins */
 #define BTN_USER_1      MCU_GPIO_PORTC(13)
 
+/* Button pin */
+#define BUTTON_1        BTN_USER_1
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTG(9)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTG(14)

--- a/hw/bsp/nucleo-l476rg/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-l476rg/include/bsp/bsp.h
@@ -41,6 +41,9 @@ extern uint8_t _ram_start;
 /* LED pins */
 #define LED_BLINK_PIN   MCU_GPIO_PORTA(5)
 
+/* Button pin */
+#define BUTTON_1        MCU_GPIO_PORTC(13)
+
 /* Arduino pins */
 #define ARDUINO_PIN_D0      MCU_GPIO_PORTA(3)
 #define ARDUINO_PIN_D1      MCU_GPIO_PORTA(2)


### PR DESCRIPTION
All nucleo 64/144 boards have button at PC13.
Some boards already had this definition.
Some boards had BTN_USER_1 instead.
Some did not have user button definition at all.

Now all have BUTTON_1 that is also present in other
BSPs.