### PR TITLE
baselibc cpp global constructors

### DIFF
--- a/hw/bsp/nucleo-f303k8/src/arch/cortex_m4/startup_stm32f303x8.s
+++ b/hw/bsp/nucleo-f303k8/src/arch/cortex_m4/startup_stm32f303x8.s
@@ -105,8 +105,6 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit
-/* Call static constructors */
-    bl __libc_init_array
 /* Call the application's entry point.*/
     bl  _start
 

--- a/hw/bsp/stm32f429discovery/src/arch/cortex_m4/startup_STM32F429x.s
+++ b/hw/bsp/stm32f429discovery/src/arch/cortex_m4/startup_STM32F429x.s
@@ -109,8 +109,6 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-    bl __libc_init_array
 /* Call the application's entry point.*/
   bl  _start
   bx  lr

--- a/hw/mcu/sifive/fe310/src/arch/rv32imac/start.s
+++ b/hw/mcu/sifive/fe310/src/arch/rv32imac/start.s
@@ -62,11 +62,6 @@ _reset_handler:
     la a1, _heap_end
     call _sbrkInit
 
-    /* Call global constructors */
-    la a0, __libc_fini_array
-    call atexit
-    call __libc_init_array
-
     call SystemInit
     call _start
     call _fini

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -26,3 +26,13 @@ syscfg.defs:
         defunct: 1
         description: 'Use OS_CRASH_FILE_LINE instead'
         value: 0
+
+    BASELIBC_EXECUTE_GLOBAL_CONSTRUCTORS:
+        description: >
+            Set to 1 if project contains C++ files with global objects that
+            that need constructors to be executed before main().
+            Setting this to 0 reduces code size if there is no need for global
+            constructors call.
+            It is still possible to use C++ code when this is set to 0 but
+            global variable can be in wrong state.
+        value: 1


### PR DESCRIPTION
Code required to execute global object constructors was usually not called.
hifive1 and two other stm32 boards had calls to __libc_init_array while all
the others did not.

Now **__libc_init_array()** is executed for all cases in **_start()**

baselibc version of this function is provided so tool chain's one does not need to be.