### PR TITLE
mcu/nrf5340: Add MCU_TARGET

### DIFF
--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -17,6 +17,14 @@
 #
 
 syscfg.defs:
+    MCU_TARGET:
+        description: >
+            Specifies target MCU.
+        value: nRF5340_APP
+        restrictions:
+            - $notnull
+        choices:
+            - nRF5340_APP
     MCU_APP_CORE:
         description: >
             Constant value always set to 1.  It allows to have common

--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -17,6 +17,14 @@
 #
 
 syscfg.defs:
+    MCU_TARGET:
+        description: >
+            Specifies target MCU.
+        value: nRF5340_NET
+        restrictions:
+            - $notnull
+        choices:
+            - nRF5340_NET
     MCU_NET_CORE:
         description: >
             Constant value always set to 1.  It allows to have common


### PR DESCRIPTION
MCU_TARGET syscfg value is commonly used in NRF5x based targets.
NRF5340 already has MCU_APP_CORE and MCU_NET_CORE but for
applications that can be built for all kinds of MCUs, it
seems that common MCU_TARGET variable is cleaner solution to have.