### PR TITLE
bus/i2c_nrf5x: Assert on not supported usage

### DIFF
--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -464,6 +464,7 @@ bus_i2c_nrf52_twim_read(struct bus_dev *bdev, struct bus_node *bnode,
          * XXX we may use PPI to workaround for missing shortcut but it's
          * probably not really that useful and not worth the effort.
          */
+        assert(0);
         return SYS_ENOTSUP;
     }
 

--- a/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
+++ b/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
@@ -260,6 +260,7 @@ bus_i2c_nrf5340_read(struct bus_dev *bdev, struct bus_node *bnode,
          * stop after receiving last byte - return not supported if NOSTOP was
          * requested for this read.
          */
+        assert(0);
         return SYS_ENOTSUP;
     }
 

--- a/hw/bus/drivers/i2c_nrf91_twim/src/i2c_nrf91_twim.c
+++ b/hw/bus/drivers/i2c_nrf91_twim/src/i2c_nrf91_twim.c
@@ -456,6 +456,7 @@ bus_i2c_nrf91_twim_read(struct bus_dev *bdev, struct bus_node *bnode,
          * XXX we may use PPI to workaround for missing shortcut but it's
          * probably not really that useful and not worth the effort.
          */
+        assert(0);
         return SYS_ENOTSUP;
     }
 


### PR DESCRIPTION
Current code return error code when read was called
with BUS_F_NOSTOP flag set.

It seems better to just assert at line where the user can
see why this not working instead of returning error code
where user will have to figure out why I2C lines are dead.
This kind of problem is not something that can be fixed
in runtime by just repeating read it will always fail
until the code is modified not to use such flag.

This change should alert the user that this kind of desired
behavior will not work on this platform.