### PR TITLE
sys/console: Add syscfg to allow restoring echo state after NLIP commands

### DIFF
--- a/sys/console/full/syscfg.yml
+++ b/sys/console/full/syscfg.yml
@@ -41,6 +41,9 @@ syscfg.defs:
     CONSOLE_ECHO:
         description: 'Default console echo'
         value: 1
+    CONSOLE_NLIP_RESTORE_ECHO:
+        description: 'Restore echo setting after NLIP commands'
+        value: 0
     CONSOLE_COMPAT:
         description: 'Console backward compatibility'
         value: 1

--- a/sys/console/minimal/syscfg.yml
+++ b/sys/console/minimal/syscfg.yml
@@ -29,6 +29,9 @@ syscfg.defs:
     CONSOLE_ECHO:
         description: 'Default console echo'
         value: 1
+    CONSOLE_NLIP_RESTORE_ECHO:
+        description: 'Restore echo setting after NLIP commands'
+        value: 0
     CONSOLE_COMPAT:
         description: 'Console backward compatibility'
         value: 1


### PR DESCRIPTION
Currently when an NLIP command is finished processing, console echo is always turned back on.

This PR adds an optional syscfg, `CONSOLE_NLIP_RESTORE_ECHO`.

`CONSOLE_NLIP_RESTORE_ECHO: 0` (default setting) retains the existing console behavior, in which completion of an NLIP command will turn on console echo.

`CONSOLE_NLIP_RESTORE_ECHO: 1` will cause the echo on/off state to be restored to the state it was in before an NLIP command was processed.