### PR TITLE
nrf53/ipc: add MCU_APP_CORE guard for NET_GPIO header includes

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -21,9 +21,11 @@
 #include <os/os.h>
 #include <ipc_nrf5340/ipc_nrf5340.h>
 #include <nrfx.h>
+#if MYNEWT_VAL(MCU_APP_CORE)
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
 #include <mcu/nrf5340_hal.h>
 #include <bsp/bsp.h>
+#endif
 #endif
 
 /* Currently this allows only for 1-1 connection. */


### PR DESCRIPTION
The header file `nrf5340_hal.h` is for app core and should be guarded accordingly