### PR TITLE
hw/mcu/nordic: use correct struct type for spi2 and spi3 bus in nrf52 periph

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
+++ b/hw/mcu/nordic/nrf52xxx/src/nrf52_periph.c
@@ -203,7 +203,7 @@ static const struct bus_spi_dev_cfg spi2_cfg = {
     .pin_mosi = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
     .pin_miso = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
 };
-static struct bus_spi_dev spi2_bus;
+static struct bus_spi_hal_dev spi2_bus;
 #else
 static const struct nrf52_hal_spi_cfg os_bsp_spi2m_cfg = {
     .sck_pin      = MYNEWT_VAL(SPI_2_MASTER_PIN_SCK),
@@ -229,7 +229,7 @@ static const struct bus_spi_dev_cfg spi3_cfg = {
     .pin_mosi = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
     .pin_miso = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
 };
-static struct bus_spi_dev spi3_bus;
+static struct bus_spi_hal_dev spi3_bus;
 #else
 static const struct nrf52_hal_spi_cfg os_bsp_spi3m_cfg = {
     .sck_pin      = MYNEWT_VAL(SPI_3_MASTER_PIN_SCK),


### PR DESCRIPTION
`bus_spi_hal_dev_create` needs struct `bus_spi_hal_dev` when using bus driver.