### PR TITLE
Update da1469x vbus

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_vbus.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_vbus.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_DA1469X_VBUS_H_
+#define __MCU_DA1469X_VBUS_H_
+
+#include <stdint.h>
+#include <mcu/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*vbus_change_handler)(bool present);
+
+void da1469x_vbus_add_handler(vbus_change_handler handler);
+void da1469x_vbus_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_DA1469X_VBUS_H_ */

--- a/hw/mcu/dialog/da1469x/src/da1469x_periph.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_periph.c
@@ -23,6 +23,7 @@
 #include "os/os_cputime.h"
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_dma.h"
+#include "mcu/da1469x_vbus.h"
 #include "bsp/bsp.h"
 
 #if MYNEWT_VAL(UART_0) || MYNEWT_VAL(UART_1) || MYNEWT_VAL(UART_2)
@@ -518,6 +519,7 @@ void
 da1469x_periph_create(void)
 {
     da1469x_dma_init();
+    da1469x_vbus_init();
 
     da1469x_periph_create_timers();
     da1469x_periph_create_adc();

--- a/hw/mcu/dialog/da1469x/src/da1469x_vbus.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_vbus.c
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/util.h>
+#include <mcu/da1469x_vbus.h>
+
+/*
+ * For now only two clients of VBUS notification are present USB and charger
+ * If more space is needed in the future more entries can be added.
+ */
+static vbus_change_handler vbus_change_handlers[2];
+static uint8_t vbus_change_handler_count;
+
+static void
+da1469x_vbus_isr(void)
+{
+    int i;
+    bool vbus_present = (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0;
+
+    CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
+    for (i = 0; i < vbus_change_handler_count; ++i) {
+        vbus_change_handlers[i](vbus_present);
+    }
+}
+
+void
+da1469x_vbus_add_handler(vbus_change_handler handler)
+{
+    int sr;
+    bool vbus_present;
+
+    assert(vbus_change_handler_count < ARRAY_SIZE(vbus_change_handlers));
+
+    OS_ENTER_CRITICAL(sr);
+
+    vbus_change_handlers[vbus_change_handler_count++] = handler;
+    vbus_present = (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0;
+
+    /* VBUS was already present notify new handler */
+    if (vbus_present) {
+        handler(vbus_present);
+    }
+
+    OS_EXIT_CRITICAL(sr);
+}
+
+void da1469x_vbus_init(void)
+{
+    NVIC_DisableIRQ(VBUS_IRQn);
+    NVIC_SetVector(VBUS_IRQn, (uint32_t)da1469x_vbus_isr);
+    CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
+    NVIC_ClearPendingIRQ(VBUS_IRQn);
+    /* Both connect and disconnect needs to be handled */
+    CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
+                                 CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;
+    NVIC_EnableIRQ(VBUS_IRQn);
+}

--- a/hw/usb/tinyusb/da146xx/include/tusb_hw.h
+++ b/hw/usb/tinyusb/da146xx/include/tusb_hw.h
@@ -23,6 +23,10 @@
 #define CFG_TUSB_MCU OPT_MCU_DA1469X
 
 #include <syscfg/syscfg.h>
+#include <stdbool.h>
+
+/* Function should be exported from TinyUSB */
+void tusb_vbus_changed(bool present);
 
 #if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
 #define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)

--- a/hw/usb/tinyusb/da146xx/syscfg.yml
+++ b/hw/usb/tinyusb/da146xx/syscfg.yml
@@ -18,6 +18,26 @@
 #
 
 syscfg.defs:
+    DA1469X_USB_VBUS_HANDLING:
+        description: >
+            Selects how VBUS changes should be detected and propagated
+            to TinyUSB stack.
+            - auto - VBUS interrupt handler notifies USB stack about
+                     VBUS changes and shuts down USB when VBUS is off.
+                     Power Domain SYS is acquired when VBUS is present
+                     preventing deep sleep. Deep sleep is possible
+                     when VBUS is not present.
+            - ignore - VBUS is not checked at all. USB stack is notified
+                     at start that VBUS is present.
+                     Suitable for bus-powered devices.
+            - custom - VBUS is not handled by this package at all.  User
+                     code will have to call tusb_vbus_changed() and
+                     take care of SYS Power Domain acquisition.
+        value: auto
+        choices:
+            - auto
+            - ignore
+            - custom
 
 syscfg.restrictions:
     - USBD_EP0_SIZE == 8


### PR DESCRIPTION
VBUS changes were handled locally by charger code.
USB code also needs to know about such events.

Now common VBUS code handles interrupt and inform
charger and/or USB module about such events

This requires: https://github.com/hathach/tinyusb/pull/1094 to be merged first for **auto** and **ignore** modes (selected by **DA1469X_USB_VBUS_HANDLING** syscfg).
Older TinyUSB can be used only with **custom** mode as there may be missing function in TinyUSB driver.