### PR TITLE
stm32 spi bus driver

### DIFF
--- a/hw/bus/drivers/spi_stm32/include/bus/drivers/spi_stm32.h
+++ b/hw/bus/drivers/spi_stm32/include/bus/drivers/spi_stm32.h
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef HW_BUS_DRIVERS_SPI_STM32_H_
+#define HW_BUS_DRIVERS_SPI_STM32_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include "os/os_dev.h"
+#include "bus/drivers/spi_common.h"
+#include <mcu/stm32_hal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize os_dev as SPI bus device using spi_hal driver
+ *
+ * This can be passed as a parameter to os_dev_create() when creating os_dev
+ * object for SPI device, however it's recommended to create devices using helper
+ * like bus_spi_hal_dev_create().
+ *
+ * @param odev  Node device object
+ * @param arg   Node configuration struct (struct bus_node_cfg)
+ */
+int
+bus_spi_stm32_dev_init_func(struct os_dev *odev, void *arg);
+
+/**
+ * Create SPI bus device using spi_hal driver
+ *
+ * This is a convenient helper and recommended way to create os_dev for bus SPI
+ * device instead of calling os_dev_create() directly.
+ *
+ * @param name  Name of device
+ * @param dev   Device state object
+ * @param cfg   Configuration
+ */
+static inline int
+bus_spi_stm32_dev_create(const char *name, struct bus_spi_dev *dev,
+                         struct bus_spi_dev_cfg *cfg)
+{
+    struct os_dev *odev = (struct os_dev *)dev;
+
+    return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 0,
+                         bus_spi_stm32_dev_init_func, cfg);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HW_BUS_DRIVERS_SPI_STM32_H_ */

--- a/hw/bus/drivers/spi_stm32/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/pkg.yml
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32
+pkg.description: SPI bus driver that uses ST HAL with interrupts and DMA
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_common
+
+pkg.deps.MCU_STM32F0:
+    - hw/bus/drivers/spi_stm32/stm32f0xx
+
+pkg.deps.MCU_STM32F1:
+    - hw/bus/drivers/spi_stm32/stm32f1xx
+
+pkg.deps.MCU_STM32F3:
+    - hw/bus/drivers/spi_stm32/stm32f3xx
+
+pkg.deps.MCU_STM32F4:
+    - hw/bus/drivers/spi_stm32/stm32f4xx
+
+pkg.deps.MCU_STM32F7:
+    - hw/bus/drivers/spi_stm32/stm32f7xx
+
+pkg.deps.MCU_STM32L0:
+    - hw/bus/drivers/spi_stm32/stm32l0xx
+
+pkg.deps.MCU_STM32L1:
+    - hw/bus/drivers/spi_stm32/stm32l1xx
+
+pkg.deps.MCU_STM32L4:
+    - hw/bus/drivers/spi_stm32/stm32l4xx
+
+pkg.deps.MCU_STM32WB:
+    - hw/bus/drivers/spi_stm32/stm32wbxx

