### PR TITLE
Fix trailing spaces in yaml files

### DIFF
--- a/apps/bleprph_oic/pkg.yml
+++ b/apps/bleprph_oic/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@mcuboot/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-nimble/nimble/host"

--- a/apps/bleprph_oic/syscfg.yml
+++ b/apps/bleprph_oic/syscfg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/blesplit/pkg.yml
+++ b/apps/blesplit/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/bus_test/lis2dh_node/pkg.yml
+++ b/apps/bus_test/lis2dh_node/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/bus_test/pkg.yml
+++ b/apps/bus_test/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/coremark/pkg.yml
+++ b/apps/coremark/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/ffs2native/pkg.yml
+++ b/apps/ffs2native/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/lora_app_shell/pkg.yml
+++ b/apps/lora_app_shell/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/loraping/pkg.yml
+++ b/apps/loraping/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/lorashell/pkg.yml
+++ b/apps/lorashell/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/metrics/pkg.yml
+++ b/apps/metrics/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,13 +17,13 @@
 #
 pkg.name: apps/metrics
 pkg.type: app
-pkg.description: 
+pkg.description:
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - kernel/os 
+    - kernel/os
     - sys/console/full
-    - sys/metrics 
+    - sys/metrics
     - sys/sysinit

--- a/apps/metrics/syscfg.yml
+++ b/apps/metrics/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/ocf_sample/pkg.yml
+++ b/apps/ocf_sample/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/sensors_test/pkg.yml
+++ b/apps/sensors_test/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/slinky/pkg.yml
+++ b/apps/slinky/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/splitty/pkg.yml
+++ b/apps/splitty/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/testbench/pkg.yml
+++ b/apps/testbench/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/apps/trng_test/pkg.yml
+++ b/apps/trng_test/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,7 +17,7 @@
 #
 pkg.name: apps/trng_test
 pkg.type: app
-pkg.description: 
+pkg.description:
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:

--- a/apps/trng_test/syscfg.yml
+++ b/apps/trng_test/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/boot/split/pkg.yml
+++ b/boot/split/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/boot/split/syscfg.yml
+++ b/boot/split/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/boot/split_app/pkg.yml
+++ b/boot/split_app/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/boot/stub/pkg.yml
+++ b/boot/stub/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arc/pkg.yml
+++ b/compiler/arc/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m0/pkg.yml
+++ b/compiler/arm-none-eabi-m0/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m3/compiler.yml
+++ b/compiler/arm-none-eabi-m3/compiler.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m3/pkg.yml
+++ b/compiler/arm-none-eabi-m3/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m33/compiler.yml
+++ b/compiler/arm-none-eabi-m33/compiler.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m33/pkg.yml
+++ b/compiler/arm-none-eabi-m33/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m4/compiler.yml
+++ b/compiler/arm-none-eabi-m4/compiler.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m4/pkg.yml
+++ b/compiler/arm-none-eabi-m4/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/arm-none-eabi-m7/pkg.yml
+++ b/compiler/arm-none-eabi-m7/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/compiler/sim/pkg.yml
+++ b/compiler/sim/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/crypto/mbedtls/pkg.yml
+++ b/crypto/mbedtls/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/crypto/mbedtls/selftest/pkg.yml
+++ b/crypto/mbedtls/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/crypto/mbedtls"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/crypto/tinycrypt/pkg.yml
+++ b/crypto/tinycrypt/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/encoding/base62/pkg.yml
+++ b/encoding/base62/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/encoding/base62/selftest/pkg.yml
+++ b/encoding/base62/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "encoding/base62"
     - "@apache-mynewt-core/test/testutil"
     - "@apache-mynewt-core/sys/console/stub"

--- a/encoding/base64/pkg.yml
+++ b/encoding/base64/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/encoding/base64/selftest/pkg.yml
+++ b/encoding/base64/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/encoding/cborattr/pkg.yml
+++ b/encoding/cborattr/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/encoding/json/hosttest/pkg.yml
+++ b/encoding/json/hosttest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,6 +22,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/encoding/json"
     - "@apache-mynewt-core/test/testutil"

--- a/encoding/json/pkg.yml
+++ b/encoding/json/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-pkg.name: encoding/json 
+pkg.name: encoding/json
 pkg.description: JSON encoding / decoding library.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"

