### PR TITLE
hw/bsp: Use BLE_LL_SCA where needed

### DIFF
--- a/hw/bsp/ada_feather_nrf52/syscfg.yml
+++ b/hw/bsp/ada_feather_nrf52/syscfg.yml
@@ -51,7 +51,7 @@ syscfg.vals:
 
 # The module on the board has +/- 40 ppm crystal. A value of 5 is
 # for crystals in the range of 31 to 50 ppm.
-    BLE_LL_MASTER_SCA: 5
+    BLE_LL_SCA: 40
 
 syscfg.vals.BLE_CONTROLLER:
     TIMER_0: 0

--- a/hw/bsp/bbc_microbit/syscfg.yml
+++ b/hw/bsp/bbc_microbit/syscfg.yml
@@ -117,5 +117,4 @@ syscfg.vals.BLE_CONTROLLER:
     # need to keep HFXO running all the time to have accurate 32k synthesized clock
     BLE_LL_RFMGMT_ENABLE_TIME: 0
     # synthesized 32k clock has 250ppm accuracy
-    BLE_LL_OUR_SCA: 250
-    BLE_LL_MASTER_SCA: 1
+    BLE_LL_SCA: 250

--- a/hw/bsp/bmd200/syscfg.yml
+++ b/hw/bsp/bmd200/syscfg.yml
@@ -114,5 +114,4 @@ syscfg.vals.BLE_CONTROLLER:
     # need to keep HFXO running all the time to have accurate 32k synthesized clock
     BLE_LL_RFMGMT_ENABLE_TIME: 0
     # synthesized 32k clock has 250ppm accuracy
-    BLE_LL_OUR_SCA: 250
-    BLE_LL_MASTER_SCA: 1
+    BLE_LL_SCA: 250

--- a/hw/bsp/calliope_mini/syscfg.yml
+++ b/hw/bsp/calliope_mini/syscfg.yml
@@ -106,5 +106,4 @@ syscfg.vals.BLE_CONTROLLER:
     # need to keep HFXO running all the time to have accurate 32k synthesized clock
     BLE_LL_RFMGMT_ENABLE_TIME: 0
     # synthesized 32k clock has 250ppm accuracy
-    BLE_LL_OUR_SCA: 250
-    BLE_LL_MASTER_SCA: 1
+    BLE_LL_SCA: 250

--- a/hw/bsp/puckjs/syscfg.yml
+++ b/hw/bsp/puckjs/syscfg.yml
@@ -47,7 +47,7 @@ syscfg.vals:
 
 # The module on the board has +/- 40 ppm crystal. A value of 5 is
 # for crystals in the range of 31 to 50 ppm.
-    BLE_LL_MASTER_SCA: 5
+    BLE_LL_SCA: 40
 
 syscfg.vals.BLE_CONTROLLER:
     TIMER_0: 0


### PR DESCRIPTION
Some BSPs still have deprecated BLL_LL_MASTER_SCA
and BLE_LL_OUR_SCA when they should have BLE_LL_SCA.

This replaces deprecated values with BLE_LL_SCA.