### PR TITLE
tinyusb: Fix build with stub console

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -23,6 +23,7 @@
  *
  */
 
+#include <assert.h>
 #include <syscfg/syscfg.h>
 #include <bsp/bsp.h>
 #include <string.h>


### PR DESCRIPTION
std_descriptors.c is using assert() but it did not explicitly
include assert.h. It was included by console.h but not in
stubbed implementation.

repos/apache-mynewt-core/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c:278:9: error: implicit declaration of function 'assert' [-Werror=implicit-function-declaration]

Now assert.h is explicitly included regardless of which version of console
is used.