--- a/encoding/json/selftest/pkg.yml
+++ b/encoding/json/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/encoding/json"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/encoding/tinycbor/pkg.yml
+++ b/encoding/tinycbor/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-pkg.name: encoding/tinycbor 
-pkg.description: CBOR encoding/decoding library 
+pkg.name: encoding/tinycbor
+pkg.description: CBOR encoding/decoding library
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:

--- a/fs/disk/pkg.yml
+++ b/fs/disk/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/fatfs/pkg.yml
+++ b/fs/fatfs/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/fatfs/syscfg.yml
+++ b/fs/fatfs/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/fcb/pkg.yml
+++ b/fs/fcb/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/fcb/selftest/pkg.yml
+++ b/fs/fcb/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/fs/fcb"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/fs/fcb2/pkg.yml
+++ b/fs/fcb2/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/fcb2/selftest/pkg.yml
+++ b/fs/fcb2/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/fs/fcb2"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/fs/fs/pkg.yml
+++ b/fs/fs/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/nffs/pkg.yml
+++ b/fs/nffs/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/fs/nffs/selftest/pkg.yml
+++ b/fs/nffs/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/fs/nffs"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"

--- a/hw/bsp/ada_feather_stm32f405/pkg.yml
+++ b/hw/bsp/ada_feather_stm32f405/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/apollo2_evb/bsp.yml
+++ b/hw/bsp/apollo2_evb/bsp.yml
@@ -23,7 +23,7 @@ bsp.name: "Apollo EVB"
 bsp.url: https://www.ambiqmicro.com/mcu/
 bsp.maker: "Ambiq micro"
 bsp.arch: cortex_m4
-bsp.compiler: compiler/arm-none-eabi-m4 
+bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:
     - "hw/bsp/apollo2_evb/apollo2.ld"
     - "@apache-mynewt-core/hw/mcu/ambiq/apollo2/apollo2.ld"

--- a/hw/bsp/b-l072z-lrwan1/pkg.yml
+++ b/hw/bsp/b-l072z-lrwan1/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/b-l475e-iot01a/pkg.yml
+++ b/hw/bsp/b-l475e-iot01a/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/black_vet6/pkg.yml
+++ b/hw/bsp/black_vet6/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/bluepill/bsp.yml
+++ b/hw/bsp/bluepill/bsp.yml
@@ -65,4 +65,4 @@ bsp.flash_map:
             device: 0
             offset: 0x08006000
             size: 8kB
-            
+

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -86,7 +86,7 @@ syscfg.defs:
         description: 'enable Button B'
         value: 0
 
-syscfg.defs.BLE_CONTROLLER: 
+syscfg.defs.BLE_CONTROLLER:
     TIMER_0:
         value: 0
     TIMER_3:
@@ -107,4 +107,4 @@ syscfg.vals.BLE_CONTROLLER:
     BLE_LL_RFMGMT_ENABLE_TIME: 0
     # synthesized 32k clock has 250ppm accuracy
     BLE_LL_OUR_SCA: 250
-    BLE_LL_MASTER_SCA: 1 
+    BLE_LL_MASTER_SCA: 1

--- a/hw/bsp/native-armv7/pkg.yml
+++ b/hw/bsp/native-armv7/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/native-mips/pkg.yml
+++ b/hw/bsp/native-mips/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/native/pkg.yml
+++ b/hw/bsp/native/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f072rb/pkg.yml
+++ b/hw/bsp/nucleo-f072rb/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f103rb/pkg.yml
+++ b/hw/bsp/nucleo-f103rb/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f103rb/syscfg.yml
+++ b/hw/bsp/nucleo-f103rb/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f303k8/pkg.yml
+++ b/hw/bsp/nucleo-f303k8/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f303re/pkg.yml
+++ b/hw/bsp/nucleo-f303re/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f401re/pkg.yml
+++ b/hw/bsp/nucleo-f401re/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f411re/pkg.yml
+++ b/hw/bsp/nucleo-f411re/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f411re/syscfg.yml
+++ b/hw/bsp/nucleo-f411re/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f413zh/pkg.yml
+++ b/hw/bsp/nucleo-f413zh/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f413zh/syscfg.yml
+++ b/hw/bsp/nucleo-f413zh/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f439zi/pkg.yml
+++ b/hw/bsp/nucleo-f439zi/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-f439zi/syscfg.yml
+++ b/hw/bsp/nucleo-f439zi/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-l073rz/pkg.yml
+++ b/hw/bsp/nucleo-l073rz/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/nucleo-l476rg/pkg.yml
+++ b/hw/bsp/nucleo-l476rg/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/olimex-p103/pkg.yml
+++ b/hw/bsp/olimex-p103/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/olimex-p103/syscfg.yml
+++ b/hw/bsp/olimex-p103/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/pic32mx470_6lp_clicker/pkg.yml
+++ b/hw/bsp/pic32mx470_6lp_clicker/pkg.yml
@@ -26,7 +26,7 @@ pkg.keywords:
     - pic32
     - microchip
     - clicker
