### PR TITLE
tinyusb: Enable USB for STM32F7

### DIFF
--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -44,6 +44,8 @@ pkg.deps.'MCU_TARGET == "nRF5340_APP"':
     - "@apache-mynewt-core/hw/usb/tinyusb/nrf53"
 pkg.deps.MCU_STM32F4:
     - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
+pkg.deps.MCU_STM32F7:
+    - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
 pkg.deps.MCU_STM32L4:
     - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
 pkg.deps.MCU_STM32F1:


### PR DESCRIPTION
STM32F7 has very similar USB block to STM32F4 and STM32L4.
This enable synopsy package that initializes interrupts
that are needed when building USB project on STM32F7 boards.