### PR TITLE
Fix STM32 HASH stream support

### DIFF
--- a/hw/drivers/hash/hash_stm32/include/hash_context.h
+++ b/hw/drivers/hash/hash_stm32/include/hash_context.h
@@ -23,15 +23,32 @@
 #include "hash/hash.h"
 
 /*
- * On STM32 the SDK already handles context...
+ * XXX: the STM32 SDK handles context, so here we just have to need to
+ *      properly implement the expected interface. Whenever updating these
+ *      structs always maintain them in sync because only hash_sha2_context
+ *      is used internally.
+ * NOTE: In the STM32 only the finish operation is able to write less than
+ *      a word (32-bit) so a bit of internal state must be maintained.
  */
+
+#define STATESZ sizeof(uint32_t)
 
 struct hash_sha224_context {
     void *dev;
+    uint8_t remain;
+    uint8_t state[STATESZ];
 };
 
 struct hash_sha256_context {
     void *dev;
+    uint8_t remain;
+    uint8_t state[STATESZ];
+};
+
+struct hash_sha2_context {
+    void *dev;
+    uint8_t remain;
+    uint8_t state[STATESZ];
 };
 
 #endif /* __HASH_CONTEXT_H__ */


### PR DESCRIPTION
apps: hash_test: add single byte multi-write test - Expand string stream test to also run on SHA-224 (when available). Add new single byte multi-write test, where a single "a" is written 257 (because odd numbers are good!) times, running on both SHA-224 and SHA-256 (where available).

hw: drivers: hash_stm32: fix stream support - The STM32 HASH HW is configured to work on a word (32-bit) write, and the only write that can be less than 4-bytes is the last write (_finish()). To be compatible with streams that are non word-boundary sized, a new pad (aka state) was added that caches writes that are less than 4 byte, so only words are ever written in an _update(), and _finish() flushes the remaining bytes that were less than 4-bytes.