### PR TITLE
flash_test: Make test output more readable

### DIFF
--- a/test/flash_test/src/flash_test.c
+++ b/test/flash_test/src/flash_test.c
@@ -292,7 +292,7 @@ flash_speed_test_cli(const struct shell_cmd *cmd, int argc, char **argv,
           "Speed test, hal_flash_read(%d, 0x%x%s, %d)\n",
           flash_dev, (unsigned int)addr, move?"..":"", (unsigned int)sz);
         cnt = flash_speed_test(flash_dev, addr, sz, move);
-        streamer_printf(streamer, "%d\n", cnt >> 1);
+        streamer_printf(streamer, "%d (%d kB/s)\n", cnt >> 1, (cnt * sz) >> 11);
     } else {
         uint32_t sizes[] = {
             1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 192, 256
@@ -301,10 +301,11 @@ flash_speed_test_cli(const struct shell_cmd *cmd, int argc, char **argv,
         streamer_printf(streamer,
           "Speed test, hal_flash_read(%d, 0x%x%s, X)\n",
           flash_dev, (unsigned int)addr, move?"..":"");
+        streamer_printf(streamer, " X  reads/s  kB/s\n");
 
         for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
             cnt = flash_speed_test(flash_dev, addr, sizes[i], move);
-            streamer_printf(streamer, "%3d %d\n", (int)sizes[i], cnt >> 1);
+            streamer_printf(streamer, "%3d %7d %5d\n", (int)sizes[i], cnt >> 1, (cnt * sizes[i]) >> 11);
             os_time_delay(OS_TICKS_PER_SEC / 8);
         }
     }


### PR DESCRIPTION
flash_test output looked like this:
```
compat> flash_speed 0 0x8000000 range
Speed test, hal_flash_read(0, 0x8000000, X)
004310   1 299288
006436   2 280513
008562   4 298043
010688   8 278327
012814  16 245812
014940  24 220095
```

It was not so clear what this output means without
checking source code.

Now header is added to range version and kB/s is
also printed like this:
```
compat> flash_speed 0 0x8000000 range
041813 Speed test, hal_flash_read(0, 0x8000000, X)
041819  X  reads/s  kB/s
043823   1  303089   295
045949   2  283850   554
048075   4  301816  1178
050201   8  281617  2200
052327  16  248369  3880
054453  24  222145  5206
```