--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -1,0 +1,881 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <mcu/stm32_hal.h>
+#include <defs/error.h>
+#include <mcu/mcu.h>
+#include <hal/hal_gpio.h>
+#include <bus/bus.h>
+#include <bus/bus_debug.h>
+#include <bus/bus_driver.h>
+#include <bus/drivers/spi_common.h>
+#include <bus/drivers/spi_stm32.h>
+#include <spidmacfg.h>
+#include <stm32_common/stm32_dma.h>
+
+#if MYNEWT_VAL(SPI_0_MASTER) && !defined(SPI1)
+#error This MCU does not have SPI1
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER) && !defined(SPI2)
+#error This MCU does not have SPI2
+#endif
+
+#if MYNEWT_VAL(SPI_2_MASTER) && !defined(SPI3)
+#error This MCU does not have SPI3
+#endif
+
+#if MYNEWT_VAL(SPI_3_MASTER) && !defined(SPI4)
+#error This MCU does not have SPI4
+#endif
+
+#if MYNEWT_VAL(SPI_4_MASTER) && !defined(SPI5)
+#error This MCU does not have SPI5
+#endif
+
+#if MYNEWT_VAL(SPI_5_MASTER) && !defined(SPI6)
+#error This MCU does not have SPI6
+#endif
+
+/* Minimum transfer size when DMA should be used, for shorter transfers
+ * interrupts are used
+ */
+#define MIN_DMA_RX_SIZE MYNEWT_VAL(SPI_STM32_MIN_RX_LENGTH_FOR_DMA)
+#define MIN_DMA_TX_SIZE MYNEWT_VAL(SPI_STM32_MIN_TX_LENGTH_FOR_DMA)
+
+#if MYNEWT_VAL(SPI_STM32_STAT)
+#include "stats/stats.h"
+#endif
+
+#if MYNEWT_VAL(SPI_STM32_STAT)
+STATS_SECT_START(spi_stm32_stats_section)
+    STATS_SECT_ENTRY(read_bytes)
+    STATS_SECT_ENTRY(written_bytes)
+    STATS_SECT_ENTRY(dma_transferred_bytes)
+STATS_SECT_END
+
+STATS_NAME_START(spi_stm32_stats_section)
+    STATS_NAME(spi_stm32_stats_section, read_bytes)
+    STATS_NAME(spi_stm32_stats_section, written_bytes)
+    STATS_NAME(spi_stm32_stats_section, dma_transferred_bytes)
+STATS_NAME_END(spi_stm32_stats_section)
+#endif
+
+/* Driver specific data needed for SPI transfer */
+struct spi_stm32_driver_data {
+    SPI_HandleTypeDef hspi;
+    DMA_HandleTypeDef dmarx;
+    DMA_HandleTypeDef dmatx;
+    struct bus_spi_dev *dev;
+    const struct stm32_spi_hw *hw;
+    /* Semaphore used for end of transfer completion notification */
+    struct os_sem sem;
+
+#if MYNEWT_VAL(SPI_STM32_STAT)
+    STATS_SECT_DECL(spi_stm32_stats_section) stats;
+#endif
+};
+
+/* Constant data needed for SPI/DMA configuration */
+struct stm32_spi_hw {
+    uint8_t spi_num;
+    IRQn_Type irqn;
+    const struct stm32_dma_cfg *dmarx_cfg;
+    const struct stm32_dma_cfg *dmatx_cfg;
+    void (*irq_handler)(void);
+    void (*enable_clock)(bool enable);
+    uint32_t (*get_pclk)(void);
+};
+
+/*
+ * SPI functions can only appear on some pins.  To take burden of specifying pin
+ * characteristics of the user, following structures and code allow to
+ * use simple pin numbers and SPI function to configure pins in MCU.
+ */
+enum spi_pin_func {
+    SPI_SCK,
+    SPI_MOSI,
+    SPI_MISO
+};
+
+enum spi_alt_num {
+    SPI_AF_0,
+    SPI_AF_1,
+    SPI_AF_2,
+    SPI_AF_5 = 5,
+    SPI_AF_6,
+    SPI_AF_7,
+    SPI_AF_INVALID = 0xFF,
+};
+
+struct spi_pin_def {
+    /** SPI master number (0-5) */
+    uint8_t spi_num;
+    /** Pin number should be created using MCU_GPIO_PORTx() macro */
+    uint8_t pin_num;
+    /** Pin function */
+    enum spi_pin_func pin_func;
+    /** Alternate function number needed for most STM MCUs (except F1) */
+    enum spi_alt_num alt_fun;
+};
+
+#define SPI_PIN_DEF(_spi_num, _pin, _func, _alt) { _spi_num, _pin, _func, _alt }
+
+/* STMF0 and STML0 have distinct alternate pin functions */
+#if MYNEWT_VAL(MCU_STM32L0) || MYNEWT_VAL(MCU_STM32F0)
+static const struct spi_pin_def spi_pin[] = {
+#if MYNEWT_VAL(SPI_0_MASTER)
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(5), SPI_SCK, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(3), SPI_SCK, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTE(13), SPI_SCK, SPI_AF_2),
+
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(7), SPI_MOSI, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(12), SPI_MOSI, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(5), SPI_MOSI, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTE(15), SPI_MOSI, SPI_AF_2),
+
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(6), SPI_MISO, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(11), SPI_MISO, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(4), SPI_MISO, SPI_AF_0),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTE(14), SPI_MISO, SPI_AF_2),
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(10), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(13), SPI_SCK, SPI_AF_0),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTD(1), SPI_SCK, SPI_AF_1),
+
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(15), SPI_MOSI, SPI_AF_0),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTC(3), SPI_MOSI, SPI_AF_2),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTD(4), SPI_MOSI, SPI_AF_1),
+
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(14), SPI_MISO, SPI_AF_0),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTC(2), SPI_MISO, SPI_AF_2),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTD(3), SPI_MISO, SPI_AF_2),
+#endif
+};
+
+#else
+
+/*
+ * All other MCU seems to have same alternate functions for each type of PIN.
+ * For F1 function is specified and later ignored as it is not needed.
+ */
+static const struct spi_pin_def spi_pin[] = {
+#if MYNEWT_VAL(SPI_0_MASTER)
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(5), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(3), SPI_SCK, SPI_AF_5),
+
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(7), SPI_MOSI, SPI_AF_5),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(5), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(0, MCU_GPIO_PORTA(6), SPI_MISO, SPI_AF_5),
+    SPI_PIN_DEF(0, MCU_GPIO_PORTB(4), SPI_MISO, SPI_AF_5),
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(10), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(13), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTC(7), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTD(3), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTI(1), SPI_SCK, SPI_AF_5),
+
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(15), SPI_MOSI, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTC(3), SPI_MOSI, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTI(3), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(1, MCU_GPIO_PORTB(14), SPI_MISO, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTC(2), SPI_MISO, SPI_AF_5),
+    SPI_PIN_DEF(1, MCU_GPIO_PORTI(2), SPI_MISO, SPI_AF_5),
+#endif
+
+#if MYNEWT_VAL(SPI_2_MASTER)
+    SPI_PIN_DEF(2, MCU_GPIO_PORTB(3), SPI_SCK, SPI_AF_6),
+    SPI_PIN_DEF(2, MCU_GPIO_PORTC(10), SPI_SCK, SPI_AF_6),
+
+    SPI_PIN_DEF(2, MCU_GPIO_PORTB(5), SPI_MOSI, SPI_AF_6),
+    SPI_PIN_DEF(2, MCU_GPIO_PORTC(12), SPI_MOSI, SPI_AF_6),
+    SPI_PIN_DEF(2, MCU_GPIO_PORTD(6), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(2, MCU_GPIO_PORTB(4), SPI_MISO, SPI_AF_6),
+    SPI_PIN_DEF(2, MCU_GPIO_PORTC(11), SPI_MISO, SPI_AF_6),
+#endif
+
+#if MYNEWT_VAL(SPI_3_MASTER)
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(2), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(12), SPI_SCK, SPI_AF_5),
+
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(6), SPI_MOSI, SPI_AF_5),
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(14), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(5), SPI_MISO, SPI_AF_5),
+    SPI_PIN_DEF(3, MCU_GPIO_PORTE(13), SPI_MISO, SPI_AF_5),
+#endif
+#if MYNEWT_VAL(SPI_4_MASTER)
+    SPI_PIN_DEF(4, MCU_GPIO_PORTF(7), SPI_SCK, SPI_AF_5),
+    SPI_PIN_DEF(4, MCU_GPIO_PORTH(6), SPI_SCK, SPI_AF_5),
+
+    SPI_PIN_DEF(4, MCU_GPIO_PORTF(9), SPI_MOSI, SPI_AF_5),
+    SPI_PIN_DEF(4, MCU_GPIO_PORTF(11), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(4, MCU_GPIO_PORTF(8), SPI_MISO, SPI_AF_5),
+    SPI_PIN_DEF(4, MCU_GPIO_PORTH(7), SPI_MISO, SPI_AF_5),
+#endif
+
+#if MYNEWT_VAL(SPI_5_MASTER)
+    SPI_PIN_DEF(5, MCU_GPIO_PORTG(13), SPI_SCK, SPI_AF_5),
+
+    SPI_PIN_DEF(5, MCU_GPIO_PORTG(14), SPI_MOSI, SPI_AF_5),
+
+    SPI_PIN_DEF(5, MCU_GPIO_PORTG(12), SPI_MISO, SPI_AF_5),
+#endif
+};
+#endif
+
+/**
+ * Function returns alternate function number.
+ * @param spi_num   SPI_x_MASTER number
+ * @param pin       pin number
+ * @param func      required pin function
+ * @return          alternate function number of SPI_AF_INVALID if pin
+ *                  can't be setup for this funciton.
+ */
+enum spi_alt_num
+spi_stm32_pin_af(int spi_num, int pin, enum spi_pin_func func)
+{
+    int i;
+    for (i = 0; i < ARRAY_SIZE(spi_pin); ++i) {
+        if (spi_pin[i].spi_num == spi_num &&
+            spi_pin[i].pin_num == pin &&
+            spi_pin[i].pin_func == func) {
+            return spi_pin[i].alt_fun;
+        }
+    }
+    return SPI_AF_INVALID;
+}
+
+/* SPI1 specific section */
+#if MYNEWT_VAL(SPI_0_MASTER)
+static void spi1_irq_handler(void);
+static void spi1_clock_enable(bool enable);
+
+static const struct stm32_spi_hw stm32_spi1_hw = {
+    .spi_num = 0,
+    .irqn = SPI1_IRQn,
+    .irq_handler = spi1_irq_handler,
+    .enable_clock = spi1_clock_enable,
+#if MYNEWT_VAL(MCU_STM32F0)
+    .get_pclk = HAL_RCC_GetPCLK1Freq,
+#else
+    .get_pclk = HAL_RCC_GetPCLK2Freq,
+#endif
+    .dmarx_cfg = &MYNEWT_VAL(SPI1_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI1_TX_DMA),
+};
+
+static struct spi_stm32_driver_data spi1_dev_data = {
+    .hw = &stm32_spi1_hw,
+    .hspi.Instance = SPI1,
+};
+
+static void
+spi1_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI1_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI1_CLK_DISABLE();
+    }
+}
+
+static void
+spi1_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi1_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+#endif
+
+/* SPI2 specific section */
+#if MYNEWT_VAL(SPI_1_MASTER)
+static void spi2_irq_handler(void);
+static void spi2_clock_enable(bool enable);
+
+static const struct stm32_spi_hw stm32_spi2_hw = {
+    .spi_num = 1,
+    .irqn = SPI2_IRQn,
+    .irq_handler = spi2_irq_handler,
+    .enable_clock = spi2_clock_enable,
+    .get_pclk = HAL_RCC_GetPCLK1Freq,
+    .dmarx_cfg = &MYNEWT_VAL(SPI2_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI2_TX_DMA),
+};
+
+static struct spi_stm32_driver_data spi2_dev_data = {
+    .hw = &stm32_spi2_hw,
+    .hspi.Instance = SPI2,
+};
+
+static void
+spi2_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI2_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI2_CLK_DISABLE();
+    }
+}
+
+static void
+spi2_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi2_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+#endif
+
+/* SPI3 specific section */
+#if MYNEWT_VAL(SPI_2_MASTER)
+static void spi3_irq_handler(void);
+static void spi3_clock_enable(bool enable);
+
+static const struct stm32_spi_hw stm32_spi3_hw = {
+    .spi_num = 2,
+    .irqn = SPI3_IRQn,
+    .irq_handler = spi3_irq_handler,
+    .enable_clock = spi3_clock_enable,
+    .get_pclk = HAL_RCC_GetPCLK1Freq,
+    .dmarx_cfg = &MYNEWT_VAL(SPI3_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI3_TX_DMA),
+};
+
+struct spi_stm32_driver_data spi3_dev_data = {
+    .hw = &stm32_spi3_hw,
+    .hspi.Instance = SPI3,
+};
+
+static void
+spi3_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI3_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI3_CLK_DISABLE();
+    }
+}
+
+static void
+spi3_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi3_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+#endif
+
+/* SPI4 specific section */
+#if MYNEWT_VAL(SPI_3_MASTER)
+static void spi4_irq_handler(void);
+static void spi4_clock_enable(bool enable);
+
+static const struct stm32_spi_hw stm32_spi4_hw = {
+    .spi_num = 3,
+    .irqn = SPI4_IRQn,
+    .irq_handler = spi4_irq_handler,
+    .enable_clock = spi4_clock_enable,
+    .get_pclk = HAL_RCC_GetPCLK2Freq,
+    .dmarx_cfg = &MYNEWT_VAL(SPI4_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI4_TX_DMA),
+};
+
+struct spi_stm32_driver_data spi4_dev_data = {
+    .hw = &stm32_spi4_hw,
+    .hspi.Instance = SPI4,
+};
+
+static void
+spi4_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI4_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI4_CLK_DISABLE();
+    }
+}
+
+static void
+spi4_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi4_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+
+#endif
+
+/* SPI5 specific section */
+#if MYNEWT_VAL(SPI_4_MASTER)
+static void spi5_irq_handler(void);
+static void spi5_clock_enable(bool enable);
+
+const struct stm32_spi_hw stm32_spi5_hw = {
+    .spi_num = 4,
+    .irqn = SPI5_IRQn,
+    .irq_handler = spi5_irq_handler,
+    .enable_clock = spi5_clock_enable,
+    .get_pclk = HAL_RCC_GetPCLK2Freq,
+    .dmarx_cfg = &MYNEWT_VAL(SPI5_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI5_TX_DMA),
+};
+
+struct spi_stm32_driver_data spi5_dev_data = {
+    .hw = &stm32_spi5_hw,
+    .hspi.Instance = SPI5,
+};
+
+static void
+spi5_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI5_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI5_CLK_DISABLE();
+    }
+}
+
+static void
+spi5_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi5_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+#endif
+
+/* SPI6 specific section */
+#if MYNEWT_VAL(SPI_5_MASTER)
+static void spi6_irq_handler(void);
+static void spi6_clock_enable(bool enable);
+
+static const struct stm32_spi_hw stm32_spi6_hw = {
+    .spi_num = 5,
+    .irqn = SPI6_IRQn,
+    .irq_handler = spi6_irq_handler,
+    .enable_clock = spi6_clock_enable,
+    .get_pclk = HAL_RCC_GetPCLK2Freq,
+    .dmarx_cfg = &MYNEWT_VAL(SPI6_RX_DMA),
+    .dmatx_cfg = &MYNEWT_VAL(SPI6_TX_DMA),
+};
+
+static struct spi_stm32_driver_data spi6_dev_data = {
+    .hw = &stm32_spi6_hw,
+    .hspi.Instance = SPI6,
+};
+
+static void
+spi6_clock_enable(bool enable)
+{
+    if (enable) {
+        __HAL_RCC_SPI6_CLK_ENABLE();
+    } else {
+        __HAL_RCC_SPI6_CLK_DISABLE();
+    }
+}
+
+static void
+spi6_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_SPI_IRQHandler(&spi6_dev_data.hspi);
+
+    os_trace_isr_exit();
+}
+#endif
+
+static inline struct spi_stm32_driver_data *
+driver_data(struct bus_spi_dev *dev)
+{
+    switch (dev->cfg.spi_num) {
+#if MYNEWT_VAL(SPI_0_MASTER)
+    case 0:
+        return &spi1_dev_data;
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+    case 1:
+        return &spi2_dev_data;
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)
+    case 2:
+        return &spi3_dev_data;
+#endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+    case 3:
+        return &spi4_dev_data;
+#endif
+#if MYNEWT_VAL(SPI_4_MASTER)
+    case 4:
+        return &spi5_dev_data;
+#endif
+#if MYNEWT_VAL(SPI_5_MASTER)
+    case 5:
+        return &spi6_dev_data;
+#endif
+    default:
+        assert(0);
+        return NULL;
+    }
+}
+
+static int
+spi_stm32_init_node(struct bus_dev *bdev, struct bus_node *bnode, void *arg)
+{
+    struct bus_spi_node *node = (struct bus_spi_node *)bnode;
+    struct bus_spi_node_cfg *cfg = arg;
+    (void)bdev;
+
+    BUS_DEBUG_POISON_NODE(node);
+
+    node->pin_cs = cfg->pin_cs;
+    node->freq = cfg->freq;
+    node->quirks = cfg->quirks;
+    node->data_order = cfg->data_order;
+    node->mode = cfg->mode;
+
+    if (node->pin_cs >= 0) {
+        hal_gpio_init_out(node->pin_cs, 1);
+    }
+
+    return 0;
+}
+
+static int
+spi_stm32_configure(struct bus_dev *bdev, struct bus_node *bnode)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)bdev;
+    struct bus_spi_node *node = (struct bus_spi_node *)bnode;
+    struct bus_spi_node *current_node = (struct bus_spi_node *)bdev->configured_for;
+    struct spi_stm32_driver_data *dd;
+    const struct stm32_spi_hw *hw;
+    uint32_t pclk;
+    uint32_t freq;
+    int prescaler;
+    int rc = 0;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    dd = driver_data(dev);
+
+    if (current_node &&
+        current_node->freq == node->freq &&
+        current_node->data_order == node->data_order &&
+        current_node->mode == node->mode) {
+        goto end;
+    }
+
+    /* Change from kHz to Hz */
+    freq = node->freq * 1000;
+    hw = dd->hw;
+    pclk = hw->get_pclk() / 2;
+    /* Find prescaler so frequency does not exceed requested one. */
+    for (prescaler = 0; freq < pclk; ++prescaler) {
+        pclk >>= 1;
+    }
+
+    if (prescaler > 7) {
+        rc = SYS_EINVAL;
+    } else {
+        dd->hspi.Init.BaudRatePrescaler = prescaler << SPI_CR1_BR_Pos;
+        dd->hspi.Init.CLKPolarity = (node->mode == BUS_SPI_MODE_0 || node->mode == BUS_SPI_MODE_1) ?
+                                    SPI_POLARITY_LOW : SPI_POLARITY_HIGH;
+        dd->hspi.Init.CLKPhase = (node->mode == BUS_SPI_MODE_0 || node->mode == BUS_SPI_MODE_2) ?
+                                 SPI_PHASE_1EDGE : SPI_PHASE_2EDGE;
+        dd->hspi.Init.FirstBit = node->data_order == BUS_SPI_DATA_ORDER_MSB ?
+                                 SPI_FIRSTBIT_MSB : SPI_FIRSTBIT_LSB;
+    }
+    if (HAL_OK != HAL_SPI_Init(&dd->hspi)) {
+        rc = SYS_EINVAL;
+    }
+
+    __HAL_SPI_ENABLE(&dd->hspi);
+
+end:
+    return rc;
+}
+
+void
+HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+    struct spi_stm32_driver_data *dd = (struct spi_stm32_driver_data *)hspi;
+
+    os_sem_release(&dd->sem);
+}
+
+void
+HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+    struct spi_stm32_driver_data *dd = (struct spi_stm32_driver_data *)hspi;
+
+    os_sem_release(&dd->sem);
+}
+
+static int
+spi_stm32_read(struct bus_dev *bdev, struct bus_node *bnode,
+               uint8_t *buf, uint16_t length, os_time_t timeout,
+               uint16_t flags)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)bdev;
+    struct bus_spi_node *node = (struct bus_spi_node *)bnode;
+    struct spi_stm32_driver_data *dd;
+    int rc;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    dd = driver_data(dev);
+
+    assert(os_sem_get_count(&dd->sem) == 0);
+
+    if (node->pin_cs >= 0) {
+        hal_gpio_write(node->pin_cs, 0);
+    }
+    if (MIN_DMA_RX_SIZE >= 0 && length >= MIN_DMA_RX_SIZE) {
+        HAL_SPI_Receive_DMA(&dd->hspi, (uint8_t *)buf, length);
+    } else {
+        HAL_SPI_Receive_IT(&dd->hspi, (uint8_t *)buf, length);
+    }
+
+    rc = os_sem_pend(&dd->sem, timeout);
+
+    if (rc) {
+        HAL_SPI_Abort(&dd->hspi);
+    }
+
+    rc = os_error_to_sys(rc);
+
+    if ((rc != 0 || !(flags & BUS_F_NOSTOP)) && node->pin_cs >= 0) {
+        hal_gpio_write(node->pin_cs, 1);
+    }
+
+    return rc;
+}
+
+static int
+spi_stm32_write(struct bus_dev *bdev, struct bus_node *bnode,
+                const uint8_t *buf, uint16_t length, os_time_t timeout,
+                uint16_t flags)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)bdev;
+    struct bus_spi_node *node = (struct bus_spi_node *)bnode;
+    struct spi_stm32_driver_data *dd;
+    int rc;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    dd = driver_data(dev);
+
+    assert(os_sem_get_count(&dd->sem) == 0);
+
+    /* Activate CS */
+    if (node->pin_cs >= 0) {
+        hal_gpio_write(node->pin_cs, 0);
+    }
+
+    if (MIN_DMA_TX_SIZE >= 0 && length >= MIN_DMA_TX_SIZE) {
+        HAL_SPI_Transmit_DMA(&dd->hspi, (uint8_t *)buf, length);
+    } else {
+        HAL_SPI_Transmit_IT(&dd->hspi, (uint8_t *)buf, length);
+    }
+
+    rc = os_sem_pend(&dd->sem, timeout);
+
+    if (rc) {
+        HAL_SPI_Abort(&dd->hspi);
+    }
+
+    rc = os_error_to_sys(rc);
+
+    /* Deactivate CS if needed */
+    if ((rc != 0 || !(flags & BUS_F_NOSTOP)) && node->pin_cs >= 0) {
+        hal_gpio_write(node->pin_cs, 1);
+    }
+
+    return rc;
+}
+
+static int
+spi_stm32_enable(struct bus_dev *bdev)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)bdev;
+    struct spi_stm32_driver_data *dd;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+
+    dd = driver_data(dev);
+    dd->hw->enable_clock(true);
+
+    return 0;
+}
+
+static int
+spi_stm32_disable(struct bus_dev *bdev)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)bdev;
+    struct spi_stm32_driver_data *dd;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+
+    dd = driver_data(dev);
+    HAL_SPI_DeInit(&dd->hspi);
+    dd->hw->enable_clock(false);
+
+    return 0;
+}
+
+static const struct bus_dev_ops bus_spi_stm32_ops = {
+    .init_node = spi_stm32_init_node,
+    .enable = spi_stm32_enable,
+    .configure = spi_stm32_configure,
+    .read = spi_stm32_read,
+    .write = spi_stm32_write,
+    .disable = spi_stm32_disable,
+};
+
+/* Helper function to setup interrupt handler for SPI and DMA */
+static void
+stm32_init_interrupt(uint8_t irqn, uint8_t pri, void (*handler)(void))
+{
+    NVIC_DisableIRQ(irqn);
+
+    NVIC_SetVector(irqn, (uint32_t)handler);
+    NVIC_SetPriority(irqn, pri);
+    NVIC_ClearPendingIRQ(irqn);
+
+    NVIC_EnableIRQ(irqn);
+}
+
+int
+bus_spi_stm32_dev_init_func(struct os_dev *odev, void *arg)
+{
+    struct bus_spi_dev *dev = (struct bus_spi_dev *)odev;
+    struct bus_spi_dev_cfg *cfg = arg;
+    struct spi_stm32_driver_data *dd;
+#if MYNEWT_VAL(SPI_STM32_STAT)
+    char *stats_name;
+#endif
+    int rc;
+    enum spi_alt_num af;
+    const struct stm32_spi_hw *spi_hw;
+
+    BUS_DEBUG_POISON_DEV(dev);
+
+    dev->cfg = *cfg;
+    dd = driver_data(dev);
+    if (dd == NULL) {
+        return SYS_EINVAL;
+    }
+    assert(dd->dev == NULL);
+    if (dd->dev) {
+        return SYS_EALREADY;
+    }
+
+    spi_hw = dd->hw;
+    dd->dev = dev;
+
+    af = spi_stm32_pin_af(cfg->spi_num, cfg->pin_sck, SPI_SCK);
+    assert(SPI_AF_INVALID != af);
+    hal_gpio_init_af(cfg->pin_sck, af, HAL_GPIO_PULL_NONE, 0);
+
+    af = spi_stm32_pin_af(cfg->spi_num, cfg->pin_mosi, SPI_MOSI);
+    assert(SPI_AF_INVALID != af);
+    hal_gpio_init_af(cfg->pin_mosi, af, HAL_GPIO_PULL_NONE, 0);
+
+    af = spi_stm32_pin_af(cfg->spi_num, cfg->pin_miso, SPI_MISO);
+    assert(SPI_AF_INVALID != af);
+    hal_gpio_init_af(cfg->pin_miso, af, HAL_GPIO_PULL_NONE, 0);
+
+    dd->hspi.Init.Mode = SPI_MODE_MASTER;
+    dd->hspi.Init.DataSize = SPI_DATASIZE_8BIT;
+    dd->hspi.Init.Direction = SPI_DIRECTION_2LINES;
+    dd->hspi.Init.NSS = SPI_NSS_SOFT;
+    dd->hspi.Init.TIMode = SPI_TIMODE_DISABLE;
+    dd->hspi.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+
+    if (MIN_DMA_RX_SIZE >= 0 || MIN_DMA_TX_SIZE >= 0) {
+        dd->dmarx.Instance = spi_hw->dmarx_cfg->regs;
+        dd->dmatx.Instance = spi_hw->dmatx_cfg->regs;
+        dd->dmarx.Init = spi_hw->dmarx_cfg->init;
+        dd->dmatx.Init = spi_hw->dmatx_cfg->init;
+
+        __HAL_LINKDMA(&dd->hspi, hdmarx, dd->dmarx);
+        __HAL_LINKDMA(&dd->hspi, hdmatx, dd->dmatx);
+
+        if (spi_hw->dmarx_cfg->dma_ch <= DMA1_CH7) {
+            __HAL_RCC_DMA1_CLK_ENABLE();
+        } else {
+#ifdef __HAL_RCC_DMA2_CLK_ENABLE
+            __HAL_RCC_DMA2_CLK_ENABLE();
+#endif
+        }
+#ifdef DMAMUX1
+        __HAL_RCC_DMAMUX1_CLK_ENABLE();
+#endif
+
+        if (stm32_dma_acquire_channel(spi_hw->dmarx_cfg->dma_ch, &dd->dmarx) == SYS_EOK) {
+            HAL_DMA_Init(&dd->dmarx);
+            stm32_init_interrupt(spi_hw->dmarx_cfg->irqn, 0, spi_hw->dmarx_cfg->irq_handler);
+        }
+
+        if (stm32_dma_acquire_channel(spi_hw->dmatx_cfg->dma_ch, &dd->dmatx) == SYS_EOK) {
+            HAL_DMA_Init(&dd->dmatx);
+            stm32_init_interrupt(spi_hw->dmatx_cfg->irqn, 0, spi_hw->dmatx_cfg->irq_handler);
+        }
+    }
+
+    stm32_init_interrupt(spi_hw->irqn, 0, spi_hw->irq_handler);
+
+    os_sem_init(&dd->sem, 0);
+
+#if MYNEWT_VAL(SPI_STM32_STAT)
+    asprintf(&stats_name, "spi_stm32_%d", cfg->spi_num);
+    stats_init_and_reg(STATS_HDR(dd->stats),
+                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                       STATS_NAME_INIT_PARMS(spi_stm32_stats_section),
+                       stats_name);
+#endif
+
+    rc = bus_dev_init_func(odev, (void *)&bus_spi_stm32_ops);
+    assert(rc == 0);
+
+    return 0;
+}
+

