### PR TITLE
tinyusb: Fix memory corruption for USB descriptors

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -266,8 +266,9 @@ tud_descriptor_string_cb(uint8_t index, uint16_t langid)
         str = string_desc_arr[index - 2];
 
         char_num = strlen(str);
-        if (char_num >= ARRAY_SIZE(desc_string)) {
-            char_num = ARRAY_SIZE(desc_string);
+        assert(char_num <= ARRAY_SIZE(desc_string) - 1);
+        if (char_num > ARRAY_SIZE(desc_string) - 1) {
+            char_num = ARRAY_SIZE(desc_string) - 1;
         }
 
         for (i = 0; i < char_num; ++i) {


### PR DESCRIPTION
Check whether string descriptor would fit in static buffer
used for unicode string was wrong by one byte this would
lead to random data corruption.

Now check (that cuts descriptor is corrected).
Additional assert is also added since user should now
that syscfg provided string descriptor will not be
transmitted out.
When mynewt adopts usual way to remove assert in release
build check that cuts over-sized string can still work.