### PR TITLE
syscfg: OS_TICKS_PER_SEC definition workaround

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
+#define OS_TICKS_PER_SEC    MYNEWT_VAL_OS_TICKS_PER_SEC
 
 static inline void
 hal_debug_break(void)

--- a/hw/mcu/sifive/fe310/include/mcu/fe310.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
+#define OS_TICKS_PER_SEC    MYNEWT_VAL_OS_TICKS_PER_SEC
 
 static inline void
 hal_debug_break(void)

--- a/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
+#define OS_TICKS_PER_SEC    MYNEWT_VAL_OS_TICKS_PER_SEC
 
 static inline void
 hal_debug_break(void)


### PR DESCRIPTION
OS_TICK_PER_SEC is configurable via syscfg in fe310/nrf52/stmf1.
nrf52 and stmf1 had this changed not so long ago.
Unfortunately the way it was defined:
#define OS_TICKS_PER_SEC MYNEWT_VAL(OS_TICKS_PER_SEC)
collides with existing usage where some other
syscfg values refer to definition OS_TICKS_PER_SEC
(not MYNEWT_VAL(..) which is not valid for all MCUs)
and that makes compilation fail with undefined MYNEWT_VAL() function.

If OS_TICKS_PER_SEC is to be configurable (and that seems reasonable
for many cases) it would be good to define it for all MCUs,
then change few yml files that refer to plain OS_TICKS_PER_SEC
to use MYNEWT_VAL() instead.

For now as workaround MYNEWT_VAL(OS_TICKS_PER_SEC) is expanded
in 3 files to avoid preprocessor problem.