--- a/hw/bus/drivers/spi_stm32/stm32f0xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32f0xx/include/spidmacfg.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32f0xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, req, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch
+
+SPI_DMA_CHANNEL(1, 2, 1, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, 1, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, 1, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, 1, spi2_tx);
+
+SPI_DMA_CHANNEL(1, 6, 1, spi2_rx);
+SPI_DMA_CHANNEL(1, 7, 1, spi2_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f0xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f0xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32f0xx
+pkg.description: STM32F0 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32f0xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32f0xx/src/spidmacfg.c
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stm32_common/stm32_dma.h>
+#include <spidmacfg.h>
+#include <stm32f0xx_hal_dma.h>
+
+#define DMA_IRQn(ch) ((ch) == DMA1_CH1 ? DMA1_Ch1_IRQn : \
+                      ((ch) >= DMA1_CH2 && (ch) <= DMA1_CH3) || \
+                      ((ch) >= DMA2_CH1 && (ch) <= DMA2_CH2) ? DMA1_Channel2_3_IRQn : \
+                      DMA1_Channel4_5_IRQn)
+#define DMA_IRQ_HANDLER(ch) ((ch) == DMA1_CH1 ? stm32_dma1_1_irq_handler : \
+                             ((ch) >= DMA1_CH2 && (ch) <= DMA1_CH3) || \
+                             ((ch) >= DMA2_CH1 && (ch) <= DMA2_CH2) ? stm32_dma1_2_3_irq_handler : \
+                             stm32_dma1_4_5_6_7_irq_handler)
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, name)                    \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = {     \
+        DMA ## dma ## _CH ## ch,                                    \
+        DMA_IRQn(ch),                                               \
+        DMA_IRQ_HANDLER(ch),                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                       \
+        .init = {                                                   \
+            .Direction = DMA_PERIPH_TO_MEMORY,                      \
+            .PeriphInc = DMA_PINC_DISABLE,                          \
+            .MemInc = DMA_MINC_ENABLE,                              \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,             \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                \
+            .Mode = DMA_NORMAL,                                     \
+            .Priority = DMA_PRIORITY_LOW,                           \
+        }                                                           \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, name)                    \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = {     \
+        DMA ## dma ## _CH ## ch,                                    \
+        DMA_IRQn(ch),                                               \
+        DMA_IRQ_HANDLER(ch),                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                       \
+        .init = {                                                   \
+            .Direction = DMA_MEMORY_TO_PERIPH,                      \
+            .PeriphInc = DMA_PINC_DISABLE,                          \
+            .MemInc = DMA_MINC_ENABLE,                              \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,             \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                \
+            .Mode = DMA_NORMAL,                                     \
+            .Priority = DMA_PRIORITY_LOW,                           \
+        }                                                           \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, spi1_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, spi2_tx);
+
+#if defined(DMA1_Channel6) && defined(DMA1_Channel7)
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, spi2_tx);
+#endif
+
+#if defined(DMA2_Channel3)
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, spi1_tx);
+#endif

