### PR TITLE
bsp/black_vet6: Fix ETH configuration

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -261,14 +261,15 @@ const struct stm32_eth_cfg os_bsp_eth0_cfg = {
     .sec_port_mask[2] = (1 << 1) | (1 << 4) | (1 << 5),
 
     /*
-     * PORTG
-     *   PG11 - ETH_RMII_TXEN
-     *   PG13 - ETH_RMII_TXD0
-     *   PG14 - ETH_RMII_TXD1
+     * PORTB
+     *   PB11 - ETH_RMII_TXEN
+     *   PB12 - ETH_RMII_TXD0
+     *   PB13 - ETH_RMII_TXD1
      */
-    .sec_port_mask[6] = (1 << 11) | (1 << 13) | (1 << 14),
-    .sec_phy_type = SMSC_8710_RMII,
-    .sec_phy_irq = MCU_GPIO_PORTA(3)
+    .sec_port_mask[1] = (1 << 11) | (1 << 12) | (1 << 13),
+    .sec_phy_type = MYNEWT_VAL(STM32_ETH_PHY_TYPE),
+    .sec_phy_irq = MYNEWT_VAL(STM32_ETH_PHY_IRQ),
+    .sec_phy_addr = MYNEWT_VAL(STM32_ETH_PHY_ADDR),
 };
 #endif
 static const struct hal_bsp_mem_dump dump_cfg[] = {

--- a/hw/bsp/black_vet6/syscfg.yml
+++ b/hw/bsp/black_vet6/syscfg.yml
@@ -25,6 +25,19 @@ syscfg.defs:
         description: 'Number of flash sectors for a non-linear STM32 MCU.'
         value: 8
 
+    STM32_ETH_PHY_TYPE:
+        description: >
+            PHY type that can be found in enum in file stm32_eth_cfg.h.
+        value: SMSC_8710_RMII
+    STM32_ETH_PHY_ADDR:
+        description: >
+            PHY address.
+        value: 0
+    STM32_ETH_PHY_IRQ:
+        description: >
+            RMII interrupt pin.
+        value: -1
+
 syscfg.vals:
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS


### PR DESCRIPTION
Some of the ETH pins were set up to port G.
There are not Port G pins on MCU on this board.
But there are pins from port B that can be used.

IRQ was hard coded to PA3 while ETH code allows
for this pin to be undefined, so now default
value is -1.

PHY address were hardcoded now they can be changed
in syscfg.