### PR TITLE
kernel/os: Revert conditions to define mtb_state on cortex m33 

### DIFF
--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -115,7 +115,9 @@ trap_to_coredump(struct trap_frame *tf, struct coredump_regs *regs)
     regs->pc = tf->ef->pc;
     regs->psr = tf->ef->psr;
 }
+#endif
 
+#if MYNEWT_VAL(OS_COREDUMP)
 struct mtb_state {
     uint32_t mtb_position_reg;
     uint32_t mtb_master_reg;


### PR DESCRIPTION
Small fix to define `struct mtb_state` as long as `OS_COREDUMP` is enabled. This was the behavior prior to the introduction of `OS_COREDUMP_CB` in https://github.com/apache/mynewt-core/pull/2687. Currently this struct will only be defined if `OS_COREDUMP && !OS_COREDUMP_CB` but it should be defined as long as `OS_COREDUMP` is true.

This returns the behavior to be the same as before