### PR TITLE
hw/mcu/da1469x: fix passing of uart name in da1469x_uart_create

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_periph.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_periph.c
@@ -356,7 +356,7 @@ static int
 da1469x_uart_create(struct uart_dev *dev, const char *name, uint8_t priority,
                     const struct da1469x_uart_cfg *cfg)
 {
-    return os_dev_create(&dev->ud_dev, "uart0",
+    return os_dev_create(&dev->ud_dev, name,
                          OS_DEV_INIT_PRIMARY, priority, uart_hal_init,
                          (void *)cfg);
 }


### PR DESCRIPTION
Fixes a bug in new `da1469x_uart_create()` with  UART_HAL: 1. The OS device name was always being set as "uart0" instead of using function arg `const char *name`.