### PR TITLE
[KINETIS] Turn pyocd into a reusable script

### DIFF
--- a/hw/bsp/frdm-k64f/frdm-k64_debug.sh
+++ b/hw/bsp/frdm-k64f/frdm-k64_debug.sh
@@ -28,20 +28,9 @@
 #  - NO_GDB set if we should not start gdb to debug
 #
 
+. $CORE_PATH/hw/scripts/pyocd.sh
+
 FILE_NAME=$BIN_BASENAME.elf
-GDB_CMD_FILE=.gdb_cmds
+TARGET=k64f
 
-echo "Debugging" $FILE_NAME
-
-#
-# Block Ctrl-C from getting passed to openocd.
-# Exit openocd when gdb detaches.
-#
-set -m
-pyocd-gdbserver &
-set +m
-
-echo "target remote localhost:3333" > $GDB_CMD_FILE
-echo "mem 0x20030000 0xffffffff rw nocache" >> $GDB_CMD_FILE
-arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
-rm $GDB_CMD_FILE
+pyocd_debug

--- a/hw/bsp/frdm-k64f/frdm-k64_download.sh
+++ b/hw/bsp/frdm-k64f/frdm-k64_download.sh
@@ -28,14 +28,13 @@
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
 
-. $CORE_PATH/hw/scripts/openocd.sh
-
-common_file_to_load
+. $CORE_PATH/hw/scripts/pyocd.sh
 
 if [ "$MFG_IMAGE" ]; then
     FLASH_OFFSET=0
 fi
 
-echo "Downloading" ${FILE_NAME} "to" ${FLASH_OFFSET}
+TARGET=k64f
 
-pyocd-flashtool -se --address ${FLASH_OFFSET} ${FILE_NAME} bin
+common_file_to_load
+pyocd_load

--- a/hw/scripts/pyocd.sh
+++ b/hw/scripts/pyocd.sh
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+. $CORE_PATH/hw/scripts/common.sh
+
+GDB=arm-none-eabi-gdb
+CONNECTION_MODE_DEFAULT="halt"
+
+#
+# FILE_NAME must contain the name of the file to load
+# FLASH_OFFSET must contain the offset in flash where to place it
+# TARGET must be correectly set by the BSP; check `pyocd list --targets`
+# CONNECTION_MODE can be one of "attach", "halt" (default), "pre-reset", "under-reset"
+#
+pyocd_load () {
+    if [ -z $TARGET ]; then
+        echo "Missing TARGET (get a list with 'pyocd list --targets')"
+        exit 1
+    fi
+
+    if [ -z $CONNECTION_MODE ]; then
+        CONNECTION_MODE=$CONNECTION_MODE_DEFAULT
+    fi
+
+    if [ -z $FILE_NAME ]; then
+        echo "Missing filename"
+        exit 1
+    fi
+    if [ ! -f "$FILE_NAME" ]; then
+        # tries stripping current path for readability
+        FILE=${FILE_NAME##$(pwd)/}
+        echo "Cannot find file" $FILE
+        exit 1
+    fi
+    if [ -z $FLASH_OFFSET ]; then
+        echo "Missing flash offset"
+        exit 1
+    fi
+
+    echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
+
+    pyocd flash -a $FLASH_OFFSET -e sector -M $CONNECTION_MODE -t $TARGET $FILE_NAME --format bin
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+    return 0
+}
+
+#
+# NO_GDB should be set if gdb should not be started
+# FILE_NAME should point to elf-file being debugged
+# TARGET must be correectly set by the BSP; check `pyocd list --targets`
+# CONNECTION_MODE can be one of "attach", "halt" (default), "pre-reset", "under-reset"
+#
+pyocd_debug () {
+    windows_detect
+    PORT=3333
+
+    parse_extra_jtag_cmd $EXTRA_JTAG_CMD
+
+    if [ -z $TARGET ]; then
+        echo "Missing TARGET (get a list with 'pyocd list --targets')"
+        exit 1
+    fi
+
+    if [ -z $CONNECTION_MODE ]; then
+        CONNECTION_MODE=$CONNECTION_MODE_DEFAULT
+    fi
+
+    if [ -z "$NO_GDB" ]; then
+        if [ -z $FILE_NAME ]; then
+            echo "Missing filename"
+            exit 1
+        fi
+        if [ ! -f "$FILE_NAME" ]; then
+            echo "Cannot find file" $FILE_NAME
+            exit 1
+        fi
+
+        if [ $WINDOWS -eq 1 ]; then
+            #
+            # Launch openocd in a separate command interpreter, to make sure
+            # it doesn't get killed by Ctrl-C signal from bash.
+            #
+
+            $COMSPEC /C "start $COMSPEC /C pyocd gdbserver -M $CONNECTION_MODE -t $TARGET -p $PORT"
+        else
+            #
+            # Block Ctrl-C from getting passed to openocd.
+            #
+            set -m
+            pyocd gdbserver -M $CONNECTION_MODE -t $TARGET -p $PORT >pyocd.log 2>&1 &
+            stpid=$!
+            set +m
+        fi
+
+        GDB_CMD_FILE=.gdb_cmds
+
+        echo "target remote localhost:$PORT" > $GDB_CMD_FILE
+        if [ ! -z "$RESET" ]; then
+            echo "mon reset halt" >> $GDB_CMD_FILE
+        fi
+
+        echo "$EXTRA_GDB_CMDS" >> $GDB_CMD_FILE
+
+        if [ $WINDOWS -eq 1 ]; then
+            FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
+            $COMSPEC /C "start $COMSPEC /C $GDB -x $GDB_CMD_FILE $FILE_NAME"
+        else
+            set -m
+            $GDB -x $GDB_CMD_FILE $FILE_NAME
+            set +m
+            rm $GDB_CMD_FILE
+            sleep 1
+            if [ -d /proc/$stpid ] ; then
+                kill -9 $stpid
+            fi
+        fi
+    else
+        # No GDB, wait for pyocd to exit
+        pyocd gdbserver -M $CONNECTION_MODE -t $TARGET -p $PORT
+        return $?
+    fi
+
+    return 0
+}


### PR DESCRIPTION
Move custom pyocd flashing/debugging scripts to a common hw/script that can be used by other KINETIS BSPs and update it to recent pyocd APIs.