### PR TITLE
sys/stats: Fix build warnings when stats are stubbed

### DIFF
--- a/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
+++ b/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
@@ -706,11 +706,11 @@ bus_i2c_da1469x_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(I2C_DA1469X_STAT)
     asprintf(&stats_name, "i2c_da1469x_%d", cfg->i2c_num);
-    /* XXX should we assert or return error on failure? */
-    stats_init_and_reg(STATS_HDR(dd->stats),
-                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(i2c_da1469x_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(dd->stats),
+                            STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(i2c_da1469x_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     rc = bus_dev_init_func(odev, (void*)&bus_i2c_da1469x_dma_ops);

--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -657,11 +657,11 @@ bus_i2c_nrf52_twim_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(I2C_NRF52_TWIM_STAT)
     asprintf(&stats_name, "i2c_nrf52_twim%d", cfg->i2c_num);
-    /* XXX should we assert or return error on failure? */
-    stats_init_and_reg(STATS_HDR(dd->stats),
-                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(twim_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(dd->stats),
+                            STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(twim_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     rc = bus_dev_init_func(odev, (void*)&bus_i2c_nrf52_twim_ops);

--- a/hw/bus/drivers/i2c_nrf91_twim/src/i2c_nrf91_twim.c
+++ b/hw/bus/drivers/i2c_nrf91_twim/src/i2c_nrf91_twim.c
@@ -650,11 +650,11 @@ bus_i2c_nrf91_twim_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(I2C_NRF91_TWIM_STAT)
     asprintf(&stats_name, "i2c_nrf91_twim%d", cfg->i2c_num);
-    /* XXX should we assert or return error on failure? */
-    stats_init_and_reg(STATS_HDR(dd->stats),
-                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(twim_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(dd->stats),
+                            STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(twim_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     rc = bus_dev_init_func(odev, (void *)&bus_i2c_nrf91_twim_ops);

--- a/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
+++ b/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
@@ -656,10 +656,11 @@ bus_spi_da1469x_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(SPI_DA1469X_STAT)
     asprintf(&stats_name, "spi_da1469x_%d", cfg->spi_num);
-    stats_init_and_reg(STATS_HDR(dd->stats),
-                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(spi_da1469x_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(dd->stats),
+                            STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(spi_da1469x_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     rc = bus_dev_init_func(odev, (void *)&bus_spi_da1469x_ops);

--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -867,10 +867,11 @@ bus_spi_stm32_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(SPI_STM32_STAT)
     asprintf(&stats_name, "spi_stm32_%d", cfg->spi_num);
-    stats_init_and_reg(STATS_HDR(dd->stats),
-                       STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(spi_stm32_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(dd->stats),
+                            STATS_SIZE_INIT_PARMS(dd->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(spi_stm32_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     rc = bus_dev_init_func(odev, (void *)&bus_spi_stm32_ops);

--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -226,6 +226,7 @@ bus_dev_init_func(struct os_dev *odev, void *arg)
     struct bus_dev_ops *ops = arg;
 #if MYNEWT_VAL(BUS_STATS)
     char *stats_name;
+    int rc;
 #endif
 
     BUS_DEBUG_POISON_DEV(bdev);
@@ -246,11 +247,11 @@ bus_dev_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(BUS_STATS)
     asprintf(&stats_name, "bd_%s", odev->od_name);
-    /* XXX should we assert or return error on failure? */
-    stats_init_and_reg(STATS_HDR(bdev->stats),
-                       STATS_SIZE_INIT_PARMS(bdev->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(bus_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(bdev->stats),
+                            STATS_SIZE_INIT_PARMS(bdev->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(bus_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     odev->od_handlers.od_suspend = bus_dev_suspend_func;
@@ -305,11 +306,11 @@ bus_node_init_func(struct os_dev *odev, void *arg)
 
 #if MYNEWT_VAL(BUS_STATS_PER_NODE)
     asprintf(&stats_name, "bn_%s", odev->od_name);
-    /* XXX should we assert or return error on failure? */
-    stats_init_and_reg(STATS_HDR(bnode->stats),
-                       STATS_SIZE_INIT_PARMS(bnode->stats, STATS_SIZE_32),
-                       STATS_NAME_INIT_PARMS(bus_stats_section),
-                       stats_name);
+    rc = stats_init_and_reg(STATS_HDR(bnode->stats),
+                            STATS_SIZE_INIT_PARMS(bnode->stats, STATS_SIZE_32),
+                            STATS_NAME_INIT_PARMS(bus_stats_section),
+                            stats_name);
+    assert(rc == 0);
 #endif
 
     if (bnode->callbacks.init) {


### PR DESCRIPTION
In several places return value of **stats_init_and_reg**() is ignored.
When stub implementation is used this evaluates to just 0 then
there are statements like:
   0;
which are reported in following way

Error: In file included from repos/apache-mynewt-core/hw/bus/include/bus/bus_driver.h:26,
                 from repos/apache-mynewt-core/hw/bus/src/bus.c:25:
repos/apache-mynewt-core/hw/bus/src/bus.c: In function 'bus_dev_init_func':
repos/apache-mynewt-core/sys/stats/stub/include/stats/stats.h:75:33: error: statement with no effect [-Werror=unused-value]
   75 | #define stats_init_and_reg(...) 0
      |                                 ^
repos/apache-mynewt-core/hw/bus/src/bus.c:250:5: note: in expansion of macro 'stats_init_and_reg'
  250 |     stats_init_and_reg(STATS_HDR(bdev->stats),

Now return value from stats_init_and_reg() is assigned to rc and verified by assert
that will fix problem with 0; statement.