### PR TITLE
pic32: Fix context initialization

### DIFF
--- a/kernel/os/src/arch/pic32/os_arch_pic32.c
+++ b/kernel/os/src/arch/pic32/os_arch_pic32.c
@@ -162,7 +162,7 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     struct ctx ctx;
     ctx.regs[3] = (uint32_t)t->t_arg;
     ctx.regs[27] = get_global_pointer();
-    ctx.status = (_CP0_GET_STATUS() & ~_CP0_STATUS_CU1_MASK) | _CP0_STATUS_IE_MASK;
+    ctx.status = (_CP0_GET_STATUS() & ~_CP0_STATUS_CU1_MASK) | _CP0_STATUS_IE_MASK | _CP0_STATUS_EXL_MASK;
     ctx.cause = _CP0_GET_CAUSE();
     ctx.epc = (uint32_t)t->t_func;
     /* copy struct onto the stack */


### PR DESCRIPTION
Bit **EXL** of **Status** register was not set in initial context.
When task was scheduled for the first time and some interrupt
fired during initial context switch task would stack in never
ending end of interrupt loop.

Here is sequence that was broken due to missing **EXL** bit set,
(at this point interrupts are disabled due to DI instruction
and additionally EXL bit when set).

```asm
    lw     k0, CTX_EPC(sp)
    mtc0   k0, _CP0_EPC      # here is correct value set to EPC register
    lw     k0, CTX_STATUS(sp)
    mtc0   k0, _CP0_STATUS   # at this point interrupt IE is 0 and EXL should be 1
```
In normal case when this happen interrupts are still disabled for **EXL** bit
but for initial context switch they are not, it there is pending interrupt
register **EPC** gets changed to address around this point instead of starting address
of the task

```asm
    ehb
    lw     k0, CTX_REG(26)(sp)
    wrpgpr sp, sp
```
; Now eret should jump to task function and enable interrupts by setting **EXL**=0,
; but instead it jumps few line above and it never starts the task
```asm
    eret
```

It may happen to any task, when it happens to idle task watchdog will not be feed at all.
It may be that some other task are running fine.

This sets **EXL** bit to 1 in the initial value of **EPC** register eliminating problem.