### PR TITLE
bsp/nordic_pca10095_net: Set empty IPC region for bootloader build

### DIFF
--- a/hw/bsp/nordic_pca10095_net/boot-nrf5340_net.ld
+++ b/hw/bsp/nordic_pca10095_net/boot-nrf5340_net.ld
@@ -20,6 +20,7 @@ MEMORY
 {
   FLASH (rx) : ORIGIN = 0x01000000, LENGTH = 0x4000
   RAM (rwx) : ORIGIN = 0x21000000, LENGTH = 0x10000
+  IPC (rw)  : ORIGIN = 0x20000400, LENGTH = 0
 }
 
 /* The bootloader does not contain an image header */


### PR DESCRIPTION
IPC is not used in bootloader but linker were complaining about IPC
region being not present.