### PR TITLE
charge-control: Fix to allow usage of an alternate event queue.

### DIFF
--- a/hw/charge-control/src/charge_control.c
+++ b/hw/charge-control/src/charge_control.c
@@ -181,6 +181,10 @@ static struct os_event charge_control_read_event = {
     .ev_cb = charge_control_read_ev_cb,
 };
 
+#ifdef MYNEWT_VAL_CHARGE_CONTROL_MGR_EVQ
+extern struct os_eventq MYNEWT_VAL(CHARGE_CONTROL_MGR_EVQ);
+#endif
+
 /* =================================================================
  * ====================== PKG ======================================
  * =================================================================
@@ -210,7 +214,7 @@ charge_control_read_ev_cb(struct os_event *ev)
     struct charge_control_read_ev_ctx *ccrec;
 
     ccrec = ev->ev_arg;
-    rc = charge_control_read(ccrec->ccrec_charge_control, ccrec->ccrec_type, 
+    rc = charge_control_read(ccrec->ccrec_charge_control, ccrec->ccrec_type,
             NULL, NULL, OS_TIMEOUT_NEVER);
     assert(rc == 0);
 }
@@ -801,7 +805,7 @@ charge_control_mgr_init(void)
     struct os_timezone ostz;
 
 #ifdef MYNEWT_VAL_CHARGE_CONTROL_MGR_EVQ
-    charge_control_mgr_evq_set(MYNEWT_VAL(CHARGE_CONTROL_MGR_EVQ));
+    charge_control_mgr_evq_set(&MYNEWT_VAL(CHARGE_CONTROL_MGR_EVQ));
 #else
     charge_control_mgr_evq_set(os_eventq_dflt_get());
 #endif


### PR DESCRIPTION
An alternate event queue can specified for `charger-control` by setting `CHARGE_CONTROL_MGR_EVQ`, but this was resulting in an undeclared identifier compiler error. 

This PR fixes the error by declaring the queue specified by `CHARGE_CONTROL_MGR_EVQ` as `extern struct os_eventq`. 

Note: This fix uses the same approach already used by `hw/sensor` to resolve an externally defined queue.