### PR TITLE
sys/id: Add override facility for functions and storage

### DIFF
--- a/sys/id/include/id/id.h
+++ b/sys/id/include/id/id.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+extern struct conf_handler id_conf;
+
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
 /*
  * Maximum expected serial number string length.

--- a/sys/id/src/id.c
+++ b/sys/id/src/id.c
@@ -32,10 +32,12 @@
 
 #define ID_BASE64_MFG_HASH_SZ  (BASE64_ENCODE_SIZE(MFG_HASH_SZ))
 
+#if !MYNEWT_VAL(ID_OVERRIDE_CONF_HELPERS)
 static char *id_conf_get(int argc, char **argv, char *val, int val_len_max);
 static int id_conf_set(int argc, char **argv, char *val);
 static int id_conf_export(void (*export_func)(char *name, char *val),
   enum conf_export_tgt tgt);
+#endif
 
 #define STAMP_STR(s) STAMP_STR1(s)
 #define STAMP_STR1(str) #str
@@ -48,6 +50,7 @@ const char *id_bsp_str = "";
 const char *id_app_str = "";
 #endif
 
+#if !MYNEWT_VAL(ID_OVERRIDE_CONF_HELPERS)
 #if MYNEWT_VAL(ID_SERIAL_PRESENT)
 char id_serial[ID_SERIAL_MAX_LEN];
 #endif
@@ -60,10 +63,12 @@ char id_manufacturer[ID_MANUFACTURER_MAX_LEN];
 #if MYNEWT_VAL(ID_MODEL_LOCAL)
 char id_model[ID_MODEL_MAX_LEN];
 #endif
+#endif
 
 /** Colon-delimited null-terminated list of base64-encoded mfgimage hashes. */
 char id_mfghash[MYNEWT_VAL(MFG_MAX_MMRS) * (ID_BASE64_MFG_HASH_SZ + 1)];
 
+#if !MYNEWT_VAL(ID_OVERRIDE_CONF_HELPERS)
 struct conf_handler id_conf = {
     .ch_name = "id",
     .ch_get = id_conf_get,
@@ -189,6 +194,7 @@ id_conf_export(void (*export_func)(char *name, char *val),
 #endif /* ID_MODEL_PRESENT */
     return 0;
 }
+#endif
 
 static void
 id_read_mfghash(void)

--- a/sys/id/syscfg.yml
+++ b/sys/id/syscfg.yml
@@ -60,6 +60,10 @@ syscfg.defs:
             # Older versions of newt don't export the target name.
             - 'TARGET_NAME'
 
+    ID_OVERRIDE_CONF_HELPERS:
+        description: 'Override config function helpers with alternative implementation'
+        value: 0
+
     ID_SYSINIT_STAGE:
         description: >
             Sysinit stage for ID functionality.


### PR DESCRIPTION
This patch adds an override facility to the sys/id package.  This allows someone
to override the functions and storage location to implement their own id 
config area.

Signed-off-by: Andy Gross <andy.gross@juul.com>