### PR TITLE
Add function to check usb console init

### DIFF
--- a/hw/usb/tinyusb/cdc_console/src/cdc_console.c
+++ b/hw/usb/tinyusb/cdc_console/src/cdc_console.c
@@ -145,3 +145,9 @@ usb_cdc_console_pkg_init(void)
 
     return 0;
 }
+
+int
+usb_cdc_console_is_init(void)
+{
+    return (int)tud_cdc_connected();
+}

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -1226,6 +1226,9 @@ console_is_init(void)
 #if MYNEWT_VAL(CONSOLE_BLE_MONITOR)
     return ble_monitor_console_is_init();
 #endif
+#if MYNEWT_VAL(CONSOLE_USB)
+    return usb_cdc_console_is_init();
+#endif
     return 0;
 }
 

--- a/sys/console/full/src/console_priv.h
+++ b/sys/console/full/src/console_priv.h
@@ -33,6 +33,7 @@ int rtt_console_is_init(void);
 int rtt_console_init(void);
 int semihosting_console_is_init(void);
 int ble_monitor_console_is_init(void);
+int usb_cdc_console_is_init(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add usb_cdc_console_is_init() to return the usb cdc console
initialization status. Without this, usb console log won't work.
