### PR TITLE
pwm/stm32_pwm: Fix PWM using advanced timers

### DIFF
--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -602,5 +602,12 @@ stm32_pwm_dev_init(struct os_dev *odev, void *arg)
     LL_TIM_CC_EnablePreload(cfg->tim);
     LL_TIM_SetCounter(pwm->timx, 0);
 
+    /* If using advanced timer, enable main output (MOE). */
+#ifdef IS_TIM_BREAK_INSTANCE
+    if (IS_TIM_BREAK_INSTANCE(pwm->timx)) {
+        LL_TIM_EnableAllOutputs(pwm->timx);
+    }
+#endif
+
     return STM32_PWM_ERR_OK;
 }

--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -599,7 +599,6 @@ stm32_pwm_dev_init(struct os_dev *odev, void *arg)
     OS_DEV_SETHANDLERS(odev, stm32_pwm_open, stm32_pwm_close);
 
     LL_TIM_EnableARRPreload(cfg->tim);
-    LL_TIM_CC_EnablePreload(cfg->tim);
     LL_TIM_SetCounter(pwm->timx, 0);
 
     /* If using advanced timer, enable main output (MOE). */


### PR DESCRIPTION
Advanced timer PWMs require the MOE bit in the TIMX_BDTR register to be set to enable output.
Enabling the compare preload function (CCxP in the TIMx_CCER register) is not supported in code for non-advanced timers. It should be explicitly disabled for advanced timers. 