### PR TITLE
crypto/tinycrypt: Update library to master

### DIFF
--- a/crypto/tinycrypt/src/cbc_mode.c
+++ b/crypto/tinycrypt/src/cbc_mode.c
@@ -91,7 +91,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	    outlen == 0 ||
 	    (inlen % TC_AES_BLOCK_SIZE) != 0 ||
 	    (outlen % TC_AES_BLOCK_SIZE) != 0 ||
-	    outlen != inlen - TC_AES_BLOCK_SIZE) {
+	    outlen != inlen) {
 		return TC_CRYPTO_FAIL;
 	}
 
@@ -101,7 +101,7 @@ int tc_cbc_mode_decrypt(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	 * that would not otherwise be possible.
 	 */
 	p = iv;
-	for (n = m = 0; n < inlen; ++n) {
+	for (n = m = 0; n < outlen; ++n) {
 		if ((n % TC_AES_BLOCK_SIZE) == 0) {
 			(void)tc_aes_decrypt(buffer, in, sched);
 			in += TC_AES_BLOCK_SIZE;

--- a/crypto/tinycrypt/src/cmac_mode.c
+++ b/crypto/tinycrypt/src/cmac_mode.c
@@ -36,7 +36,7 @@
 #include <tinycrypt/utils.h>
 
 /* max number of calls until change the key (2^48).*/
-const static uint64_t MAX_CALLS = ((uint64_t)1 << 48);
+static const uint64_t MAX_CALLS = ((uint64_t)1 << 48);
 
 /*
  *  gf_wrap -- In our implementation, GF(2^128) is represented as a 16 byte

--- a/crypto/tinycrypt/src/ecc_dsa.c
+++ b/crypto/tinycrypt/src/ecc_dsa.c
@@ -57,11 +57,6 @@
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dsa.h>
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
 
 static void bits2int(uECC_word_t *native, const uint8_t *bits,
 		     unsigned bits_size, uECC_Curve curve)
@@ -124,7 +119,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* If an RNG function was specified, get a random number
 	to prevent side channel analysis of k. */
-	if (!g_rng_function) {
+	if (!uECC_get_rng()) {
 		uECC_vli_clear(tmp, num_n_words);
 		tmp[0] = 1;
 	}

--- a/crypto/tinycrypt/src/hmac.c
+++ b/crypto/tinycrypt/src/hmac.c
@@ -52,20 +52,19 @@ static void rekey(uint8_t *key, const uint8_t *new_key, unsigned int key_size)
 int tc_hmac_set_key(TCHmacState_t ctx, const uint8_t *key,
 		    unsigned int key_size)
 {
-
-	/* input sanity check: */
+	/* Input sanity check */
 	if (ctx == (TCHmacState_t) 0 ||
 	    key == (const uint8_t *) 0 ||
 	    key_size == 0) {
 		return TC_CRYPTO_FAIL;
 	}
 
-	const uint8_t dummy_key[key_size];
+	const uint8_t dummy_key[TC_SHA256_BLOCK_SIZE];
 	struct tc_hmac_state_struct dummy_state;
 
 	if (key_size <= TC_SHA256_BLOCK_SIZE) {
 		/*
-		 * The next three lines consist of dummy calls just to avoid
+		 * The next three calls are dummy calls just to avoid
 		 * certain timing attacks. Without these dummy calls,
 		 * adversaries would be able to learn whether the key_size is
 		 * greater than TC_SHA256_BLOCK_SIZE by measuring the time


### PR DESCRIPTION
Tinycrypt has not been updated in `mynewt-core` since version `0.2.8`. It has since received numerous bug fixes(without a release), such as [Fix incorrect buffer size](https://github.com/intel/tinycrypt/commit/da923ca2293018e0ba7102d6650867aa6812b0e8) , [Fix HMAC-PRNG implementation](https://github.com/intel/tinycrypt/commit/6e0eb53fc8403988f97345e94081b0453f47231d). Would like these fixes, upto the latest commit to be merged into the core-repo.