### PR TITLE
Remove unistd.h from files that don't need it

### DIFF
--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "os/mynewt.h"
 #include "console/console.h"

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "os/mynewt.h"
 #include "console/console.h"

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "os/mynewt.h"
 #include "console/console.h"

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "os/mynewt.h"
 #include "console/console.h"

--- a/kernel/os/src/arch/cortex_m7/os_fault.c
+++ b/kernel/os/src/arch/cortex_m7/os_fault.c
@@ -27,7 +27,6 @@
 #endif
 
 #include <stdint.h>
-#include <unistd.h>
 
 struct exception_frame {
     uint32_t r0;

--- a/kernel/os/src/arch/rv32imac/os_fault.c
+++ b/kernel/os/src/arch/rv32imac/os_fault.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "os/mynewt.h"
 #include "os_priv.h"

--- a/libc/baselibc/src/sprintf.c
+++ b/libc/baselibc/src/sprintf.c
@@ -3,7 +3,6 @@
  */
 
 #include <stdio.h>
-#include <unistd.h>
 #include <stdint.h>
 
 int sprintf(char *buffer, const char *format, ...)

--- a/libc/baselibc/src/vsprintf.c
+++ b/libc/baselibc/src/vsprintf.c
@@ -3,7 +3,6 @@
  */
 
 #include <stdio.h>
-#include <unistd.h>
 #include <stdint.h>
 
 int vsprintf(char *buffer, const char *format, va_list ap)


### PR DESCRIPTION
unistd.h is included in several files that seems not to need
it for anything.