### PR TITLE
hw: handle hal_spi_enable/disable errors

### DIFF
--- a/hw/drivers/flash/at45db/src/at45db.c
+++ b/hw/drivers/flash/at45db/src/at45db.c
@@ -446,7 +446,6 @@ at45db_init(const struct hal_flash *hal_flash_dev)
     }
 
     hal_spi_set_txrx_cb(dev->spi_num, NULL, NULL);
-    hal_spi_enable(dev->spi_num);
-
-    return 0;
+    rc = hal_spi_enable(dev->spi_num);
+    return (rc);
 }

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -1445,7 +1445,10 @@ hal_spiflash_init(const struct hal_flash *hal_flash_dev)
     }
 
     hal_spi_set_txrx_cb(dev->spi_num, NULL, NULL);
-    hal_spi_enable(dev->spi_num);
+    rc = hal_spi_enable(dev->spi_num);
+    if (rc) {
+        return (rc);
+    }
 #endif
     rc = spiflash_identify(dev);
 

--- a/hw/drivers/led/tlc5971/src/tlc5971.c
+++ b/hw/drivers/led/tlc5971/src/tlc5971.c
@@ -49,12 +49,18 @@ tlc5971_open(struct os_dev *odev, uint32_t wait, void *arg)
     spi_cfg.word_size = HAL_SPI_WORD_SIZE_8BIT;
 
     spi_num = dev->tlc_itf.tpi_spi_num;
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        return rc;
+    }
     rc = hal_spi_config(spi_num, &spi_cfg);
     if (rc) {
         return rc;
     }
-    hal_spi_enable(spi_num);
+    rc = hal_spi_enable(spi_num);
+    if (rc) {
+        return (rc);
+    }
 
     dev->is_enabled = true;
     return 0;

--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -208,7 +208,10 @@ mmc_init(int spi_num, void *spi_cfg, int ss_pin)
     }
 
     hal_spi_set_txrx_cb(mmc->spi_num, NULL, NULL);
-    hal_spi_enable(mmc->spi_num);
+    rc = hal_spi_enable(mmc->spi_num);
+    if (rc) {
+        return (rc);
+    }
 
     /**
      * NOTE: The state machine below follows:

--- a/hw/mcu/dialog/da1469x/src/hal_spi.c
+++ b/hw/mcu/dialog/da1469x/src/hal_spi.c
@@ -257,7 +257,10 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
 
     spi->spi_type  = spi_type;
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        return rc;
+    }
 
     if (spi_type == HAL_SPI_TYPE_MASTER && SPI_MASTER_CODE) {
         rc = hal_spi_init_master(spi, (struct da1469x_hal_spi_cfg *)cfg);

--- a/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
@@ -976,8 +976,14 @@ hal_spi_abort(int spi_num)
         }
     } else {
         /* Only way I can see doing this is to disable, then re-enable */
-        hal_spi_disable(spi_num);
-        hal_spi_enable(spi_num);
+        rc = hal_spi_disable(spi_num);
+        if (rc) {
+            goto err;
+        }
+        rc = hal_spi_enable(spi_num);
+        if (rc) {
+            goto err;
+        }
     }
 
 err:

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -744,7 +744,10 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         goto err;
     }
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        goto err;
+    }
 
     if (spi_type == HAL_SPI_TYPE_MASTER) {
         rc = hal_spi_init_master(spi, (struct nrf52_hal_spi_cfg *)cfg,
@@ -1036,7 +1039,10 @@ hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int len)
         spim = hal_spi->nhs_spi.spim;
         enabled = spim->ENABLE;
         if (enabled == SPIM_ENABLE_ENABLE_Enabled) {
-            hal_spi_disable(spi_num);
+            rc = hal_spi_disable(spi_num);
+            if (rc) {
+                goto err;
+            }
             enabled = 0;
         }
 
@@ -1276,8 +1282,14 @@ hal_spi_abort(int spi_num)
         }
     } else {
         /* Only way I can see doing this is to disable, then re-enable */
-        hal_spi_disable(spi_num);
-        hal_spi_enable(spi_num);
+        rc = hal_spi_disable(spi_num);
+        if (rc) {
+            goto err;
+        }
+        rc = hal_spi_enable(spi_num);
+        if (rc) {
+            goto err;
+        }
     }
 
 err:

--- a/hw/mcu/nordic/nrf5340/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_spi.c
@@ -718,7 +718,10 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         goto err;
     }
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        goto err;
+    }
 
     if (spi_type == HAL_SPI_TYPE_MASTER) {
         rc = hal_spi_init_master(spi, (struct nrf5340_hal_spi_cfg *)cfg,
@@ -1092,8 +1095,14 @@ hal_spi_abort(int spi_num)
         }
     } else {
         /* Only way I can see doing this is to disable, then re-enable */
-        hal_spi_disable(spi_num);
-        hal_spi_enable(spi_num);
+        rc = hal_spi_disable(spi_num);
+        if (rc) {
+            goto err;
+        }
+        rc = hal_spi_enable(spi_num);
+        if (rc) {
+            goto err;
+        }
     }
 
 err:

--- a/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
@@ -466,7 +466,14 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         return EINVAL;
     }
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        return rc;
+    }
+    rc = hal_spi_enable(spi_num);
+    if (rc) {
+        return rc;
+    }
 
     return hal_spi_init_master(spi, (struct nrf5340_net_hal_spi_cfg *)cfg);
 #endif
@@ -476,7 +483,10 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         return EINVAL;
     }
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        return rc;
+    }
 
     return hal_spi_init_slave(spi, (struct nrf5340_net_hal_spi_cfg *)cfg);
 #endif
@@ -815,8 +825,14 @@ hal_spi_abort(int spi_num)
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
     /* Only way I can see doing this is to disable, then re-enable */
-    hal_spi_disable(spi_num);
-    hal_spi_enable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        return rc;
+    }
+    rc = hal_spi_enable(spi_num);
+    if (rc) {
+        return rc;
+    }
 #endif
 
     return 0;

--- a/hw/mcu/nordic/nrf91xx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf91xx/src/hal_spi.c
@@ -672,7 +672,10 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         goto err;
     }
 
-    hal_spi_disable(spi_num);
+    rc = hal_spi_disable(spi_num);
+    if (rc) {
+        goto err;
+    }
 
     if (spi_type == HAL_SPI_TYPE_MASTER) {
         rc = hal_spi_init_master(spi, (struct nrf91_hal_spi_cfg *)cfg,
@@ -1050,8 +1053,14 @@ hal_spi_abort(int spi_num)
         }
     } else {
         /* Only way I can see doing this is to disable, then re-enable */
-        hal_spi_disable(spi_num);
-        hal_spi_enable(spi_num);
+        rc = hal_spi_disable(spi_num);
+        if (rc) {
+            goto err;
+        }
+        rc = hal_spi_enable(spi_num);
+        if (rc) {
+            goto err;
+        }
     }
 
 err:


### PR DESCRIPTION
hal_spi_enable/disable errors were handled, but not everywhere. This
unifies handling manner.