### PR TITLE
hw/mcu/da1469x: Allow to release GPIO pin in ISR

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -292,12 +292,15 @@ hal_gpio_irq_handler(void)
     struct hal_gpio_irq *irq;
     uint32_t stat;
     int i;
+    int pin;
 
     *WKUP_RESET_IRQ_REG_ADDR = 1;
     NVIC_ClearPendingIRQ(KEY_WKUP_GPIO_IRQn);
 
     for (i = 0; i < HAL_GPIO_MAX_IRQ; i++) {
         irq = &hal_gpio_irqs[i];
+
+        pin = irq->pin;
 
         /* Read latched status value from relevant GPIO port */
         stat = WKUP_STAT(irq->pin);
@@ -306,7 +309,7 @@ hal_gpio_irq_handler(void)
             irq->func(irq->arg);
         }
 
-        WKUP_CLEAR_PX(irq->pin);
+        WKUP_CLEAR_PX(pin);
     }
 }
 


### PR DESCRIPTION
When GPIO pin is configured as input with interrupt it seems
reasonable to be able to release this interrupt during
GPIO interrupt handler without need to go through threaded code.

To achieve this WKUP_CLEAR_PX() must be called with correct pin
number. If interrupt handler released currently handled GPIO
interrupt handler pin in hal_gpio_irqs is no longer valid.

Now local copy of pin number is used when WKUP_CLEAR_PX is called
to make sure releasing GPIO IRQ is safe.