### PR TITLE
hw/drivers/bmp388: Fix compilation warning

### DIFF
--- a/hw/drivers/sensors/bmp388/src/bmp388.c
+++ b/hw/drivers/sensors/bmp388/src/bmp388.c
@@ -3375,7 +3375,7 @@ bmp388_hybrid_read(struct sensor *sensor,
                    void *read_arg,
                    uint32_t time_ms)
 {
-    int rc;
+    int rc = 0;
     struct bmp388 *bmp388;
     struct bmp388_cfg *cfg;
     os_time_t time_ticks;


### PR DESCRIPTION
Compiler detects this:
bmp388.c:3596:12: error: 'rc' may be used uninitialized in this function

Fixed by initializing variable to 0.