### PR TITLE
baselibc: Fix build with -Werror=array-parameter enabled

### DIFF
--- a/libc/baselibc/include/stdlib.h
+++ b/libc/baselibc/include/stdlib.h
@@ -63,9 +63,9 @@ __extern void *bsearch(const void *, const void *, size_t, size_t,
 		       __comparefunc_t);
 __extern void qsort(void *, size_t, size_t, __comparefunc_t);
 
-__extern long jrand48(unsigned short *);
+__extern long jrand48(unsigned short xsubi[3]);
 __extern long mrand48(void);
-__extern long nrand48(unsigned short *);
+__extern long nrand48(unsigned short xsubi[3]);
 __extern long lrand48(void);
 __extern unsigned short *seed48(const unsigned short *);
 __extern void srand48(long);


### PR DESCRIPTION
repos/apache-mynewt-core/libc/baselibc/src/jrand48.c:8:29: error: argument 1 of type
    ‘short unsigned int[3]’ with mismatched bound [-Werror=array-parameter=]
    8 | long jrand48(unsigned short xsubi[3])
      |              ~~~~~~~~~~~~~~~^~~~~~~~
In file included from repos/apache-mynewt-core/libc/baselibc/src/jrand48.c:5:
repos/apache-mynewt-core/libc/baselibc/include/stdlib.h:66:23: note: previously declared
    as ‘short unsigned int *’
   66 | __extern long jrand48(unsigned short *);
      |                       ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors