### PR TITLE
standardize OS_TICKS_PER_SEC definition

### DIFF
--- a/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
+++ b/hw/mcu/ambiq/apollo2/include/mcu/cortex_m4.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/ambiq/apollo2/syscfg.yml
+++ b/hw/mcu/ambiq/apollo2/syscfg.yml
@@ -123,3 +123,6 @@ syscfg.defs:
                     APOLLO2_TIMER_SOURCE_TMRPINA
                     APOLLO2_TIMER_SOURCE_BUCKA
         value:
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128

--- a/hw/mcu/arc/snps/include/mcu/mcu_arc.h
+++ b/hw/mcu/arc/snps/include/mcu/mcu_arc.h
@@ -24,8 +24,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (100)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/dialog/cmac/include/mcu/cortex_m0.h
+++ b/hw/mcu/dialog/cmac/include/mcu/cortex_m0.h
@@ -24,8 +24,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/dialog/cmac/syscfg.yml
+++ b/hw/mcu/dialog/cmac/syscfg.yml
@@ -77,5 +77,8 @@ syscfg.defs:
         value: -1
         range: -1,0..31
 
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.restrictions:
     - BLE_CONTROLLER

--- a/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/cortex_m33.h
@@ -27,8 +27,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -474,6 +474,9 @@ syscfg.defs:
         restrictions:
             - '!GPADC_BATTERY'
 
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.vals.'MCU_SYSCLK_SOURCE == "PLL96"':
     MCU_PLL_ENABLE: 1
 

--- a/hw/mcu/microchip/pic32mx470f512h/include/mcu/pic32.h
+++ b/hw/mcu/microchip/pic32mx470f512h/include/mcu/pic32.h
@@ -20,8 +20,6 @@
 #ifndef __MCU_PIC32_H__
 #define __MCU_PIC32_H__
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/microchip/pic32mx470f512h/syscfg.yml
+++ b/hw/mcu/microchip/pic32mx470f512h/syscfg.yml
@@ -42,3 +42,6 @@ syscfg.defs:
         value:  0
         restrictions:
             - "!SPI_1_MASTER"
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/microchip/pic32mz2048efg100/include/mcu/pic32.h
+++ b/hw/mcu/microchip/pic32mz2048efg100/include/mcu/pic32.h
@@ -20,8 +20,6 @@
 #ifndef __MCU_PIC32_H__
 #define __MCU_PIC32_H__
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/microchip/pic32mz2048efg100/syscfg.yml
+++ b/hw/mcu/microchip/pic32mz2048efg100/syscfg.yml
@@ -42,3 +42,6 @@ syscfg.defs:
         value:  0
         restrictions:
             - "!SPI_1_MASTER"
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/mips/danube/include/mcu/mips.h
+++ b/hw/mcu/mips/danube/include/mcu/mips.h
@@ -20,8 +20,6 @@
 #ifndef __MCU_MIPS_H__
 #define __MCU_MIPS_H__
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/mips/danube/syscfg.yml
+++ b/hw/mcu/mips/danube/syscfg.yml
@@ -22,3 +22,6 @@ syscfg.defs:
             Specifies the required alignment for internal flash writes.
             Used internally by the newt tool.
         value: 1
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/native/include/mcu/mcu_sim.h
+++ b/hw/mcu/native/include/mcu/mcu_sim.h
@@ -23,8 +23,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (100)
-
 extern char *native_flash_file;
 extern char *native_uart_log_file;
 extern const char *native_uart_dev_strs[];

--- a/hw/mcu/native/syscfg.yml
+++ b/hw/mcu/native/syscfg.yml
@@ -70,3 +70,6 @@ syscfg.defs:
         description: 'Priority of native HAL timer task.'
         type: task_priority
         value: 0
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 100

