### PR TITLE
hw: hal: flash: Add proper check for erase

### DIFF
--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -269,7 +269,9 @@ hal_flash_erase(uint8_t id, uint32_t address, uint32_t num_bytes)
     }
 
     if (hf->hf_itf->hff_erase) {
-        hf->hf_itf->hff_erase(hf, address, num_bytes);
+        if (hf->hf_itf->hff_erase(hf, address, num_bytes)) {
+            return SYS_EIO;
+        }
 #if MYNEWT_VAL(HAL_FLASH_VERIFY_ERASES)
         assert(hal_flash_isempty_no_buf(id, address, num_bytes) == 1);
 #endif


### PR DESCRIPTION
When a flash erase failed the error was ignored. This doesn't usually happen in the internal flash but can happen on external flash due to bus related issues, etc. Add a proper check and return an error that can be used for verification.