### PR TITLE
hw/ipc_nrf5340: Fix enabling multiple GPIOs passed to network core 

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -162,7 +162,7 @@ ipc_nrf5340_init(void)
 
 #if MYNEWT_VAL(MCU_APP_CORE)
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
-    unsigned int gpios[] = { MYNEWT_VAL(IPC_NRF5340_NET_GPIO) };
+    uint64_t gpios = MYNEWT_VAL(IPC_NRF5340_NET_GPIO);
     NRF_GPIO_Type *nrf_gpio;
 #endif
 
@@ -183,11 +183,14 @@ ipc_nrf5340_init(void)
     memset(shms, 0, sizeof(shms));
 
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
-    /* Configure GPIOs for Networking Core */
-    for (i = 0; i < ARRAY_SIZE(gpios); i++) {
-        nrf_gpio = HAL_GPIO_PORT(gpios[i]);
-        nrf_gpio->PIN_CNF[HAL_GPIO_INDEX(gpios[i])] =
-            GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+    /* Configure GPIOs for Networking Core, nrf5340 has 48 GPIOs */
+    for (i = 0; i < 48; i++) {
+        if (gpios & 0x1) {
+            nrf_gpio = HAL_GPIO_PORT(i);
+            nrf_gpio->PIN_CNF[HAL_GPIO_INDEX(i)] =
+                GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+        }
+        gpios >>= 1;
     }
 #endif
 #endif

--- a/hw/drivers/ipc_nrf5340/syscfg.yml
+++ b/hw/drivers/ipc_nrf5340/syscfg.yml
@@ -43,11 +43,12 @@ syscfg.defs:
 
     IPC_NRF5340_NET_GPIO:
         description: >
-            List of comma separated GPIO that should be configured for Network
-            Core usage. Can be define numeric or with constants from bsp.h
-            eg "LED_1, LED_2" or "1, 2". Further GPIO configuration should be
-            done by Network Core.
-        value: ""
+            Bitfield with 1s for each GPIO that should be configured for Network
+            Core usage. Can be defined with numeric or with constants from bsp.h
+            eg "(1ULL << LED_1 | 1ULL << LED_2)" or "(1 << 1 | 1ULL << 34)".
+            The "ULL" qualifier is needed for pins > 31.
+            Further GPIO configuration should be done by Network Core.
+        value: 0
 
 syscfg.restrictions:
     - "!BSP_NRF5340 || BSP_NRF5340_NET_ENABLE"


### PR DESCRIPTION
Due to the way MYNEWT_VAL is defined (always within ()) some preprocesor
magic is required when passing comma separated values.

Heavily Inspired by #2628 but using preprocessor magic to initialise the original vector instead.
Tested with 0, 1, and multiple pins redirected to networking core. 