### PR TITLE
nrf5340 combine app/net build

### DIFF
--- a/hw/bsp/nordic_pca10095_net/bsp.yml
+++ b/hw/bsp/nordic_pca10095_net/bsp.yml
@@ -45,10 +45,10 @@ bsp.flash_map:
             device: 0
             offset: 0x01008000
             size: 100kB
-        # TODO this should map to app flash
+        # This maps to app flash and uses vflash
         FLASH_AREA_IMAGE_1:
-            device: 0
-            offset: 0x01021000
+            device: 1
+            offset: 0x00000000
             size: 100kB
         FLASH_AREA_IMAGE_SCRATCH:
             device: 0

--- a/hw/bsp/nordic_pca10095_net/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10095_net/src/hal_bsp.c
@@ -25,6 +25,7 @@
 #include <flash_map/flash_map.h>
 #include <hal/hal_bsp.h>
 #include <hal/hal_flash.h>
+#include <hal/hal_flash_int.h>
 #include <hal/hal_system.h>
 #include <mcu/nrf5340_net_hal.h>
 #include <mcu/nrf5340_net_periph.h>
@@ -49,6 +50,11 @@ hal_bsp_flash_dev(uint8_t id)
     if (id == 0) {
         return &nrf5340_net_flash_dev;
     }
+#if MCUBOOT_MYNEWT
+    if (id == 1) {
+        return &nrf5340_net_vflash_dev.nv_flash;
+    }
+#endif
 
     return NULL;
 }

--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -31,6 +31,19 @@
 #define IPC_MAX_CHANS MYNEWT_VAL(IPC_NRF5340_CHANNELS)
 #define IPC_BUF_SIZE MYNEWT_VAL(IPC_NRF5340_BUF_SZ)
 
+#if MYNEWT_VAL(MCU_APP_CORE) && MYNEWT_VAL(NRF5340_EMBED_NET_CORE)
+/*
+ * For combine build (app and net) network core image will be included in application
+ * image only if it is referenced. Those to symbols are used to force linker to
+ * include network core image.
+ * Those are used also to provide net core image data (and its size) to virtual
+ * flash driver that is used by bootloader to bring network image from application
+ * flash to network flash slot 1.
+ */
+extern uint8_t _binary_net_core_img_start;
+extern uint8_t _binary_net_core_img_end;
+#endif
+
 struct ipc_channel {
     ipc_nrf5340_recv_cb cb;
     void *user_data;
@@ -160,6 +173,18 @@ ipc_nrf5340_init(void)
     NRF_GPIO_Type *nrf_gpio;
 #endif
 
+#if MYNEWT_VAL(MCU_APP_CORE) && MYNEWT_VAL(NRF5340_EMBED_NET_CORE)
+    /*
+     * Get network core image size and placement in application flash.
+     * Then pass those two values in NRF_IPC GPMEM registers to be used
+     * by virtual flash driver on network side.
+     */
+    if (&_binary_net_core_img_end - &_binary_net_core_img_start > 32) {
+        NRF_IPC->GPMEM[0] = (uint32_t)&_binary_net_core_img_start;
+        NRF_IPC->GPMEM[1] = &_binary_net_core_img_end - &_binary_net_core_img_start;
+    }
+#endif
+
     /* Make sure network core if off when we set up IPC */
     NRF_RESET_S->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Hold;
     memset(shms, 0, sizeof(shms));
@@ -172,6 +197,19 @@ ipc_nrf5340_init(void)
             GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
     }
 #endif
+#endif
+
+#if MYNEWT_VAL(MCU_NET_CORE)
+    /*
+     * When network core IPCs starts it clears GPMEM from APP core registers
+     * So IPC nows that netcore is running.
+     * This is a workaround that is needed till application side code waits
+     * on IPC for network core controller to sent NOP first.
+     */
+#define NRF_APP_IPC_NS                  ((NRF_IPC_Type *)0x4002A000)
+#define NRF_APP_IPC_S                   ((NRF_IPC_Type *)0x5002A000)
+    NRF_APP_IPC_S->GPMEM[0] = 0;
+    NRF_APP_IPC_S->GPMEM[1] = 0;
 #endif
 
     /* Enable IPC channels */
