### PR TITLE
hw: battery: Check return code from adc_chan_config

### DIFF
--- a/hw/battery/src/battery_adc.c
+++ b/hw/battery/src/battery_adc.c
@@ -118,8 +118,11 @@ battery_adc_open(struct os_dev *dev, uint32_t timeout, void *arg)
         (char *)bat_adc->cfg.adc_dev_name, timeout, bat_adc->cfg.adc_open_arg);
     if (bat_adc->adc_dev) {
         /* Setup channel configuration to use for battery voltage */
-        adc_chan_config(bat_adc->adc_dev, bat_adc->cfg.channel,
-                bat_adc->cfg.adc_channel_cfg);
+        rc = adc_chan_config(bat_adc->adc_dev, bat_adc->cfg.channel,
+                             bat_adc->cfg.adc_channel_cfg);
+        if (rc) {
+            return rc;
+        }
 
         /* Additional GPIO needed before measurement ? */
         if (bat_adc->cfg.activation_pin_needed &&

--- a/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
+++ b/hw/drivers/adc/gpadc_da1469x/src/gpadc_da1469x.c
@@ -682,7 +682,10 @@ da1469x_open_battery_adc(const char *dev_name, uint32_t wait)
     if (adc) {
         /* call adc_chan_config to setup correct multiplier so read returns
          * value in mV */
-        adc_chan_config((struct adc_dev *)adc, 0, NULL);
+        if (adc_chan_config((struct adc_dev *)adc, 0, NULL)) {
+            os_dev_close(adc);
+            adc = NULL;
+        }
     }
     return adc;
 }

--- a/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
+++ b/hw/drivers/adc/sdadc_da1469x/src/sdadc_da1469x.c
@@ -471,7 +471,10 @@ da1469x_open_battery_adc(const char *dev_name, uint32_t wait)
     if (adc) {
         /* call adc_chan_config to setup correct multiplier so read returns
          * value in mV */
-        adc_chan_config((struct adc_dev *)adc, 0, NULL);
+        if (adc_chan_config((struct adc_dev *)adc, 0, NULL)) {
+            os_dev_close(adc);
+            adc = NULL;
+        }
     }
     return adc;
 }


### PR DESCRIPTION
This patch fixes an unchecked return value when invoking the adc_chan_config
call.  This issue was found as part of a static analysis tool.  Fixed all
instances using this API that were not checking return value.

Signed-off-by: Andy Gross <andy.gross@juul.com>