### PR TITLE
net/osdp: add a polling timeout for non-secure session

### DIFF
--- a/net/osdp/include/osdp/osdp.h
+++ b/net/osdp/include/osdp/osdp.h
@@ -43,6 +43,11 @@ extern "C" {
 #define OSDP_FLAG_INSTALL_MODE         0x00020000
 
 /**
+ * @brief When set, the PD will not set up secure mode capability.
+ */
+#define OSDP_FLAG_NON_SECURE_MODE      0x00040000
+
+/**
  * @brief Various PD capability function codes.
  */
 enum osdp_pd_cap_function_code_e {

--- a/net/osdp/include/osdp/osdp_common.h
+++ b/net/osdp/include/osdp/osdp_common.h
@@ -144,6 +144,7 @@ union osdp_ephemeral_data {
 #define PD_FLAG_CHN_SHARED      0x00000400 /* PD's channel is shared */
 #define PD_FLAG_PKT_SKIP_MARK   0x00000800 /* CONFIG_OSDP_SKIP_MARK_BYTE */
 #define PD_FLAG_PKT_HAS_MARK    0x00001000 /* Packet has mark byte */
+#define PD_FLAG_CP_POLL_ACTIVE  0x00002000 /* PD is getting polled by CP, for non-secure mode */
 
 #define osdp_dump(b, l, f, ...) hexdump(b, l, f, __VA_ARGS__)
 

--- a/net/osdp/src/osdp_common.c
+++ b/net/osdp/src/osdp_common.c
@@ -199,8 +199,11 @@ osdp_get_status_mask(osdp_t *ctx)
             }
         }
     } else {
-        /* PD is stateless */
-        mask = 1;
+        /* PD state is either online or offline based on whether it got polled from CP */
+        pd = TO_PD(ctx, 0);
+        if (ISSET_FLAG(pd, PD_FLAG_CP_POLL_ACTIVE)) {
+            mask = 1;
+        }
     }
 
     return mask;

--- a/net/osdp/syscfg.yml
+++ b/net/osdp/syscfg.yml
@@ -56,6 +56,10 @@ syscfg.defs:
         value: 400
         description: 'Timeout in milliseconds for secure mode session.'
 
+    OSDP_PD_IDLE_TIMEOUT_MS:
+        value: 800
+        description: 'Idle line timeout. PD has not heard a POLL from CP for this duration.'
+
     OSDP_DEVICE_LOCK_TIMEOUT_MS:
         value: 20
         description: 'Event/Command mutex timeout in milliseconds'


### PR DESCRIPTION
- Raise a timeout flag if the peripheral device does not hear from the control panel for said time interval