### PR TITLE
stm32/hal_spi: Enable SPI in hal_spi_enable

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -532,7 +532,7 @@ hal_spi_enable(int spi_num)
     rc = 0;
     STM32_HAL_SPI_RESOLVE(spi_num, spi);
 
-    /* XXX power up */
+    __HAL_SPI_ENABLE(&spi->handle);
 err:
     return rc;
 }
@@ -554,7 +554,7 @@ hal_spi_disable(int spi_num)
     rc = 0;
     STM32_HAL_SPI_RESOLVE(spi_num, spi);
 
-    /* XXX power down */
+    __HAL_SPI_DISABLE(&spi->handle);
 err:
     return rc;
 }


### PR DESCRIPTION
Functions hal_spi_enable() and hal_spi_disable() did not do
anything useful.

Now like many other implementations (NRF, DA1469x) those functions
actually enable and disable SPI.

Without this change SPI peripheral could be enabled by
ST HAL functions like HAL_SPI_Transmit_Receive() but
if that was the case chip select would be asserted before
SPI peripheral was enabled.
In some cases it could lead to clock PIN going to inactive state
after chip select was active.
With this change SPI pins are in correct state before CS is activated during transmission.