### PR TITLE
tinyusb: Remove deprecated definition CFG_TUD_NET

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -80,7 +80,6 @@ extern "C" {
 #define CFG_TUD_USBTMC           0
 #define CFG_TUD_DFU_RT           0
 #define CFG_TUD_DFU              MYNEWT_VAL(USBD_DFU)
-#define CFG_TUD_NET              0
 #define CFG_TUD_BTH              MYNEWT_VAL(USBD_BTH)
 
 /* Minimal number for alternative interfaces that is recognized by Windows as Bluetooth radio controller */


### PR DESCRIPTION
CFG_TUD_NET was deprecated in TinyUSB it is replaced with
CFG_TUD_ECM_RNDIS but since Mynewt does not have support
for RNDIS yet, definition is removed so code can be used with older
version of TinyUSB.
CFG_TUD_NET when present causes warning that is promoted
to error in most mynewt builds.