### PR TITLE
sys/console/minimal: Fix RTT console compiler error for minimal console

### DIFF
--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -134,6 +134,7 @@ end:
     return rc;
 }
 
+#if MYNEWT_VAL(CONSOLE_UART)
 int
 console_out(int c)
 {
@@ -150,6 +151,7 @@ console_out(int c)
 
     return rc;
 }
+#endif
 
 void
 console_prompt_set(const char *prompt, const char *line)


### PR DESCRIPTION
Compile `console_out` for UART console only. RTT console has it's own implementation of `console_out` which conflicts if RTT_CONSOLE is used with console/minimal