### PR TITLE
flash_map: make mfg support optional

### DIFF
--- a/sys/flash_map/pkg.yml
+++ b/sys/flash_map/pkg.yml
@@ -27,8 +27,10 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/sys/defs"
-    - "@apache-mynewt-core/sys/mfg"
     - "@apache-mynewt-core/sys/log/modlog"
+
+pkg.deps.FLASH_MAP_SUPPORT_MFG:
+    - "@apache-mynewt-core/sys/mfg"
 
 pkg.init:
     flash_map_init: 'MYNEWT_VAL(FLASH_MAP_SYSINIT_STAGE)'

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -25,7 +25,9 @@
 #include "hal/hal_bsp.h"
 #include "hal/hal_flash.h"
 #include "hal/hal_flash_int.h"
+#if MYNEWT_VAL(FLASH_MAP_SUPPORT_MFG)
 #include "mfg/mfg.h"
+#endif
 #include "flash_map/flash_map.h"
 
 const struct flash_area *flash_map;
@@ -360,6 +362,7 @@ flash_area_id_to_image_slot(int area_id)
  *
  * @return                      0 on success; nonzero on failure.
  */
+#if MYNEWT_VAL(FLASH_MAP_SUPPORT_MFG)
 static int
 flash_map_read_mfg(int max_areas,
                    struct flash_area *out_areas, int *out_num_areas)
@@ -405,6 +408,7 @@ flash_map_read_mfg(int max_areas,
         (*out_num_areas)++;
     }
 }
+#endif
 
 /**
  * Determines if the specified flash area overlaps any areas in the flash map.
@@ -487,9 +491,11 @@ flash_map_add_new_dflt_areas(void)
 void
 flash_map_init(void)
 {
+#if MYNEWT_VAL(FLASH_MAP_SUPPORT_MFG)
     static struct flash_area mfg_areas[MYNEWT_VAL(FLASH_MAP_MAX_AREAS)];
-
     int num_areas;
+#endif
+
     int rc;
 
     /* Ensure this function only gets called by sysinit. */
@@ -509,6 +515,7 @@ flash_map_init(void)
     flash_map = sysflash_map_dflt;
     flash_map_entries = sizeof sysflash_map_dflt / sizeof sysflash_map_dflt[0];
 
+#if MYNEWT_VAL(FLASH_MAP_SUPPORT_MFG)
     /* Attempt to read the flash map from the manufacturing meta regions.  On
      * success, use the new flash map instead of the default hardcoded one.
      */
@@ -519,6 +526,7 @@ flash_map_init(void)
     }
     flash_map = mfg_areas;
     flash_map_entries = num_areas;
+#endif
 
     /* The hardcoded flash map may contain new areas that aren't present in the
      * manufacturing flash map.  Try including them if they don't overlap with

--- a/sys/flash_map/syscfg.yml
+++ b/sys/flash_map/syscfg.yml
@@ -20,6 +20,10 @@ syscfg.defs:
         description: 'Maximum number of expected flash areas'
         value: 10
 
+    FLASH_MAP_SUPPORT_MFG:
+        description: 'Enable use of flash map stored in manufacturing meta region'
+        value: 0
+
     FLASH_MAP_SYSINIT_STAGE:
         description: >
             Sysinit stage for flash map functionality.


### PR DESCRIPTION
A flash map configuration may be stored in the manufacturing meta region, and be used instead of the one build time generated from bsp.yml. This is currently hard-coded in the flash map code. For users who don't use a mmr, this adds somewhere between 500 and 1000 bytes of code who serves no purpose. This PR adds a syscfg to allow enabling/disabling the use of the MMR in the flash map thus making the mfg dependency optional.

PS: I am adding `FLASH_MAP_SUPPORT_MFG` unset, which breaks backwards compatibility, but on the assumption that most users **don't use** an MMR.