### PR TITLE
sys/reboot: Move LOG_SOFT_RESET to mcumgr

### DIFF
--- a/apps/splitty/pkg.yml
+++ b/apps/splitty/pkg.yml
@@ -39,3 +39,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/shell"
     - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/reboot"

--- a/mgmt/smp/pkg.yml
+++ b/mgmt/smp/pkg.yml
@@ -31,9 +31,6 @@ pkg.deps:
     - "@apache-mynewt-mcumgr/smp"
     - "@apache-mynewt-mcumgr/cmd/os_mgmt"
 
-pkg.deps.LOG_SOFT_RESET:
-    - "@apache-mynewt-core/sys/reboot"
-
 pkg.deps.TIMEPERSIST:
     - "@apache-mynewt-core/time/timepersist"
 

--- a/mgmt/smp/smp_os/pkg.yml
+++ b/mgmt/smp/smp_os/pkg.yml
@@ -32,9 +32,6 @@ pkg.deps:
     - "@apache-mynewt-core/encoding/tinycbor"
     - "@apache-mynewt-mcumgr/cborattr"
 
-pkg.deps.LOG_SOFT_RESET:
-    - "@apache-mynewt-core/sys/reboot"
-
 pkg.deps.TIMEPERSIST:
     - "@apache-mynewt-core/time/timepersist"
 

--- a/sys/reboot/syscfg.yml
+++ b/sys/reboot/syscfg.yml
@@ -59,8 +59,3 @@ syscfg.defs:
     REBOOT_LOG_MOD:
         description: 'Numeric module ID to use for reboot log messages.'
         value: 6
-
-    LOG_SOFT_RESET:
-        description: >
-            Log soft resets.
-        value: 1


### PR DESCRIPTION
sys/reboot defined value LOG_SOFT_RESET that it never used.
mgmt/smp and mgmt/smp/smp_os used this value to include sys/reboot
which did not do anything due to catch 22.

This change removes LOG_SOFT_RESET from mynewt-core it will be added
to package in mcumgr that uses it.

this should be merged prior to https://github.com/apache/mynewt-mcumgr/pull/156 to avoid double definition