--- a/hw/bus/drivers/spi_stm32/stm32f0xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f0xx/syscfg.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+#        value: DMA2_channel3
+        value: DMA1_channel2
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+#        value: DMA2_channel4
+        value: DMA1_channel3
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+#        value: DMA1_channel7
+        value: DMA1_channel4
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+#        value: DMA1_channel7
+        value: DMA1_channel5

--- a/hw/bus/drivers/spi_stm32/stm32f1xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32f1xx/include/spidmacfg.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32f1xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch
+
+SPI_DMA_CHANNEL(1, 2, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, spi2_tx);
+
+SPI_DMA_CHANNEL(2, 1, spi3_rx);
+SPI_DMA_CHANNEL(2, 2, spi3_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f1xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f1xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32f1xx
+pkg.description: STM32F1 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32f1xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32f1xx/src/spidmacfg.c
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stm32_common/stm32_dma.h>
+#include <spidmacfg.h>
+#include <stm32f1xx_hal_dma.h>
+
+extern DMA_HandleTypeDef *stm32_dma_ch[];
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_PERIPH_TO_MEMORY,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_MEMORY_TO_PERIPH,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#ifdef SPI1
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, spi1_tx);
+#endif
+
+#ifdef SPI2
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, spi2_tx);
+#endif
+
+#ifdef SPI3
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, spi3_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, spi3_tx);
+#endif

--- a/hw/bus/drivers/spi_stm32/stm32f1xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f1xx/syscfg.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+        value: DMA1_channel2
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+        value: DMA1_channel3
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+        value: DMA1_channel4
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+        value: DMA1_channel5
+    SPI3_RX_DMA:
+        description: 'DMA channel to use for SPI3 RX'
+        value: DMA2_channel1
+    SPI3_TX_DMA:
+        description: 'DMA channel to use for SPI3 TX'
+        value: DMA2_channel2

--- a/hw/bus/drivers/spi_stm32/stm32f3xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32f3xx/include/spidmacfg.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32f3xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch
+
+SPI_DMA_CHANNEL(1, 2, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, spi2_tx);
+
+SPI_DMA_CHANNEL(2, 1, spi3_rx);
+SPI_DMA_CHANNEL(2, 2, spi3_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f3xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f3xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32f3xx
+pkg.description: STM32F3 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32f3xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32f3xx/src/spidmacfg.c
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stm32_common/stm32_dma.h>
+#include <spidmacfg.h>
+#include <stm32f3xx_hal_dma.h>
+
+extern DMA_HandleTypeDef *stm32_dma_ch[];
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_PERIPH_TO_MEMORY,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_MEMORY_TO_PERIPH,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#ifdef SPI1
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, spi1_tx);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, spi1_tx);
+#endif
+
+#ifdef SPI2
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, spi2_tx);
+#endif
+
+#ifdef SPI3
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, spi3_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, spi3_tx);
+#endif
+
+#ifdef SPI4
+SPI_DMA_RX_CHANNEL_DEFINE(2, 4, spi4_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 5, spi4_tx);
+#endif

--- a/hw/bus/drivers/spi_stm32/stm32f3xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f3xx/syscfg.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI4_DMA_PRIORITY:
+        description: 'DMA priority for SPI4 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+#        value: DMA1_channel6
+        value: DMA1_channel2
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+#        value: DMA1_channel7
+        value: DMA1_channel3
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+        value: DMA1_channel4
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+        value: DMA1_channel5
+    SPI3_RX_DMA:
+        description: 'DMA channel to use for SPI3 RX'
+        value: DMA2_channel1
+    SPI3_TX_DMA:
+        description: 'DMA channel to use for SPI3 TX'
+        value: DMA2_channel2
+    SPI4_RX_DMA:
+        description: 'DMA channel to use for SPI4 RX'
+        value: DMA2_channel4
+    SPI4_TX_DMA:
+        description: 'DMA channel to use for SPI4 TX'
+        value: DMA2_channel5

