### PR TITLE
mcu/nrf5340: Allow changing HFCLK divider

### DIFF
--- a/hw/mcu/nordic/nrf5340/src/system_nrf5340.c
+++ b/hw/mcu/nordic/nrf5340/src/system_nrf5340.c
@@ -25,6 +25,7 @@ NOTICE: This file has been modified by Nordic Semiconductor ASA.
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <syscfg/syscfg.h>
 #include <nrf.h>
 #include <nrf_erratas.h>
 #include <system_nrf5340_application.h>
@@ -244,6 +245,12 @@ void SystemInit(void)
         __DSB();
         __ISB();
     #endif
+
+    if (MYNEWT_VAL(MCU_HFCLK_DIV) == 1) {
+        NRF_CLOCK_S->HFCLKCTRL = CLOCK_HFCLKCTRL_HCLK_Div1 << CLOCK_HFCLKCTRL_HCLK_Pos;
+    } else {
+        NRF_CLOCK_S->HFCLKCTRL = CLOCK_HFCLKCTRL_HCLK_Div2 << CLOCK_HFCLKCTRL_HCLK_Pos;
+    }
 
     SystemCoreClockUpdate();
 

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -68,6 +68,13 @@ syscfg.defs:
         range: 1,2,4
         value: 4
 
+    MCU_HFCLK_DIV:
+        description: >
+            Divider of 128MHz system clock.
+            Default value 2, clock runs at 64MHz.
+        range: 1,2
+        value: 2
+
     MCU_CACHE_ENABLED:
         description: >
             Enable instruction and data cache


### PR DESCRIPTION
MCU starts with HFCLK divder set to 2, meaning APP core
runs at 64MHz.
Now divider can be set to 1 in syscfg allowing to run
MCU at 128MHz.