### PR TITLE
hw/mcu/da14699: Use defines for USB pins

### DIFF
--- a/hw/mcu/dialog/da14699/include/mcu/mcu.h
+++ b/hw/mcu/dialog/da14699/include/mcu/mcu.h
@@ -119,6 +119,9 @@ typedef enum {
 #define MCU_GPIO_PORT1(pin)		((1 * 32) + (pin))
 #define MCU_DMA_CHAN_MAX                    8
 
+#define MCU_PIN_USB_DP                      MCU_GPIO_PORT0(14)
+#define MCU_PIN_USB_DM                      MCU_GPIO_PORT0(15)
+
 #define MCU_PIN_GPADC_SEL0               MCU_GPIO_PORT1(9)
 #define MCU_PIN_GPADC_SEL1               MCU_GPIO_PORT0(25)
 #define MCU_PIN_GPADC_SEL2               MCU_GPIO_PORT0(8)

--- a/hw/usb/tinyusb/da146xx/src/da1469x.c
+++ b/hw/usb/tinyusb/da146xx/src/da1469x.c
@@ -41,6 +41,6 @@ tinyusb_hardware_init(void)
     /* Use PLL96 / 2 clock not HCLK */
     CRG_TOP->CLK_CTRL_REG &= ~CRG_TOP_CLK_CTRL_REG_USB_CLK_SRC_Msk;
 
-    mcu_gpio_set_pin_function(14, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
-    mcu_gpio_set_pin_function(15, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+    mcu_gpio_set_pin_function(MCU_PIN_USB_DP, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+    mcu_gpio_set_pin_function(MCU_PIN_USB_DM, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
 }


### PR DESCRIPTION
USB pins were hardcoded.