-    
+
 pkg.cflags:
     - -mprocessor=32MX470F512H
 pkg.lflags:

--- a/hw/bsp/stm32f3discovery/pkg.yml
+++ b/hw/bsp/stm32f3discovery/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32f411discovery/pkg.yml
+++ b/hw/bsp/stm32f411discovery/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32f411discovery/syscfg.yml
+++ b/hw/bsp/stm32f411discovery/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32f4discovery/pkg.yml
+++ b/hw/bsp/stm32f4discovery/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32f4discovery/syscfg.yml
+++ b/hw/bsp/stm32f4discovery/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32l152discovery/pkg.yml
+++ b/hw/bsp/stm32l152discovery/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/bsp/stm32l152discovery/syscfg.yml
+++ b/hw/bsp/stm32l152discovery/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/cmsis-core/pkg.yml
+++ b/hw/cmsis-core/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/drivers/bq27z561/syscfg.yml
+++ b/hw/drivers/bq27z561/syscfg.yml
@@ -37,7 +37,7 @@ syscfg.defs:
         value: 2
     BQ27Z561_I2C_TIMEOUT_TICKS:
         description: >
-            Number of OS ticks to wait for each I2C transaction to complete.            
+            Number of OS ticks to wait for each I2C transaction to complete.
         value: 6
     BQ27Z561_SYSINIT_STAGE:
         description: >

--- a/hw/drivers/chg_ctrl/bq24040/pkg.yml
+++ b/hw/drivers/chg_ctrl/bq24040/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: hw/drivers/chg_ctrl/bq24040
-pkg.description: 
+pkg.description:
 pkg.keywords:
     - Charge Controller
     - bq24040

--- a/hw/drivers/chg_ctrl/da1469x_charger/pkg.yml
+++ b/hw/drivers/chg_ctrl/da1469x_charger/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: hw/drivers/chg_ctrl/da1469x_charger
-pkg.description: 
+pkg.description:
 pkg.keywords:
     - Charge Controller
     - DA1469x

--- a/hw/drivers/debounce/pkg.yml
+++ b/hw/drivers/debounce/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/drivers/debounce/syscfg.yml
+++ b/hw/drivers/debounce/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/drivers/led/lp5523/pkg.yml
+++ b/hw/drivers/led/lp5523/pkg.yml
@@ -25,7 +25,7 @@ pkg.keywords:
     - led
     - texas
     - lp5523
-        
+
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/led/tlc5971/pkg.yml
+++ b/hw/drivers/led/tlc5971/pkg.yml
@@ -24,7 +24,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - led
     - tlc5971
-        
+
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"

--- a/hw/drivers/rtt/pkg.yml
+++ b/hw/drivers/rtt/pkg.yml
@@ -23,7 +23,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-pkg.req_apis: 
+pkg.req_apis:
 
 pkg.build_profile: speed
 pkg.cflags:

--- a/hw/drivers/sensors/bme680/syscfg.yml
+++ b/hw/drivers/sensors/bme680/syscfg.yml
@@ -17,8 +17,8 @@
 #
 
 # Package: hw/drivers/sensors/bme680
- 
- syscfg.defs:
+
+syscfg.defs:
     BME680_FLOATING_POINT_COMPENSATION:
         description: 'Enable floating point compensation'
         value: 0

--- a/hw/drivers/sensors/dps368/pkg.yml
+++ b/hw/drivers/sensors/dps368/pkg.yml
@@ -36,7 +36,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/sensor"
     - "@apache-mynewt-core/sys/log/modlog"
 
-    
 pkg.deps.!BUS_DRIVER_PRESENT:
     - "@apache-mynewt-core/hw/util/i2cn"
 pkg.deps.BUS_DRIVER_PRESENT:
@@ -47,4 +46,3 @@ pkg.req_apis:
 
 pkg.deps.DPS368_CLI:
     - "@apache-mynewt-core/util/parse"
-    

