### PR TITLE
syscfg: Fix invalid restriction definition

### DIFF
--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -31,7 +31,7 @@ syscfg.defs:
             packages for network and application core that do have
             some differences depending on which core they are build for.
         value: 1
-        restriction: MCU_APP_CORE==0
+        restrictions: !MCU_APP_CORE
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.

--- a/hw/mcu/nxp/kinetis/syscfg.yml
+++ b/hw/mcu/nxp/kinetis/syscfg.yml
@@ -22,7 +22,7 @@ syscfg.defs:
             Specifies the required alignment for internal flash writes.
             Used internally by the newt tool.
         value:
-        restriction: $notnull
+        restrictions: $notnull
 
     TRNG:
         description: 'Enable True Random Number Generator (RNGA)'

--- a/sys/console/full/tcp_console/syscfg.yml
+++ b/sys/console/full/tcp_console/syscfg.yml
@@ -20,4 +20,4 @@ syscfg.defs:
     TCP_CONSOLE_PORT:
         description: 'Set console TCP port'
         value: 4444
-        restriction: $notnull
+        restrictions: $notnull

--- a/test/spiflash_stress_test/syscfg.yml
+++ b/test/spiflash_stress_test/syscfg.yml
@@ -19,7 +19,7 @@
 syscfg.defs:
     SPIFLASH_STRESS_TEST_FLASH_AREA_ID:
         description: 'Flash area ID to use for stress testing'
-        restriction: !null
+        restrictions: $notnull
         value:
     SPIFLASH_STRESS_TEST_STACK_SIZE:
         description: 'Stack size for flash stressing tasks'


### PR DESCRIPTION
Syntax was incorrect so checks were not performed.

`restriction:` should be **restrictions:**

and `!null` should be **$notnull**