### PR TITLE
nrf5340: Conditional Rev A errata 26 fix

### DIFF
--- a/hw/mcu/nordic/nrf5340/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/pkg.yml
@@ -104,3 +104,6 @@ pkg.deps.I2C_3':
 
 pkg.deps.NRF5340_EMBED_NET_CORE:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf5340/net_core_image"
+
+pkg.cflags.MCU_NRF5340_EN_APPROTECT_USERHANDLING:
+    - "-DENABLE_APPROTECT_USER_HANDLING"

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -25,13 +25,14 @@ syscfg.defs:
             - $notnull
         choices:
             - nRF5340_APP
+
     MCU_APP_CORE:
         description: >
             Constant value always set to 1.  It allows to have common
             packages for network and application core that do have
             some differences depending on which core they are build for.
         value: 1
-        restriction: MCU_NET_CORE==0
+
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.
@@ -87,6 +88,12 @@ syscfg.defs:
         description: >
             Enable instruction and data cache
             Default value is 0, so disabled.
+        value: 0
+
+    MCU_NRF5340_EN_APPROTECT_USERHANDLING:
+        description: >
+            This needs to be set by the BSP/App/Target if the
+            MCU/BSP wants to handle APPROTECT on its own.
         value: 0
 
 # MCU peripherals definitions


### PR DESCRIPTION
- As per Errata 26, CTRL-AP: APPROTECT.DISABLE and
  SECUREAPPROTECT.DISABLE registers are not functional
- So we need to conditionally disable its usage
- Adding a syscfg so we can rely on UICR config instead of CTRLAP
-  Remove MCU_NET_CORE restriction from APP CORE, does not matter anymore since MCUs are different

Note: Somehow this fix is not required on the netcore side. Hence, only making this fix on the app core side.

** BEFORE **
A `HardFault` would happen at `57             NRF_CTRLAP_S->APPROTECT.DISABLE = NRF_UICR_S->APPROTECT;` in `repos/apache-mynewt-core/hw/mcu/nordic/src/ext/nrfx/mdk/system_nrf5340_application.c` which would be seen in the bootloader.

** AFTER **
No `HardFault`