--- a/hw/drivers/uart/pkg.yml
+++ b/hw/drivers/uart/pkg.yml
@@ -23,4 +23,4 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 pkg.deps:
-pkg.req_apis: 
+pkg.req_apis:

--- a/hw/hal/pkg.yml
+++ b/hw/hal/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/ambiq/pkg.yml
+++ b/hw/mcu/ambiq/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -35,6 +35,6 @@ pkg.src_dirs:
 pkg.cflags:
     - '-Wno-enum-compare'
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/cmsis-core"

--- a/hw/mcu/arc/pkg.yml
+++ b/hw/mcu/arc/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -35,5 +35,5 @@ pkg.cflags: -Wno-unused-but-set-variable -Wno-unused-function
 pkg.src_dirs:
     - "src/ext/sdk/"
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/arc/snps/pkg.yml
+++ b/hw/mcu/arc/snps/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -24,6 +24,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - arc
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/arc"

--- a/hw/mcu/dialog/da1469x/hosttest/pkg.yml
+++ b/hw/mcu/dialog/da1469x/hosttest/pkg.yml
@@ -4,7 +4,7 @@
 # regarding copyright ownership.  The ASF licenses this file # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/test/testutil"
     - "@apache-mynewt-core/hw/mcu/dialog"
 

--- a/hw/mcu/dialog/pkg.yml
+++ b/hw/mcu/dialog/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: hw/mcu/dialog
-pkg.description: Common MCU definitions for Dialog DA1469x series chips 
+pkg.description: Common MCU definitions for Dialog DA1469x series chips
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:

--- a/hw/mcu/native/pkg.yml
+++ b/hw/mcu/native/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/nordic/nrf51xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf51xxx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -25,7 +25,7 @@ pkg.keywords:
     - nrf51
     - nrfx
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -25,7 +25,7 @@ pkg.keywords:
     - nrf52
     - nrfx
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
@@ -37,10 +37,10 @@ pkg.deps.'BUS_DRIVER_PRESENT && MCU_BUS_DRIVER_I2C_USE_TWIM':
 pkg.deps.'BUS_DRIVER_PRESENT && !MCU_BUS_DRIVER_I2C_USE_TWIM':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_hal"
 
-pkg.cflags.NFC_PINS_AS_GPIO: 
+pkg.cflags.NFC_PINS_AS_GPIO:
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
 
-pkg.cflags.GPIO_AS_PIN_RESET: 
+pkg.cflags.GPIO_AS_PIN_RESET:
     - '-DCONFIG_GPIO_AS_PINRESET=1'
 
 pkg.deps.BLE_CONTROLLER:

--- a/hw/mcu/nordic/nrf5340/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -25,7 +25,7 @@ pkg.keywords:
     - nrf53
     - nrfx
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
@@ -35,10 +35,10 @@ pkg.deps.BUS_DRIVER_PRESENT:
     - "@apache-mynewt-core/hw/bus/drivers/i2c_common"
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
 
-pkg.cflags.NFC_PINS_AS_GPIO: 
+pkg.cflags.NFC_PINS_AS_GPIO:
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
 
-pkg.cflags.GPIO_AS_PIN_RESET: 
+pkg.cflags.GPIO_AS_PIN_RESET:
     - '-DCONFIG_GPIO_AS_PINRESET=1'
 
 pkg.deps.UART_0:
@@ -92,10 +92,10 @@ pkg.deps.SPI_4_MASTER:
 
 pkg.deps.I2C_0':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
-    
+
 pkg.deps.I2C_1':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
-    
+
 pkg.deps.I2C_2':
     - "@apache-mynewt-core/hw/bus/drivers/i2c_nrf5340"
 

--- a/hw/mcu/nordic/nrf5340_net/pkg.yml
+++ b/hw/mcu/nordic/nrf5340_net/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -25,15 +25,15 @@ pkg.keywords:
     - nrf53
     - nrfx
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
 
-pkg.cflags.NFC_PINS_AS_GPIO: 
+pkg.cflags.NFC_PINS_AS_GPIO:
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'
 
-pkg.cflags.GPIO_AS_PIN_RESET: 
+pkg.cflags.GPIO_AS_PIN_RESET:
     - '-DCONFIG_GPIO_AS_PINRESET=1'
 
 pkg.deps.UART_0:

