### PR TITLE
net/oic: Minor modification to prevent transmission no data

### DIFF
--- a/net/oic/src/port/mynewt/ble_adaptor.c
+++ b/net/oic/src/port/mynewt/ble_adaptor.c
@@ -482,6 +482,9 @@ oc_ble_frag(struct os_mbuf *m, uint16_t mtu)
     }
 
     off = pkt->omp_len - (pkt->omp_len % mtu);
+    if (off == pkt->omp_len) {
+        off -= mtu;
+    }
     while (off >= mtu) {
         n = os_msys_get_pkthdr(mtu, 0);
         if (!n) {


### PR DESCRIPTION
This is a minor change to the code which should prevent the code
from sending a fragment with no data in it. In the case where
the packet length is greater than the mtu but is an integer
multiple of the mtu (pktlength % mtu equals 0) the code would
allocate a packet header mbuf with no data in it and send it.
This change should prevent that from occurring.

NOTE: I do not think sending the zero length frame breaks anything; the change is merely to
prevent allocating a mbuf and sending a frame which does not do anything as far as I can
tell.