### PR TITLE
apps/sensors_test: Remove blinking tasks

### DIFF
--- a/apps/sensors_test/src/main.c
+++ b/apps/sensors_test/src/main.c
@@ -32,10 +32,6 @@
 #include <reboot/log_reboot.h>
 #include <id/id.h>
 
-#ifndef LED_BLINK_PIN
-#define LED_BLINK_PIN 15
-#endif
-
 #if MYNEWT_VAL(BNO055_CLI)
 #include <bno055/bno055.h>
 #endif
@@ -102,24 +98,6 @@ static int sensor_oic_gap_event(struct ble_gap_event *event, void *arg);
 #ifdef ARCH_sim
 #include <mcu/mcu_sim.h>
 #endif
-
-/* Task 1 */
-#define TASK1_PRIO (8)
-#define TASK1_STACK_SIZE    OS_STACK_ALIGN(192)
-static struct os_task task1;
-static volatile int g_task1_loops;
-
-/* Task 2 */
-#define TASK2_PRIO (9)
-#define TASK2_STACK_SIZE    OS_STACK_ALIGN(64)
-static struct os_task task2;
-static volatile int g_task2_loops;
-
-/* Global test semaphore */
-static struct os_sem g_test_sem;
-
-/* For LED toggling */
-static int g_led_pin;
 
 #if MYNEWT_VAL(SENSOR_OIC) && MYNEWT_VAL(SENSOR_BLE)
 
@@ -341,80 +319,44 @@ sensor_oic_gap_event(struct ble_gap_event *event, void *arg)
 }
 #endif
 
-static void
-task1_handler(void *arg)
-{
-    struct os_task *t;
+#ifdef LED_BLINK_PIN
 
-    /* Set the led pin for the E407 devboard */
-    g_led_pin = LED_BLINK_PIN;
-    hal_gpio_init_out(g_led_pin, 1);
+/* The timer callout */
+static struct os_callout blink_callout;
 
-    console_printf("\nSensors Test App\n");
+/* For LED toggling */
+static int g_led_pin;
 
-    while (1) {
-        t = os_sched_get_current_task();
-        assert(t->t_func == task1_handler);
-
-        ++g_task1_loops;
-
-        /* Wait one second */
-        os_time_delay(OS_TICKS_PER_SEC * MYNEWT_VAL(SENSOR_OIC_OBS_RATE));
-
-        /* Toggle the LED */
-        (void)hal_gpio_toggle(g_led_pin);
-
-        /* Release semaphore to task 2 */
-        os_sem_release(&g_test_sem);
-    }
-}
-
-static void
-task2_handler(void *arg)
-{
-    struct os_task *t;
-
-    while (1) {
-        /* just for debug; task 2 should be the running task */
-        t = os_sched_get_current_task();
-        assert(t->t_func == task2_handler);
-
-        /* Increment # of times we went through task loop */
-        ++g_task2_loops;
-
-        /* Wait for semaphore from ISR */
-        os_sem_pend(&g_test_sem, OS_TIMEOUT_NEVER);
-    }
-}
-
-/**
- * init_tasks
- *
- * Called by main.c after sysinit(). This function performs initializations
- * that are required before tasks are running.
- *
- * @return int 0 success; error otherwise.
+/*
+ * Event callback function for timer events. It toggles the led pin.
  */
 static void
-init_tasks(void)
+blink_ev_cb(struct os_event *ev)
 {
-    os_stack_t *pstack;
+    assert(ev != NULL);
 
-    /* Initialize global test semaphore */
-    os_sem_init(&g_test_sem, 0);
+    hal_gpio_toggle(g_led_pin);
 
-    pstack = malloc(sizeof(os_stack_t)*TASK1_STACK_SIZE);
-    assert(pstack);
-
-    os_task_init(&task1, "task1", task1_handler, NULL,
-            TASK1_PRIO, OS_WAIT_FOREVER, pstack, TASK1_STACK_SIZE);
-
-    pstack = malloc(sizeof(os_stack_t)*TASK2_STACK_SIZE);
-    assert(pstack);
-
-    os_task_init(&task2, "task2", task2_handler, NULL,
-            TASK2_PRIO, OS_WAIT_FOREVER, pstack, TASK2_STACK_SIZE);
+    os_callout_reset(&blink_callout, OS_TICKS_PER_SEC);
 }
+
+static void
+init_blink(void)
+{
+    g_led_pin = LED_BLINK_PIN;
+    hal_gpio_init_out(g_led_pin, 1);
+    /*
+     * Initialize the callout for a timer event.
+     */
+    os_callout_init(&blink_callout, os_eventq_dflt_get(),
+                    blink_ev_cb, NULL);
+
+    os_callout_reset(&blink_callout, OS_TICKS_PER_SEC);
+}
+
+#else
+#define init_blink()
+#endif
 
 static void
 sensors_dev_shell_init(void)
@@ -516,8 +458,8 @@ main(int argc, char **argv)
     /* Initialize OS */
     sysinit();
 
-    /* Initialize tasks */
-    init_tasks();
+    /* Initialize blinking led */
+    init_blink();
 
     /* Sensor device shell init */
     sensors_dev_shell_init();
@@ -527,6 +469,8 @@ main(int argc, char **argv)
 
     /* log reboot */
     reboot_start(hal_reset_cause());
+
+    console_printf("\nSensors Test App\n");
 
     /*
      * As the last thing, process events from default event queue.


### PR DESCRIPTION
Application defined 2 tasks to blink 1 led.
It also provided default pin (15) for led if
BSP did not provide LED_BLINK_PIN definition.

Amount of RAM used for tasks and stacks prevents
this application to run on MCUs with 20KB of RAM.

This:
- replaces tasks with callout reducing RAM used.
- removes local hard coded definition of LED,
  so pin 15 may be used for something else.