### PR TITLE
sys/console: Stop history auto search when echo is off

### DIFF
--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -710,7 +710,8 @@ insert_char(char *pos, char c)
     if (trailing_chars == 0) {
         *pos = c;
         if (!MYNEWT_VAL_CHOICE(CONSOLE_HISTORY, none) &&
-            MYNEWT_VAL(CONSOLE_HISTORY_AUTO_SEARCH) && cur > 1) {
+            MYNEWT_VAL(CONSOLE_HISTORY_AUTO_SEARCH) &&
+            echo != 0 && cur > 1) {
             history_line = 0;
             console_history_search(pos - cur + 1, HFT_MATCH_PREV);
             return;


### PR DESCRIPTION
When echo is off history auto search should not output anything.
This allows to have **newtmgr** upload working while code
is build with history auto search support.