### PR TITLE
sensor_creator: Add LIS2DW12 configuration for bus drivers

### DIFF
--- a/hw/sensor/creator/syscfg.yml
+++ b/hw/sensor/creator/syscfg.yml
@@ -185,6 +185,45 @@ syscfg.defs:
     LIS2DW12_OFB:
         description: 'LIS2DW12 is present'
         value : 0
+    LIS2DW12_OFB_BUS:
+        description: 'I2C or SPI interface used for LIS2DW12'
+        value: '"i2c0"'
+    LIS2DW12_OFB_ITF_ADDR:
+        description: 'I2C address of LIS2DW12 0x18 or 0x19'
+        value: 0x18
+        range: 0x18,0x19
+    LIS2DW12_OFB_I2C_NUM:
+        description: 'I2C interface used for LIS2DW12'
+        value: -1
+        restrictions:
+            - '(LIS2DW12_OFB == 0) ||
+            ((LIS2DW12_OFB_I2C_NUM == 0) && (I2C_0 == 1)) ||
+            ((LIS2DW12_OFB_I2C_NUM == 1) && (I2C_1 == 1)) ||
+            ((LIS2DW12_OFB_I2C_NUM == 2) && (I2C_2 == 1)) ||
+            ((LIS2DW12_OFB_I2C_NUM == 3) && (I2C_3 == 1)) ||
+            ((LIS2DW12_OFB_I2C_NUM == -1))'
+    LIS2DW12_OFB_SPI_NUM:
+        description: 'SPI interface used for LIS2DW12'
+        value: -1
+        restrictions:
+            - '(LIS2DW12_OFB == 0) ||
+            ((LIS2DW12_OFB_SPI_NUM == 0) && (SPI_0_MASTER == 1)) ||
+            ((LIS2DW12_OFB_SPI_NUM == 1) && (SPI_1_MASTER == 1)) ||
+            ((LIS2DW12_OFB_SPI_NUM == 2) && (SPI_2_MASTER == 1)) ||
+            ((LIS2DW12_OFB_SPI_NUM == 3) && (SPI_3_MASTER == 1)) ||
+            ((LIS2DW12_OFB_SPI_NUM == -1))'
+    LIS2DW12_OFB_INT1_PIN_HOST:
+        description: 'Host pin for LIS2DW12 INT1 pin'
+        value: -1
+    LIS2DW12_OFB_INT1_PIN_DEVICE:
+        description: 'Interrupt pin number 1 or 2 on accelerometer device'
+        value: 1
+    LIS2DW12_OFB_INT_CFG_ACTIVE:
+        description: 'Set 0 for active-low, 1 for active-high'
+        value: 1
+    LIS2DW12_OFB_BAUDRATE:
+        description: 'LIS2DW12 speed'
+        value: 400
     LIS2DH12_OFB:
         description: 'LIS2DH12 is present'
         value : 0


### PR DESCRIPTION
LIS2DW12 has support for bus driver.
Now it can be used with sensor_creator.