### PR TITLE
da1469x disable dcdc when vbus is present

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_prail.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_prail.c
@@ -24,6 +24,9 @@
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_prail.h"
 #include "mcu/da1469x_retreg.h"
+#if MYNEWT_VAL_CHOICE(BLE_HCI_TRANSPORT, dialog_cmac)
+#include "cmac_driver/cmac_shared.h"
+#endif
 #include "os/util.h"
 
 #define POWER_CTRL_REG_SET(_field, _val)                                        \
@@ -176,6 +179,10 @@ da1469x_prail_dcdc_restore(void)
     if (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_COMP_VBAT_HIGH_Msk) {
         da1469x_retreg_restore(g_mcu_dcdc_config, ARRAY_SIZE(g_mcu_dcdc_config));
         DCDC->DCDC_CTRL1_REG |= DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
+#if MYNEWT_VAL_CHOICE(BLE_HCI_TRANSPORT, dialog_cmac)
+        /* Enable turning DCDC on from CMAC core. */
+        g_cmac_shared_data->dcdc.enabled = 1;
+#endif
     }
 }
 #endif
@@ -183,6 +190,10 @@ da1469x_prail_dcdc_restore(void)
 void
 da1469x_prail_dcdc_disable(void)
 {
+#if MYNEWT_VAL_CHOICE(BLE_HCI_TRANSPORT, dialog_cmac)
+    /* Prevent CMAC from turning DCDC on. */
+    g_cmac_shared_data->dcdc.enabled = 0;
+#endif
     DCDC->DCDC_CTRL1_REG &= ~DCDC_DCDC_CTRL1_REG_DCDC_ENABLE_Msk;
 }
 


### PR DESCRIPTION
DCDC is more efficient then LDO to provide power rails but in case
when VBUS (charger) is present, it is actually more efficient from
battery point of view to disable DCDC (which is powered by battery)
and use LDO that is powered by VBUS.
This way charging current will go to battery and not to DCDC reducing charge time.
It will also prevent discharging battery when it was fully changed and not removed
from charger.