### PR TITLE
hw/mcu/cmac: Fix os_cputime wrap around handling

### DIFF
--- a/hw/mcu/dialog/cmac/src/cmac_priv.h
+++ b/hw/mcu/dialog/cmac/src/cmac_priv.h
@@ -27,10 +27,13 @@
 extern "C" {
 #endif
 
+#define LLT_AT_HAL_WRAP_AROUND_VAL  (0x1e84800000)
+
 extern int8_t g_cmac_pdc_cmac2sys;
 
 void cmac_sleep(void);
 void cmac_sleep_recalculate(void);
+void cmac_timer_wrap_llt(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
os_cputime uses LLT internally which is a 37-bit timer at 1MHz and
thus it wraps around later than 32-bit os_cputime at 32768Hz. This
mean safter os_cputime wraps back to 0 any comparison between LLT
value converted from os_cputime and an actual LLT value will fail.

This fixes the problem by wrapping LLT at the same time as os_cputime.
LLT value at which os_cputime wraps back to 0 is 0x1e84800000 so once
LLT hits that value we also wrap it back to 0.