### PR TITLE
sysview: Fix build for c++

### DIFF
--- a/kernel/os/include/os/os_trace_api.h
+++ b/kernel/os/include/os/os_trace_api.h
@@ -68,7 +68,7 @@ static inline uint32_t
 os_trace_module_register(os_trace_module_t *m, const char *name,
                          uint32_t num_events, void (* send_desc_func)(void))
 {
-    char *desc = "M=???";
+    char *desc;
 
     asprintf(&desc, "M=%s", name);
 


### PR DESCRIPTION
Initializing non-const char pointer with constant string literal
is an error in c++ according to g++ compiler.
`error: ISO C++ forbids converting a string constant to 'char*' [-Werror=write-strings]
`
This assignment even for c build is not useful since
_asprintf_ assigns new value (possible NULL) to **desc** anyway.

This change just drops meaningless initialization that makes g++ unhappy.