### PR TITLE
mcu/nrf5340: Add MCU_APP_CORE/MCU_NET_CORE syscfg values

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -154,7 +154,7 @@ ipc_nrf5340_init(void)
 {
     int i;
 
-#if MYNEWT_VAL(BSP_NRF5340)
+#if MYNEWT_VAL(MCU_APP_CORE)
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
     unsigned int gpios[] = { MYNEWT_VAL(IPC_NRF5340_NET_GPIO) };
     NRF_GPIO_Type *nrf_gpio;
@@ -182,7 +182,7 @@ ipc_nrf5340_init(void)
     NVIC_SetVector(IPC_IRQn, (uint32_t)ipc_nrf5340_isr);
     NVIC_EnableIRQ(IPC_IRQn);
 
-#if MYNEWT_VAL(BSP_NRF5340)
+#if MYNEWT_VAL(MCU_APP_CORE)
     /* this allows netcore to access appcore RAM */
     NRF_SPU_S->EXTDOMAIN[0].PERM = SPU_EXTDOMAIN_PERM_SECATTR_Secure << SPU_EXTDOMAIN_PERM_SECATTR_Pos;
 

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -17,6 +17,13 @@
 #
 
 syscfg.defs:
+    MCU_APP_CORE:
+        description: >
+            Constant value always set to 1.  It allows to have common
+            packages for network and application core that do have
+            some differences depending on which core they are build for.
+        value: 1
+        restriction: MCU_NET_CORE==0
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.

--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -17,6 +17,13 @@
 #
 
 syscfg.defs:
+    MCU_NET_CORE:
+        description: >
+            Constant value always set to 1.  It allows to have common
+            packages for network and application core that do have
+            some differences depending on which core they are build for.
+        value: 1
+        restriction: MCU_APP_CORE==0
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.


### PR DESCRIPTION
ipc driver was depending on `BSP_NRF5340` (which is specific to
nordic_pca100095) to determine which core was code built for.

Custom bsp would need to introduce same name to use IPC driver.
Now MCUs define own constants that could be used.