--- a/hw/bus/drivers/spi_stm32/stm32f4xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32f4xx/include/spidmacfg.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32f4xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Stream_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define DMA_STREAM(dma, ch, st, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch
+
+DMA_STREAM(1, 0, 0, spi3_rx);
+DMA_STREAM(1, 0, 2, spi3_rx);
+DMA_STREAM(1, 0, 3, spi2_rx);
+DMA_STREAM(1, 0, 4, spi2_tx);
+DMA_STREAM(1, 0, 5, spi3_tx);
+DMA_STREAM(1, 0, 7, spi3_tx);
+
+DMA_STREAM(2, 1, 5, spi6_tx);
+DMA_STREAM(2, 1, 6, spi6_rx);
+
+DMA_STREAM(2, 2, 2, spi1_tx);
+DMA_STREAM(2, 2, 3, spi5_rx);
+DMA_STREAM(2, 2, 4, spi5_tx);
+
+DMA_STREAM(2, 3, 0, spi1_rx);
+DMA_STREAM(2, 3, 2, spi1_rx);
+DMA_STREAM(2, 3, 3, spi1_tx);
+DMA_STREAM(2, 3, 5, spi1_tx);
+
+DMA_STREAM(2, 4, 0, spi4_rx);
+DMA_STREAM(2, 4, 1, spi4_tx);
+DMA_STREAM(2, 4, 4, spi4_rx);
+
+DMA_STREAM(2, 5, 3, spi4_rx);
+DMA_STREAM(2, 5, 4, spi4_tx);
+DMA_STREAM(2, 5, 5, spi5_tx);
+
+DMA_STREAM(2, 7, 5, spi5_rx);
+DMA_STREAM(2, 7, 6, spi5_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f4xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f4xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32f4xx
+pkg.description: STM32F4 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32f4xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32f4xx/src/spidmacfg.c
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32f4xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_STREAM_DEFINE(dma, ch, st, name)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch = {  \
+        DMA ## dma ## _CH ## st,                                            \
+        DMA ## dma ## _Stream ## st ## _IRQn,                               \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        DMA ## dma ## _Stream ## st,                                        \
+        .init = {                                                           \
+            .Channel = DMA_CHANNEL_ ## ch,                                  \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+            .FIFOMode = DMA_FIFOMODE_DISABLE,                               \
+            .FIFOThreshold = DMA_FIFO_THRESHOLD_1QUARTERFULL,               \
+            .MemBurst = DMA_MBURST_SINGLE,                                  \
+            .PeriphBurst = DMA_PBURST_SINGLE,                               \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_STREAM_DEFINE(dma, ch, st, name)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch = {  \
+        DMA ## dma ## _CH ## st,                                            \
+        DMA ## dma ## _Stream ## st ## _IRQn,                               \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        DMA ## dma ## _Stream ## st,                                        \
+        .init = {                                                           \
+            .Channel = DMA_CHANNEL_ ## ch,                                  \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+            .FIFOMode = DMA_FIFOMODE_DISABLE,                               \
+            .FIFOThreshold = DMA_FIFO_THRESHOLD_1QUARTERFULL,               \
+            .MemBurst = DMA_MBURST_SINGLE,                                  \
+            .PeriphBurst = DMA_PBURST_SINGLE,                               \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 0, spi3_rx);
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 2, spi3_rx);
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 3, spi2_rx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 4, spi2_tx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 5, spi3_tx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 7, spi3_tx);
+
+SPI_DMA_TX_STREAM_DEFINE(2, 1, 5, spi6_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 1, 6, spi6_rx);
+
+SPI_DMA_TX_STREAM_DEFINE(2, 2, 2, spi1_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 2, 3, spi5_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 2, 4, spi5_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 3, 0, spi1_rx);
+SPI_DMA_RX_STREAM_DEFINE(2, 3, 2, spi1_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 3, 3, spi1_tx);
+SPI_DMA_TX_STREAM_DEFINE(2, 3, 5, spi1_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 4, 0, spi4_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 4, 1, spi4_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 4, 4, spi4_rx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 5, 3, spi4_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 5, 4, spi4_tx);
+SPI_DMA_TX_STREAM_DEFINE(2, 5, 5, spi5_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 7, 5, spi5_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 7, 6, spi5_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f4xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f4xx/syscfg.yml
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI4_DMA_PRIORITY:
+        description: 'DMA priority for SPI4 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI5_DMA_PRIORITY:
+        description: 'DMA priority for SPI5 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI6_DMA_PRIORITY:
+        description: 'DMA priority for SPI6 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA stream to use for SPI1 RX'
+#        value: DMA2_stream0_channel3
+#        value: DMA2_stream2_channel3
+        value: DMA2_stream0_channel3
+    SPI1_TX_DMA:
+        description: 'DMA stream to use for SPI1 TX'
+#        value: DMA2_stream3_channel3
+#        value: DMA2_stream5_channel3
+#        value: DMA2_stream2_channel2
+        value: DMA2_stream3_channel3
+    SPI2_RX_DMA:
+        description: 'DMA stream to use for SPI2 RX'
+#        value: DMA1_stream3_channel0
+        value: DMA1_stream3_channel0
+    SPI2_TX_DMA:
+        description: 'DMA stream to use for SPI2 TX'
+#        value: DMA1_stream4_channel0
+        value: DMA1_stream4_channel0
+    SPI3_RX_DMA:
+        description: 'DMA stream to use for SPI3 RX'
+#        value: DMA1_stream0_channel0
+#        value: DMA1_stream2_channel0
+        value: DMA1_stream0_channel0
+    SPI3_TX_DMA:
+        description: 'DMA stream to use for SPI3 TX'
+#        value: DMA1_stream5_channel0
+#        value: DMA1_stream7_channel0
+        value: DMA1_stream5_channel0
+    SPI4_RX_DMA:
+        description: 'DMA stream to use for SPI4 RX'
+#        value: DMA2_stream0_channel4
+#        value: DMA2_stream3_channel5
+        value: DMA2_stream0_channel4
+    SPI4_TX_DMA:
+        description: 'DMA stream to use for SPI4 TX'
+#        value: DMA2_stream1_channel4
+#        value: DMA2_stream4_channel5
+        value: DMA2_stream1_channel4
+    SPI5_RX_DMA:
+        description: 'DMA stream to use for SPI5 RX'
+#        value: DMA2_stream5_channel7
+        value: DMA2_stream5_channel7
+    SPI5_TX_DMA:
+        description: 'DMA stream to use for SPI5 TX'
+#        value: DMA2_stream6_channel7
+        value: DMA2_stream6_channel7
+    SPI6_RX_DMA:
+        description: 'DMA stream to use for SPI6 RX'
+#        value: DMA2_stream5_channel1
+        value: DMA2_stream5_channel1
+    SPI6_TX_DMA:
+        description: 'DMA stream to use for SPI6 TX'
+#        value: DMA2_stream6_channel1
+        value: DMA2_stream6_channel1

--- a/hw/bus/drivers/spi_stm32/stm32f7xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32f7xx/include/spidmacfg.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32f7xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Stream_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define DMA_STREAM(dma, ch, st, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch
+
+DMA_STREAM(1, 0, 0, spi3_rx);
+DMA_STREAM(1, 0, 2, spi3_rx);
+DMA_STREAM(1, 0, 3, spi2_rx);
+DMA_STREAM(1, 0, 4, spi2_tx);
+DMA_STREAM(1, 0, 5, spi3_tx);
+DMA_STREAM(1, 0, 7, spi3_tx);
+
+DMA_STREAM(2, 1, 5, spi6_tx);
+DMA_STREAM(2, 1, 6, spi6_rx);
+
+DMA_STREAM(2, 2, 2, spi1_tx);
+DMA_STREAM(2, 2, 3, spi5_rx);
+DMA_STREAM(2, 2, 4, spi5_tx);
+
+DMA_STREAM(2, 3, 0, spi1_rx);
+DMA_STREAM(2, 3, 2, spi1_rx);
+DMA_STREAM(2, 3, 3, spi1_tx);
+DMA_STREAM(2, 3, 5, spi1_tx);
+
+DMA_STREAM(2, 4, 0, spi4_rx);
+DMA_STREAM(2, 4, 1, spi4_tx);
+DMA_STREAM(2, 4, 4, spi4_rx);
+
+DMA_STREAM(2, 5, 3, spi4_rx);
+DMA_STREAM(2, 5, 4, spi4_tx);
+DMA_STREAM(2, 5, 5, spi5_tx);
+
+DMA_STREAM(2, 7, 5, spi5_rx);
+DMA_STREAM(2, 7, 6, spi5_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f7xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f7xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32f7xx
+pkg.description: STM32F7 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32f7xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32f7xx/src/spidmacfg.c
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32f7xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_STREAM_DEFINE(dma, ch, st, name)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch = {  \
+        DMA ## dma ## _CH ## st,                                            \
+        DMA ## dma ## _Stream ## st ## _IRQn,                               \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        DMA ## dma ## _Stream ## st,                                        \
+        .init = {                                                           \
+            .Channel = DMA_CHANNEL_ ## ch,                                  \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+            .FIFOMode = DMA_FIFOMODE_DISABLE,                               \
+            .FIFOThreshold = DMA_FIFO_THRESHOLD_1QUARTERFULL,               \
+            .MemBurst = DMA_MBURST_SINGLE,                                  \
+            .PeriphBurst = DMA_PBURST_SINGLE,                               \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_STREAM_DEFINE(dma, ch, st, name)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _channel ## ch = {  \
+        DMA ## dma ## _CH ## st,                                            \
+        DMA ## dma ## _Stream ## st ## _IRQn,                               \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        DMA ## dma ## _Stream ## st,                                        \
+        .init = {                                                           \
+            .Channel = DMA_CHANNEL_ ## ch,                                  \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+            .FIFOMode = DMA_FIFOMODE_DISABLE,                               \
+            .FIFOThreshold = DMA_FIFO_THRESHOLD_1QUARTERFULL,               \
+            .MemBurst = DMA_MBURST_SINGLE,                                  \
+            .PeriphBurst = DMA_PBURST_SINGLE,                               \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 0, spi3_rx);
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 2, spi3_rx);
+SPI_DMA_RX_STREAM_DEFINE(1, 0, 3, spi2_rx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 4, spi2_tx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 5, spi3_tx);
+SPI_DMA_TX_STREAM_DEFINE(1, 0, 7, spi3_tx);
+
+SPI_DMA_TX_STREAM_DEFINE(2, 1, 5, spi6_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 1, 6, spi6_rx);
+
+SPI_DMA_TX_STREAM_DEFINE(2, 2, 2, spi1_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 2, 3, spi5_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 2, 4, spi5_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 3, 0, spi1_rx);
+SPI_DMA_RX_STREAM_DEFINE(2, 3, 2, spi1_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 3, 3, spi1_tx);
+SPI_DMA_TX_STREAM_DEFINE(2, 3, 5, spi1_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 4, 0, spi4_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 4, 1, spi4_tx);
+SPI_DMA_RX_STREAM_DEFINE(2, 4, 4, spi4_rx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 5, 3, spi4_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 5, 4, spi4_tx);
+SPI_DMA_TX_STREAM_DEFINE(2, 5, 5, spi5_tx);
+
+SPI_DMA_RX_STREAM_DEFINE(2, 7, 5, spi5_rx);
+SPI_DMA_TX_STREAM_DEFINE(2, 7, 6, spi5_tx);

--- a/hw/bus/drivers/spi_stm32/stm32f7xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32f7xx/syscfg.yml
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI4_DMA_PRIORITY:
+        description: 'DMA priority for SPI4 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI5_DMA_PRIORITY:
+        description: 'DMA priority for SPI5 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI6_DMA_PRIORITY:
+        description: 'DMA priority for SPI6 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA stream to use for SPI1 RX'
+        #        value: DMA2_stream0_channel3
+        #        value: DMA2_stream2_channel3
+        value: DMA2_stream0_channel3
+    SPI1_TX_DMA:
+        description: 'DMA stream to use for SPI1 TX'
+        #        value: DMA2_stream3_channel3
+        #        value: DMA2_stream5_channel3
+        #        value: DMA2_stream2_channel2
+        value: DMA2_stream3_channel3
+    SPI2_RX_DMA:
+        description: 'DMA stream to use for SPI2 RX'
+        #        value: DMA1_stream3_channel0
+        value: DMA1_stream3_channel0
+    SPI2_TX_DMA:
+        description: 'DMA stream to use for SPI2 TX'
+        #        value: DMA1_stream4_channel0
+        value: DMA1_stream4_channel0
+    SPI3_RX_DMA:
+        description: 'DMA stream to use for SPI3 RX'
+        #        value: DMA1_stream0_channel0
+        #        value: DMA1_stream2_channel0
+        value: DMA1_stream0_channel0
+    SPI3_TX_DMA:
+        description: 'DMA stream to use for SPI3 TX'
+        #        value: DMA1_stream5_channel0
+        #        value: DMA1_stream7_channel0
+        value: DMA1_stream5_channel0
+    SPI4_RX_DMA:
+        description: 'DMA stream to use for SPI4 RX'
+        #        value: DMA2_stream0_channel4
+        #        value: DMA2_stream3_channel5
+        value: DMA2_stream0_channel4
+    SPI4_TX_DMA:
+        description: 'DMA stream to use for SPI4 TX'
+        #        value: DMA2_stream1_channel4
+        #        value: DMA2_stream4_channel5
+        value: DMA2_stream1_channel4
+    SPI5_RX_DMA:
+        description: 'DMA stream to use for SPI5 RX'
+        #        value: DMA2_stream5_channel7
+        value: DMA2_stream5_channel7
+    SPI5_TX_DMA:
+        description: 'DMA stream to use for SPI5 TX'
+        #        value: DMA2_stream6_channel7
+        value: DMA2_stream6_channel7
+    SPI6_RX_DMA:
+        description: 'DMA stream to use for SPI6 RX'
+        #        value: DMA2_stream5_channel1
+        value: DMA2_stream5_channel1
+    SPI6_TX_DMA:
+        description: 'DMA stream to use for SPI6 TX'
+        #        value: DMA2_stream6_channel1
+        value: DMA2_stream6_channel1

--- a/hw/bus/drivers/spi_stm32/stm32l0xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32l0xx/include/spidmacfg.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32l0xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, req, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req
+
+SPI_DMA_CHANNEL(1, 2, 1, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, 1, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, 1, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, 1, spi2_tx);
+
+SPI_DMA_CHANNEL(1, 6, 1, spi2_rx);
+SPI_DMA_CHANNEL(1, 7, 1, spi2_tx);

--- a/hw/bus/drivers/spi_stm32/stm32l0xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l0xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32l0xx
+pkg.description: STM32L0 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32l0xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32l0xx/src/spidmacfg.c
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32l0xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define DMA_IRQn(ch) ((uint8_t)DMA1_Channel1_IRQn + (((DMA1_CH3) > 3) ? 2 : ((DMA1_CH3) >> 1)))
+#define DMA_IRQ_HANDLER(ch) (((ch) > DMA1_CH3) ? stm32_dma1_4_5_6_7_irq_handler : stm32_dma1_2_3_irq_handler)
+
+extern DMA_HandleTypeDef *stm32_dma_ch[];
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, req, name)               \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req = {  \
+        DMA ## dma ## _CH ## ch,                                    \
+        DMA_IRQn(ch),                                               \
+        DMA_IRQ_HANDLER(ch),                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                       \
+        .init = {                                                   \
+            .Request = DMA_REQUEST_ ## req,                         \
+            .Direction = DMA_PERIPH_TO_MEMORY,                      \
+            .PeriphInc = DMA_PINC_DISABLE,                          \
+            .MemInc = DMA_MINC_ENABLE,                              \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,             \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                \
+            .Mode = DMA_NORMAL,                                     \
+            .Priority = DMA_PRIORITY_LOW,                           \
+        }                                                           \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, req, name)               \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req = {  \
+        DMA ## dma ## _CH ## ch,                                    \
+        DMA_IRQn(ch),                                               \
+        DMA_IRQ_HANDLER(ch),                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                       \
+        .init = {                                                   \
+            .Request = DMA_REQUEST_ ## req,                         \
+            .Direction = DMA_MEMORY_TO_PERIPH,                      \
+            .PeriphInc = DMA_PINC_DISABLE,                          \
+            .MemInc = DMA_MINC_ENABLE,                              \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,             \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                \
+            .Mode = DMA_NORMAL,                                     \
+            .Priority = DMA_PRIORITY_LOW,                           \
+        }                                                           \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1, spi1_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1, spi1_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 2, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 2, spi2_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 2, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 2, spi2_tx);

--- a/hw/bus/drivers/spi_stm32/stm32l0xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l0xx/syscfg.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+#        value: DMA2_channel3_request4
+        value: DMA1_channel2_request1
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+#        value: DMA2_channel4_request4
+        value: DMA1_channel3_request1
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+        value: DMA1_channel4_request1
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+        value: DMA1_channel5_request1

--- a/hw/bus/drivers/spi_stm32/stm32l1xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32l1xx/include/spidmacfg.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32l1xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch
+
+SPI_DMA_CHANNEL(1, 2, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, spi2_tx);
+
+SPI_DMA_CHANNEL(2, 1, spi3_rx);
+SPI_DMA_CHANNEL(2, 2, spi3_tx);

--- a/hw/bus/drivers/spi_stm32/stm32l1xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l1xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32l1xx
+pkg.description: STM32L1 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32l1xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32l1xx/src/spidmacfg.c
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stm32_common/stm32_dma.h>
+#include <spidmacfg.h>
+#include <stm32l1xx_hal_dma.h>
+
+extern DMA_HandleTypeDef *stm32_dma_ch[];
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_PERIPH_TO_MEMORY,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, name)                \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch = { \
+        DMA ## dma ## _CH ## ch,                                \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                  \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,            \
+        .regs = DMA ## dma ## _Channel ## ch,                   \
+        .init = {                                               \
+            .Direction = DMA_MEMORY_TO_PERIPH,                  \
+            .PeriphInc = DMA_PINC_DISABLE,                      \
+            .MemInc = DMA_MINC_ENABLE,                          \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,         \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,            \
+            .Mode = DMA_NORMAL,                                 \
+            .Priority = DMA_PRIORITY_LOW,                       \
+        }                                                       \
+    }
+
+#ifdef SPI1
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, spi1_tx);
+#endif
+
+#ifdef SPI2
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, spi2_tx);
+#endif
+
+#ifdef SPI3
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, spi3_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, spi3_tx);
+#endif

--- a/hw/bus/drivers/spi_stm32/stm32l1xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l1xx/syscfg.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+        value: DMA1_channel2
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+        value: DMA1_channel3
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+        value: DMA1_channel4
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+        value: DMA1_channel5
+    SPI3_RX_DMA:
+        description: 'DMA channel to use for SPI3 RX'
+        value: DMA2_channel1
+    SPI3_TX_DMA:
+        description: 'DMA channel to use for SPI3 TX'
+        value: DMA2_channel2

--- a/hw/bus/drivers/spi_stm32/stm32l4xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32l4xx/include/spidmacfg.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32l4xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_CHANNEL(dma, ch, req, name) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req
+
+SPI_DMA_CHANNEL(1, 2, 1, spi1_rx);
+SPI_DMA_CHANNEL(1, 3, 1, spi1_tx);
+
+SPI_DMA_CHANNEL(1, 4, 1, spi2_rx);
+SPI_DMA_CHANNEL(1, 5, 1, spi2_tx);
+
+SPI_DMA_CHANNEL(2, 1, 3, spi3_rx);
+SPI_DMA_CHANNEL(2, 2, 3, spi3_tx);
+
+SPI_DMA_CHANNEL(2, 3, 4, spi1_rx);
+SPI_DMA_CHANNEL(2, 4, 4, spi1_tx);

--- a/hw/bus/drivers/spi_stm32/stm32l4xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l4xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32l4xx
+pkg.description: STM32L4 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32l4xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32l4xx/src/spidmacfg.c
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32l4xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, req, name)                       \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req = {  \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_ ## req,                                 \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, req, name)                       \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _request ## req = {  \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_ ## req,                                 \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1, spi1_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1, spi2_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1, spi2_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, 3, spi3_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, 3, spi3_tx);
+
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, 4, spi1_rx);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, 4, spi1_tx);

