### PR TITLE
Debug: Test 2 : CI Test Debug

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -126,7 +126,7 @@ struct log_handler {
     lh_registered_func_t log_registered;
 };
 
-/* Image hash length to be looged */
+/* Image hash length to be logged */
 #define LOG_IMG_HASHLEN 4
 
 /* Flags used to indicate type of data in reserved payload*/

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -955,18 +955,17 @@ log_read_hdr(struct log *log, const void *dptr, struct log_entry_hdr *hdr)
 {
     int bytes_read;
 
+#if MYNEWT_VAL(LOG_FLAGS_IMAGE_HASH)
+    bytes_read = log_read(log, dptr, hdr, 0, (LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN));
+    if (bytes_read != (LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN)) {
+        return SYS_EIO;
+    }
+#else
     bytes_read = log_read(log, dptr, hdr, 0, LOG_BASE_ENTRY_HDR_SIZE);
     if (bytes_read != LOG_BASE_ENTRY_HDR_SIZE) {
         return SYS_EIO;
     }
-
-    if (hdr->ue_flags & LOG_FLAGS_IMG_HASH) {
-        bytes_read = log_read(log, dptr, hdr->ue_imghash,
-                              LOG_BASE_ENTRY_HDR_SIZE, LOG_IMG_HASHLEN);
-        if (bytes_read != LOG_IMG_HASHLEN) {
-            return SYS_EIO;
-        }
-    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
With LOG_FLAGS_IMAGE_HASH defined, the log_hdr_read
function needs to read the LOG_BASE_ENTRY_HDR_SIZE and
the additional 4 bytes of image hash.

Optimize this step with one flash read instead of two
to improve performance.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>