### PR TITLE
da1469x: Add peripheral DMA read and write

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_dma.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_dma.h
@@ -133,6 +133,34 @@ int da1469x_dma_configure(struct da1469x_dma_regs *chan,
                            const struct da1469x_dma_config *cfg,
                            da1469x_dma_interrupt_cb isr_cb, void *isr_arg);
 
+/**
+ * Start writing to peripheral with DMA
+ * Destination register with peripheral address should be setup before calling
+ * this function.
+ * It setup source address, the length of the transfer and starts DMA.
+ *
+ * @param chan - DMA registers from da1469x_dma_acquire_periph
+ * @param mem  - memory data pointer
+ * @param size - number of transfers
+ *
+ * @return 0 on success, negative value on failure
+ */
+int da1469x_dma_write_peripheral(struct da1469x_dma_regs *chan, const void *mem, uint16_t size);
+
+/**
+ * Start reading from peripheral with DMA
+ * Source register with peripheral address should be setup before calling
+ * this function.
+ * It setups destination address, the length of the transfer and starts DMA.
+ *
+ * @param chan - DMA registers from da1469x_dma_acquire_periph
+ * @param mem  - memory data pointer
+ * @param size - number of transfers
+ *
+ * @return 0 on success, negative value on failure
+ */
+int da1469x_dma_read_peripheral(struct da1469x_dma_regs *chan, void *mem, uint16_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/da1469x_dma.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_dma.c
@@ -287,3 +287,31 @@ da1469x_dma_configure(struct da1469x_dma_regs *chan,
 
     return 0;
 }
+
+int
+da1469x_dma_write_peripheral(struct da1469x_dma_regs *chan, const void *mem, uint16_t size)
+{
+    if (chan == NULL || mem == NULL || size == 0 || chan->DMA_B_START_REG == 0) {
+        return SYS_EINVAL;
+    }
+    chan->DMA_A_START_REG = (uint32_t)mem;
+    chan->DMA_INT_REG = size - 1;
+    chan->DMA_LEN_REG = size - 1;
+    chan->DMA_CTRL_REG |= DMA_DMA0_CTRL_REG_DMA_ON_Msk;
+
+    return SYS_EOK;
+}
+
+int
+da1469x_dma_read_peripheral(struct da1469x_dma_regs *chan, void *mem, uint16_t size)
+{
+    if (chan == NULL || mem == NULL || size == 0 || chan->DMA_A_START_REG == 0) {
+        return SYS_EINVAL;
+    }
+    chan->DMA_B_START_REG = (uint32_t)mem;
+    chan->DMA_INT_REG = size - 1;
+    chan->DMA_LEN_REG = size - 1;
+    chan->DMA_CTRL_REG |= DMA_DMA0_CTRL_REG_DMA_ON_Msk;
+
+    return SYS_EOK;
+}


### PR DESCRIPTION
For peripherals that are used with DMA it's quite common
to change memory address used, leave peripheral address
intact since same register is usually used for subsequent
transmissions, then set transmission size and start DMA.

This adds two convenience function for starting read and write
to peripherals when common configuration part is already done.