--- a/hw/bus/drivers/spi_stm32/stm32l4xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32l4xx/syscfg.yml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI3_DMA_PRIORITY:
+        description: 'DMA priority for SPI3 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: 'DMA channel to use for SPI1 RX'
+#        value: DMA2_channel3_request4
+        value: DMA1_channel2_request1
+    SPI1_TX_DMA:
+        description: 'DMA channel to use for SPI1 TX'
+#        value: DMA2_channel4_request4
+        value: DMA1_channel3_request1
+    SPI2_RX_DMA:
+        description: 'DMA channel to use for SPI2 RX'
+        value: DMA1_channel4_request1
+    SPI2_TX_DMA:
+        description: 'DMA channel to use for SPI2 TX'
+        value: DMA1_channel5_request1
+    SPI3_RX_DMA:
+        description: 'DMA channel to use for SPI3 RX'
+        value: DMA2_channel1_request3
+    SPI3_TX_DMA:
+        description: 'DMA channel to use for SPI3 TX'
+        value: DMA2_channel2_request3

--- a/hw/bus/drivers/spi_stm32/stm32wbxx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32wbxx/include/spidmacfg.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32wbxx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_RX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx;
+
+#define SPI_DMA_TX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx;
+
+SPI_DMA_RX_CHANNEL(1, 1, 1);
+SPI_DMA_RX_CHANNEL(1, 2, 1);
+SPI_DMA_RX_CHANNEL(1, 3, 1);
+SPI_DMA_RX_CHANNEL(1, 4, 1);
+SPI_DMA_RX_CHANNEL(1, 5, 1);
+SPI_DMA_RX_CHANNEL(1, 6, 1);
+SPI_DMA_RX_CHANNEL(1, 7, 1);
+SPI_DMA_RX_CHANNEL(2, 1, 1);
+SPI_DMA_RX_CHANNEL(2, 2, 1);
+SPI_DMA_RX_CHANNEL(2, 3, 1);
+SPI_DMA_RX_CHANNEL(2, 4, 1);
+SPI_DMA_RX_CHANNEL(2, 5, 1);
+SPI_DMA_RX_CHANNEL(2, 6, 1);
+SPI_DMA_RX_CHANNEL(2, 7, 1);
+
+SPI_DMA_RX_CHANNEL(1, 1, 2);
+SPI_DMA_RX_CHANNEL(1, 2, 2);
+SPI_DMA_RX_CHANNEL(1, 3, 2);
+SPI_DMA_RX_CHANNEL(1, 4, 2);
+SPI_DMA_RX_CHANNEL(1, 5, 2);
+SPI_DMA_RX_CHANNEL(1, 6, 2);
+SPI_DMA_RX_CHANNEL(1, 7, 2);
+SPI_DMA_RX_CHANNEL(2, 1, 2);
+SPI_DMA_RX_CHANNEL(2, 2, 2);
+SPI_DMA_RX_CHANNEL(2, 3, 2);
+SPI_DMA_RX_CHANNEL(2, 4, 2);
+SPI_DMA_RX_CHANNEL(2, 5, 2);
+SPI_DMA_RX_CHANNEL(2, 6, 2);
+SPI_DMA_RX_CHANNEL(2, 7, 2);
+
+SPI_DMA_TX_CHANNEL(1, 1, 1);
+SPI_DMA_TX_CHANNEL(1, 2, 1);
+SPI_DMA_TX_CHANNEL(1, 3, 1);
+SPI_DMA_TX_CHANNEL(1, 4, 1);
+SPI_DMA_TX_CHANNEL(1, 5, 1);
+SPI_DMA_TX_CHANNEL(1, 6, 1);
+SPI_DMA_TX_CHANNEL(1, 7, 1);
+SPI_DMA_TX_CHANNEL(2, 1, 1);
+SPI_DMA_TX_CHANNEL(2, 2, 1);
+SPI_DMA_TX_CHANNEL(2, 3, 1);
+SPI_DMA_TX_CHANNEL(2, 4, 1);
+SPI_DMA_TX_CHANNEL(2, 5, 1);
+SPI_DMA_TX_CHANNEL(2, 6, 1);
+SPI_DMA_TX_CHANNEL(2, 7, 1);
+
+SPI_DMA_TX_CHANNEL(1, 1, 2);
+SPI_DMA_TX_CHANNEL(1, 2, 2);
+SPI_DMA_TX_CHANNEL(1, 3, 2);
+SPI_DMA_TX_CHANNEL(1, 4, 2);
+SPI_DMA_TX_CHANNEL(1, 5, 2);
+SPI_DMA_TX_CHANNEL(1, 6, 2);
+SPI_DMA_TX_CHANNEL(1, 7, 2);
+SPI_DMA_TX_CHANNEL(2, 1, 2);
+SPI_DMA_TX_CHANNEL(2, 2, 2);
+SPI_DMA_TX_CHANNEL(2, 3, 2);
+SPI_DMA_TX_CHANNEL(2, 4, 2);
+SPI_DMA_TX_CHANNEL(2, 5, 2);
+SPI_DMA_TX_CHANNEL(2, 6, 2);
+SPI_DMA_TX_CHANNEL(2, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32wbxx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32wbxx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32wbxx
+pkg.description: STM32WB specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32wbxx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32wbxx/src/spidmacfg.c
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32wbxx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _RX,                   \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _TX,                   \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 2, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 4, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 5, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 6, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 7, 1);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 2, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 4, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 5, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 6, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 7, 2);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 1, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 3, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 5, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 6, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 7, 1);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 1, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 3, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 5, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 6, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32wbxx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32wbxx/syscfg.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel1_spi1_rx
+    SPI1_TX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel2_spi1_tx
+    SPI2_RX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel3_spi2_rx
+    SPI2_TX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel4_spi2_tx

