### PR TITLE
i2s: Add extern "C" for c++ build

### DIFF
--- a/hw/drivers/i2s/i2s_da1469x/include/i2s_da1469x/i2s_da1469x.h
+++ b/hw/drivers/i2s/i2s_da1469x/include/i2s_da1469x/i2s_da1469x.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct da1469x_dma_buffer {
     uint16_t size;
     uint8_t *buffer;
@@ -65,5 +69,9 @@ struct i2s_cfg {
     /* DMA buffers, should be set with I2S_DA1469X_DMA_BUFFER(). */
     struct da1469x_dma_buffer *dma_memory;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _I2S_DA1469X_H */

--- a/hw/drivers/i2s/i2s_nrf52/include/i2s_nrf52/i2s_nrf52.h
+++ b/hw/drivers/i2s/i2s_nrf52/include/i2s_nrf52/i2s_nrf52.h
@@ -24,6 +24,10 @@
 #include <nrfx/nrfx.h>
 #include <nrfx/drivers/include/nrfx_i2s.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct i2s;
 
 struct i2s_cfg {
@@ -33,5 +37,9 @@ struct i2s_cfg {
 
     struct i2s_buffer_pool *pool;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _I2S_NRF52_H */

--- a/hw/drivers/i2s/i2s_stm32f1/include/i2s_stm32f1/i2s_stm32f1.h
+++ b/hw/drivers/i2s/i2s_stm32f1/include/i2s_stm32f1/i2s_stm32f1.h
@@ -23,6 +23,10 @@
 #include <mcu/stm32_hal.h>
 #include <i2s_stm32f1/stm32_pin_cfg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Structure with I2S config, needed for i2s_create() */
 struct i2s_cfg {
     /* Value I2S_MODE_xxxxxx */
@@ -117,5 +121,9 @@ I2S_WS_PIN_DECLARE(3, A, 15)
 I2S_SD_PIN_DECLARE(3, B, 5)
 /* I2S3 possible MCK pins */
 I2S_PIN_DECLARE(3, C, 7)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _I2S_STM32F1_H */

--- a/hw/drivers/i2s/i2s_stm32f4/include/i2s_stm32f4/i2s_stm32f4.h
+++ b/hw/drivers/i2s/i2s_stm32f4/include/i2s_stm32f4/i2s_stm32f4.h
@@ -23,6 +23,10 @@
 #include <stm32f4xx_hal.h>
 #include <i2s_stm32f4/stm32_pin_cfg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct i2s;
 struct i2s_cfg;
 struct stm32_spi_cfg;
@@ -271,5 +275,9 @@ I2S_SD_PIN_DECLARE(5, A, 10)
 I2S_SD_PIN_DECLARE(5, B, 8)
 I2S_SD_PIN_DECLARE(5, E, 6)
 I2S_SD_PIN_DECLARE(5, E, 14)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _I2S_STM32_H */

--- a/hw/drivers/i2s/include/i2s/i2s.h
+++ b/hw/drivers/i2s/include/i2s/i2s.h
@@ -23,6 +23,10 @@
 #include <stdint.h>
 #include <os/os_dev.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * I2S API does not specify this structure. It is used by i2s_create() and is defined
  * by specific driver.
@@ -268,5 +272,9 @@ i2s_get_sample_rate(struct i2s *i2s)
 {
     return i2s->sample_rate;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _HW_DRIVERS_I2S_H */

--- a/hw/drivers/i2s/include/i2s/i2s_driver.h
+++ b/hw/drivers/i2s/include/i2s/i2s_driver.h
@@ -20,6 +20,10 @@
 #ifndef _HW_DRIVERS_I2S_DRIVER_H
 #define _HW_DRIVERS_I2S_DRIVER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct i2s;
 struct i2s_cfg;
 struct i2s_sample_buffer;
@@ -39,5 +43,9 @@ int i2s_init(struct i2s *i2s, struct i2s_buffer_pool *pool);
 void i2s_driver_state_changed(struct i2s *i2s, enum i2s_state);
 void i2s_driver_buffer_put(struct i2s *i2s, struct i2s_sample_buffer *buffer);
 struct i2s_sample_buffer *i2s_driver_buffer_get(struct i2s *i2s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _HW_DRIVERS_I2S_DRIVER_H */


### PR DESCRIPTION
Most I2S related headers were missing extern "C" block
for correct c++ build.