### PR TITLE
hw/mcu/da1469x: Fix HAL UART creation

### DIFF
--- a/hw/mcu/dialog/da1469x/pkg.yml
+++ b/hw/mcu/dialog/da1469x/pkg.yml
@@ -39,10 +39,10 @@ pkg.deps.TRNG:
 pkg.deps.CRYPTO:
     - "@apache-mynewt-core/hw/drivers/crypto/crypto_da1469x"
 
-pkg.deps.'(UART_0 || UART_1 || UART_2) && HAL_UART':
+pkg.deps.'(UART_0 || UART_1 || UART_2) && UART_HAL':
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
-pkg.deps.'(UART_0 || UART_1 || UART_2) && !HAL_UART':
+pkg.deps.'(UART_0 || UART_1 || UART_2) && !UART_HAL':
     - "@apache-mynewt-core/hw/drivers/uart/uart_da1469x"
 
 pkg.deps.'(I2C_0 || I2C_1) && BUS_DRIVER_PRESENT':

--- a/hw/mcu/dialog/da1469x/src/da1469x_periph.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_periph.c
@@ -27,7 +27,7 @@
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2)
 #include "uart/uart.h"
-#if MYNEWT_VAL(HAL_UART)
+#if MYNEWT_VAL(UART_HAL)
 #include "uart_hal/uart_hal.h"
 #else
 #include "uart_da1469x/uart_da1469x.h"
@@ -350,19 +350,25 @@ da1469x_periph_create_adc(void)
 #endif
 }
 
+#if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2)
+#if MYNEWT_VAL(UART_HAL)
+static int
+da1469x_uart_create(struct uart_dev *dev, const char *name, uint8_t priority,
+                    const struct da1469x_uart_cfg *cfg)
+{
+    return os_dev_create(&dev->ud_dev, "uart0",
+                         OS_DEV_INIT_PRIMARY, priority, uart_hal_init,
+                         (void *)cfg);
+}
+#else
 static int
 da1469x_uart_create(struct da1469x_uart_dev *dev, const char *name, uint8_t priority,
                     const struct da1469x_uart_cfg *cfg)
 {
-#if MYNEWT_VAL(HAL_UART)
-    return os_dev_create(&dev->ud_dev, "uart0",
-                         OS_DEV_INIT_PRIMARY, priority, uart_hal_init,
-                         (void *)&os_bsp_uart0_cfg);
-#else
-    (void)priority;
     return da1469x_uart_dev_create(dev, name, priority, cfg);
-#endif
 }
+#endif
+#endif
 
 static void
 da1469x_periph_create_uart(void)

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -336,8 +336,8 @@ syscfg.defs:
         description: 'SS pin for SPI_1_SLAVE'
         value: ''
 
-    HAL_UART:
-        description: 'Use hal_uart driver instead of da1469x_uart.'
+    UART_HAL:
+        description: 'Use uart_hal driver instead of uart_da1469x.'
         value: 0
 
     UART_0:


### PR DESCRIPTION
Introduction of dedicated UART driver broke build when user
decided to use HAL driver instead.
When HAL_UART was set in syscfg.yml da1469x_periph.c would not
build due to conditional compilation inconsistency.

This also changes HAL_UART syscfg to UART_HAL which is more
consistent with driver name.