### PR TITLE
hal/flash: Relax flash id number restriction

### DIFF
--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -34,11 +34,17 @@ hal_flash_init(void)
     const struct hal_flash *hf;
     uint8_t i;
     int rc = 0;
+    const uint8_t max_id = MYNEWT_VAL(HAL_FLASH_MAX_DEVICE_COUNT) ? MYNEWT_VAL(HAL_FLASH_MAX_DEVICE_COUNT) : 0xFF;
 
-    for (i = 0; ; i++) {
+    for (i = 0; i < max_id; i++) {
         hf = hal_bsp_flash_dev(i);
         if (!hf) {
-            break;
+            if (MYNEWT_VAL(HAL_FLASH_MAX_DEVICE_COUNT) == 0) {
+                /* Max device count not set, stop at first NULL value returned */
+                break;
+            } else {
+                continue;
+            }
         }
         if (hf->hf_itf->hff_init(hf)) {
             rc = SYS_EIO;

--- a/hw/hal/syscfg.yml
+++ b/hw/hal/syscfg.yml
@@ -47,6 +47,11 @@ syscfg.defs:
             If set HAL provides standard implementation of _sbrk function.
             It also provides _sbrkInit function that sets up heap space for malloc.
         value: 1
+    HAL_FLASH_MAX_DEVICE_COUNT:
+        description: >
+            If set to zero, flash device ids have continues numbers 0,1,2,...
+            If set to value > 0. Device ID can be any number <0, HAL_FLASH_MAX_DEVICE_ID].
+        value: 0
 syscfg.vals.OS_DEBUG_MODE:
     HAL_FLASH_VERIFY_WRITES: 1
     HAL_FLASH_VERIFY_ERASES: 1


### PR DESCRIPTION
So far flash ids needed to start from 0 to some number.
It was not possible to have only some numbers.
If BSP specified flash areas that belonged to 3 devices.
Device ID would be 0,1,2.
If bootloader (or some application configuration) was not
to touch some of the devices hal_bsp_flash_dev() function
would just return NULL to end flash device enumeration.
If bsp.yml contained flash areas belonging to 3 flash devices,
application (bootloader) could have access to 0, or 0,1 or 0,1,2
devices. It could not access only 0 and 2.

This change introduces HAL_FLASH_MAX_DEVICE_COUNT that when specified
allows to not have driver present for some of the flash devices.

Default value (0) keeps old behavior.