### PR TITLE
stm32 PWM fixes

### DIFF
--- a/hw/bsp/nucleo-l073rz/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l073rz/src/hal_bsp.c
@@ -89,6 +89,20 @@ const struct stm32_hal_i2c_cfg os_bsp_i2c2_cfg = {
 };
 #endif
 
+#if MYNEWT_VAL(PWM_0)
+struct stm32_pwm_conf os_bsp_pwm0_cfg = {
+    .tim = TIM3,
+    .irq = TIM3_IRQn,
+};
+#endif
+
+#if MYNEWT_VAL(PWM_1)
+struct stm32_pwm_conf os_bsp_pwm1_cfg = {
+    .tim = TIM2,
+    .irq = TIM2_IRQn,
+};
+#endif
+
 static const struct hal_bsp_mem_dump dump_cfg[] = {
     [0] = {
         .hbmd_start = &_ram_start,

--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -345,7 +345,7 @@ stm32_pwm_set_frequency(struct pwm_dev *dev, uint32_t freq_hz)
     LL_TIM_SetPrescaler(pwm->timx, div1);
     LL_TIM_SetAutoReload(pwm->timx, div2);
 
-    return STM32_PWM_ERR_OK;
+    return timer_clock / (div1 + 1) / (div2 + 1);
 }
 
 static int

--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -468,7 +468,11 @@ stm32_pwm_dev_init(struct os_dev *odev, void *arg)
     switch ((uintptr_t)cfg->tim) {
 #ifdef TIM1
     case (uintptr_t)TIM1:
+#if defined(LL_APB2_GRP1_PERIPH_TIM1)
         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM1);
+#elif defined(LL_APB1_GRP2_PERIPH_TIM1)
+        LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_TIM1);
+#endif
         dev->pwm_chan_count = 4;
         break;
 #endif
@@ -543,19 +547,31 @@ stm32_pwm_dev_init(struct os_dev *odev, void *arg)
 #endif
 #ifdef TIM15
     case (uintptr_t)TIM15:
+#if defined(LL_APB2_GRP1_PERIPH_TIM15)
         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM15);
+#elif defined(LL_APB1_GRP2_PERIPH_TIM15)
+        LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_TIM15);
+#endif
         dev->pwm_chan_count = 2;
         break;
 #endif
 #ifdef TIM16
     case (uintptr_t)TIM16:
+#if defined(LL_APB2_GRP1_PERIPH_TIM16)
         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM16);
+#elif defined(LL_APB1_GRP2_PERIPH_TIM16)
+        LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_TIM16);
+#endif
         dev->pwm_chan_count = 1;
         break;
 #endif
 #ifdef TIM17
     case (uintptr_t)TIM17:
+#if defined(LL_APB2_GRP1_PERIPH_TIM17)
         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM17);
+#elif defined(LL_APB1_GRP2_PERIPH_TIM17)
+        LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_TIM17);
+#endif
         dev->pwm_chan_count = 1;
         break;
 #endif


### PR DESCRIPTION
This updates STM32 PWM usability:
- fixes return value from` stm32_pwm_set_frequency()` (**pwm_test** application assert failure)
- fixes build for **STM32F0** with PWM driver
- adds **PWM** peripherals configuration to **nucleo-l073rz** board