### PR TITLE
ctype: Fix undefined behavior in ctype.h usage

### DIFF
--- a/encoding/base64/src/hex.c
+++ b/encoding/base64/src/hex.c
@@ -80,7 +80,7 @@ hex_parse(const char *src, int src_len, void *dst_v, int dst_len)
     }
     for (i = 0; i < src_len; i++, src++) {
         c = *src;
-        if (isdigit((int) c)) {
+        if (isdigit((unsigned char)c)) {
             c -= '0';
         } else if (c >= 'a' && c <= 'f') {
             c -= ('a' - 10);

--- a/encoding/json/src/json_decode.c
+++ b/encoding/json/src/json_decode.c
@@ -86,7 +86,7 @@ json_skip_ws(struct json_buffer *jb)
 
     do {
         c = jb->jb_read_next(jb);
-    } while (isspace((int) c));
+    } while (isspace((unsigned char) c));
 
     jb->jb_read_prev(jb);
 }

--- a/hw/drivers/uart/uart_hal/src/uart_hal.c
+++ b/hw/drivers/uart/uart_hal/src/uart_hal.c
@@ -178,7 +178,7 @@ uart_hal_init(struct os_dev *odev, void *arg)
     dev = (struct uart_dev *)odev;
 
     ch = odev->od_name[strlen(odev->od_name) - 1];
-    if (!isdigit((int) ch)) {
+    if (!isdigit((unsigned char)ch)) {
         return OS_EINVAL;
     }
     uart_hal_dev_set_id(dev, ch - '0');

--- a/net/ip/mn_socket/src/mn_socket_aconv.c
+++ b/net/ip/mn_socket/src/mn_socket_aconv.c
@@ -224,7 +224,7 @@ mn_inet_pton(int af, const char *src, void *dst)
             if (cnt > 4) {
                 return 0;
             }
-            if (isdigit(*ch_src)) {
+            if (isdigit((unsigned char)*ch_src)) {
                 val = val * 10 + *ch_src - '0';
                 if (val > 255) {
                     return 0;

--- a/net/oic/src/api/oc_uuid.c
+++ b/net/oic/src/api/oc_uuid.c
@@ -34,7 +34,7 @@ oc_str_to_uuid(const char *str, oc_uuid_t *uuid)
   for (i = 0; i < strlen(str); i++) {
     if (str[i] == '-')
       continue;
-    else if (isalpha((int)str[i])) {
+    else if (isalpha((unsigned char)str[i])) {
       switch (str[i]) {
       case 65:
       case 97:

--- a/sys/console/full/history_log/src/history_log.c
+++ b/sys/console/full/history_log/src/history_log.c
@@ -140,9 +140,9 @@ console_history_add_to_cache(const char *line)
     }
 
     /* Trim from spaces */
-    while (isspace(*line)) {
+    while (isspace((unsigned char)*line)) {
         line++;
-    };
+    }
 
     len = strlen(line);
     if (len == 0) {
@@ -153,7 +153,7 @@ console_history_add_to_cache(const char *line)
      * Trim trailing spaces. It does not touch input buffer, it just
      * corrects len variable.
      */
-    while (isspace(line[len - 1])) {
+    while (isspace((unsigned char)line[len - 1])) {
         len--;
     }
 

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -117,7 +117,7 @@ shell_log_dump_cmd(int argc, char **argv)
             list_only = true;
             break;
         }
-        if (isdigit(argv[i][0])) {
+        if (isdigit((unsigned char)argv[i][0])) {
             log_limit = parse_ll_bounds(argv[i], 1, 1000000, &rc);
         } else {
             log_name = argv[i];

--- a/time/datetime/src/datetime.c
+++ b/time/datetime/src/datetime.c
@@ -205,7 +205,7 @@ parse_number(const char *str, int digits, int *val)
     cp = str;
     end = str + digits;
     while (cp < end) {
-        if (!isdigit((int) *cp)) {
+        if (!isdigit((unsigned char)*cp)) {
             return (NULL);
         }
         *val *= 10;
@@ -271,7 +271,7 @@ datetime_parse(const char *input, struct os_timeval *tv, struct os_timezone *tz)
     /* parse fractional seconds if specified */
     if (*cp == '.') {
         ep = ++cp;
-        while (isdigit((int) *ep)) {
+        while (isdigit((unsigned char)*ep)) {
             ep++;
         }
         digits = ep - cp;


### PR DESCRIPTION
Although ctype.h functions/macros like isalpha, isdigit etc.
take int argument as input behaviour is undefined if value
passed to those are not from unsigned char + EOF.
If the implementation choose to use simple macro that accesses
table indexed by argument and it was negative as it can be
when char is cast to int (as was the case in some places)
result would be unpredictable.
In most cases argument to ctype define functions was correctly
cast to unsigned (json/lwip and many other places).

This updates places that could be prone to this problem with
cast to (unsigned char).
For baselibc implementation it does not make difference but
if some other libc was chosen it could lead to potential
problems (warnings at build time or unpredictable behavior).

Problem was observed when gcc provided ctype.h was used
instead of baselibc one.

Line from code build against non-baselibc implementation of ctype.h
`error: array subscript has type 'char' [-Werror=char-subscripts]`