### PR TITLE
hw/ipc_nrf5340: (Re-)Fix enabling GPIO passing to network core

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -155,6 +155,11 @@ ipc_nrf5340_isr(void)
     os_trace_isr_exit();
 }
 
+/* Below is to unmangle comma separated GPIO pins from MYNEWT_VAL */
+#define _Args(...) __VA_ARGS__
+#define STRIP_PARENS(X) X
+#define UNMANGLE_MYNEWT_VAL(X) STRIP_PARENS(_Args X)
+
 void
 ipc_nrf5340_init(void)
 {
@@ -162,7 +167,7 @@ ipc_nrf5340_init(void)
 
 #if MYNEWT_VAL(MCU_APP_CORE)
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
-    unsigned int gpios[] = { MYNEWT_VAL(IPC_NRF5340_NET_GPIO) };
+    unsigned int gpios[] = { UNMANGLE_MYNEWT_VAL(MYNEWT_VAL(IPC_NRF5340_NET_GPIO)) };
     NRF_GPIO_Type *nrf_gpio;
 #endif
 

--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -162,7 +162,7 @@ ipc_nrf5340_init(void)
 
 #if MYNEWT_VAL(MCU_APP_CORE)
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
-    uint64_t gpios = MYNEWT_VAL(IPC_NRF5340_NET_GPIO);
+    unsigned int gpios[] = { MYNEWT_VAL(IPC_NRF5340_NET_GPIO) };
     NRF_GPIO_Type *nrf_gpio;
 #endif
 
@@ -183,14 +183,11 @@ ipc_nrf5340_init(void)
     memset(shms, 0, sizeof(shms));
 
 #if MYNEWT_VAL(IPC_NRF5340_NET_GPIO)
-    /* Configure GPIOs for Networking Core, nrf5340 has 48 GPIOs */
-    for (i = 0; i < 48; i++) {
-        if (gpios & 0x1) {
-            nrf_gpio = HAL_GPIO_PORT(i);
-            nrf_gpio->PIN_CNF[HAL_GPIO_INDEX(i)] =
-                GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
-        }
-        gpios >>= 1;
+    /* Configure GPIOs for Networking Core */
+    for (i = 0; i < ARRAY_SIZE(gpios); i++) {
+        nrf_gpio = HAL_GPIO_PORT(gpios[i]);
+        nrf_gpio->PIN_CNF[HAL_GPIO_INDEX(gpios[i])] =
+            GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
     }
 #endif
 #endif

--- a/hw/drivers/ipc_nrf5340/syscfg.yml
+++ b/hw/drivers/ipc_nrf5340/syscfg.yml
@@ -43,12 +43,11 @@ syscfg.defs:
 
     IPC_NRF5340_NET_GPIO:
         description: >
-            Bitfield with 1s for each GPIO that should be configured for Network
-            Core usage. Can be defined with numeric or with constants from bsp.h
-            eg "(1ULL << LED_1 | 1ULL << LED_2)" or "(1 << 1 | 1ULL << 34)".
-            The "ULL" qualifier is needed for pins > 31.
-            Further GPIO configuration should be done by Network Core.
-        value: 0
+            List of comma separated GPIO that should be configured for Network
+            Core usage. Can be define numeric or with constants from bsp.h
+            eg "LED_1, LED_2" or "1, 2". Further GPIO configuration should be
+            done by Network Core.
+        value: ""
 
 syscfg.restrictions:
     - "!BSP_NRF5340 || BSP_NRF5340_NET_ENABLE"


### PR DESCRIPTION
The outcome of #2629 used a bitmask to set which GPIOs the application core handed over to the networking core. 
This made for neat code but complicated the syscfg handling. 

This PR undoes #2629, the bitmask change, and uses preprocessor magic to accomplish the same with a simple comma separated syscfg value for specifying pins.  

Feedback welcome again, and this time I'll hang out for consensus before merging. 