### PR TITLE
kernel/os: Remove min/max macros for C++

### DIFF
--- a/kernel/os/include/os/os.h
+++ b/kernel/os/include/os/os.h
@@ -27,7 +27,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#else
 
 #ifndef min
 #define min(a, b) ((a)<(b)?(a):(b))
@@ -35,6 +35,7 @@ extern "C" {
 
 #ifndef max
 #define max(a, b) ((a)>(b)?(a):(b))
+#endif
 #endif
 
 #define os_get_return_addr() (__builtin_return_address(0))


### PR DESCRIPTION
Symbols min and max are standard template functions.
When os.h is included from C++ code macros provided
by this header break build.

mynewt is written in C hence removing min/max definitions
just from C++ build will not break any existing code.