### PR TITLE
apps/pwm_test: Fix pin handling for STM32

### DIFF
--- a/apps/pwm_test/src/pwm_shell.c
+++ b/apps/pwm_test/src/pwm_shell.c
@@ -182,7 +182,7 @@ static const struct shell_cmd_help start_help = {
 static int
 cmd_start(int argc, char **argv)
 {
-    uint8_t pin = LED_BLINK_PIN;
+    int pin = LED_BLINK_PIN;
     char *tmp;
     char *pwm = "pwm0";
     int freq = 200;

--- a/apps/pwm_test/src/pwm_shell.c
+++ b/apps/pwm_test/src/pwm_shell.c
@@ -241,13 +241,13 @@ cmd_start(int argc, char **argv)
     chan_conf.pin = pin;
     rc = pwm_configure_channel(dev, chan, &chan_conf);
     if (rc) {
-        console_printf("Could configure channel %d on %s\n", chan, pwm);
+        console_printf("Could not configure channel %d on %s\n", chan, pwm);
         return 0;
     }
 
    rc = pwm_set_frequency(dev, freq);
    if (rc < 0) {
-       console_printf("Could configure frequency %s\n", pwm);
+       console_printf("Could not configure frequency %s\n", pwm);
        return 0;
    }
 
@@ -257,7 +257,7 @@ cmd_start(int argc, char **argv)
 
    rc = pwm_set_duty_cycle(dev, chan, ((top * dc) / 100));
    if (rc) {
-      console_printf("Could configure duty cycle %d on %s\n", ((top * dc) / 100), pwm);
+      console_printf("Could not configure duty cycle %d on %s\n", ((top * dc) / 100), pwm);
       return 0;
    }
 


### PR DESCRIPTION
STM32 PWM driver encodes alternate pin function
at higher bits of pin definition.

Definition of pins with alternate function > 0 are 16 bits long,
where bits 12:15 specify function.

pwm_shell assumed that 8 bits is enough for pin number, but it will
not work for most ST cases.

This changes local variable type to accommodate ST encoding of pins
with alternate function.