### PR TITLE
fs: littlefs: add migrate/readonly build options

### DIFF
--- a/fs/littlefs/pkg.yml
+++ b/fs/littlefs/pkg.yml
@@ -33,5 +33,11 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/flash_map"
 
+pkg.cflags.LITTLEFS_MIGRATE_V1:
+    - -DLFS_MIGRATE
+
+pkg.cflags.LITTLEFS_READONLY:
+    - -DLFS_READONLY
+
 pkg.init:
     littlefs_pkg_init: 'MYNEWT_VAL(LITTLEFS_SYSINIT_STAGE)'

--- a/fs/littlefs/syscfg.yml
+++ b/fs/littlefs/syscfg.yml
@@ -36,6 +36,16 @@ syscfg.defs:
             must have the same size.
         value: -1
 
+    LITTLEFS_MIGRATE_V1:
+        description: >
+            Enable support for migrating LFSv1 filesystems to v2.
+        value: 0
+
+    LITTLEFS_READONLY:
+        description: >
+            Build LittleFS without write support.
+        value: 0
+
     LITTLEFS_BLOCK_COUNT:
         description: >
             Number of blocks/sectors use by this partition.


### PR DESCRIPTION
Add syscfg options that enable building the v1 metadata format migration to v2, and read-only support (for smaller build sizes).