--- a/hw/mcu/nordic/nrf91xx/pkg.yml
+++ b/hw/mcu/nordic/nrf91xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -25,7 +25,7 @@ pkg.keywords:
     - nrf91
     - nrfx
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
@@ -34,7 +34,7 @@ pkg.deps.BUS_DRIVER_PRESENT:
     - "@apache-mynewt-core/hw/bus/drivers/i2c_hal"
     - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
 
-pkg.cflags.GPIO_AS_PIN_RESET: 
+pkg.cflags.GPIO_AS_PIN_RESET:
     - '-DCONFIG_GPIO_AS_PINRESET=1'
 
 pkg.deps.UART_0:

--- a/hw/mcu/stm/stm32_common/pkg.yml
+++ b/hw/mcu/stm/stm32_common/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32f0xx/pkg.yml
+++ b/hw/mcu/stm/stm32f0xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32f1xx/pkg.yml
+++ b/hw/mcu/stm/stm32f1xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32f3xx/pkg.yml
+++ b/hw/mcu/stm/stm32f3xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32f4xx/pkg.yml
+++ b/hw/mcu/stm/stm32f4xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32f7xx/pkg.yml
+++ b/hw/mcu/stm/stm32f7xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32l0xx/pkg.yml
+++ b/hw/mcu/stm/stm32l0xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32l1xx/pkg.yml
+++ b/hw/mcu/stm/stm32l1xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/mcu/stm/stm32l4xx/pkg.yml
+++ b/hw/mcu/stm/stm32l4xx/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/sensor/pkg.yml
+++ b/hw/sensor/pkg.yml
@@ -35,6 +35,6 @@ pkg.deps.SENSOR_CLI:
 
 pkg.req_apis:
     - console
-    
+
 pkg.init:
     sensor_pkg_init: 'MYNEWT_VAL(SENSOR_SYSINIT_STAGE)'

--- a/hw/sensor/selftest/pkg.yml
+++ b/hw/sensor/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/hw/sensor"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"

--- a/hw/sensor/selftest/syscfg.yml
+++ b/hw/sensor/selftest/syscfg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/util/blinker/pkg.yml
+++ b/hw/util/blinker/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/util/break_hook_example/pkg.yml
+++ b/hw/util/break_hook_example/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/util/button/pkg.yml
+++ b/hw/util/button/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/hw/util/i2cn/pkg.yml
+++ b/hw/util/i2cn/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/kernel/os/selftest/pkg.yml
+++ b/kernel/os/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/kernel/sim/pkg.yml
+++ b/kernel/sim/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/libc/baselibc/selftest/pkg.yml
+++ b/libc/baselibc/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "libc/baselibc"
     - "@apache-mynewt-core/test/testutil"
     - "@apache-mynewt-core/sys/console/stub"

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/imgmgr/pkg.yml
+++ b/mgmt/imgmgr/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/mgmt/pkg.yml
+++ b/mgmt/mgmt/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/mgmt/syscfg.yml
+++ b/mgmt/mgmt/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/pkg.yml
+++ b/mgmt/newtmgr/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/syscfg.yml
+++ b/mgmt/newtmgr/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/transport/ble/pkg.yml
+++ b/mgmt/newtmgr/transport/ble/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/transport/ble/syscfg.yml
+++ b/mgmt/newtmgr/transport/ble/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
+++ b/mgmt/newtmgr/transport/nmgr_shell/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/newtmgr/transport/nmgr_shell/syscfg.yml
+++ b/mgmt/newtmgr/transport/nmgr_shell/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/oicmgr/pkg.yml
+++ b/mgmt/oicmgr/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/oicmgr/syscfg.yml
+++ b/mgmt/oicmgr/syscfg.yml
@@ -33,5 +33,5 @@ syscfg.defs:
 
     OICMGR_OIC_RESOURCE_NAME:
         description: >
-            The OMP OIC Resource name. 
+            The OMP OIC Resource name.
         value: '"x.mynewt.nmgr"'

