### PR TITLE
hw/bus: Fix inactivity timeout usage

### DIFF
--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -512,7 +512,7 @@ bus_node_unlock(struct os_dev *node)
     /* In auto PM we should disable bus device on last unlock */
     if ((bdev->pm_mode == BUS_PM_MODE_AUTO) &&
         (os_mutex_get_level(&bdev->lock) == 1)) {
-        if (bdev->pm_opts.pm_mode_auto.disable_tmo) {
+        if (bdev->pm_opts.pm_mode_auto.disable_tmo == 0) {
             bus_dev_disable(bdev);
         } else {
             os_callout_reset(&bdev->inactivity_tmo,


### PR DESCRIPTION
Inactivity timeout used for power management was not really using
time value.
- if timeout was greater then 0 it was ignored and device was disabled
  at once instead of later.
- if timeout was 0 device should be disabled at once but it was scheduled
  to be run 1 tick later according to os_callout_reset way

Now checking timeout condition is reversed that seems to be intended
behavior.