### PR TITLE
baselibc: Always define static_assert for C

### DIFF
--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #endif
 
-#if __STDC_VERSION__ >= 201112L && !defined __cplusplus
+#if !defined __cplusplus
 #define static_assert _Static_assert
 #endif
 


### PR DESCRIPTION
Currently **static_assert** is only defined when
```__STDC_VERSION__ >= 201112L```.

Static asserts present in header files should
use static_assert to be able to build with C++.

For non C++ build it should map **_Static_assert**.
While _Static_assert is C11 feature it can be
present for older compilers.

This drops checking for compiler version,
if compiler does not support _Static_assert it
will fail anyway.

This resolves #2040 