### PR TITLE
hw/mcu/nordic/nrf52xxx: Using hfxo_request and release. Addresses #2393.

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -22,6 +22,7 @@
 #include "hal/hal_system.h"
 #include "hal/hal_debug.h"
 #include "nrf.h"
+#include "mcu/nrf52_clock.h"
 
 /**
  * Function called at startup. Called after BSS and .data initialized but
@@ -92,16 +93,7 @@ hal_system_clock_start(void)
 
 #if MYNEWT_VAL_CHOICE(MCU_LFCLK_SOURCE, LFSYNTH)
     /* Must turn on HFLCK for synthesized 32768 crystal */
-    if ((NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) !=
-                (CLOCK_HFCLKSTAT_STATE_Running << CLOCK_HFCLKSTAT_STATE_Pos)) {
-        NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
-        NRF_CLOCK->TASKS_HFCLKSTART = 1;
-        while (1) {
-            if ((NRF_CLOCK->EVENTS_HFCLKSTARTED) != 0) {
-                break;
-            }
-        }
-    }
+    nrf52_clock_hfxo_request();
 #else
     /* Make sure HFCLK is stopped */
     NRF_CLOCK->TASKS_HFCLKSTOP = 1;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -102,6 +102,9 @@ hal_system_clock_start(void)
             }
         }
     }
+#else
+    /* Make sure HFCLK is stopped */
+    NRF_CLOCK->TASKS_HFCLKSTOP = 1;
 #endif
 
     /* Check if this clock source is already running */


### PR DESCRIPTION
hal_timer and hal_system_clock_start both enabled the HFXO directly. 
Now they use the nrf52_clock_hfxo_request, and where suitable also nrf52_clock_hfxo_release. 