--- a/mgmt/smp/pkg.yml
+++ b/mgmt/smp/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/smp/syscfg.yml
+++ b/mgmt/smp/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/smp/transport/ble/pkg.yml
+++ b/mgmt/smp/transport/ble/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/smp/transport/ble/syscfg.yml
+++ b/mgmt/smp/transport/ble/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/smp/transport/smp_shell/pkg.yml
+++ b/mgmt/smp/transport/smp_shell/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/mgmt/smp/transport/smp_shell/syscfg.yml
+++ b/mgmt/smp/transport/smp_shell/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/inet_def_service/pkg.yml
+++ b/net/ip/inet_def_service/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/lwip_base/pkg.yml
+++ b/net/ip/lwip_base/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/lwip_mn/pkg.yml
+++ b/net/ip/lwip_mn/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/mn_socket/pkg.yml
+++ b/net/ip/mn_socket/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/mn_socket/selftest/pkg.yml
+++ b/net/ip/mn_socket/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/net/ip/mn_socket"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/net/ip/native_sockets/pkg.yml
+++ b/net/ip/native_sockets/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/ip/pkg.yml
+++ b/net/ip/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/mqtt/eclipse/pkg.yml
+++ b/net/mqtt/eclipse/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,7 +18,7 @@
 #
 
 pkg.name: net/mqtt/eclipse
-pkg.description: Eclipse Paho MQTT client for Embedded platforms 
+pkg.description: Eclipse Paho MQTT client for Embedded platforms
 pkg.author: "eclipse"
 pkg.homepage: "http://eclipse.org/paho"
 pkg.keywords:

--- a/net/oic/pkg.yml
+++ b/net/oic/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/net/oic/selftest/pkg.yml
+++ b/net/oic/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/project.yml
+++ b/project.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/config/pkg.yml
+++ b/sys/config/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/config/selftest-fcb/pkg.yml
+++ b/sys/config/selftest-fcb/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/fs/fcb"
     - "@apache-mynewt-core/sys/config"
     - "@apache-mynewt-core/sys/console/stub"

--- a/sys/config/selftest-nffs/pkg.yml
+++ b/sys/config/selftest-nffs/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/fs/nffs"
     - "@apache-mynewt-core/sys/config"
     - "@apache-mynewt-core/sys/console/stub"

--- a/sys/config/selftest-nffs/syscfg.yml
+++ b/sys/config/selftest-nffs/syscfg.yml
@@ -18,5 +18,5 @@
 
 syscfg.vals:
     CONFIG_NFFS: 1
-    CONFIG_FCB_FLASH_AREA: 
+    CONFIG_FCB_FLASH_AREA:
     CONFIG_AUTO_INIT: 0

--- a/sys/console/full/history_ram/pkg.yml
+++ b/sys/console/full/history_ram/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/console/full/pkg.yml
+++ b/sys/console/full/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/console/stub/pkg.yml
+++ b/sys/console/stub/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/coredump/pkg.yml
+++ b/sys/coredump/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/coredump/syscfg.yml
+++ b/sys/coredump/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/fault/fault_cli/pkg.yml
+++ b/sys/fault/fault_cli/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/fault/fault_cli/syscfg.yml
+++ b/sys/fault/fault_cli/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/fault/pkg.yml
+++ b/sys/fault/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -19,7 +19,7 @@
 
 pkg.name: sys/fault
 pkg.type: lib
-pkg.description: Tracks, logs, and recovers from errors.  
+pkg.description: Tracks, logs, and recovers from errors.
 pkg.keywords:
     - fault
 

--- a/sys/fault/syscfg.yml
+++ b/sys/fault/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/flash_map/pkg.yml
+++ b/sys/flash_map/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/flash_map/selftest/pkg.yml
+++ b/sys/flash_map/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/flash_map/syscfg.yml
+++ b/sys/flash_map/syscfg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/log/common/syscfg.yml
+++ b/sys/log/common/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/log/full/selftest/align1/pkg.yml
+++ b/sys/log/full/selftest/align1/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/align1_imghash/pkg.yml
+++ b/sys/log/full/selftest/align1_imghash/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/align1_imghash/syscfg.yml
+++ b/sys/log/full/selftest/align1_imghash/syscfg.yml
@@ -26,4 +26,3 @@ syscfg.vals:
     IMGMGR_DUMMY_HDR: 1
     LOG_MGMT: 0
     IMG_MGMT: 0
-    

--- a/sys/log/full/selftest/align2/pkg.yml
+++ b/sys/log/full/selftest/align2/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/align4/pkg.yml
+++ b/sys/log/full/selftest/align4/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/align8/pkg.yml
+++ b/sys/log/full/selftest/align8/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/fcb_bookmarks/pkg.yml
+++ b/sys/log/full/selftest/fcb_bookmarks/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/perlogidx/pkg.yml
+++ b/sys/log/full/selftest/perlogidx/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"

