### PR TITLE
hw/bsp/dialog: Bump default msys block size for CMAC

### DIFF
--- a/hw/bsp/dialog_cmac/syscfg.yml
+++ b/hw/bsp/dialog_cmac/syscfg.yml
@@ -18,6 +18,7 @@
 #
 
 syscfg.vals:
+    MSYS_1_BLOCK_SIZE: 308
     OS_CPUTIME_FREQ: 32768
     BLE_HCI_TRANSPORT: dialog_cmac
 


### PR DESCRIPTION
If msys block size is less than 308, all PDUs with max length will be
fragmented into chain. This is not only inefficient in terms of block
usage but also costs some time when allocating and copying RX PDUs
and as a result we may be late on some transitions. This is especially
troublesome when scanning chains spaced at min offset (T_mafs) since
we are quite often too late to schedule next aux scan and thus it's
unlikely we can scan complete chain.