### PR TITLE
hw/mcu/da1469x: Allow RCX reference count calibration value to be configurable

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -204,13 +204,8 @@ da1469x_clock_calibrate(uint8_t clock_sel, uint16_t ref_cnt)
 void
 da1469x_clock_lp_rcx_calibrate(void)
 {
-    /*
-     * XXX not sure what is a good value here, this is just some value that
-     *     seems to work fine; we need to check how accurate this is and perhaps
-     *     also make it configurable if necessary
-     */
-    const uint32_t ref_cnt = 100;
-    g_mcu_clock_rcx_freq = da1469x_clock_calibrate(3, ref_cnt);
+    g_mcu_clock_rcx_freq =
+        da1469x_clock_calibrate(3, MYNEWT_VAL(MCU_CLOCK_RCX_CAL_REF_CNT));
 }
 
 void

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -66,6 +66,17 @@ syscfg.defs:
         description: >
             Specifies settling time [ms] of 32K crystal oscillator.
         value: 8000
+
+    MCU_CLOCK_RCX_CAL_REF_CNT:
+        description: >
+            Reference count value for calibration of RCX clock. The higher
+            the value the more accurate the calibration but also increases
+            calibration time. The calibration time is approximately this
+            value multiplied by one 15kHz clock cycle, thus total calibration
+            time will be approx 66.67 usecs * MCU_CLOCK_RCX_CAL_REF_CNT.
+        value: 100
+        restrictions: '!0'
+
     MCU_SYSCLK_SOURCE:
         description: >
             Specifies system clock source
@@ -114,7 +125,7 @@ syscfg.defs:
         value: 0
     MCU_DMA_IRQ_PRIO:
         description: >
-            Specifies the NVIC interrupt priority to assign for the DMA_IRQn 
+            Specifies the NVIC interrupt priority to assign for the DMA_IRQn
             interrupt.
         value: 15
 


### PR DESCRIPTION
Code prior to this change fixed the reference count value used for RCX calibration to 100. This change allows it to be configured by the user as a value of 100 makes for a long calibration time (on the order of 6.67 msecs).