### PR TITLE
flash_test: Add flash area list

### DIFF
--- a/test/flash_test/src/flash_test.c
+++ b/test/flash_test/src/flash_test.c
@@ -59,6 +59,18 @@ flash_cli_cmd(const struct shell_cmd *cmd, int argc, char **argv,
         streamer_printf(streamer, "flash <flash-id> read <offset> <size> -- reads bytes from flash \n");
         streamer_printf(streamer, "flash <flash-id> write <offset>  <size>  -- writes incrementing data pattern 0-8 to flash \n");
         streamer_printf(streamer, "flash <flash-id> erase <offset> <size> -- erases flash \n");
+        streamer_printf(streamer, "flash area -- shows flash areas \n");
+        return 0;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "area") == 0) {
+        streamer_printf(streamer, "AreaID FlashId     Offset     Size\n");
+        for (i = 0; i < ARRAY_SIZE(sysflash_map_dflt); ++i) {
+            streamer_printf(streamer, "%6u %7u 0x%08x 0x%06x\n", sysflash_map_dflt[i].fa_id,
+                            sysflash_map_dflt[i].fa_device_id,
+                            (unsigned)sysflash_map_dflt[i].fa_off,
+                            (unsigned)sysflash_map_dflt[i].fa_size);
+        }
         return 0;
     }
 


### PR DESCRIPTION
flash command now can display flash areas like this
```
compat> flash area
000852 AreaID FlashId     Offset     Size
000853      0       0 0x00000000 0x008000
000854      1       0 0x0000c000 0x076000
000855      2       0 0x00082000 0x076000
000856      3       0 0x000f8000 0x004000
000857     16       0 0x00008000 0x004000
000858     17       0 0x000fc000 0x004000
000859     18       2 0x01028000 0x011000
```