### PR TITLE
kernel/os: Fix semaphore release hazard

### DIFF
--- a/kernel/os/src/os_sem.c
+++ b/kernel/os/src/os_sem.c
@@ -88,8 +88,16 @@ os_sem_release(struct os_sem *sem)
         rdy->t_flags &= ~OS_TASK_FLAG_SEM_WAIT;
         os_sched_wakeup(rdy);
 
-        /* Schedule if waiting task higher priority */
-        if (current->t_prio > rdy->t_prio) {
+        /*
+         * Schedule if waiting task higher priority.
+         * current->t_prio == rdy->t_prio means that current task
+         * was already put in semaphore waiting list and context
+         * switch may already started, in that case start next
+         * context switch. In worst case scenario second task
+         * switch interrupt will check that there is no need
+         * for switching.
+         */
+        if (current->t_prio >= rdy->t_prio) {
             resched = 1;
         }
     } else {


### PR DESCRIPTION
Context switch is performed in low priority interrupt.
If higher priority interrupt code releases semaphore
BEFORE g_current_task is updated in context switch,
os_sem_release() function can see that task
that entered os_sem_pend() and initiated context switch
is still running and there is no need to switch tasks.
As a result task is marked as ready.
Then high priority interrupt ends and context switch is
finished leaving lower priority task running.
When this happens and current task is idle it may take
a while till reschedule is done again leaving task that
should be running in ready state.

To prevent this, condition to reschedule is now changed
so that if current task is same as task that should be woken
context switch is also initiated just in case switching
already started and g_current_task was not updated.