### PR TITLE
hw/bsp/dwm1001-dev Add LIS2DH12 accelerometer support

### DIFF
--- a/hw/bsp/dwm1001-dev/pkg.yml
+++ b/hw/bsp/dwm1001-dev/pkg.yml
@@ -41,3 +41,9 @@ pkg.deps.SOFT_PWM:
 
 pkg.deps.UARTBB_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"
+
+pkg.deps.LIS2DH12_ONB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
+    
+pkg.init:
+    config_lis2dh12_sensor: 'MYNEWT_VAL(DWM1001_DEV_SYSINIT_STAGE_LIS2DH12)'

--- a/hw/bsp/dwm1001-dev/syscfg.yml
+++ b/hw/bsp/dwm1001-dev/syscfg.yml
@@ -29,6 +29,15 @@ syscfg.defs:
         description: 'Enable bit-banger UART 0'
         value: 0
 
+    LIS2DH12_ONB:
+        description: 'Enable DWM1001 onboard LIS2DH12 sensor'
+        value:  0
+
+    DWM1001_DEV_SYSINIT_STAGE_LIS2DH12:
+        description: >
+            Sysinit stage for the DWM1001-dev; initializes the LIS2DH12 sensor.
+        value: 400
+
 syscfg.vals:
     # Enable nRF52832 MCU
     MCU_TARGET: nRF52832
@@ -62,3 +71,6 @@ syscfg.vals.BLE_CONTROLLER:
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_LL_RFMGMT_ENABLE_TIME: 1500
+
+syscfg.restrictions:
+    - "LIS2DH12_ONB && I2C_0_PIN_SCL == 28 && I2C_0_PIN_SDA == 29"


### PR DESCRIPTION
Hey guys,

thanks for this awesome piece of software!
This PR is an attempt at adding support for the LIS2DH12 accelerometer sensor, which is integrated with [DWM1001-DEV](https://www.decawave.com/dwm1001dev/datasheet/) boards.
I'm fairly new to mynewt, so this PR is more like a shot in the dark, and mostly copied from other BSPs with the same accelerometer.
The `sensor_itf.si_ints` values are chosen, such that it does not crash - which does not mean that it's working ;). Would be good if somebody with more hardware knowledge could take a look at them (the `.active = true` certainly isn't true, this should be something like `HAL_GPIO_TRIG_RISING` or `HAL_GPIO_TRIG_FALLING`).

Here is an example application:
```c
#include <assert.h>
#include <string.h>
#include <stdio.h>
#include <math.h>
#include "sysinit/sysinit.h"
#include "os/os.h"
#include "bsp/bsp.h"
#include "hal/hal_gpio.h"
#include "hal/hal_bsp.h"
#include "hal/hal_i2c.h"
#include "mcu/nrf52_hal.h"
#ifdef ARCH_sim
#include "mcu/mcu_sim.h"
#endif

#include <config/config.h>

#include <sensor/sensor.h>
#include "sensor/accel.h"
#include <lis2dh12/lis2dh12.h>

#if MYNEWT_VAL(DW1000_DEVICE_0)
#include <dw1000/dw1000_hal.h>
#endif

int accel_data_cb(struct sensor* sensor, void* a, void* databuf, sensor_type_t sensorType) {
    if(!databuf) { return SYS_EINVAL; }
    struct sensor_accel_data* sad = (struct sensor_accel_data*) databuf;
    if (!sad->sad_x_is_valid || !sad->sad_y_is_valid || !sad->sad_z_is_valid) { return SYS_EINVAL; }
    printf("%s: [ secs: %ld usecs: %d cputime: %u ]\n",
                   "LISTENER_CB",
                   (long int)sensor->s_sts.st_ostv.tv_sec,
                   (int)sensor->s_sts.st_ostv.tv_usec,
                   (unsigned int)sensor->s_sts.st_cputime);

    printf("x = %f, y = %f, z = %f\n", sad->sad_x, sad->sad_y, sad->sad_z);
    return 0;
}

static struct sensor_listener sensor_listener = {
    .sl_sensor_type = SENSOR_TYPE_ACCELEROMETER,
    .sl_func = accel_data_cb,  
    .sl_arg = NULL
};

 

int main(int argc, char **argv){
    sysinit();

    struct sensor* accel = sensor_mgr_find_next_bydevname("lis2dh12_0", NULL);
    assert(accel != NULL);

    assert(0 == lis2dh12_set_full_scale(&accel->s_itf, LIS2DH12_FS_2G));
    assert(0 == lis2dh12_set_op_mode(&accel->s_itf, LIS2DH12_OM_HIGH_RESOLUTION));

    sensor_set_poll_rate_ms(accel->s_dev->od_name, 1000 / 50);
    sensor_register_listener(accel, &sensor_listener);

    while (1) {
        os_eventq_run(os_eventq_dflt_get());
    }
    assert(0);
    return 0;
}
```