--- a/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
+++ b/hw/mcu/nordic/nrf51xxx/include/mcu/cortex_m0.h
@@ -27,13 +27,6 @@
 extern "C" {
 #endif
 
-/*
- * The nRF51 microcontroller uses RTC0 for periodic interrupts and it is
- * clocked at 32768Hz. The tick frequency is chosen such that it divides
- * cleanly into 32768 to avoid a systemic bias in the actual tick frequency.
- */
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -106,3 +106,9 @@ syscfg.defs:
         restrictions:
             - "!XTAL_RC"
             - "!XTAL_32768"
+
+syscfg.vals:
+    # The nRF51 microcontroller uses RTC0 for periodic interrupts and it is
+    # clocked at 32768Hz. The tick frequency is chosen such that it divides
+    # cleanly into 32768 to avoid a systemic bias in the actual tick frequency.
+    OS_TICKS_PER_SEC: 128

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -92,11 +92,6 @@ syscfg.defs:
             the breakpoint wherever it gets called, For example, reset and crash
        value: 0
 
-    OS_TICKS_PER_SEC:
-        description: >
-            Desired ticks frequency in Hz. Note: Value must be a power of 2.
-        value: 128
-        range: 128,256,512,1024
 
 # MCU peripherals definitions
     I2C_0:
@@ -457,6 +452,9 @@ syscfg.defs:
             - "!XTAL_RC"
         deprecated: 1
 
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.vals.MCU_NRF52832:
     MCU_TARGET: nRF52832
 syscfg.vals.MCU_NRF52840:
@@ -481,3 +479,4 @@ syscfg.restrictions:
     - "!SPI_2_SLAVE || (SPI_2_SLAVE_PIN_SCK && SPI_2_SLAVE_PIN_MOSI && SPI_2_SLAVE_PIN_MISO && SPI_2_SLAVE_PIN_SS)"
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"
     - "!UART_1 || (UART_1_PIN_TX && UART_1_PIN_RX)"
+    - "(OS_TICKS_PER_SEC == 128 || OS_TICKS_PER_SEC == 256 || OS_TICKS_PER_SEC == 512 || OS_TICKS_PER_SEC == 1024)"

--- a/hw/mcu/nordic/nrf5340/include/mcu/cortex_m33.h
+++ b/hw/mcu/nordic/nrf5340/include/mcu/cortex_m33.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -408,7 +408,10 @@ syscfg.defs:
     I2C_3_FREQ_KHZ:
         description: 'Frequency [kHz] for I2C_3'
         value: 100
-        
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.restrictions:
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"
     - "!UART_1 || (UART_1_PIN_TX && UART_1_PIN_RX)"

--- a/hw/mcu/nordic/nrf5340_net/include/mcu/cortex_m33.h
+++ b/hw/mcu/nordic/nrf5340_net/include/mcu/cortex_m33.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -126,5 +126,9 @@ syscfg.defs:
     SPI_0_SLAVE_PIN_SS:
         description: 'SS pin for SPI_0_SLAVE'
         value: ''
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.restrictions:
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"

--- a/hw/mcu/nordic/nrf91xx/include/mcu/cortex_m33.h
+++ b/hw/mcu/nordic/nrf91xx/include/mcu/cortex_m33.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (128)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nordic/nrf91xx/syscfg.yml
+++ b/hw/mcu/nordic/nrf91xx/syscfg.yml
@@ -429,6 +429,9 @@ syscfg.defs:
         description: 'Enable pin reset'
         value: 0
 
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
 syscfg.vals.MCU_NRF9160:
     MCU_TARGET: nRF9160
 

--- a/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
+++ b/hw/mcu/nxp/MK64F12/include/mcu/cortex_m4.h
@@ -30,8 +30,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC	(1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nxp/MK64F12/syscfg.yml
+++ b/hw/mcu/nxp/MK64F12/syscfg.yml
@@ -34,3 +34,6 @@ syscfg.defs:
     HASH:
         description: 'Enable hash accelerator (CAU)'
         value: 0
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/nxp/mkw41z/include/mcu/cortex_m0.h
+++ b/hw/mcu/nxp/mkw41z/include/mcu/cortex_m0.h
@@ -26,14 +26,6 @@
 extern "C" {
 #endif
 
-/*
- * NOTE: the current timer used for this chip is a 1 kHz clock. Thus, the
- * number of OS ticks per second should be a multiple of 1000. If interrupts
- * are disabled for longer than an ostick it is possible that os time will not
- * be accurate.
- */
-#define OS_TICKS_PER_SEC	(1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/nxp/mkw41z/syscfg.yml
+++ b/hw/mcu/nxp/mkw41z/syscfg.yml
@@ -17,4 +17,8 @@
 #
 
 syscfg.vals:
-    OS_TICKS_PER_SEC: 100
+    # NOTE: the current timer used for this chip is a 1 kHz clock. Thus, the
+    # number of OS ticks per second should be a multiple of 1000. If interrupts
+    # are disabled for longer than an ostick it is possible that os time will not
+    # be accurate.
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/sifive/fe310/include/mcu/fe310.h
+++ b/hw/mcu/sifive/fe310/include/mcu/fe310.h
@@ -30,8 +30,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/sifive/fe310/syscfg.yml
+++ b/hw/mcu/sifive/fe310/syscfg.yml
@@ -70,10 +70,6 @@ syscfg.defs:
     TIMER_2:
         description: 'Whether to use PWM0 8 bit timer as system timer'
         value:  0
-    OS_TICKS_PER_SEC:
-        description: 'Desired ticks frequency in Hz'
-        value: 128
-        range: 128,256,512,1024
     OS_TICKLESS_SLEEP:
         description: 'Enable tickless sleep'
         value: 1
@@ -85,3 +81,9 @@ syscfg.defs:
             This maybe useful when .bssnz section is being used to store data across
             software reboots.
         value: 1
+
+syscfg.vals:
+    OS_TICKS_PER_SEC: 128
+
+syscfg.restrictions:
+    - "(OS_TICKS_PER_SEC == 128 || OS_TICKS_PER_SEC == 256 || OS_TICKS_PER_SEC == 512 || OS_TICKS_PER_SEC == 1024)"

--- a/hw/mcu/stm/stm32_common/syscfg.yml
+++ b/hw/mcu/stm/stm32_common/syscfg.yml
@@ -433,7 +433,5 @@ syscfg.defs:
         description: "ADC_2"
         value:  0
 
-    OS_TICKS_PER_SEC:
-        description: >
-            Desired ticks frequency in Hz.
-        value: 1000
+syscfg.vals:
+    OS_TICKS_PER_SEC: 1000

--- a/hw/mcu/stm/stm32f0xx/include/mcu/cortex_m0.h
+++ b/hw/mcu/stm/stm32f0xx/include/mcu/cortex_m0.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/cortex_m3.h
@@ -27,8 +27,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    MYNEWT_VAL(OS_TICKS_PER_SEC)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32f3xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/cortex_m4.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/cortex_m4.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32f7xx/include/mcu/cortex_m7.h
+++ b/hw/mcu/stm/stm32f7xx/include/mcu/cortex_m7.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32l0xx/include/mcu/cortex_m0.h
+++ b/hw/mcu/stm/stm32l0xx/include/mcu/cortex_m0.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32l1xx/include/mcu/cortex_m3.h
+++ b/hw/mcu/stm/stm32l1xx/include/mcu/cortex_m3.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32l4xx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32l4xx/include/mcu/cortex_m4.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/hw/mcu/stm/stm32wbxx/include/mcu/cortex_m4.h
+++ b/hw/mcu/stm/stm32wbxx/include/mcu/cortex_m4.h
@@ -26,8 +26,6 @@
 extern "C" {
 #endif
 
-#define OS_TICKS_PER_SEC    (1000)
-
 static inline void
 hal_debug_break(void)
 {

--- a/kernel/os/include/os/os_time.h
+++ b/kernel/os/include/os/os_time.h
@@ -77,6 +77,16 @@ extern "C" {
 #define INT32_MAX   0x7FFFFFFF
 #endif
 
+#ifdef OS_TICKS_PER_SEC
+#warning "OS_TICKS_PER_SEC should be configured in syscfg"
+#else
+#if MYNEWT_VAL(OS_TICKS_PER_SEC)
+#define OS_TICKS_PER_SEC        MYNEWT_VAL(OS_TICKS_PER_SEC)
+#else
+#error "Application, BSP or target must specify OS_TICKS_PER_SEC syscfg value"
+#endif
+#endif
+
 typedef uint32_t os_time_t;
 typedef int32_t os_stime_t;
 #define OS_TIME_MAX UINT32_MAX

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -145,6 +145,11 @@ syscfg.defs:
             on error detection.  Enabling this setting increases stack usage.
         value: 0
 
+    OS_TICKS_PER_SEC:
+        description: 'Desired ticks frequency in Hz'
+        value:
+        restrictions: $notnull
+
     OS_IDLE_TICKLESS_MS_MIN:
         description: >
             Minimum duration of tickless idle period in miliseconds.


### PR DESCRIPTION
In several instances OS_TICKS_PER_SEC was configurable via syscfg.

This PR proposes to have same behavior across all MCUs.

Now only one definition in os_time.h exists and it gets it form syscfg.
All MCUs have definition moved to syscfg.
~~In few cases other syscfg values that referred to OS_TICKS_PER_SEC
are using MYNEWT_VAL(OS_TICKS_PER_SEC) to avoid circular
dependency problem.~~

This requires **newt** with https://github.com/apache/mynewt-newt/pull/423 included.