### PR TITLE
apps/coremark: Remove bootutil dependency

### DIFF
--- a/apps/coremark/pkg.yml
+++ b/apps/coremark/pkg.yml
@@ -25,7 +25,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@mcuboot/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/sys/stats/stub"


### PR DESCRIPTION
Application package referenced "@mcuboot/boot/bootutil"
which was not used.