### PR TITLE
hw/mcu/dialog: Disconnect UART RX pin when grounded

### DIFF
--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -105,6 +105,13 @@ syscfg.defs:
             Used internally by the newt tool.
         value: 1
 
+    MCU_UART_DICONNECT_RX_ON_BUSY:
+        description: >
+            If set to 1, UART RX pin will be configured to GPIO once busy state is
+            detected.  UART block can stuck in busy state when RX line is set to 0.
+            This will result in continuous BUSY interrupt.
+            To prevent such case RX pin can be configured to GPIO.
+        value: 0
     MCU_DMA_IRQ_PRIO:
         description: >
             Specifies the NVIC interrupt priority to assign for the DMA_IRQn 


### PR DESCRIPTION
When UART RX pin is shorted to ground and UART is enabled it enters
busy state.
In this state busy interrupt fires constantly it prevents non-interrupt code
to be executed and can lead to watchdog reboot.
In function hal_uart_config() pullup was added to RX pin to enable configuration
(which was not successful in busy state).
This counter measure worked fined when RX pin was floating and just happen to be
low for a while but internal pull-up resistor was enough to make is stable.
However when RX pin is shorted to ground internal pull-up will not solve the problem.

- now RX pin is not routed to UART during configuration to prevent busy state at that time.
- RX can be disconnected from UART once it enters busy state, pin is reconfigured for
GPIO with interrupt to detect end of short condition. (This functionality is optionall
and can be enabled with syscfg value MCU_UART_DICONNECT_RX_ON_BUSY).