### PR TITLE
Add more Mbed TLS alt implementations support

### DIFF
--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -57,6 +57,7 @@ extern "C" {
 #define MBEDTLS_ECDSA_SIGN_ALT          /* Enable alternative sign() */
 #define MBEDTLS_ECDSA_VERIFY_ALT        /* Enable alternative verify() */
 #define MBEDTLS_ECDSA_GENKEY_ALT        /* Enable alternative genkey() */
+#define MBEDTLS_BIGNUM_ALT              /* Enable alternative MPI implementation */
 
 /**
  * \name SECTION: Module configuration options
@@ -381,6 +382,10 @@ extern "C" {
 #define MBEDTLS_MPI_MAX_SIZE 1024
 #else
 #define MBEDTLS_MPI_MAX_SIZE MYNEWT_VAL(MBEDTLS_MPI_MAX_SIZE)
+#endif
+
+#if MYNEWT_VAL(MBEDTLS_BIGNUM_ALT) == 0
+#undef MBEDTLS_BIGNUM_ALT
 #endif
 
 #ifdef __cplusplus

--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -46,10 +46,17 @@ extern "C" {
 #undef MBEDTLS_SELF_TEST
 #endif
 
-#define MBEDTLS_SHA256_SMALLER       /* comes with performance hit */
-#define MBEDTLS_ENTROPY_HARDWARE_ALT /* hardware entropy source */
-#define MBEDTLS_NIST_KW_C            /* encrypted images with AES-KW */
-#define MBEDTLS_AES_ALT              /* enable HW based AES */
+#define MBEDTLS_SHA256_SMALLER          /* Comes with performance hit */
+#define MBEDTLS_ENTROPY_HARDWARE_ALT    /* Hardware entropy source */
+#define MBEDTLS_NIST_KW_C               /* Encrypted images with AES-KW */
+#define MBEDTLS_AES_ALT                 /* Enable HW based AES */
+#define MBEDTLS_ECP_ALT                 /* Enable for high-level EC HW accel */
+#define MBEDTLS_ECP_RESTARTABLE         /* Non-blocking EC operations */
+#define MBEDTLS_ECDH_GEN_PUBLIC_ALT     /* Enable ECDH public alternative */
+#define MBEDTLS_ECDH_COMPUTE_SHARED_ALT /* Enable ECDH shared alternative */
+#define MBEDTLS_ECDSA_SIGN_ALT          /* Enable alternative sign() */
+#define MBEDTLS_ECDSA_VERIFY_ALT        /* Enable alternative verify() */
+#define MBEDTLS_ECDSA_GENKEY_ALT        /* Enable alternative genkey() */
 
 /**
  * \name SECTION: Module configuration options
@@ -145,7 +152,31 @@ extern "C" {
 /* \} name SECTION: Module configuration options */
 
 
-/* enable support for configured curves only */
+#if MYNEWT_VAL(MBEDTLS_ECP_ALT) == 0
+#undef MBEDTLS_ECP_ALT
+#endif
+#if MYNEWT_VAL(MBEDTLS_ECP_RESTARTABLE) == 0
+#undef MBEDTLS_ECP_RESTARTABLE
+#endif
+
+#if MYNEWT_VAL(MBEDTLS_ECDH_GEN_PUBLIC_ALT) == 0
+#undef MBEDTLS_ECDH_GEN_PUBLIC_ALT
+#endif
+#if MYNEWT_VAL(MBEDTLS_ECDH_COMPUTE_SHARED_ALT) == 0
+#undef MBEDTLS_ECDH_COMPUTE_SHARED_ALT
+#endif
+
+#if MYNEWT_VAL(MBEDTLS_ECDSA_SIGN_ALT) == 0
+#undef MBEDTLS_ECDSA_SIGN_ALT
+#endif
+#if MYNEWT_VAL(MBEDTLS_ECDSA_VERIFY_ALT) == 0
+#undef MBEDTLS_ECDSA_VERIFY_ALT
+#endif
+#if MYNEWT_VAL(MBEDTLS_ECDSA_GENKEY_ALT) == 0
+#undef MBEDTLS_ECDSA_GENKEY_ALT
+#endif
+
+/* Enable support for configured curves only */
 #if MYNEWT_VAL(MBEDTLS_ECP_DP_SECP192R1) == 0
 #undef MBEDTLS_ECP_DP_SECP192R1_ENABLED
 #endif

--- a/crypto/mbedtls/include/mbedtls/config_mynewt.h
+++ b/crypto/mbedtls/include/mbedtls/config_mynewt.h
@@ -377,6 +377,12 @@ extern "C" {
 #undef MBEDTLS_SSL_DTLS_BADMAC_LIMIT
 #endif
 
+#if MYNEWT_VAL(MBEDTLS_MPI_MAX_SIZE) == 0
+#define MBEDTLS_MPI_MAX_SIZE 1024
+#else
+#define MBEDTLS_MPI_MAX_SIZE MYNEWT_VAL(MBEDTLS_MPI_MAX_SIZE)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/crypto/mbedtls/src/bignum.c
+++ b/crypto/mbedtls/src/bignum.c
@@ -74,6 +74,8 @@
 
 #include <string.h>
 
+#if !defined(MBEDTLS_BIGNUM_ALT)
+
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
@@ -2956,5 +2958,7 @@ cleanup:
 }
 
 #endif /* MBEDTLS_SELF_TEST */
+
+#endif /* !MBEDTLS_BIGNUM_ALT */
 
 #endif /* MBEDTLS_BIGNUM_C */

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -192,3 +192,5 @@ syscfg.defs:
   # MPI
   MBEDTLS_MPI_MAX_SIZE:
     value: 1024
+  MBEDTLS_BIGNUM_ALT:
+    value: 0

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -27,9 +27,9 @@ syscfg.defs:
   MBEDTLS_ECP_DP_SECP192R1:
     value: 0
   MBEDTLS_ECP_DP_SECP224R1:
-    value: 1
-  MBEDTLS_ECP_DP_SECP256R1:
     value: 0
+  MBEDTLS_ECP_DP_SECP256R1:
+    value: 1
   MBEDTLS_ECP_DP_SECP384R1:
     value: 0
   MBEDTLS_ECP_DP_SECP521R1:

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -17,7 +17,13 @@
 #
 
 syscfg.defs:
-  # Enabled curves
+  # Eliptic curves
+  MBEDTLS_ECP_ALT:
+    description: 'Enable alternative EC point implementation'
+    value: 0
+  MBEDTLS_ECP_RESTARTABLE:
+    description: 'Enable EC non-blocking operation'
+    value: 0
   MBEDTLS_ECP_DP_SECP192R1:
     value: 0
   MBEDTLS_ECP_DP_SECP224R1:
@@ -43,6 +49,25 @@ syscfg.defs:
   MBEDTLS_ECP_DP_CURVE25519:
     value: 0
   MBEDTLS_ECJPAKE_C:
+    value: 0
+
+  # ECDH
+  MBEDTLS_ECDH_GEN_PUBLIC_ALT:
+    description: 'ECDH alternative public key generation implementation'
+    value: 0
+  MBEDTLS_ECDH_COMPUTE_SHARED_ALT:
+    description: 'ECDH alternative shared secret generation implementation'
+    value: 0
+
+  # ECDSA
+  MBEDTLS_ECDSA_SIGN_ALT:
+    description: 'ECDSA alternative sign implementation'
+    value: 0
+  MBEDTLS_ECDSA_VERIFY_ALT:
+    description: 'ECDSA alternative verify implementation'
+    value: 0
+  MBEDTLS_ECDSA_GENKEY_ALT:
+    description: 'ECDSA alternative genkey implementation'
     value: 0
 
   # Ciphers

--- a/crypto/mbedtls/syscfg.yml
+++ b/crypto/mbedtls/syscfg.yml
@@ -188,3 +188,7 @@ syscfg.defs:
   # SSL/TLS support
   MBEDTLS_SSL_TLS_C:
     value: 0
+
+  # MPI
+  MBEDTLS_MPI_MAX_SIZE:
+    value: 1024


### PR DESCRIPTION
* crypto: mbedtls: allow EC customizations - Add options to implement EC point operations, ECDH and ECDSA with external libraries. This can be used to accelerate math in custom HW based implementations.

* crypto: mbedtls: allow MPI size customization - This syscfg can be used to lower the amount of RAM used by MPIs, when it is known that less than 1024 bytes are required, eg, EC operations (or small RSA).

* crypto: mbedtls: allow alt bignum implementation - Add options that allows overriding the bignum (aka MPI) implementation so that HW accelerators for math in modular fields can be used as alternative to SW based MPI calculation. PS: This is not a standard Mbed TLS option, so care must be taken when upgrading.

* crypto: mbedtls: default secp256r1 to enabled - secp224r1, which is not a commonly used curve, was enabled by default so
disable it and instead enable secp256r1 (aka EC256), which is used by MCUboot for example.