### PR TITLE
remove OS_TICKS_PER_SEC from syscfg when not needed

### DIFF
--- a/hw/util/button/src/button.c
+++ b/hw/util/button/src/button.c
@@ -370,14 +370,14 @@ button_exec_fsm(button_t *button, int action)
  do_pressed:
 #if MYNEWT_VAL(BUTTON_USE_LONG)
     if (button->mode & BUTTON_FLG_LONG) {
-        os_callout_reset(callout, MYNEWT_VAL(BUTTON_LONGHOLD_TICKS));
+        os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_LONGHOLD_TIME_MS)));
 #if MYNEWT_VAL(BUTTON_USE_REPEAT)
     } else if (button->mode & BUTTON_FLG_REPEATING) {
-        os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_FIRST_TICKS));
+        os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_FIRST_TIME_MS)));
 #endif
     }
 #elif MYNEWT_VAL(BUTTON_USE_REPEAT)
-    os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_FIRST_TICKS));
+    os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_FIRST_TIME_MS)));
 #endif
     button->state = BUTTON_FLG_PRESSED;
 #if MYNEWT_VAL(BUTTON_EMIT_STATE_CHANGED)
@@ -391,23 +391,23 @@ button_exec_fsm(button_t *button, int action)
     
 #if MYNEWT_VAL(BUTTON_USE_DOUBLE)
  to_wait_dblpressed:
-    os_callout_reset(callout, MYNEWT_VAL(BUTTON_DBLCLICK_TICKS));
+    os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_DBLCLICK_TIMEOUT_MS)));
     button->fsm_state = _BUTTON_FSM_WAIT_DBLPRESSED;
     return;
     
  do_dblpressed:
 #if MYNEWT_VAL(BUTTON_USE_LONG)
     if (button->mode & BUTTON_FLG_LONG) {
-        os_callout_reset(callout, MYNEWT_VAL(BUTTON_LONGHOLD_TICKS));
+        os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_LONGHOLD_TIME_MS)));
 #if MYNEWT_VAL(BUTTON_USE_REPEAT)
     } else if (button->mode & BUTTON_FLG_REPEATING) {
-        os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_FIRST_TICKS)); 
+        os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_FIRST_TIME_MS)));
 #endif
     } else {
         os_callout_stop(callout);
     }   
 #elif MYNEWT_VAL(BUTTON_USE_REPEAT)
-    os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_FIRST_TICKS)); 
+    os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_FIRST_TIME_MS)));
 #else
     os_callout_stop(callout);
 #endif
@@ -423,7 +423,7 @@ button_exec_fsm(button_t *button, int action)
  do_longpress:
 #if MYNEWT_VAL(BUTTON_USE_REPEAT)
     if (button->mode & BUTTON_FLG_REPEATING)
-        os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_FIRST_TICKS));
+        os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_FIRST_TIME_MS)));
 #endif
     button->state |= BUTTON_FLG_LONG;
 #if MYNEWT_VAL(BUTTON_EMIT_STATE_CHANGED)
@@ -435,7 +435,7 @@ button_exec_fsm(button_t *button, int action)
     
 #if MYNEWT_VAL(BUTTON_USE_REPEAT)
  do_repeat:
-    os_callout_reset(callout, MYNEWT_VAL(BUTTON_REPEAT_TICKS));
+    os_callout_reset(callout, os_time_ms_to_ticks32(MYNEWT_VAL(BUTTON_REPEAT_TIME_MS)));
     
 #if MYNEWT_VAL(BUTTON_EMIT_ACTION)
 #if MYNEWT_VAL(BUTTON_USE_EMULATION)

--- a/hw/util/button/syscfg.yml
+++ b/hw/util/button/syscfg.yml
@@ -19,24 +19,40 @@
 
 syscfg.defs:
     BUTTON_DBLCLICK_TICKS:
+        description: Use BUTTON_DBLCLICK_TIMEOUT_MS instead.
+        defunct: 1
+        value:
+    BUTTON_LONGHOLD_TICKS:
+        description: Use BUTTON_LONGHOLD_TIME_MS instead.
+        defunct: 1
+        value:
+    BUTTON_REPEAT_FIRST_TICKS:
+        description: Use BUTTON_REPEAT_FIRST_TIME_MS instead.
+        defunct: 1
+        value:
+    BUTTON_REPEAT_TICKS:
+        description: Use BUTTON_REPEAT_TIME_MS instead.
+        defunct: 1
+        value:
+    BUTTON_DBLCLICK_TIMEOUT_MS:
         description: >
-            Maximum time in wich a second click should be performed
+            Maximum time in which a second click should be performed
             to consider it a double click. This will also introduce
             a delay for generating the single click event.
-        value: '(OS_TICKS_PER_SEC / 4)'
-    BUTTON_LONGHOLD_TICKS:
+        value: 250
+    BUTTON_LONGHOLD_TIME_MS:
         description: >
             Minimum time to wait with the button pressed to consider
             it a long hold (long press, long click, long double click).
-        value: '(OS_TICKS_PER_SEC)'
-    BUTTON_REPEAT_FIRST_TICKS:
+        value: 1000
+    BUTTON_REPEAT_FIRST_TIME_MS:
         description: >
             Time to wait before generating the first repeated action.
-        value: '(OS_TICKS_PER_SEC)'
-    BUTTON_REPEAT_TICKS:
+        value: 1000
+    BUTTON_REPEAT_TIME_MS:
         description: >
             Time to wait before generating consecutive repeated action.
-        value: '(OS_TICKS_PER_SEC)'
+        value: 1000
     BUTTON_EVENT_MAX:
         description: >
             Maximum number of pending button event. (about 20bytes/event)

--- a/net/ip/native_sockets/src/native_sock.c
+++ b/net/ip/native_sockets/src/native_sock.c
@@ -754,7 +754,7 @@ socket_task(void *arg)
     os_mutex_pend(&nss->mtx, OS_WAIT_FOREVER);
     while (1) {
         os_mutex_release(&nss->mtx);
-        os_time_delay(MYNEWT_VAL(NATIVE_SOCKETS_POLL_ITVL));
+        os_time_delay(os_time_ms_to_ticks32(MYNEWT_VAL(NATIVE_SOCKETS_POLL_INTERVAL_MS)));
         os_mutex_pend(&nss->mtx, OS_WAIT_FOREVER);
         if (nss->poll_fd_cnt) {
             rc = poll(nss->poll_fds, nss->poll_fd_cnt, 0);

--- a/net/ip/native_sockets/syscfg.yml
+++ b/net/ip/native_sockets/syscfg.yml
@@ -24,10 +24,14 @@ syscfg.defs:
         description: 'The maximum UDP datagram size (send and receive).'
         value: 2048
     NATIVE_SOCKETS_POLL_ITVL:
+        description: Use NATIVE_SOCKETS_POLL_INTERVAL instead.
+        defunct: 1
+        value:
+    NATIVE_SOCKETS_POLL_INTERVAL_MS:
         description: >
             The frequency at which to poll for received data.  Units
-            are OS ticks.
-        value: 'OS_TICKS_PER_SEC / 5'
+            are ms.
+        value: 200
     NATIVE_SOCKETS_STACK_SZ:
         description: 'The size of the native sockets task stack, in bytes.'
         value: 4096


### PR DESCRIPTION
Button and native sockets had some time values that measured in ticks
but value used indicated that normal time values could be applied.
syscfg values were updated to be more natural for human the machine.