### PR TITLE
drivers/da1469x_charger: Enable custom value for NTC

### DIFF
--- a/hw/drivers/chg_ctrl/da1469x_charger/syscfg.yml
+++ b/hw/drivers/chg_ctrl/da1469x_charger/syscfg.yml
@@ -74,3 +74,7 @@ syscfg.defs:
         description: >
             End of charge current settings, 4-35 (%).
         value: 7
+    DA1469X_CHARGER_NTC_VALUE:
+        description: >
+            NTC value in ohms.
+        value: 15000


### PR DESCRIPTION
Battery temperature values from CHARGER_TEMPSET_PARAM_REG
could be incorrectly decoded in shell command `charger dump decode`
when NTC value was different then datasheet recommended 15k ohm.

Now real pull-up resistor value is taken into account when values
are displayed.
Value of the resistor can be set in syscfg file.