### PR TITLE
mcu/nrf5340: Fix flash sector info

### DIFF
--- a/hw/mcu/nordic/nrf5340_net/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_flash.c
@@ -131,7 +131,7 @@ nrf5340_net_flash_sector_info(const struct hal_flash *dev, int idx,
                               uint32_t *address, uint32_t *sz)
 {
     assert(idx < nrf5340_net_flash_dev.hf_sector_cnt);
-    *address = idx * NRF5340_NET_FLASH_SECTOR_SZ;
+    *address = dev->hf_base_addr + idx * NRF5340_NET_FLASH_SECTOR_SZ;
     *sz = NRF5340_NET_FLASH_SECTOR_SZ;
     return 0;
 }


### PR DESCRIPTION
Function nrf5340_net_flash_sector_info was returning wrong
address for all sectors. It was not using hf_base_addr for
calculation and network core flash does not starts from 0
but from 0x1000000. It prevents mcuboot from correctly
identify slot size.

This just takes into account base address of netcore flash.