### PR TITLE
da1469x/i2c: Correct CON_REG settings

### DIFF
--- a/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
+++ b/hw/bus/drivers/i2c_da1469x/src/i2c_da1469x.c
@@ -680,6 +680,7 @@ bus_i2c_da1469x_dev_init_func(struct os_dev *odev, void *arg)
 
     i2c_hw->regs->I2C_CON_REG = (1U << I2C_I2C_CON_REG_I2C_MASTER_MODE_Pos) |
                                 (1U << I2C_I2C_CON_REG_I2C_SPEED_Pos) |
+                                (1U << I2C_I2C_CON_REG_I2C_SLAVE_DISABLE_Pos) |
                                 (1U << I2C_I2C_CON_REG_I2C_RESTART_EN_Pos);
 
     i2c_hw->regs->I2C_INTR_MASK_REG = 0;

--- a/hw/mcu/dialog/da1469x/src/hal_i2c.c
+++ b/hw/mcu/dialog/da1469x/src/hal_i2c.c
@@ -165,7 +165,8 @@ i2c_init_hw(const struct da1469x_hal_i2c *i2c, int pin_scl, int pin_sda)
     mcu_gpio_set_pin_function(pin_sda, MCU_GPIO_MODE_OUTPUT_OPEN_DRAIN, i2c->sda_func);
 
     /* Configure I2C_CON_REG, first configure to master */
-    i2c_con_reg = (1 << I2C_I2C_CON_REG_I2C_MASTER_MODE_Pos);
+    i2c_con_reg = (1 << I2C_I2C_CON_REG_I2C_MASTER_MODE_Pos) |
+                  (1 << I2C_I2C_CON_REG_I2C_SLAVE_DISABLE_Pos);
 
     /* Use 7-bit addressing */
     i2c_con_reg &= ~(1 << I2C_I2C_CON_REG_I2C_10BITADDR_MASTER_Pos);


### PR DESCRIPTION
For register I2C_CON_REG datasheet description of
bit I2C_MASTER_MODE:
This bit controls whether the controller master is enabled.
 0= master disabled
 1= master enabled
Software should ensure that if this bit is written with
'1' then bit 6 (SLAVE_DISABLE) should also be written with a '1'.

It's not clear what will happened otherwise, so far it seemed to
work without this but to be on the safe side.