### PR TITLE
mcu/nrf5340_net: Add ipc_nrf5340 dependency for nrf5340_net_vflash_init

### DIFF
--- a/hw/mcu/nordic/nrf5340_net/pkg.yml
+++ b/hw/mcu/nordic/nrf5340_net/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/cmsis-core"
     - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/drivers/ipc_nrf5340"
 
 pkg.cflags.NFC_PINS_AS_GPIO:
     - '-DCONFIG_NFCT_PINS_AS_GPIOS=1'


### PR DESCRIPTION
`nrf5340_net_vflash_init` is currently using a struct (`ipc_shared`) defined in `ipc_nrf5340/ipc_nrf5340_priv.h`.

When building, there will be an error due to the fact that the `ipc_nrf5340` package is not a dependency so the header cannot be found.