--- a/hw/bus/drivers/spi_stm32/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/syscfg.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI_STM32_BUS_DRIVER:
+        description: 'Constant value set to 1 when package is included'
+        value: 1
+    SPI_STM32_STAT:
+        description: >
+            Enable statistics for driver errors and applied workarounds.
+        value: 0
+
+    SPI_STM32_MIN_RX_LENGTH_FOR_DMA:
+        description: >
+            Minimum data length to use DMA for transfers.
+            When set to -1, DMA will not be used at all.
+        value: 4
+    SPI_STM32_MIN_TX_LENGTH_FOR_DMA:
+        description: >
+            Minimum data length to use DMA for transfers.
+            When set to -1, DMA will not be used at all.
+        value: 4

--- a/hw/mcu/stm/stm32_common/include/stm32_common/stm32_dma.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/stm32_dma.h
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __STM32_DMA_H_
+#define __STM32_DMA_H_
+
+#include <stm32_common/stm32_hal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Enum for DMA channel.
+ * For F0, F1, F3, L0, L1, L4, WB it represents channel
+ * For F4, F7 it represents stream (because channel has other meaning).
+ */
+typedef enum {
+    DMA1_CH0,
+    DMA1_CH1,
+    DMA1_CH2,
+    DMA1_CH3,
+    DMA1_CH4,
+    DMA1_CH5,
+    DMA1_CH6,
+    DMA1_CH7,
+    DMA2_CH0,
+    DMA2_CH1,
+    DMA2_CH2,
+    DMA2_CH3,
+    DMA2_CH4,
+    DMA2_CH5,
+    DMA2_CH6,
+    DMA2_CH7,
+    DMA_CH_NUM,
+} stm32_dma_ch_t;
+
+/**
+ * Allocate DMA channel for specific ST DMA handle.
+ *
+ * Function assigns DMA handle to DMA channel.
+ * This handle is later used in interrupt handlers.
+ *
+ * @param ch    DMA channel id
+ * @param hdma  DMA handle to assign to channel
+ * @return SYS_EBUSY - when channel is already allocated
+ *         SYS_EOK - on success
+ */
+int stm32_dma_acquire_channel(stm32_dma_ch_t ch, DMA_HandleTypeDef *hdma);
+
+/**
+ * Release DMA channel.
+ *
+ * @param ch    DMA channel that was allocated with stm32_dma_acquire_channel()
+ *
+ * @return  SYS_EOK on success
+ *          SYS_EINVAL if channel was not previously allocated
+ */
+int stm32_dma_release_channel(stm32_dma_ch_t ch);
+
+/*
+ * Functions that can be used as interrupt handlers that redirect
+ * code execution to ST HAL drivers.
+ */
+void stm32_dma1_0_irq_handler(void);
+void stm32_dma1_1_irq_handler(void);
+void stm32_dma1_2_irq_handler(void);
+void stm32_dma1_3_irq_handler(void);
+void stm32_dma1_4_irq_handler(void);
+void stm32_dma1_5_irq_handler(void);
+void stm32_dma1_6_irq_handler(void);
+void stm32_dma1_7_irq_handler(void);
+void stm32_dma2_0_irq_handler(void);
+void stm32_dma2_1_irq_handler(void);
+void stm32_dma2_2_irq_handler(void);
+void stm32_dma2_3_irq_handler(void);
+void stm32_dma2_4_irq_handler(void);
+void stm32_dma2_5_irq_handler(void);
+void stm32_dma2_6_irq_handler(void);
+void stm32_dma2_7_irq_handler(void);
+
+/* F0 and L0 can have common vector for several DMA channels */
+void stm32_dma1_2_3_irq_handler(void);
+void stm32_dma1_4_5_6_7_irq_handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32_DMA_H_ */

