### PR TITLE
hw/mcu/cmac: Fix os_cputime and LLT wrap around handling

### DIFF
--- a/hw/mcu/dialog/cmac/src/cmac_timer.c
+++ b/hw/mcu/dialog/cmac/src/cmac_timer.c
@@ -49,6 +49,7 @@ struct cmac_timer_slp {
 };
 
 static struct cmac_timer_slp g_cmac_timer_slp;
+struct cmac_timer_ctrl g_cmac_timer_ctrl;
 
 static cmac_timer_int_func_t *cmac_timer_int_hal_timer;
 static cmac_timer_int_func_t *cmac_timer_int_hal_os_tick;
@@ -283,7 +284,7 @@ cmac_timer_get_hal_os_tick(void)
     uint32_t rem_val;
     uint32_t ret;
 
-    val = (uint64_t)cmac_timer_read_hi() << 10;
+    val = cmac_timer_read64();
 
     if (SYNC_TICK_VAL_INTERVAL == 2000000) {
         while (val >= sync_tick_val_next) {

--- a/hw/mcu/dialog/cmac/src/hal_os_tick.c
+++ b/hw/mcu/dialog/cmac/src/hal_os_tick.c
@@ -65,6 +65,7 @@ os_tick_handle_tick(void)
 
     cur_tick = cmac_timer_get_hal_os_tick();
     delta = cur_tick - g_os_tick_last;
+
     os_time_advance(delta);
 
     g_os_tick_last = cur_tick;


### PR DESCRIPTION
os_cputime runs at 32768Hz but it uses LLT internally which runs at
1MHz. This means both timers will wrap around at different time. This
means after one of timers wraps around (os_cputime wraps earlier),
calculations that use values converted between both timers will fail.

To fix this we "manually" extend LLT value to 64-bit internally so it
takes zillion of years before it wraps around. Also conversions from
os_cputime (a.k.a. HAL) value to LLT value take os_cputime value wrap
around into account and return proper 64-bit LLT value.