@@ -188,6 +226,24 @@ ipc_nrf5340_init(void)
 
     /* Start Network Core */
     NRF_RESET_S->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+#endif
+#if MYNEWT_VAL(MCU_APP_CORE) && MYNEWT_VAL(NRF5340_EMBED_NET_CORE)
+    /*
+     * TODO: Remove below workaround:
+     * For now app core waits for NET core to start.
+     * It is needed for case when network core was updated with new
+     * image and due to several second delay caused by bootloader
+     * copy image application starts to send HCI reset requests via
+     * IPC and network HCI transport is not really ready to handle
+     * more then one command.
+     */
+    if (&_binary_net_core_img_end - &_binary_net_core_img_start > 32) {
+        /*
+         * Application side prepared image for net core.
+         * When net core starts it's ipc_nrf5340_init() will clear those.
+         */
+        while (NRF_IPC->GPMEM[1]);
+    }
 #endif
 }
 

--- a/hw/mcu/nordic/nrf5340/net_core_image/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/net_core_image/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/mcu/nordic/nrf5340/net_core_image
+pkg.description: Package that incorporates net core build into app image
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - nrf5340
+
+pkg.pre_link_cmds:
+    scripts/build_net_core.sh: 100

--- a/hw/mcu/nordic/nrf5340/net_core_image/scripts/build_net_core.sh
+++ b/hw/mcu/nordic/nrf5340/net_core_image/scripts/build_net_core.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+NEWT=${MYNEWT_NEWT_PATH}
+OBJCOPY=${MYNEWT_OBJCOPY_PATH}
+AR=${MYNEWT_AR_PATH}
+NET_CORE_A=${MYNEWT_USER_SRC_DIR}/net_core_img.a
+NET_CORE_O=${MYNEWT_USER_SRC_DIR}/net_core_img.o
+
+export WORK_DIR=${MYNEWT_USER_WORK_DIR}
+
+export NEWT_CREATE_IMAGE_OUTPUT=$WORK_DIR/create_image_output
+pushd $MYNEWT_PROJECT_ROOT
+
+${NEWT} create-image ${MYNEWT_VAL_NET_CORE_IMAGE_TARGET_NAME} timestamp -o $NEWT_CREATE_IMAGE_OUTPUT
+# Extract image name from output
+export NET_CORE_IMG=`awk '/App image successfully generated:/ { print $NF }' $NEWT_CREATE_IMAGE_OUTPUT`
+
+cd ${WORK_DIR}
+if [ -n "$NET_CORE_IMG" ] ; then
+  # Copy image to local folder so objcopy creates symbols with short names instead of very long ones.
+  # Name net_core.img translates to two symbols created by objcopy:
+  # _binary_net_core_img_start, _binary_net_core_img_end those symbols are then used to reference content
+  # of net_core.img. Changing this name could lead to invalid builds.
+  cp $NET_CORE_IMG ${WORK_DIR}/net_core.img
+
+  # Make .o file from existing binary image
+  ${OBJCOPY} --rename-section .data=.net_core_img,alloc,load,readonly,data,contents -O elf32-littlearm -B armv8-m.main -I binary net_core.img ${NET_CORE_O}
+
+  # Archive .o for newt to use
+  ${AR} -rcs ${NET_CORE_A} ${NET_CORE_O}
+fi
+popd

