### PR TITLE
tinyusb: Add hardware initialization for NRF5340

### DIFF
--- a/hw/usb/tinyusb/nrf53/include/tusb_hw.h
+++ b/hw/usb/tinyusb/nrf53/include/tusb_hw.h
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TUSB_HW_H__
+#define __TUSB_HW_H__
+
+#define CFG_TUSB_MCU OPT_MCU_NRF5X
+
+#include <syscfg/syscfg.h>
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
+#define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)
+#else
+#define USBD_CDC_NOTIFY_EP      0x81
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP_SIZE)
+#define USBD_CDC_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_NOTIFY_EP_SIZE 0x08
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_OUT_EP)
+#define USBD_CDC_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_DATA_OUT_EP)
+#else
+#define USBD_CDC_DATA_OUT_EP    0x02
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_IN_EP)
+#define USBD_CDC_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_DATA_IN_EP)
+#else
+#define USBD_CDC_DATA_IN_EP     0x82
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_EP_SIZE)
+#define USBD_CDC_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_DATA_EP_SIZE)
+#else
+#define USBD_CDC_DATA_EP_SIZE   0x40
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP)
+#define USBD_HID_REPORT_EP      MYNEWT_VAL(USBD_HID_REPORT_EP)
+#else
+#define USBD_HID_REPORT_EP      0x83
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_SIZE)
+#define USBD_HID_REPORT_EP_SIZE MYNEWT_VAL(USBD_HID_REPORT_EP_SIZE)
+#else
+#define USBD_HID_REPORT_EP_SIZE 0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_INTERVAL)
+#define USBD_HID_REPORT_EP_INTERVAL MYNEWT_VAL(USBD_HID_REPORT_EP_INTERVAL)
+#else
+#define USBD_HID_REPORT_EP_INTERVAL 1
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_EVENT_EP)
+#define USBD_BTH_EVENT_EP       MYNEWT_VAL(USBD_BTH_EVENT_EP)
+#else
+#define USBD_BTH_EVENT_EP       0x84
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_EVENT_EP_SIZE)
+#define BTH_EVENT_EP_SIZE       MYNEWT_VAL(BTH_EVENT_EP_SIZE)
+#else
+#define USBD_BTH_EVENT_EP_SIZE  0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_EVENT_EP_INTERVAL)
+#define USBD_BTH_EVENT_EP_INTERVAL  MYNEWT_VAL(USBD_BTH_EVENT_EP_INTERVAL)
+#else
+#define USBD_BTH_EVENT_EP_INTERVAL 10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_DATA_OUT_EP)
+#define USBD_BTH_DATA_OUT_EP    MYNEWT_VAL(USBD_BTH_DATA_OUT_EP)
+#else
+#define USBD_BTH_DATA_OUT_EP    0x05
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_DATA_IN_EP)
+#define USBD_BTH_DATA_IN_EP     MYNEWT_VAL(USBD_BTH_DATA_IN_EP)
+#else
+#define USBD_BTH_DATA_IN_EP     0x85
+#endif
+
+#if defined(MYNEWT_VAL_USBD_BTH_DATA_EP_SIZE)
+#define USBD_BTH_DATA_EP_SIZE   MYNEWT_VAL(USBD_BTH_DATA_EP_SIZE)
+#else
+#define USBD_BTH_DATA_EP_SIZE   0x40
+#endif
+
+#endif

--- a/hw/usb/tinyusb/nrf53/pkg.yml
+++ b/hw/usb/tinyusb/nrf53/pkg.yml
@@ -17,39 +17,17 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb
-pkg.description: >
-    Package provides task for TinyUSB.
-    This package requires API TINYUSB_HW_INIT that will
-    provide function tinyusb_hardware_init().
-
+pkg.name: hw/usb/tinyusb/nrf53
+pkg.description: Hardware initialization for Tinyusb
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - usb
     - tinyusb
 
+pkg.apis:
+    - TINYUSB_HW_INIT
+
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@tinyusb/tinyusb"
-
-pkg.init:
-    tinyusb_start: 'MYNEWT_VAL(USBD_SYSINIT_STAGE)'
-
-pkg.deps.USBD_STD_DESCRIPTORS:
-    - "@apache-mynewt-core/hw/usb/tinyusb/std_descriptors"
-pkg.deps.'MCU_TARGET == "nRF52840"':
-    - "@apache-mynewt-core/hw/usb/tinyusb/nrf5x"
-pkg.deps.'MCU_TARGET == "nRF5340_APP"':
-    - "@apache-mynewt-core/hw/usb/tinyusb/nrf53"
-pkg.deps.MCU_STM32F4:
-    - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
-pkg.deps.MCU_STM32L4:
-    - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
-pkg.deps.MCU_STM32F1:
-    - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
-pkg.deps.'(MCU_TARGET == "DA14691" || MCU_TARGET == "DA14695" || MCU_TARGET == "DA14697" || MCU_TARGET == "DA14699")':
-    - "@apache-mynewt-core/hw/usb/tinyusb/da146xx"
-
-pkg.req_apis:
-    - TINYUSB_HW_INIT

