### PR TITLE
docs: fix simple typo, availabe -> available

### DIFF
--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xc.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xc.h
@@ -8416,7 +8416,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xe.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xe.h
@@ -8416,7 +8416,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f405xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f405xx.h
@@ -14012,7 +14012,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f407xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f407xx.h
@@ -15303,7 +15303,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410cx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410cx.h
@@ -7190,7 +7190,7 @@ typedef struct
 /********************** TIM Instances : 32 bit Counter ************************/
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)((INSTANCE) == TIM5)
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM5))
 

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410rx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410rx.h
@@ -7194,7 +7194,7 @@ typedef struct
 /********************** TIM Instances : 32 bit Counter ************************/
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)((INSTANCE) == TIM5)
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM5))
 

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410tx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410tx.h
@@ -7138,7 +7138,7 @@ typedef struct
 /********************** TIM Instances : 32 bit Counter ************************/
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)((INSTANCE) == TIM5)
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM5))
 

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f411xe.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f411xe.h
@@ -8451,7 +8451,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412cx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412cx.h
@@ -13228,7 +13228,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412rx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412rx.h
@@ -14206,7 +14206,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412vx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412vx.h
@@ -14220,7 +14220,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412zx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412zx.h
@@ -14242,7 +14242,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f413xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f413xx.h
@@ -15169,7 +15169,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f415xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f415xx.h
@@ -14296,7 +14296,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f417xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f417xx.h
@@ -15582,7 +15582,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f423xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f423xx.h
@@ -15322,7 +15322,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f427xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f427xx.h
@@ -16512,7 +16512,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f429xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f429xx.h
@@ -16870,7 +16870,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f437xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f437xx.h
@@ -16814,7 +16814,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f439xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f439xx.h
@@ -17164,7 +17164,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f446xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f446xx.h
@@ -15659,7 +15659,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f469xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f469xx.h
@@ -19960,7 +19960,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f479xx.h
+++ b/hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f479xx.h
@@ -20257,7 +20257,7 @@ typedef struct
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE)(((INSTANCE) == TIM2) || \
                                               ((INSTANCE) == TIM5))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
                                         ((INSTANCE) == TIM2) || \
                                         ((INSTANCE) == TIM3) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x4.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x4.h
@@ -5687,7 +5687,7 @@ typedef struct
 #define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
                                                      ((INSTANCE) == TIM21))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21))
 

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x6.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x6.h
@@ -5744,7 +5744,7 @@ typedef struct
 #define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
                                                      ((INSTANCE) == TIM21))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21))
 

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x8.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x8.h
@@ -5739,7 +5739,7 @@ typedef struct
 #define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
                                                      ((INSTANCE) == TIM21))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21))
 

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010xb.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010xb.h
@@ -5811,7 +5811,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l011xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l011xx.h
@@ -5829,7 +5829,7 @@ typedef struct
 #define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
                                                      ((INSTANCE) == TIM21))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21))
 

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l021xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l021xx.h
@@ -5969,7 +5969,7 @@ typedef struct
 #define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
                                                      ((INSTANCE) == TIM21))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21))
 

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l031xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l031xx.h
@@ -5969,7 +5969,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l041xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l041xx.h
@@ -6109,7 +6109,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l051xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l051xx.h
@@ -6131,7 +6131,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l052xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l052xx.h
@@ -7208,7 +7208,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l053xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l053xx.h
@@ -7365,7 +7365,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l061xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l061xx.h
@@ -6271,7 +6271,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l062xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l062xx.h
@@ -7348,7 +7348,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l063xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l063xx.h
@@ -7505,7 +7505,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM21) || \
                                             ((INSTANCE) == TIM22))

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l071xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l071xx.h
@@ -6346,7 +6346,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l072xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l072xx.h
@@ -7525,7 +7525,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l073xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l073xx.h
@@ -7684,7 +7684,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l081xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l081xx.h
@@ -6486,7 +6486,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l082xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l082xx.h
@@ -7665,7 +7665,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \

--- a/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l083xx.h
+++ b/hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l083xx.h
@@ -7824,7 +7824,7 @@ typedef struct
                                                      ((INSTANCE) == TIM21)  || \
                                                      ((INSTANCE) == TIM22))
 
-/***************** TIM Instances : external trigger input availabe ************/
+/***************** TIM Instances : external trigger input available ************/
 #define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
                                             ((INSTANCE) == TIM3)  || \
                                             ((INSTANCE) == TIM21) || \


### PR DESCRIPTION
There is a small typo in hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xc.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f401xe.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f405xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f407xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410cx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410rx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f410tx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f411xe.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412cx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412rx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412vx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f412zx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f413xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f415xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f417xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f423xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f427xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f429xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f437xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f439xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f446xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f469xx.h, hw/mcu/stm/stm32f4xx/src/ext/Drivers/CMSIS/Device/ST/STM32F4xx/Include/stm32f479xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x4.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x6.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010x8.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l010xb.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l011xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l021xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l031xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l041xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l051xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l052xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l053xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l061xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l062xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l063xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l071xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l072xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l073xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l081xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l082xx.h, hw/mcu/stm/stm32l0xx/src/ext/Drivers/CMSIS/Device/ST/STM32L0xx/Include/stm32l083xx.h.

Closes #2443


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md