### PR TITLE
hw/ipc_nrf5340: Fix build for network core

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -21,8 +21,10 @@
 #include <os/os.h>
 #include <ipc_nrf5340/ipc_nrf5340.h>
 #include <nrfx.h>
+#if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
 #include <mcu/nrf5340_hal.h>
 #include <bsp/bsp.h>
+#endif
 
 /* Currently this allows only for 1-1 connection. */
 


### PR DESCRIPTION
File 'mcu/nrf5340_hal.h' is application core specific and is not
used when file is build for network code.
IPC_NRF5340_NET_GPIO is defined in application build only
and is used to conditionally include offending file.