### PR TITLE
hw/mcu/cmac: Fix hal_timer_read

### DIFF
--- a/hw/mcu/dialog/cmac/include/mcu/cmac_timer.h
+++ b/hw/mcu/dialog/cmac/include/mcu/cmac_timer.h
@@ -184,7 +184,7 @@ cmac_timer_write_eq_hal_os_tick(uint64_t val)
 }
 
 /* Convert ll_timer value to hal_timer value */
-static inline uint32_t
+static inline uint64_t
 cmac_timer_convert_llt2hal(uint64_t val)
 {
     return (val << 9) / 15625;

--- a/hw/mcu/dialog/cmac/src/hal_timer.c
+++ b/hw/mcu/dialog/cmac/src/hal_timer.c
@@ -209,12 +209,13 @@ uint32_t
 hal_timer_read(int timer_num)
 {
     uint64_t llt;
-    uint32_t val;
+    uint64_t val;
 
     assert(timer_num == 0);
 
     llt = cmac_timer_read64();
     val = cmac_timer_convert_llt2hal(llt);
+    llt = (val * 15625) >> 9;
 
     __disable_irq();
 


### PR DESCRIPTION
This is regression after c9f72793d712365e6bdc0b5a3386f6e3caebee11.

LLT value stored for given HAL value needs to correspond precisely to
HAL value converted to LLT, otherwise conversion from HAL to LLL will
not be accurate and calculated times e.g. for scheduling may be off by
up to 1 tick.