### PR TITLE
sys/console/minimal: Fix RTT console compiler error for minimal console

### DIFF
--- a/sys/console/minimal/src/console.c
+++ b/sys/console/minimal/src/console.c
@@ -134,7 +134,6 @@ end:
     return rc;
 }
 
-#if MYNEWT_VAL(CONSOLE_UART)
 int
 console_out(int c)
 {
@@ -151,7 +150,6 @@ console_out(int c)
 
     return rc;
 }
-#endif
 
 void
 console_prompt_set(const char *prompt, const char *line)

--- a/sys/console/minimal/src/rtt_console.c
+++ b/sys/console/minimal/src/rtt_console.c
@@ -33,7 +33,7 @@ static struct hal_timer rtt_timer;
 static const char CR = '\r';
 
 int
-console_out(int character)
+console_out_nolock(int character)
 {
     char c = (char)character;
 


### PR DESCRIPTION
Revert changes in commit b22aea6433dd2663861ed8c2ea56cc229c6c64dd. Instead rename `console_out` to `console_out_nolock` in `rtt_console.c` per suggestions here: https://github.com/apache/mynewt-core/pull/2649#issuecomment-894658567

cc @vrahane @kasjer