--- a/hw/mcu/nordic/nrf5340/net_core_image/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/net_core_image/syscfg.yml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    NET_CORE_IMAGE_TARGET_NAME:
+        description: >
+            Target name to build for NET core binary for single image build.
+            Default is set for nordic_pca10095 bsp and could be changed,
+            although right now this targets could be used for other bsp
+            that are based on NRF5340 since target build just BLE controller
+            without anything specific to pca10095 board.
+        value: "@apache-mynewt-nimble/targets/nordic_pca10095-blehci"

--- a/hw/mcu/nordic/nrf5340/nrf5340.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340.ld
@@ -86,6 +86,13 @@ SECTIONS
     } > FLASH
 
 
+    .net_core_img :
+    {
+        PROVIDE(net_core_img_start = .);
+        KEEP(*(.net_core_img));
+        PROVIDE(net_core_img_end = .);
+    } > FLASH
+
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)

--- a/hw/mcu/nordic/nrf5340/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/pkg.yml
@@ -96,3 +96,6 @@ pkg.deps.I2C_2':
 
 pkg.deps.I2C_3':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
+
+pkg.deps.NRF5340_EMBED_NET_CORE:
+    - "@apache-mynewt-core/hw/mcu/nordic/nrf5340/net_core_image"

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -496,6 +496,10 @@ syscfg.defs:
         description: 'Frequency [kHz] for I2C_3'
         value: 100
 
+    NRF5340_EMBED_NET_CORE:
+        description: Embed net core image in application image for single image build.
+        value: 0
+
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
 

