### PR TITLE
Improve bus write read transactions

### DIFF
--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -63,6 +63,11 @@ struct bus_dev_ops {
                   uint16_t length, os_time_t timeout,  uint16_t flags);
     /* Disable bus device */
     int (* disable)(struct bus_dev *bus);
+    /* Write data to node */
+    int (* write_read)(struct bus_dev *dev, struct bus_node *node,
+                       const uint8_t *wbuf, uint16_t wlength,
+                       uint8_t *rbuf, uint16_t rlength,
+                       os_time_t timeout,  uint16_t flags);
 };
 
 /**


### PR DESCRIPTION
Change extends bus driver operations to allow faster transfer.

New driver function **write_read** allow for faster transaction implementation.

Existing function **bus_node_write_read_transact()** was using **write** that **read**.
It turns out that for short transfers (1 or 2 bytes written) several bytes read it is worth
to implement custom function that writes and read.

This code also adds first implementation of such function for spi_hal driver that can
benefit around 50% time reduction on single transfer.