--- a/hw/usb/tinyusb/nrf53/src/nrf53.c
+++ b/hw/usb/tinyusb/nrf53/src/nrf53.c
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+
+#include <device/usbd.h>
+#include <nrfx/hal/nrf_usbreg.h>
+
+/* same value as NRFX_POWER_USB_EVT_* in nrfx_power */
+enum {
+    USB_EVT_DETECTED = 0,
+    USB_EVT_REMOVED = 1,
+    USB_EVT_READY = 2
+};
+
+/**
+ * tinyusb function that handles power event (0: detected, 1: remove, 2: ready)
+ * We must call it within SD's SOC event handler, or set it as power event handler if SD is not enabled.
+ */
+extern void tusb_hal_nrf_power_event(uint32_t event);
+
+static void
+USBD_IRQHandler(void)
+{
+    tud_int_handler(0);
+}
+
+static bool
+nrf_usbreg_event_get_and_clear(NRF_USBREG_Type *p_reg,
+                               nrf_usbreg_event_t event)
+{
+    bool ret = nrf_usbreg_event_check(p_reg, event);
+    if (ret) {
+        nrf_usbreg_event_clear(p_reg, event);
+    }
+    return ret;
+}
+
+
+/* Power ISR to detect USB VBUS state */
+static void
+USBREG_IRQHandler(void)
+{
+    if (nrf_usbreg_int_enable_check(NRF_USBREGULATOR_S, NRF_USBREG_INT_USBDETECTED) &&
+        (nrf_usbreg_event_get_and_clear(NRF_USBREGULATOR_S, NRF_USBREG_EVENT_USBDETECTED))) {
+        tusb_hal_nrf_power_event(USB_EVT_DETECTED);
+    }
+
+    if (nrf_usbreg_int_enable_check(NRF_USBREGULATOR_S, NRF_USBREG_INT_USBREMOVED) &&
+        nrf_usbreg_event_get_and_clear(NRF_USBREGULATOR_S,NRF_USBREG_EVENT_USBREMOVED)) {
+        tusb_hal_nrf_power_event(USB_EVT_REMOVED);
+    }
+
+    if (nrf_usbreg_int_enable_check(NRF_USBREGULATOR_S, NRF_USBREG_INT_USBPWRRDY) &&
+        nrf_usbreg_event_get_and_clear(NRF_USBREGULATOR_S, NRF_USBREG_EVENT_USBPWRRDY)) {
+        tusb_hal_nrf_power_event(USB_EVT_READY);
+    }
+}
+
+void
+tinyusb_hardware_init(void)
+{
+    /* Setup USB IRQ */
+    NVIC_SetVector(USBD_IRQn, (uint32_t)USBD_IRQHandler);
+    NVIC_SetPriority(USBD_IRQn, 2);
+
+    /* Setup Power IRQ to detect USB VBUS state (detected, ready, removed) */
+    NVIC_SetVector(USBREGULATOR_IRQn, (uint32_t)USBREG_IRQHandler);
+    NVIC_SetPriority(USBREGULATOR_IRQn, 7);
+    nrf_usbreg_int_enable(NRF_USBREGULATOR_S,
+                          USBREG_INTEN_USBDETECTED_Msk |
+                          USBREG_INTEN_USBREMOVED_Msk |
+                          USBREG_INTEN_USBPWRRDY_Msk);
+
+    NVIC_EnableIRQ(USBREGULATOR_IRQn);
+
+    /*
+     * USB power may already be ready at this time -> no event generated
+     * We need to invoke the handler based on the status initially
+     */
+    uint32_t usb_reg = NRF_USBREGULATOR_S->USBREGSTATUS;
+
+    if (usb_reg & USBREG_USBREGSTATUS_VBUSDETECT_Msk) {
+        tusb_hal_nrf_power_event(USB_EVT_DETECTED);
+    }
+
+    if (usb_reg & USBREG_USBREGSTATUS_OUTPUTRDY_Msk) {
+        tusb_hal_nrf_power_event(USB_EVT_READY);
+    }
+}


### PR DESCRIPTION
This provides code for hardware initialization.
Part of this initialization is present in tinyusb bsps which
are not used by mynewt since it has own bsps.

This part is distinct from NRF52 since some hardware registers
were changed.