### PR TITLE
da1469x: Increase size of loadable binaries in development mode

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
+++ b/hw/bsp/dialog_da1469x-dk-pro/da1469x_serial.py
@@ -88,8 +88,17 @@ def load(infile, uart, reset_script):
             som_detected = True
             print("Detected serial boot protocol")
             msg = bytes([0x1])
-            msg += bytes([len(data) & 0xff])
-            msg += bytes([len(data) >> 8])
+
+            if len(data) > 65535:
+                msg += bytes([0x0])
+                msg += bytes([0x0])
+                msg += bytes([len(data) & 0xff])
+                msg += bytes([(len(data) >> 8) & 0xff])
+                msg += bytes([len(data) >> 16])
+            else:
+                msg += bytes([len(data) & 0xff])
+                msg += bytes([len(data) >> 8])
+
             ser.write(msg)
             ser.timeout = 10
             msg = ser.read()


### PR DESCRIPTION
This patch increases the maximum supported size of ram loaded binaries using the
serial loading protocol.

Images < 64k in size use the original load method.  Any binary exceeding 64k but less than 128k needs to use the extended load sequence.

Signed-off-by: Andy Gross <andy.gross@juul.com>