### PR TITLE
travis.yml: Bump Go to 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ _addons: &addon_conf
       - linux-libc-dev:i386
 
 go:
-  - "1.12"
+  - "1.16"
 
 git:
   depth: false


### PR DESCRIPTION
This is required for updated install script to work properly.