### PR TITLE
Update MCUboot repo and branch

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -110,8 +110,9 @@ repo.deps:
 
     mcuboot:
         type: github
-        user: JuulLabs-OSS
+        user: mcu-tools
         repo: mcuboot
+        branch: main
         vers:
             master: 0-dev
             mynewt_1_7_0_tag: 1.3.1


### PR DESCRIPTION
MCUboot was moved to mcu-tools org, and now uses "main" instead of "master" branch.