### PR TITLE
mmc: Decrease mmc/sd initialization time

### DIFF
--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -221,8 +221,8 @@ mmc_init(int spi_num, void *spi_cfg, int ss_pin)
 
     hal_gpio_write(mmc->ss_pin, 0);
 
-    /* send the required >= 74 clock cycles */
-    for (i = 0; i < 74; i++) {
+    /* send the required >= 74 clock cycles (10 bytes, 80 clock cycles). */
+    for (i = 0; i < 10; i++) {
         hal_spi_tx_val(mmc->spi_num, 0xff);
     }
 


### PR DESCRIPTION
SD specification section "6.4.1 Power Up"
requires 74 clocks with high CS.
Code was sending 592 clocks (it was sending 74 bytes).

Now code sends 10 bytes (80 cycles).