### PR TITLE
kernel/arch/m33: Update context switch for TrustZone

### DIFF
--- a/kernel/os/src/arch/cortex_m33/m33/HAL_CM33.s
+++ b/kernel/os/src/arch/cortex_m33/m33/HAL_CM33.s
@@ -173,10 +173,10 @@ PendSV_Handler:
 
         MRS     R12,PSP                 /* Read PSP */
 #if MYNEWT_VAL(HARDFLOAT)
-        TST     LR,#0x10                /* is it extended frame? */
+        ANDS    R0,LR,#0x10             /* is it extended frame? */
         IT      EQ
         VSTMDBEQ R12!,{S16-S31}         /* yes; push the regs */
-        STMDB   R12!,{R4-R11,LR}        /* Save Old context */
+        STMDB   R12!,{R0,R4-R11}        /* Save Old context */
 #else
         STMDB   R12!,{R4-R11}           /* Save Old context */
 #endif
@@ -187,12 +187,12 @@ PendSV_Handler:
         MSR     PSPLIM,R12              /* update stack limit register */
         LDR     R12,[R2,#0]             /* get stack pointer of task we will start */
 #if MYNEWT_VAL(HARDFLOAT)
-        LDMIA   R12!,{R4-R11,LR}        /* Restore New Context */
-        TST     LR,#0x10                /* is it extended frame? */
+        LDMIA   R12!,{R0,R4-R11}        /* Restore New Context */
+        ANDS    R0,#0x10                /* is it extended frame? */
         ITTE    EQ
         VLDMIAEQ R12!,{S16-S31}         /* yes; pull the regs */
-        MVNEQ   LR,#~0xFFFFFFED         /* BX treats it as extended */
-        MVNNE   LR,#~0xFFFFFFFD         /* BX treats is as basic frame */
+        BICEQ   LR,#0x10                /* Clear FType bit in LR, BX treats it as extended */
+        ORRNE   LR,#0x10                /* Set FType bit in LR, BX treats it as standard frame */
 #else
         LDMIA   R12!,{R4-R11}           /* Restore New Context */
 #endif

--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -35,9 +35,10 @@ extern void SysTick_Handler(void);
 
 /*
  * Initial LR indicating basic frame.
- * See ARMv7-M Architecture Ref Manual
+ * Only FType bit is used.
+ * See ARMv8-M Architecture Ref Manual
  */
-#define INITIAL_LR      0xfffffffd;
+#define INITIAL_LR_FPTYPE      0x10;
 
 /*
  * Exception priorities. The higher the number, the lower the priority. A
@@ -51,6 +52,9 @@ extern void SysTick_Handler(void);
 
 /* Stack frame structure */
 struct stack_frame {
+#if MYNEWT_VAL(HARDFLOAT)
+    uint32_t    exc_lr;
+#endif
     uint32_t    r4;
     uint32_t    r5;
     uint32_t    r6;
@@ -59,9 +63,6 @@ struct stack_frame {
     uint32_t    r9;
     uint32_t    r10;
     uint32_t    r11;
-#if MYNEWT_VAL(HARDFLOAT)
-    uint32_t    exc_lr;
-#endif
     uint32_t    r0;
     uint32_t    r1;
     uint32_t    r2;
@@ -200,7 +201,7 @@ os_arch_task_stack_init(struct os_task *t, os_stack_t *stack_top, int size)
     /* Set function to cache returns from tasks. */
     sf->lr = (uint32_t)os_arch_task_return_handler;
 #if MYNEWT_VAL(HARDFLOAT)
-    sf->exc_lr = INITIAL_LR;
+    sf->exc_lr = INITIAL_LR_FPTYPE;
 #endif
 
     return (s);


### PR DESCRIPTION
When build with hardware floating point enabled, context
switch code had hard-coded LR value that were correct
for code running without TrustZone or with TrustZone
present but code running in secure mode.

LR modification during task switch only needs to have
FType bit set correctly (1 when there are no floating
point registers on stack, 0 when FP registers are there).
Other bits from link register should stay unchanged
to be correctly handled in TrustZone environment.

This saves only FType bit from LR during context switch store
phase, during restore phase bit FType from saved context is
set to LR. This way there is no need to
hard-code other possible values that LR can have.

As side effect LR[FType] is placed at very bottom of stack_frame
to keep code size unchanged.
LDMIA and STMDB are used with R0 instead of LR hence
register placement change.