### PR TITLE
hw/ipc_nrf5340: Allow sending data in fragments

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -48,7 +48,8 @@ void ipc_nrf5340_recv(int channel, ipc_nrf5340_recv_cb cb, void *user_data);
 
 /**
  * Sends data over specified IPC channel. IPC uses ring buffer for data passing.
- * If there is not enough space to store data -ENOMEM error is returned.
+ * If IPC_NRF5340_BLOCKING_WRITE is not enable and there is not enough space to
+ * store data SYS_ENOMEM error is returned.
  *
  * @param channel     IPC channel number to send on
  * @param data        Data to be sent over IPC. If this is NULL only signal is

--- a/hw/drivers/ipc_nrf5340/syscfg.yml
+++ b/hw/drivers/ipc_nrf5340/syscfg.yml
@@ -28,6 +28,7 @@ syscfg.defs:
             Shared memory ring buffer size used for IPC (per enabled channel).
             It is recommended to use size which is power of two.
         value: 256
+        range: 2..65535
 
     IPC_NRF5340_BLOCKING_WRITE:
         description: >


### PR DESCRIPTION
This allows to send data over IPC in fragments. Previously data size
was limited to IPC buffer size. In extreme case IPC buffer can now have
size of 2, although this may result in excessive number of interrupts.