### PR TITLE
os/cortex_m: Fix semaphore release hazard

### DIFF
--- a/kernel/os/src/arch/cortex_m33/m33/HAL_CM33.s
+++ b/kernel/os/src/arch/cortex_m33/m33/HAL_CM33.s
@@ -163,13 +163,19 @@ PendSV_Handler:
         .fnstart
         .cantunwind
 
-        LDR     R3,=g_os_run_list       /* Get highest priority task ready to run */
-        LDR     R2,[R3]                 /* Store in R2 */
+        LDR     R1,=g_os_run_list       /* Get highest priority task ready to run */
         LDR     R3,=g_current_task      /* Get current task */
+        CPSID   i                       /* Block interrupts till g_current_task is updated */
+        LDR     R2,[R1]                 /* Highest priority task in R2 */
         LDR     R1,[R3]                 /* Current task in R1 */
         CMP     R1,R2
-        IT      EQ
-        BXEQ    LR                      /* RETI, no task switch */
+        BNE     context_switch
+        CPSIE   i                       /* No context switch needed */
+        BX      LR
+
+context_switch:
+        STR     R2,[R3]                 /* g_current_task = highest ready */
+        CPSIE   i
 
         MRS     R12,PSP                 /* Read PSP */
 #if MYNEWT_VAL(HARDFLOAT)
@@ -181,7 +187,6 @@ PendSV_Handler:
         STMDB   R12!,{R4-R11}           /* Save Old context */
 #endif
         STR     R12,[R1,#0]             /* Update stack pointer in current task */
-        STR     R2,[R3]                 /* g_current_task = highest ready */
 
         LDR     R12,[R2,#4]             /* get stack bottom of task we will start */
         MSR     PSPLIM,R12              /* update stack limit register */

--- a/kernel/os/src/arch/cortex_m4/m4/HAL_CM4.s
+++ b/kernel/os/src/arch/cortex_m4/m4/HAL_CM4.s
@@ -163,13 +163,19 @@ PendSV_Handler:
         .fnstart
         .cantunwind
 
-        LDR     R3,=g_os_run_list       /* Get highest priority task ready to run */
-        LDR     R2,[R3]                 /* Store in R2 */
+        LDR     R1,=g_os_run_list       /* Get highest priority task ready to run */
         LDR     R3,=g_current_task      /* Get current task */
+        CPSID   i                       /* Block interrupts till g_current_task is updated */
+        LDR     R2,[R1]                 /* Highest priority task in R2 */
         LDR     R1,[R3]                 /* Current task in R1 */
         CMP     R1,R2
-        IT      EQ
-        BXEQ    LR                      /* RETI, no task switch */
+        BNE     context_switch
+        CPSIE   i                       /* No context switch needed */
+        BX      LR
+
+context_switch:
+        STR     R2,[R3]                 /* g_current_task = highest ready */
+        CPSIE   i
 
         MRS     R12,PSP                 /* Read PSP */
 #if MYNEWT_VAL(HARDFLOAT)
@@ -181,7 +187,6 @@ PendSV_Handler:
         STMDB   R12!,{R4-R11}           /* Save Old context */
 #endif
         STR     R12,[R1,#0]             /* Update stack pointer in current task */
-        STR     R2,[R3]                 /* g_current_task = highest ready */
 
         LDR     R12,[R2,#0]             /* get stack pointer of task we will start */
 #if MYNEWT_VAL(HARDFLOAT)

--- a/kernel/os/src/arch/cortex_m7/m7/HAL_CM7.s
+++ b/kernel/os/src/arch/cortex_m7/m7/HAL_CM7.s
@@ -147,13 +147,19 @@ PendSV_Handler:
         .fnstart
         .cantunwind
 
-        LDR     R3,=g_os_run_list       /* Get highest priority task ready to run */
-        LDR     R2,[R3]                 /* Store in R2 */
+        LDR     R1,=g_os_run_list       /* Get highest priority task ready to run */
         LDR     R3,=g_current_task      /* Get current task */
+        CPSID   i                       /* Block interrupts till g_current_task is updated */
+        LDR     R2,[R1]                 /* Highest priority task in R2 */
         LDR     R1,[R3]                 /* Current task in R1 */
         CMP     R1,R2
-        IT      EQ
-        BXEQ    LR                      /* RETI, no task switch */
+        BNE     context_switch
+        CPSIE   i                       /* No context switch needed */
+        BX      LR
+
+context_switch:
+        STR     R2,[R3]                 /* g_current_task = highest ready */
+        CPSIE   i
 
         MRS     R12,PSP                 /* Read PSP */
 #if MYNEWT_VAL(HARDFLOAT)
@@ -165,7 +171,6 @@ PendSV_Handler:
         STMDB   R12!,{R4-R11}           /* Save Old context */
 #endif
         STR     R12,[R1,#0]             /* Update stack pointer in current task */
-        STR     R2,[R3]                 /* g_current_task = highest ready */
 
         LDR     R12,[R2,#0]             /* get stack pointer of task we will start */
 #if MYNEWT_VAL(HARDFLOAT)


### PR DESCRIPTION
Context switch is performed in low priority interrupt.
If higher priority interrupt code releases semaphore
BEFORE g_current_task is updated in context switch,
os_sem_release() function can see that task
that entered os_sem_pend() and initiated context switch
is still running and there is no need to switch tasks.
As a result task is marked as ready.
Then high priority interrupt ends and context switch is
finished leaving lower priority task running.
When this happens and current task is idle it may take
a while till reschedule is done again leaving task that
should be running in ready state.

To prevent this interrupts are now masked while context switch
code check current task against ready list.
Interrupts are enabled again once g_current_task is updated, rest of
context switch may be performed (as it was) with interrupts enabled.