### PR TITLE
i2c scan for bus driver usage

### DIFF
--- a/hw/bus/drivers/i2c_common/include/bus/drivers/i2c_common.h
+++ b/hw/bus/drivers/i2c_common/include/bus/drivers/i2c_common.h
@@ -90,6 +90,11 @@ struct bus_i2c_node {
 #endif
 };
 
+struct i2c_dev_ops {
+    struct bus_dev_ops bus_ops;
+    int (*probe)(struct bus_i2c_dev *dev, uint16_t address, os_time_t timeout);
+};
+
 /**
  * Create bus I2C node
  *
@@ -111,6 +116,14 @@ bus_i2c_node_create(const char *name, struct bus_i2c_node *node,
 
     return os_dev_create(odev, name, OS_DEV_INIT_PRIMARY, 1,
                          bus_node_init_func, (void *)cfg);
+}
+
+static inline int
+bus_i2c_probe(struct bus_i2c_dev *dev, uint16_t address, int timeout)
+{
+    struct i2c_dev_ops *i2c_ops = (struct i2c_dev_ops *)dev->bdev.dops;
+
+    return i2c_ops->probe ? i2c_ops->probe(dev, address, timeout) : SYS_ENOTSUP;
 }
 
 #ifdef __cplusplus

--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -580,6 +580,59 @@ bus_i2c_nrf52_twim_write(struct bus_dev *bdev, struct bus_node *bnode,
     return rc;
 }
 
+int
+bus_i2c_nrf52_twim_probe(struct bus_i2c_dev *dev, uint16_t address, os_time_t timeout)
+{
+    struct twim_dev_data *dd;
+    NRF_TWIM_Type *nrf_twim;
+    int rc;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+
+    rc = os_error_to_sys(os_mutex_pend(&dev->bdev.lock, timeout));
+    if (rc == 0) {
+        rc = bus_i2c_nrf52_twim_configure_controller(dev, address, 100);
+        assert(rc == 0);
+        nrf_twim = twims[dev->cfg.i2c_num].nrf_twim;
+        dd = &twim_devs_data[dev->cfg.i2c_num];
+
+        nrf_twim->TXD.MAXCNT = 0;
+        nrf_twim->TXD.LIST = 0;
+
+        nrf_twim->EVENTS_STOPPED = 0;
+        nrf_twim->EVENTS_ERROR = 0;
+
+        nrf_twim->SHORTS = 0;
+        nrf_twim->INTEN = TWIM_INTEN_ERROR_Msk;
+
+        nrf_twim->TASKS_STARTTX = 1;
+
+        /* Wait for enough time to have NACK detected. */
+        os_cputime_delay_usecs(125);
+
+        /* If semaphore is signaled, there was an error. */
+        rc = os_sem_pend(&dd->sem, 0);
+        /* Stop condition was not automatically send. */
+        nrf_twim->INTEN = TWIM_INTEN_STOPPED_Msk;
+        nrf_twim->TASKS_STOP = 1;
+
+        /*
+         * Previous os_sem_pend() returning OS_TIMEOUT means that
+         * device ACK'ed address.
+         */
+        if (rc == OS_TIMEOUT) {
+            rc = 0;
+        } else {
+            rc = SYS_ENOENT;
+        }
+        /* Wait for STOP condition interrupt. */
+        (void)os_sem_pend(&dd->sem, OS_TICKS_PER_SEC);
+        (void)os_mutex_release(&dev->bdev.lock);
+    }
+
+    return rc;
+}
+
 static int bus_i2c_nrf52_twim_disable(struct bus_dev *bdev)
 {
     struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
@@ -593,13 +646,16 @@ static int bus_i2c_nrf52_twim_disable(struct bus_dev *bdev)
     return 0;
 }
 
-static const struct bus_dev_ops bus_i2c_nrf52_twim_ops = {
-    .init_node = bus_i2c_nrf52_twim_init_node,
-    .enable = bus_i2c_nrf52_twim_enable,
-    .configure = bus_i2c_nrf52_twim_configure,
-    .read = bus_i2c_nrf52_twim_read,
-    .write = bus_i2c_nrf52_twim_write,
-    .disable = bus_i2c_nrf52_twim_disable,
+static const struct i2c_dev_ops bus_i2c_nrf52_twim_ops = {
+    .bus_ops = {
+        .init_node = bus_i2c_nrf52_twim_init_node,
+        .enable = bus_i2c_nrf52_twim_enable,
+        .configure = bus_i2c_nrf52_twim_configure,
+        .read = bus_i2c_nrf52_twim_read,
+        .write = bus_i2c_nrf52_twim_write,
+        .disable = bus_i2c_nrf52_twim_disable,
+    },
+    .probe = bus_i2c_nrf52_twim_probe,
 };
 
 int

--- a/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
+++ b/hw/bus/drivers/i2c_nrf52_twim/src/i2c_nrf52_twim.c
@@ -399,28 +399,16 @@ bus_i2c_nrf52_twim_enable(struct bus_dev *bdev)
 }
 
 static int
