### PR TITLE
hw/mcu/dialog: Add calibration of RC32K and RC32M

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -91,9 +91,29 @@ void da1469x_clock_lp_rcx_switch(void);
 void da1469x_clock_lp_rcx_calibrate(void);
 
 /**
+ * Calibrate RC32K
+ */
+void da1469x_clock_lp_rc32k_calibrate(void);
+
+/**
+ * Calibrate RC32M
+ */
+void da1469x_clock_lp_rc32m_calibrate(void);
+
+/**
  * Get calibrated (measured) RCX frequency
  */
 uint32_t da1469x_clock_lp_rcx_freq_get(void);
+
+/**
+ * Get calibrated (measured) RC32K frequency
+ */
+uint32_t da1469x_clock_lp_rc32k_freq_get(void);
+
+/**
+ * Get calibrated (measured) RC32M frequency
+ */
+uint32_t da1469x_clock_lp_rc32m_freq_get(void);
 
 /**
  * Disable RCX


### PR DESCRIPTION
There was code to calibrate RCX oscillator.
Now similar code can measure RC32K and RC32M if needed.