### PR TITLE
pic32: Fix crt0.S build error

### DIFF
--- a/kernel/os/src/arch/pic32/startup/crt0.S
+++ b/kernel/os/src/arch/pic32/startup/crt0.S
@@ -311,7 +311,7 @@ _dinit_clear:
 
 _dinit_end:
         addu    SRC,3
-        addiu   LEN,$0,0xFFFFFFFC
+        addiu   LEN,$0,-4
         and     SRC,LEN,SRC
         lw      DST,0(SRC)
         bne     DST,$0,0b


### PR DESCRIPTION
xc32 compiler version 3.xx starts to complain
about constant value range

Error: repos/apache-mynewt-core/kernel/os/src/arch/pic32/startup/crt0.S: Assembler messages:
repos/apache-mynewt-core/kernel/os/src/arch/pic32/startup/crt0.S:314: Error: operand 3 out of range `addiu $10,$0,0xFFFFFFFC'

previous compiler did not complain

This changes 32bit unsigned interpretation of -4 (0xFFFFFFFC)
to just -4, so 2.5 and 3.x versions are happy.

-4 can be found in SDK provided crt0.S files.