### PR TITLE
hw: driver: crypto: Mbed TLS alt improvements

### DIFF
--- a/hw/drivers/crypto/include/crypto/aes_alt.h
+++ b/hw/drivers/crypto/include/crypto/aes_alt.h
@@ -39,9 +39,14 @@ typedef struct mbedtls_aes_context {
 void mbedtls_aes_init(mbedtls_aes_context *ctx);
 void mbedtls_aes_free(mbedtls_aes_context *ctx);
 int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
-        unsigned int keybits);
+                           unsigned int keybits);
+int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
+                           unsigned int keybits);
 int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx, int mode,
-        const unsigned char input[16], unsigned char output[16]);
+                          const unsigned char input[16], unsigned char output[16]);
+int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx, int mode,
+                          size_t length, unsigned char iv[16], const unsigned char *input,
+                          unsigned char *output);
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/crypto/src/mbedtls_aes_alt.c
+++ b/hw/drivers/crypto/src/mbedtls_aes_alt.c
@@ -94,9 +94,44 @@ int
 mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx, int mode,
                       const unsigned char input[16], unsigned char output[16])
 {
-    int ret = crypto_encrypt_aes_ecb(ctx->crypto, ctx->key, ctx->keylen,
+    int ret;
+
+    switch (mode) {
+    case MBEDTLS_AES_ENCRYPT:
+        ret = crypto_encrypt_aes_ecb(ctx->crypto, ctx->key, ctx->keylen,
                                      (const uint8_t *)input, (uint8_t *)output, AES_BLOCK_LEN);
+        break;
+    case MBEDTLS_AES_DECRYPT:
+        ret = crypto_decrypt_aes_ecb(ctx->crypto, ctx->key, ctx->keylen,
+                                     (const uint8_t *)input, (uint8_t *)output, AES_BLOCK_LEN);
+        break;
+    default:
+        return -1;
+    }
+
     return (ret == AES_BLOCK_LEN) ? 0 : -1;
+}
+
+int
+mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx, int mode, size_t length, unsigned char iv[16],
+                      const unsigned char *input, unsigned char *output)
+{
+    int ret;
+
+    switch (mode) {
+    case MBEDTLS_AES_ENCRYPT:
+        ret = crypto_encrypt_aes_cbc(ctx->crypto, ctx->key, ctx->keylen, (uint8_t *)iv,
+                                     (uint8_t *)input, (uint8_t *)output, length);
+        break;
+    case MBEDTLS_AES_DECRYPT:
+        ret = crypto_decrypt_aes_cbc(ctx->crypto, ctx->key, ctx->keylen, (uint8_t *)iv,
+                                     (uint8_t *)input, (uint8_t *)output, length);
+        break;
+    default:
+        return -1;
+    }
+
+    return (ret == length) ? 0 : -1;
 }
 
 #endif /* MYNEWT_VAL(MBEDTLS_AES_ALT) */


### PR DESCRIPTION
* Export `mbedtls_aes_setkey_dec`
* Correctly handle encryption/decryption in ECB mode
* Add CBC alt implementation