### PR TITLE
hw/mcu/nrf5340_net: Remove enable/disable from hal_spi_init

### DIFF
--- a/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
@@ -466,26 +466,12 @@ hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
         return EINVAL;
     }
 
-    rc = hal_spi_disable(spi_num);
-    if (rc) {
-        return rc;
-    }
-    rc = hal_spi_enable(spi_num);
-    if (rc) {
-        return rc;
-    }
-
     return hal_spi_init_master(spi, (struct nrf5340_net_hal_spi_cfg *)cfg);
 #endif
 
 #if MYNEWT_VAL(SPI_0_SLAVE)
     if (spi_type != HAL_SPI_TYPE_SLAVE) {
         return EINVAL;
-    }
-
-    rc = hal_spi_disable(spi_num);
-    if (rc) {
-        return rc;
     }
 
     return hal_spi_init_slave(spi, (struct nrf5340_net_hal_spi_cfg *)cfg);


### PR DESCRIPTION
This applies when using bus driver and SPIM0 for the networking core, and SPIM0 is initialised from hal_spi_init_hw. 
During ```hal_spi_init``` it called ```hal_spi_enable``` which returs an error because the txrx_cb isn't set.

This change makes hal_spi_init similar on networking core to application core where no extra disabling or enabling occurs. 

Without this change the bus device isn't properly initialised and causes a segfault as soon as you try to use the spi. 