### PR TITLE
For Testing Only: Do not merge: Debug CI FCB test

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -126,7 +126,7 @@ struct log_handler {
     lh_registered_func_t log_registered;
 };
 
-/* Image hash length to be looged */
+/* Image hash length to be logged */
 #define LOG_IMG_HASHLEN 4
 
 /* Flags used to indicate type of data in reserved payload*/

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -955,18 +955,17 @@ log_read_hdr(struct log *log, const void *dptr, struct log_entry_hdr *hdr)
 {
     int bytes_read;
 
+#if MYNEWT_VAL(LOG_FLAGS_IMAGE_HASH)
+    bytes_read = log_read(log, dptr, hdr, 0, (LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN));
+    if (bytes_read != (LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN)) {
+        return SYS_EIO;
+    }
+#else
     bytes_read = log_read(log, dptr, hdr, 0, LOG_BASE_ENTRY_HDR_SIZE);
     if (bytes_read != LOG_BASE_ENTRY_HDR_SIZE) {
         return SYS_EIO;
     }
-
-    if (hdr->ue_flags & LOG_FLAGS_IMG_HASH) {
-        bytes_read = log_read(log, dptr, hdr->ue_imghash,
-                              LOG_BASE_ENTRY_HDR_SIZE, LOG_IMG_HASHLEN);
-        if (bytes_read != LOG_IMG_HASHLEN) {
-            return SYS_EIO;
-        }
-    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
In scenarios where the interested record lies towards the end of a
large circular buffer, walking it from the beginning can take up
significant amount of time.

It is possible that the thread that walks the log is shared among
other user interfaces and until the bookmarks are built up, flash
based walks and lookups can make the system quite slow to respond.

Optimize this by beginning to walk from the flash area that is closer
to the latest one in use.

In the tests performed, the walk time was reduced by 2 orders of
magnitude (e.g 9000 ms to 50 ms).

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>