### PR TITLE
hw: kinetis: Only allow aligned block erases

### DIFF
--- a/hw/mcu/nxp/kinetis/src/hal_qspi.c
+++ b/hw/mcu/nxp/kinetis/src/hal_qspi.c
@@ -320,10 +320,10 @@ nxp_qspi_erase(const struct hal_flash *dev,
         QSPI_ClearFifo(QuadSPI0, kQSPI_TxFifo);
         QSPI_SetIPCommandAddress(QuadSPI0, FSL_FEATURE_QSPI_AMBA_BASE + address);
         cmd_write_enable();
-        if (size >= SZ64K) {
+        if (size >= SZ64K && (address % SZ64K) == 0) {
             QSPI_ExecuteIPCommand(QuadSPI0, LUT_CMD_ERASE_BLOCK64K);
             erased_size = SZ64K;
-        } else if (size >= SZ32K) {
+        } else if (size >= SZ32K && (address % SZ32K) == 0) {
             QSPI_ExecuteIPCommand(QuadSPI0, LUT_CMD_ERASE_BLOCK32K);
             erased_size = SZ32K;
         } else {


### PR DESCRIPTION
This fixes an issue where an erase command with sizes larger or equal than a block erase (32K or 64K) could delete the whole block even when it was not aligned. A block erase command is accepted for any address inside the block, but if a flash area is not aligned to this block size, it will result in erasing data which are not part of the expected requested range. With this change the alignment must be valid when doing block erases.