### PR TITLE
stm32/hal_uart: Fix blocking write

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -273,7 +273,7 @@ hal_uart_blocking_tx(int port, uint8_t data)
     USART_TypeDef *regs;
 
     u = uart_by_port(port);
-    if (!u || u->u_open) {
+    if (!u || !u->u_open) {
         return;
     }
 


### PR DESCRIPTION
Function hal_uart_blocking_tx() had incorrect condition
checking if UART is open, this prevented non-blocking writes.

Condition:
    if (!u || u->u_open)
was obviously wrong and is now changed to
    if (!u || !u->u_open)