### PR TITLE
hw/drivers/spiram: Fix 4 bytes address handling

### DIFF
--- a/hw/drivers/ram/spiram/src/spiram.c
+++ b/hw/drivers/ram/spiram/src/spiram.c
@@ -102,7 +102,7 @@ spiram_write_enable(struct spiram_dev *dev)
 int
 spiram_read(struct spiram_dev *dev, uint32_t addr, void *buf, uint32_t size)
 {
-    uint8_t cmd[5] = { SPIRAM_READ };
+    uint8_t cmd[6] = { SPIRAM_READ };
     int i;
     int rc;
     int cmd_size = 1 + dev->characteristics->address_bytes + dev->characteristics->dummy_bytes;
@@ -147,7 +147,7 @@ spiram_read(struct spiram_dev *dev, uint32_t addr, void *buf, uint32_t size)
 int
 spiram_write(struct spiram_dev *dev, uint32_t addr, void *buf, uint32_t size)
 {
-    uint8_t cmd[4] = { SPIRAM_WRITE };
+    uint8_t cmd[5] = { SPIRAM_WRITE };
     int rc;
     int i;
     bool locked;

--- a/hw/drivers/ram/spiram/syscfg.yml
+++ b/hw/drivers/ram/spiram/syscfg.yml
@@ -66,6 +66,7 @@ syscfg.defs:
     SPIRAM_0_DUMMY_BYTES:
         description: >
             SPI RAM number of dummy bytes to send after address during read command.
+        range: 0,1
         value: 0
 
     SPIRAM_0_WRITE_ENABLE_CMD:


### PR DESCRIPTION
Even though there is no 4 bytes addressing RAM out there,
because syscfg allowed such value to be set update code
to handle this case correctly to be future proof.

Also restriction was added for dummy bytes.