--- a/sys/log/full/selftest/util/pkg.yml
+++ b/sys/log/full/selftest/util/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,6 +22,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/test/testutil"
     - "@apache-mynewt-core/sys/log/full"

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -34,7 +34,7 @@ syscfg.defs:
 
     LOG_FLAGS_IMAGE_HASH:
         description: >
-            Enable logging of the first 4 bytes of the image hash. 0 - disable; 
+            Enable logging of the first 4 bytes of the image hash. 0 - disable;
             1 - enable.
         value: 0
 

--- a/sys/log/modlog/pkg.yml
+++ b/sys/log/modlog/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/log/modlog/selftest/pkg.yml
+++ b/sys/log/modlog/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - '@apache-mynewt-core/sys/console/stub'
     - '@apache-mynewt-core/sys/log/full'
     - '@apache-mynewt-core/sys/log/modlog'

--- a/sys/log/modlog/syscfg.yml
+++ b/sys/log/modlog/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/log/util/log_cbor_reader/pkg.yml
+++ b/sys/log/util/log_cbor_reader/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/metrics/pkg.yml
+++ b/sys/metrics/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-pkg.name: sys/shell 
+pkg.name: sys/shell
 pkg.description: Command processor for console-based applications.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"

--- a/sys/shell/syscfg.yml
+++ b/sys/shell/syscfg.yml
@@ -75,7 +75,7 @@ syscfg.defs:
         description: >
             Datetime command enabled, read 1,
             write 2, read/write 3 (default)
-        value: 3 
+        value: 3
 
     SHELL_BRIDGE:
         description: >

--- a/sys/stats/full/pkg.yml
+++ b/sys/stats/full/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/test/flash_test/pkg.yml
+++ b/test/flash_test/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/test/flash_test/syscfg.yml
+++ b/test/flash_test/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/test/i2c_scan/pkg.yml
+++ b/test/i2c_scan/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/test/i2c_scan/syscfg.yml
+++ b/test/i2c_scan/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/test/testutil/pkg.yml
+++ b/test/testutil/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/time/datetime/pkg.yml
+++ b/time/datetime/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.description: Library containing miscellaneous utilities.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - date 
+    - date
     - datetime
 
 pkg.deps:

--- a/time/timesched/pkg.yml
+++ b/time/timesched/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.description: Scheduling on clock time
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - date 
+    - date
     - datetime
 
 pkg.deps:

--- a/time/timesched/syscfg.yml
+++ b/time/timesched/syscfg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/cbmem/hosttest/pkg.yml
+++ b/util/cbmem/hosttest/pkg.yml
@@ -4,7 +4,7 @@
 # regarding copyright ownership.  The ASF licenses this file # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,6 +22,6 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/test/testutil"
     - "@apache-mynewt-core/util/cbmem"

--- a/util/cbmem/pkg.yml
+++ b/util/cbmem/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/cbmem/selftest/pkg.yml
+++ b/util/cbmem/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/test/testutil"

--- a/util/cmdarg/pkg.yml
+++ b/util/cmdarg/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/crc/pkg.yml
+++ b/util/crc/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.description: Library containing encoding functions
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - crc16 
+    - crc16
     - crc32
     - crc8
     - crc

--- a/util/debounce/selftest/pkg.yml
+++ b/util/debounce/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -23,7 +23,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/sys/log/stub"
     - '@apache-mynewt-core/sys/console/stub'
     - '@apache-mynewt-core/test/testutil'

--- a/util/mem/pkg.yml
+++ b/util/mem/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/parse/pkg.yml
+++ b/util/parse/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/rwlock/pkg.yml
+++ b/util/rwlock/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -21,5 +21,5 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/kernel/os"

--- a/util/rwlock/selftest/pkg.yml
+++ b/util/rwlock/selftest/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/stub"
     - "@apache-mynewt-core/sys/log/stub"

--- a/util/scfg/pkg.yml
+++ b/util/scfg/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/util/streamer/pkg.yml
+++ b/util/streamer/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -21,7 +21,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/kernel/os"
 
 pkg.req_apis:

--- a/util/taskpool/pkg.yml
+++ b/util/taskpool/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -21,7 +21,7 @@ pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
-pkg.deps: 
+pkg.deps:
     - "@apache-mynewt-core/kernel/os"
 
 pkg.init:


### PR DESCRIPTION
Clean up trailing spaces, to avoid copypasta of pkg.yml and syscfg.yml with trailing spaces in the license headers to keep propagating.