### PR TITLE
Bus driver power management improvments 

### DIFF
--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -256,7 +256,9 @@ bus_dev_init_func(struct os_dev *odev, void *arg)
     odev->od_handlers.od_suspend = bus_dev_suspend_func;
     odev->od_handlers.od_resume = bus_dev_resume_func;
 
-    bus_dev_enable(bdev);
+    if (!MYNEWT_VAL(BUS_PM) || MYNEWT_VAL_CHOICE(BUS_PM_MODE, MANUAL)) {
+        bus_dev_enable(bdev);
+    }
 
     return 0;
 }

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -238,6 +238,10 @@ bus_dev_init_func(struct os_dev *odev, void *arg)
     /* XXX allow custom eventq */
     os_callout_init(&bdev->inactivity_tmo, os_eventq_dflt_get(),
                     bus_dev_inactivity_tmo_func, odev);
+    bdev->pm_mode = MYNEWT_VAL_CHOICE(BUS_PM_MODE, AUTO) ? BUS_PM_MODE_AUTO : BUS_PM_MODE_MANUAL;
+    if (MYNEWT_VAL_CHOICE(BUS_PM_MODE, AUTO)) {
+        bdev->pm_opts.pm_mode_auto.disable_tmo = MYNEWT_VAL(BUS_PM_INACTIVITY_TMO);
+    }
 #endif
 
 #if MYNEWT_VAL(BUS_STATS)

--- a/hw/bus/syscfg.yml
+++ b/hw/bus/syscfg.yml
@@ -37,6 +37,22 @@ syscfg.defs:
             allows for some automatic management of bus device state instead of
             implementing this manually.
         value: 0
+    BUS_PM_MODE:
+        description: >
+            Default power management mode for bus drivers.  When set to AUTO
+            bus drivers will take care of turning off controllers when they
+            are not needed for some time.
+            When set to MANUAL bus driver will not enable/disable controllers
+            leaving it to the application code.
+            This setting is only valid when BUS_PM == 1.
+        choices:
+            - AUTO
+            - MANUAL
+        value: AUTO
+    BUS_PM_INACTIVITY_TMO:
+        description: >
+            Default inactivity time after which bus controller will be disabled (in ticks).
+        value: 1
 
     BUS_STATS:
         description: >


### PR DESCRIPTION
Automatic mode for bus required calling function **bus_dev_set_pm()**.
Now it's possible to enable automatic mode using syscfg values.

When automatic mode is chosen, bus is not enabled till it is used.
Before even if **bus_dev_set_pm()** was called to set automatic mode,
bus that was enabled during initialization stayed enabled and would
be automatically disabled after first use.