--- a/hw/mcu/nordic/nrf5340_net/include/mcu/nrf5340_net_hal.h
+++ b/hw/mcu/nordic/nrf5340_net/include/mcu/nrf5340_net_hal.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#include <hal/hal_flash_int.h>
+
 /* Helper functions to enable/disable interrupts. */
 #define __HAL_DISABLE_INTERRUPTS(x)                     \
     do {                                                \
@@ -46,7 +48,14 @@ struct nrf5340_net_uart_cfg {
 };
 const struct nrf5340_net_uart_cfg *bsp_uart_config(void);
 
-struct hal_flash;
+struct nrf5340_vflash {
+    struct hal_flash nv_flash;
+    const uint8_t *nv_image_address;
+    uint32_t nv_image_size;
+    const struct flash_area *nv_slot1;
+};
+extern struct nrf5340_vflash nrf5340_net_vflash_dev;
+
 extern const struct hal_flash nrf5340_net_flash_dev;
 
 /* SPI configuration (used for both master and slave) */

--- a/hw/mcu/nordic/nrf5340_net/src/hal_vflash.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_vflash.c
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#if MCUBOOT_MYNEWT
+#include <string.h>
+#include <assert.h>
+#include <nrf.h>
+#include <mcu/nrf5340_net_hal.h>
+#include <hal/hal_flash_int.h>
+#include <nrfx_ipc.h>
+#include <bootutil/bootutil.h>
+#include <bootutil/image.h>
+
+#define NRF5340_NET_VFLASH_SECTOR_SZ 2048
+
+#define NRF_APP_IPC_NS                  ((NRF_IPC_Type *)0x4002A000)
+#define NRF_APP_IPC_S                   ((NRF_IPC_Type *)0x5002A000)
+
+struct swap_data {
+    uint32_t encryption_key0[4];
+    uint32_t encryption_key1[4];
+    uint32_t swap_size;
+    struct image_trailer trailer;
+};
+
+static const struct swap_data swap_data_template = {
+    .encryption_key0 = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff},
+    .encryption_key1 = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff},
+    .swap_size = 0xffffffff,
+    .trailer = {
+        .swap_type = BOOT_SWAP_TYPE_PERM,
+        .pad1 = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+        .copy_done = 0xff,
+        .pad2 = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+        .image_ok = 0x01,
+        .pad3 = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+        .magic = { 0x77, 0xc2, 0x95, 0xf3, 0x60, 0xd2, 0xef, 0x7f,
+                   0x35, 0x52, 0x50, 0x0f, 0x2c, 0xb6, 0x79, 0x80 },
+    }
+};
+
+int
+nrf5340_net_get_image_hash(uint8_t area_id, uint8_t hash[32])
+{
+    const struct flash_area *fa = NULL;
+    struct image_header header;
+    uint32_t addr;
+    uint32_t limit;
+    struct image_tlv_info info;
+    struct image_tlv tlv;
+    int rc = -1;
+
+    if (flash_area_open(area_id, &fa) != 0) {
+        goto end;
+    }
+
+    /* Does slot contain valid image */
+    if (flash_area_read(fa, 0, &header, sizeof(header)) != 0 ||
+        header.ih_magic != IMAGE_MAGIC) {
+        goto end;
+    }
+
+    addr = header.ih_hdr_size + header.ih_img_size;
+    /* Does image has TLV? (needed for image hash verification) */
+    if (flash_area_read(fa, addr, &info, sizeof(info)) != 0 ||
+        info.it_magic != IMAGE_TLV_INFO_MAGIC) {
+        goto end;
+    }
+
+    addr += sizeof(info);
+    limit = addr + info.it_tlv_tot;
+    while (addr + sizeof(tlv) + 32 <= limit) {
+        if (flash_area_read(fa, addr, &tlv, sizeof(tlv)) != 0) {
+            goto end;
+        }
+        addr += sizeof(tlv);
+        if (tlv.it_type == IMAGE_TLV_SHA256) {
+            if (tlv.it_len != 32) {
+                goto end;
+            }
+            rc = flash_area_read(fa, addr, hash, 32);
+            break;
+        }
+        addr += tlv.it_len;
+    }
+end:
+    if (fa) {
+        flash_area_close(fa);
+    }
+    return rc;
+}
+
+bool
+nrf5340_net_images_match(void)
+{
+    uint8_t active_slot_hash[32];
+    uint8_t pending_slot_hash[32];
+
+    if (nrf5340_net_get_image_hash(FLASH_AREA_IMAGE_0, active_slot_hash) == 0 &&
+        nrf5340_net_get_image_hash(FLASH_AREA_IMAGE_1, pending_slot_hash) == 0 &&
+        memcmp(pending_slot_hash, active_slot_hash, 32) == 0) {
+        /* Same hash for current and pending slot, act as slot 2 was empty */
+        return true;
+    }
+    return false;
+}
+
+static int
+nrf5340_net_vflash_read(const struct hal_flash *dev, uint32_t address, void *dst,
+                        uint32_t num_bytes)
+{
+    struct nrf5340_vflash *vflash = (struct nrf5340_vflash *)dev;
+    uint32_t write_bytes = num_bytes;
+    uint8_t *wp = dst;
+    const struct flash_area *fa;
+    struct swap_data swap_data;
+
+    if ((vflash->nv_image_size > 0) && (vflash->nv_slot1 == NULL)) {
+        flash_area_open(FLASH_AREA_IMAGE_1, &vflash->nv_slot1);
+
+        /*
+         * If application side provided image check if same image was already
+         * provided before and if so mark virtual slot as empty
+         */
+        if (nrf5340_net_images_match()) {
+            /* Same hash for current and pending slot, act as slot 2 was empty */
+            vflash->nv_image_size = 0;
+        }
+    }
+    fa = vflash->nv_slot1;
+
+    /* Copy data from image */
+    if (address < vflash->nv_image_size) {
+        if (address + write_bytes > vflash->nv_image_size) {
+            write_bytes = vflash->nv_image_size - address;
+        }
+        memcpy(wp, vflash->nv_image_address + address, write_bytes);
+        address += write_bytes;
+        wp += write_bytes;
+        num_bytes -= write_bytes;
+    }
+    /* Copy data from image trailer */
+    if (num_bytes > 0 && fa != NULL && address >= (fa->fa_off + fa->fa_size - sizeof(swap_data))) {
+        swap_data = swap_data_template;
+        uint32_t off = address - (fa->fa_off + fa->fa_size - sizeof(swap_data));
+        write_bytes = num_bytes;
+        if (num_bytes > sizeof(swap_data) + off) {
+            write_bytes = sizeof(swap_data) - off;
+        }
+        memcpy(wp, ((uint8_t *)&swap_data) + off, write_bytes);
+        wp += write_bytes;
+        address += write_bytes;
+        num_bytes -= write_bytes;
+    }
+    /* Fill the rest with FF */
+    if (num_bytes > 0) {
+        memset(wp, 0xff, num_bytes);
+    }
+    return 0;
+}
+
+/*
+ * Flash write is done by writing 4 bytes at a time at a word boundary.
+ */
+static int
+nrf5340_net_vflash_write(const struct hal_flash *dev, uint32_t address,
+                         const void *src, uint32_t num_bytes)
+{
+    (void)dev;
+    (void)address;
+    (void)src;
+    (void)num_bytes;
+
+    return 0;
+}
+
+static int
+nrf5340_net_vflash_erase_sector(const struct hal_flash *dev, uint32_t sector_address)
+{
+    (void)dev;
+    (void)sector_address;
+
+    return 0;
+}
+
+static int
+nrf5340_net_vflash_sector_info(const struct hal_flash *dev, int idx,
+                               uint32_t *address, uint32_t *sz)
+{
+    (void)dev;
+
+    assert(idx < nrf5340_net_flash_dev.hf_sector_cnt);
+    *address = idx * NRF5340_NET_VFLASH_SECTOR_SZ;
+    *sz = NRF5340_NET_VFLASH_SECTOR_SZ;
+
+    return 0;
+}
+
+static int
+nrf5340_net_vflash_init(const struct hal_flash *dev)
+{
+    struct nrf5340_vflash *vflash = (struct nrf5340_vflash *)dev;
+
+    /*
+     * Application side IPC will set GPMEM registers to address and size of
+     * memory where net core image is present in application flash.
+     * If those values are 0, application image does not have embedded image,
+     * and there no need to provide any data.
+     * Set nv_image_size to 0 and all reads will return empty values (0xff)
+     */
+    vflash->nv_image_address = (const uint8_t *)NRF_APP_IPC_S->GPMEM[0];
+    vflash->nv_image_size = NRF_APP_IPC_S->GPMEM[1];
+
+    return 0;
+}
+
+static const struct hal_flash_funcs nrf5340_net_vflash_funcs = {
+    .hff_read = nrf5340_net_vflash_read,
+    .hff_write = nrf5340_net_vflash_write,
+    .hff_erase_sector = nrf5340_net_vflash_erase_sector,
+    .hff_sector_info = nrf5340_net_vflash_sector_info,
+    .hff_init = nrf5340_net_vflash_init
+};
+
+struct nrf5340_vflash nrf5340_net_vflash_dev = {
+    .nv_flash = {
+        .hf_itf = &nrf5340_net_vflash_funcs,
+        .hf_base_addr = 0x00000000,
+        .hf_size = 256 * 1024,
+        .hf_sector_cnt = 128,
+        .hf_align = 1,
+        .hf_erased_val = 0xff,
+    }
+};
+
+#endif


### PR DESCRIPTION
This adds a way to have single image used to upgrade code on both cores.
Combine build advantages:
- easy upgrade deployment
- possible upgrade off application side only
- synchronization of code between net and app side
- **newtmgr** just works
- **mcuboot** works (but could be changed to embrace this approach batter)
- similar pattern of combine build is already present for Dialog network core (made possible by @andrzej-kaczmarek, scripting know-how part borrowed from his cmac)

For this to work **mcuboot** on **network** core have to be build with
```yml
    BOOTUTIL_OVERWRITE_ONLY: 1
```

In the **application** core target
```yml
    NRF5340_EMBED_NET_CORE: 1
```