--- a/hw/mcu/stm/stm32_common/src/stm32_dma.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_dma.c
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <os/os_trace_api.h>
+#include <stm32_common/stm32_dma.h>
+#include <defs/error.h>
+
+#ifdef DMA2
+DMA_HandleTypeDef *stm32_dma_ch[16];
+#else
+DMA_HandleTypeDef *stm32_dma_ch[8];
+#endif
+
+int
+stm32_dma_acquire_channel(stm32_dma_ch_t ch, DMA_HandleTypeDef *hdma)
+{
+    int rc = SYS_EBUSY;
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+
+    if (ch <= DMA_CH_NUM && stm32_dma_ch[ch] == NULL) {
+        stm32_dma_ch[ch] = hdma;
+        rc = SYS_EOK;
+    }
+
+    OS_EXIT_CRITICAL(sr);
+
+    return rc;
+}
+
+int
+stm32_dma_release_channel(stm32_dma_ch_t ch)
+{
+    int rc = SYS_EINVAL;
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+
+    if (stm32_dma_ch[ch]) {
+        stm32_dma_ch[ch] = NULL;
+        rc = SYS_EOK;
+    }
+    OS_EXIT_CRITICAL(sr);
+
+    return rc;
+}
+
+void
+stm32_dma1_0_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH0]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_1_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH1]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_2_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH2]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_3_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH3]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_4_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH4]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_5_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH5]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_6_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH6]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_7_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH7]);
+
+    os_trace_isr_exit();
+}
+
+#ifdef DMA2
+
+void
+stm32_dma2_0_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH0]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_1_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH1]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_2_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH2]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_3_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH3]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_4_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH4]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_5_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH5]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_6_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH6]);
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma2_7_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH7]);
+
+    os_trace_isr_exit();
+}
+
+#endif
+
+/*
+ * Next two handlers are used by F0 and L0 devices that have shared interrupt for
+ * several channels.
+ */
+void
+stm32_dma1_2_3_irq_handler(void)
+{
+    os_trace_isr_enter();
+
+    if (stm32_dma_ch[DMA1_CH2]) {
+        HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH2]);
+    }
+    if (stm32_dma_ch[DMA1_CH3]) {
+        HAL_DMA_IRQHandler(stm32_dma_ch[DMA1_CH3]);
+    }
+#ifdef DMA2
+    if (stm32_dma_ch[DMA2_CH1]) {
+        HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH1]);
+    }
+    if (stm32_dma_ch[DMA2_CH2]) {
+        HAL_DMA_IRQHandler(stm32_dma_ch[DMA2_CH2]);
+    }
+#endif
+
+    os_trace_isr_exit();
+}
+
+void
+stm32_dma1_4_5_6_7_irq_handler(void)
+{
+    stm32_dma_ch_t i;
+
+    os_trace_isr_enter();
+
+    for (i = DMA1_CH4; i <= DMA1_CH7; ++i) {
+        if (stm32_dma_ch[i]) {
+            HAL_DMA_IRQHandler(stm32_dma_ch[i]);
+        }
+    }
+#ifdef DMA2
+    for (i = DMA2_CH3; i <= DMA2_CH5; ++i) {
+        if (stm32_dma_ch[i]) {
+            HAL_DMA_IRQHandler(stm32_dma_ch[i]);
+        }
+    }
+#endif
+
+    os_trace_isr_exit();
+}
+

--- a/hw/mcu/stm/stm32_common/src/stm32_periph.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_periph.c
@@ -41,6 +41,13 @@
 #include "uart/uart.h"
 #include "uart_hal/uart_hal.h"
 #endif
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_1_MASTER) || MYNEWT_VAL(SPI_2_MASTER) || MYNEWT_VAL(SPI_3_MASTER) || \
+    MYNEWT_VAL(SPI_4_MASTER) || MYNEWT_VAL(SPI_5_MASTER)
+#include "bus/drivers/spi_stm32.h"
+#endif
+#endif
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_stm32/pwm_stm32.h>
 #endif
@@ -148,6 +155,69 @@ extern const struct stm32_hal_i2c_cfg os_bsp_i2c1_cfg;
 extern const struct stm32_hal_i2c_cfg os_bsp_i2c2_cfg;
 #endif
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+static const struct bus_spi_dev_cfg spi0_cfg = {
+    .spi_num = 0,
+    .pin_sck = MYNEWT_VAL(SPI_0_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_0_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_0_PIN_MISO),
+};
+static struct bus_spi_dev spi0_bus;
+#endif
+
+#if MYNEWT_VAL(SPI_1_MASTER)
+static const struct bus_spi_dev_cfg spi1_cfg = {
+    .spi_num = 1,
+    .pin_sck = MYNEWT_VAL(SPI_1_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_1_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_1_PIN_MISO),
+};
+static struct bus_spi_dev spi1_bus;
+#endif
+
+#if MYNEWT_VAL(SPI_2_MASTER)
+static const struct bus_spi_dev_cfg spi2_cfg = {
+    .spi_num = 2,
+    .pin_sck = MYNEWT_VAL(SPI_2_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_2_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_2_PIN_MISO),
+};
+static struct bus_spi_dev spi2_bus;
+#endif
+
+#if MYNEWT_VAL(SPI_3_MASTER)
+static const struct bus_spi_dev_cfg spi3_cfg = {
+    .spi_num = 3,
+    .pin_sck = MYNEWT_VAL(SPI_3_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_3_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_3_PIN_MISO),
+};
+static struct bus_spi_dev spi3_bus;
+#endif
+
+#if MYNEWT_VAL(SPI_4_MASTER)
+static const struct bus_spi_dev_cfg spi4_cfg = {
+    .spi_num = 4,
+    .pin_sck = MYNEWT_VAL(SPI_4_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_4_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_4_PIN_MISO),
+};
+static struct bus_spi_dev spi4_bus;
+#endif
+
+#if MYNEWT_VAL(SPI_5_MASTER)
+static const struct bus_spi_dev_cfg spi5_cfg = {
+    .spi_num = 5,
+    .pin_sck = MYNEWT_VAL(SPI_5_PIN_SCK),
+    .pin_mosi = MYNEWT_VAL(SPI_5_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_5_PIN_MISO),
+};
+static struct bus_spi_dev spi5_bus;
+#endif
+
+#else
 #if (MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE))
 #if MYNEWT_VAL(SPI_0_CUSTOM_CFG)
 extern const struct stm32_hal_spi_cfg os_bsp_spi0_cfg;
@@ -198,6 +268,7 @@ static const struct stm32_hal_spi_cfg os_bsp_spi3_cfg = {
     .ss_pin = MYNEWT_VAL(SPI_3_PIN_SS),
     .irq_prio = 2,
 };
+#endif
 #endif
 #endif
 
@@ -403,6 +474,47 @@ stm32_periph_create_i2c(void)
 #endif
 }
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+static void
+stm32_periph_create_spi(void)
+{
+    int rc;
+
+    (void)rc;
+
+#if MYNEWT_VAL(SPI_0_MASTER)
+    rc = bus_spi_stm32_dev_create("spi0", &spi0_bus,
+                                  (struct bus_spi_dev_cfg *)&spi0_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_1_MASTER)
+    rc = bus_spi_stm32_dev_create("spi1", &spi1_bus,
+                                  (struct bus_spi_dev_cfg *)&spi1_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_2_MASTER)
+    rc = bus_spi_stm32_dev_create("spi2", &spi2_bus,
+                                  (struct bus_spi_dev_cfg *)&spi2_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_3_MASTER)
+    rc = bus_spi_stm32_dev_create("spi3", &spi3_bus,
+                                  (struct bus_spi_dev_cfg *)&spi3_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_4_MASTER)
+    rc = bus_spi_stm32_dev_create("spi4", &spi4_bus,
+                                  (struct bus_spi_dev_cfg *)&spi4_cfg);
+    assert(rc == 0);
+#endif
+#if MYNEWT_VAL(SPI_5_MASTER)
+    rc = bus_spi_stm32_dev_create("spi5", &spi5_bus,
+                                  (struct bus_spi_dev_cfg *)&spi5_cfg);
+    assert(rc == 0);
+#endif
+}
+
+#else
 static void
 stm32_periph_create_spi(void)
 {
@@ -443,6 +555,7 @@ stm32_periph_create_spi(void)
     assert(rc == 0);
 #endif
 }
+#endif
 
 static void
 stm32_periph_create_adc(void)

--- a/hw/mcu/stm/stm32f0xx/pkg.yml
+++ b/hw/mcu/stm/stm32f0xx/pkg.yml
@@ -38,3 +38,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
 
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32f1xx/pkg.yml
+++ b/hw/mcu/stm/stm32f1xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32/stm32f1xx"

--- a/hw/mcu/stm/stm32f3xx/pkg.yml
+++ b/hw/mcu/stm/stm32f3xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER || SPI_3_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32f4xx/pkg.yml
+++ b/hw/mcu/stm/stm32f4xx/pkg.yml
@@ -43,3 +43,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER || SPI_3_MASTER || SPI_4_MASTER || SPI_5_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32f7xx/pkg.yml
+++ b/hw/mcu/stm/stm32f7xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER || SPI_3_MASTER || SPI_4_MASTER || SPI_5_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32l0xx/pkg.yml
+++ b/hw/mcu/stm/stm32l0xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - hw/hal
     - hw/mcu/stm/stm32_common
     - hw/cmsis-core
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32l1xx/pkg.yml
+++ b/hw/mcu/stm/stm32l1xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32l4xx/pkg.yml
+++ b/hw/mcu/stm/stm32l4xx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32wbxx/pkg.yml
+++ b/hw/mcu/stm/stm32wbxx/pkg.yml
@@ -37,3 +37,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
     - "@apache-mynewt-core/hw/cmsis-core"
+
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER) && BUS_DRIVER_PRESENT':
+    - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"


### PR DESCRIPTION
This adds SPI bus driver that utilizes DMA.

Code uses ST HAL drivers for all MCUs.

