### PR TITLE
hw/bsp/nordic_pca10095: Add reduced size crash dumps

### DIFF
--- a/hw/bsp/nordic_pca10095/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10095/src/hal_bsp.c
@@ -33,12 +33,18 @@
 /*
  * What memory to include in coredump.
  */
+#if !MYNEWT_VAL(COREDUMP_SKIP_UNUSED_HEAP)
 static const struct hal_bsp_mem_dump dump_cfg[] = {
     [0] = {
         .hbmd_start = &_ram_start,
         .hbmd_size = RAM_SIZE
     }
 };
+#else
+static struct hal_bsp_mem_dump dump_cfg[2];
+extern uint8_t __StackLimit;
+extern uint8_t __StackTop;
+#endif
 
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
@@ -60,6 +66,15 @@ hal_bsp_flash_dev(uint8_t id)
 const struct hal_bsp_mem_dump *
 hal_bsp_core_dump(int *area_cnt)
 {
+#if MYNEWT_VAL(COREDUMP_SKIP_UNUSED_HEAP)
+    /* Interrupt stack first */
+    dump_cfg[0].hbmd_start = &__StackLimit;
+    dump_cfg[0].hbmd_size = &__StackTop - &__StackLimit;
+    /* RAM from _ram_start to end of used heap */
+    dump_cfg[1].hbmd_start = &_ram_start;
+    dump_cfg[1].hbmd_size = (uint8_t *)_sbrk(0) - &_ram_start;
+#endif
+
     *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
     return dump_cfg;
 }

--- a/hw/bsp/nordic_pca10095/syscfg.yml
+++ b/hw/bsp/nordic_pca10095/syscfg.yml
@@ -30,6 +30,13 @@ syscfg.defs:
             When enabled Network Core of nRF5340 is started on init.
        value: 0
 
+    COREDUMP_SKIP_UNUSED_HEAP:
+        description: >
+            Store whole RAM in crash dump.
+            When 1 only part of heap that was used will be dumped, that
+            can reduce size of crash dump.
+        value: 0
+
 syscfg.vals:
     # Set default pins for peripherals
     UART_0_PIN_TX: 20

--- a/hw/bsp/nordic_pca10095_net/syscfg.yml
+++ b/hw/bsp/nordic_pca10095_net/syscfg.yml
@@ -21,6 +21,13 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF5340 NET'
         value: 1
 
+    COREDUMP_SKIP_UNUSED_HEAP:
+        description: >
+            Store whole RAM in crash dump.
+            When 1 only part of heap that was used will be dumped, that
+            can reduce size of crash dump.
+        value: 0
+
 syscfg.vals:
     # Set default pins for peripherals
     UART_0_PIN_TX: 20


### PR DESCRIPTION
So far crash dumps had whole RAM image stored in flash.
If flash area assigned to coredumps were to small, end
of RAM was not dumped (including interrupt stack).

This adds possibility to skip dumping unused heap space.
This can reduce size of core dumps.