### PR TITLE
sys log shell improvements

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -675,6 +675,15 @@ uint8_t log_get_level(const struct log *log);
  */
 void log_set_max_entry_len(struct log *log, uint16_t max_entry_len);
 
+/**
+ * Return last entry index in log.
+ *
+ * @param log Log to check last entry index from.
+ *
+ * @return last entry index
+ */
+uint32_t log_get_last_index(struct log *log);
+
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 /**
  * Return information about log storage

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -40,6 +40,7 @@ pkg.deps.LOG_CLI:
     - "@apache-mynewt-core/sys/shell"
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/encoding/tinycbor"
+    - "@apache-mynewt-core/util/parse"
 
 pkg.deps.LOG_CONSOLE:
     - "@apache-mynewt-mcumgr/cborattr"

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -1122,3 +1122,13 @@ log_fill_current_img_hash(struct log_entry_hdr *hdr)
 
     return SYS_ENOTSUP;
 }
+
+uint32_t
+log_get_last_index(struct log *log)
+{
+#if MYNEWT_VAL(LOG_GLOBAL_IDX)
+    return g_log_info.li_next_index;
+#else
+    return log->l_idx;
+#endif
+}


### PR DESCRIPTION
- Added function to get last log index
- Dumping log from shell with partial log name match
```shell
log my*
```
- Limit number of logs shown using index
```shell
log 1000 mylog
```
- List streaming logs
```shell
log -l
218506 console (stream)
218506 mylog
```

