### PR TITLE
hw/mcu/dialog: Fix setting up clock source with PLL enabled

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_sleep.c
@@ -135,6 +135,12 @@ da1469x_sleep(os_time_t ticks)
 #if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, PLL96)
     da1469x_clock_pll_wait_to_lock();
     da1469x_clock_sys_pll_switch();
+#else
+    /*
+     * PLL is enabled but XTAL32M still used as system clock.
+     * No need to wait for PLL, switch to XTAL32M it is ready.
+     */
+    da1469x_clock_sys_xtal32m_switch();
 #endif
 #else
     da1469x_clock_sys_xtal32m_switch_safe();


### PR DESCRIPTION
When PLL is enabled but not selected as system clock (just for USB)
switching to XTAL32M was missing even though XTAL32M was running.

This error was introduced when PLL was added as system clock source.

This change restores switching to XTAL32M clock when PLL is enabled
but not selected as system clock when system wakes from sleep.