### PR TITLE
apps/ble: Use store/config instead of store/ram

### DIFF
--- a/apps/bleprph_oic/pkg.yml
+++ b/apps/bleprph_oic/pkg.yml
@@ -28,7 +28,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/bleprph_oic/syscfg.yml
+++ b/apps/bleprph_oic/syscfg.yml
@@ -71,3 +71,6 @@ syscfg.vals:
     # ATT MTU values.
     MSYS_1_BLOCK_COUNT: 20
     MSYS_1_BLOCK_SIZE: 150
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blesplit/pkg.yml
+++ b/apps/blesplit/pkg.yml
@@ -37,7 +37,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/services/ans"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport/ram"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/id"

--- a/apps/blesplit/syscfg.yml
+++ b/apps/blesplit/syscfg.yml
@@ -40,3 +40,6 @@ syscfg.vals:
 
     # OS main/default task
     OS_MAIN_STACK_SIZE: 468
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/bleuart/pkg.yml
+++ b/apps/bleuart/pkg.yml
@@ -28,7 +28,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/bleuart/syscfg.yml
+++ b/apps/bleuart/syscfg.yml
@@ -23,3 +23,6 @@ syscfg.vals:
 
     # Default task settings
     OS_MAIN_STACK_SIZE: 336
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/bsncent/pkg.yml
+++ b/apps/bsncent/pkg.yml
@@ -27,7 +27,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/bsncent/syscfg.yml
+++ b/apps/bsncent/syscfg.yml
@@ -27,3 +27,6 @@ syscfg.vals:
 
     # Turn strict scheduling on
     BLE_LL_STRICT_CONN_SCHEDULING: 1
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/bsnprph/pkg.yml
+++ b/apps/bsnprph/pkg.yml
@@ -34,7 +34,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/services/ans"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/bsnprph/syscfg.yml
+++ b/apps/bsnprph/syscfg.yml
@@ -30,3 +30,6 @@ syscfg.vals:
     BLE_ROLE_CENTRAL: 0
     BLE_ROLE_OBSERVER: 0
     BLE_ROLE_PERIPHERAL: 1
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/ocf_sample/pkg.yml
+++ b/apps/ocf_sample/pkg.yml
@@ -38,5 +38,5 @@ pkg.deps.OC_TRANSPORT_SERIAL:
 
 pkg.deps.OC_TRANSPORT_GATT:
     - "@apache-mynewt-nimble/nimble/host"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"

--- a/apps/ocf_sample/syscfg.yml
+++ b/apps/ocf_sample/syscfg.yml
@@ -22,3 +22,7 @@ syscfg.vals:
 
     # Default task settings
     OS_MAIN_STACK_SIZE: 512
+
+syscfg.vals.OC_TRANSPORT_GATT:
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/sensors_test/pkg.yml
+++ b/apps/sensors_test/pkg.yml
@@ -47,7 +47,7 @@ pkg.deps.SENSOR_BLE:
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport"
 
 pkg.deps.CONFIG_NFFS:

--- a/apps/sensors_test/syscfg.yml
+++ b/apps/sensors_test/syscfg.yml
@@ -67,3 +67,7 @@ syscfg.defs:
         - '!BLE_ROLE_CENTRAL'
         - '!BLE_ROLE_OBSERVER'
         - BLE_ROLE_PERIPHERAL
+
+syscfg.vals.SENSOR_BLE:
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/testbench/pkg.yml
+++ b/apps/testbench/pkg.yml
@@ -48,6 +48,6 @@ pkg.deps.TESTBENCH_BLE:
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/host/util"
     - "@apache-mynewt-nimble/nimble/transport"

--- a/apps/testbench/syscfg.yml
+++ b/apps/testbench/syscfg.yml
@@ -69,3 +69,6 @@ syscfg.vals:
     # Optionally add OC BLE transport.
 syscfg.vals.TESTBENCH_BLE:
     OC_TRANSPORT_GATT: 1
+
+    # Config in RAM
+    BLE_STORE_CONFIG_PERSIST: 0


### PR DESCRIPTION
store/ram was deprecated
Now application are configured to use store/config and
BLE_STORE_CONFIG_PERSIST set to 0.