### PR TITLE
i2s fixes

### DIFF
--- a/hw/drivers/i2s/i2s_nrf52/src/i2s_nrf52.c
+++ b/hw/drivers/i2s/i2s_nrf52/src/i2s_nrf52.c
@@ -155,10 +155,10 @@ i2s_driver_stop(struct i2s *i2s)
 {
     struct i2s_sample_buffer *buffer;
 
-    nrf52_i2s.running = false;
-    nrfx_i2s_stop();
-
-    assert(nrf52_i2s.i2s->state == I2S_STATE_STOPPED);
+    if (nrf52_i2s.running) {
+        nrf52_i2s.running = false;
+        nrfx_i2s_stop();
+    }
 
     while (NULL != (buffer = i2s_driver_buffer_get(i2s))) {
         i2s_driver_buffer_put(i2s, buffer);

--- a/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
+++ b/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
@@ -170,10 +170,10 @@ i2s_driver_stop(struct i2s *i2s)
 {
     struct i2s_sample_buffer *buffer;
 
-    i2s_nrfx.running = false;
-    nrfx_i2s_stop();
-
-    assert(i2s_nrfx.i2s->state == I2S_STATE_STOPPED);
+    if (i2s_nrfx.running) {
+        i2s_nrfx.running = false;
+        nrfx_i2s_stop();
+    }
 
     while (NULL != (buffer = i2s_driver_buffer_get(i2s))) {
         i2s_driver_buffer_put(i2s, buffer);

--- a/hw/drivers/i2s/src/i2s.c
+++ b/hw/drivers/i2s/src/i2s.c
@@ -180,7 +180,6 @@ i2s_close(struct i2s *i2s)
 int
 i2s_write(struct i2s *i2s, void *samples, uint32_t sample_buffer_size)
 {
-    uint32_t sample_pair_size = (i2s->sample_size_in_bytes * 2);
     size_t sample_count;
     struct i2s_sample_buffer *buffer;
 
@@ -193,15 +192,16 @@ i2s_write(struct i2s *i2s, void *samples, uint32_t sample_buffer_size)
     }
 
     /* Calculate buffer size */
-    sample_count = sample_buffer_size / sample_pair_size;
+    sample_count = sample_buffer_size / i2s->sample_size_in_bytes;
     if (buffer->capacity < sample_count) {
         sample_count = buffer->capacity;
     }
 
-    sample_buffer_size = sample_count * sample_pair_size;
+    sample_buffer_size = sample_count * i2s->sample_size_in_bytes;
 
     /* Move data to buffer */
     memcpy(buffer->sample_data, samples, sample_buffer_size);
+    buffer->sample_count = sample_count;
 
     /* Pass buffer to output device */
     i2s_buffer_put(i2s, buffer);


### PR DESCRIPTION
Two fixes related to I2S.

- NRF5x versions would assert when i2s_open and i2s_close were issued without transferring any data
- i2s_write did not fill correctly sample count field in i2s_buffer