-bus_i2c_nrf52_twim_configure(struct bus_dev *bdev, struct bus_node *bnode)
+bus_i2c_nrf52_twim_configure_controller(struct bus_i2c_dev *dev, uint8_t address, uint16_t freq)
 {
-    struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
-    struct bus_i2c_node *node = (struct bus_i2c_node *)bnode;
-    struct bus_i2c_node *current_node = (struct bus_i2c_node *)bdev->configured_for;
     NRF_TWIM_Type *nrf_twim;
-    int rc;
+    int rc = 0;
 
     BUS_DEBUG_VERIFY_DEV(dev);
-    BUS_DEBUG_VERIFY_NODE(node);
 
     nrf_twim = twims[dev->cfg.i2c_num].nrf_twim;
 
-    nrf_twim->ADDRESS = node->addr;
-
-    if (current_node && (current_node->freq == node->freq)) {
-        return 0;
-    }
-
-    rc = 0;
-
-    switch (node->freq) {
+    switch (freq) {
     case 100:
         nrf_twim->FREQUENCY = TWIM_FREQUENCY_FREQUENCY_K100;
         break;
@@ -437,9 +425,24 @@ bus_i2c_nrf52_twim_configure(struct bus_dev *bdev, struct bus_node *bnode)
         rc = SYS_EIO;
     }
 
+    if (rc == 0) {
+        nrf_twim->ADDRESS = address;
+    }
+
     return rc;
 }
 
+static int
+bus_i2c_nrf52_twim_configure(struct bus_dev *bdev, struct bus_node *bnode)
+{
+    struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
+    struct bus_i2c_node *node = (struct bus_i2c_node *)bnode;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    return bus_i2c_nrf52_twim_configure_controller(dev, node->addr, node->freq);
+}
 
 static int
 bus_i2c_nrf52_twim_read(struct bus_dev *bdev, struct bus_node *bnode,

--- a/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
+++ b/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
@@ -233,6 +233,9 @@ bus_i2c_nrf5340_configure(struct bus_dev *bdev, struct bus_node *bnode)
     case 400:
         nrf_twim->FREQUENCY = TWIM_FREQUENCY_FREQUENCY_K400;
         break;
+    case 1000:
+        nrf_twim->FREQUENCY = TWIM_FREQUENCY_FREQUENCY_K1000;
+        break;
     default:
         rc = SYS_EIO;
     }

--- a/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
+++ b/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
@@ -202,28 +202,14 @@ bus_i2c_nrf5340_enable(struct bus_dev *bdev)
 }
 
 static int
-bus_i2c_nrf5340_configure(struct bus_dev *bdev, struct bus_node *bnode)
+bus_i2c_nrf5340_configure_controller(struct bus_i2c_dev *dev, uint8_t address, uint16_t freq)
 {
-    struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
-    struct bus_i2c_node *node = (struct bus_i2c_node *)bnode;
-    struct bus_i2c_node *current_node = (struct bus_i2c_node *)bdev->configured_for;
     NRF_TWIM_Type *nrf_twim;
-    int rc;
-
-    BUS_DEBUG_VERIFY_DEV(dev);
-    BUS_DEBUG_VERIFY_NODE(node);
+    int rc = 0;
 
     nrf_twim = twims[dev->cfg.i2c_num].nrf_twim;
 
-    nrf_twim->ADDRESS = node->addr;
-
-    if (current_node && (current_node->freq == node->freq)) {
-        return 0;
-    }
-
-    rc = 0;
-
-    switch (node->freq) {
+    switch (freq) {
     case 100:
         nrf_twim->FREQUENCY = TWIM_FREQUENCY_FREQUENCY_K100;
         break;
@@ -240,7 +226,23 @@ bus_i2c_nrf5340_configure(struct bus_dev *bdev, struct bus_node *bnode)
         rc = SYS_EIO;
     }
 
+    if (rc == 0) {
+        nrf_twim->ADDRESS = address;
+    }
+
     return rc;
+}
+
+static int
+bus_i2c_nrf5340_configure(struct bus_dev *bdev, struct bus_node *bnode)
+{
+    struct bus_i2c_dev *dev = (struct bus_i2c_dev *)bdev;
+    struct bus_i2c_node *node = (struct bus_i2c_node *)bnode;
+
+    BUS_DEBUG_VERIFY_DEV(dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    return bus_i2c_nrf5340_configure_controller(dev, node->addr, node->freq);
 }
 
 static int


### PR DESCRIPTION
This introduces additional i2c bus driver function to probe bus for
specific address.

nrf5x, da1469x and hal drivers were updated to allow this functionality.

i2c_scan package can now be used with bus driver.