### PR TITLE
nrf5340/nrf52xxx: Add support for enabling instruction/data cache in hal_system_init() and add dependencies for BUS DRIVER

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system.c
@@ -37,6 +37,11 @@
 void
 hal_system_init(void)
 {
+
+#if MYNEWT_VAL(MCU_ICACHE_ENABLED)
+    NRF_NVMC->ICACHECNF = 1;
+#endif
+
 #if MYNEWT_VAL(MCU_DCDC_ENABLED)
     NRF_POWER->DCDCEN = 1;
 #endif

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -92,6 +92,10 @@ syscfg.defs:
             the breakpoint wherever it gets called, For example, reset and crash
        value: 0
 
+    MCU_ICACHE_ENABLED:
+       description: >
+            Enabled Instruction code cache
+       value: 0
 
 # MCU peripherals definitions
     I2C_0:

--- a/hw/mcu/nordic/nrf5340/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/pkg.yml
@@ -30,6 +30,11 @@ pkg.deps:
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
 
+pkg.deps.BUS_DRIVER_PRESENT:
+    - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
+    - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
+
 pkg.cflags.NFC_PINS_AS_GPIO: 
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
 

--- a/hw/mcu/nordic/nrf5340/src/hal_system.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_system.c
@@ -36,7 +36,6 @@
 void
 hal_system_init(void)
 {
-
 #if MYNEWT_VAL(MCU_ICACHE_ENABLED)
     NRF_NVMC_S->ICACHECNF = 1;
 #endif
@@ -81,7 +80,6 @@ hal_debugger_connected(void)
 void
 hal_system_clock_start(void)
 {
-
 #if MYNEWT_VAL(MCU_LFCLK_SOURCE)
     uint32_t regmsk;
     uint32_t regval;

--- a/hw/mcu/nordic/nrf5340/src/hal_system.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_system.c
@@ -36,6 +36,15 @@
 void
 hal_system_init(void)
 {
+
+#if MYNEWT_VAL(MCU_ICACHE_ENABLED)
+    NRF_NVMC_S->ICACHECNF = 1;
+#endif
+
+#if MYNEWT_VAL(MCU_CACHE_ENABLED)
+    NRF_CACHE_S->ENABLE = 1;
+#endif
+
 #if MYNEWT_VAL(MCU_DCDC_ENABLED)
     NRF_REGULATORS_S->VREGMAIN.DCDCEN = 1;
 
@@ -72,6 +81,7 @@ hal_debugger_connected(void)
 void
 hal_system_clock_start(void)
 {
+
 #if MYNEWT_VAL(MCU_LFCLK_SOURCE)
     uint32_t regmsk;
     uint32_t regval;

--- a/hw/mcu/nordic/nrf5340/src/nrf5340_periph.c
+++ b/hw/mcu/nordic/nrf5340/src/nrf5340_periph.c
@@ -25,6 +25,10 @@
 #include <nrfx.h>
 #include "hal/hal_spi.h"
 
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#endif
+
 #if MYNEWT_VAL(ADC_0)
 #include <adc/adc.h>
 #include <adc_nrf52/adc_nrf52.h>

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -60,12 +60,25 @@ syscfg.defs:
             When enabled, asm(bkpt) will be ignored. If not set, it will hit
             the breakpoint wherever it gets called, For example, reset and crash
        value: 0
+
     MCU_HFCLCK192_DIV:
         description: >
             Divider of 192MHz clock that is used for QSPI.
             Default value 4, clock runs at 48MHz.
         range: 1,2,4
         value: 4
+ 
+    MCU_CACHE_ENABLED:
+        description: >
+            Enable instruction and data cache
+            Default value is 0, so disabled.
+        value: 0
+
+    MCU_ICACHE_ENABLED:
+        description: >
+            Enable instruction code cache
+            Default value is 0, so disabled.
+        value: 0
 
 # MCU peripherals definitions
     ADC_0:


### PR DESCRIPTION
- nrf5340: Add support for enabling instruction/data cache in hal_system_init() based on syscfg and add dependencies for BUS_DRIVER

- nrf52xxx: Enable instruction code cache in hal_system_init() based on syscfg