### PR TITLE
MTB in core dump

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/arch/cortex_m33/gcc_startup_da1469x.S
@@ -272,6 +272,13 @@ Reset_Handler:
 /* Default interrupt handler */
     .type   Default_Handler, %function
 Default_Handler:
+#if MYNEWT_VAL(MCU_MTB_ENABLE)
+    /* Disable MTB, otherwise it will quickly fill up buffer with infinite loop branch. */
+    ldr     r1, =MTB_POSITION_REG
+    ldr     r2, [r1, #4]
+    bic     r2, #0x80000000
+    str     r2, [r1, #4]
+#endif
     ldr     r1, =SYS_CTRL_REG
     ldrh    r2, [r1, #0]
     orrs    r2, r2, #0x80   /* DEBUGGER_ENABLE */

--- a/hw/scripts/micro-trace-buffer.py
+++ b/hw/scripts/micro-trace-buffer.py
@@ -37,6 +37,12 @@ class MicroTraceBuffer(gdb.Command):
 
     def __init__(self):
         super(MicroTraceBuffer, self).__init__("mtb", gdb.COMMAND_STATUS, gdb.COMPLETE_NONE)
+        try:
+            mtb_state_at_crash = gdb.lookup_symbol("mtb_state_at_crash")[0]
+            if mtb_state_at_crash is not None and int(gdb.parse_and_eval('mtb_state_at_crash.mtb_base_reg')) != 0:
+                self._mtb_base_addr = int(gdb.parse_and_eval('mtb_state_at_crash').address)
+        except gdb.error:
+            pass
         if colorama:
             self._colors = {"A": colorama.Fore.BLUE,
                             "D": colorama.Fore.RESET,

--- a/hw/scripts/micro-trace-buffer.py
+++ b/hw/scripts/micro-trace-buffer.py
@@ -18,7 +18,7 @@
 try:
     import colorama
 except ImportError:
-    pass
+    colorama = None
 import re
 
 


### PR DESCRIPTION
- MTB registers are stored in RAM when crash happens so MTB can be used check what lead to crash
- MTB is also stopped in __assert_function() not only in default interrupt handler
- disassemble of non existing memory region does not stop script for continuing
- instruction preceding exception are displayed