### PR TITLE
hw/ipc_nrf5340: Assert on ipc_nrf5340_recv if channel is already in use

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -249,6 +249,8 @@ ipc_nrf5340_recv(int channel, ipc_nrf5340_recv_cb cb, void *user_data)
     assert(channel < IPC_MAX_CHANS);
 
     if (cb) {
+        assert(ipcs[channel].cb == NULL);
+
         ipcs[channel].cb = cb;
         ipcs[channel].user_data = user_data;
         NRF_IPC->RECEIVE_CNF[channel] = (0x1UL << channel);


### PR DESCRIPTION
Calling ipc_nrf5340_recv on channel which is already enabled is always
an application error which leads to confusing behaviour (or crashes).

If application want to change receive handler for specified channel it
shall first unregister old one by passing NULL pointer.