### PR TITLE
mcu/nrf5340: Add RAM location check to calls using easyDMA

### DIFF
--- a/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
+++ b/hw/bus/drivers/i2c_nrf5340/src/i2c_nrf5340.c
@@ -254,6 +254,10 @@ bus_i2c_nrf5340_read(struct bus_dev *bdev, struct bus_node *bnode,
     BUS_DEBUG_VERIFY_DEV(dev);
     BUS_DEBUG_VERIFY_NODE(node);
 
+    if (!nrfx_is_in_ram(buf)) {
+        return SYS_EINVAL;
+    }
+
     if (flags & BUS_F_NOSTOP) {
         /*
          * There's no shortcut available for LASTRX->SUSPEND so we can only
@@ -315,6 +319,10 @@ bus_i2c_nrf5340_write(struct bus_dev *bdev, struct bus_node *bnode,
 
     BUS_DEBUG_VERIFY_DEV(dev);
     BUS_DEBUG_VERIFY_NODE(node);
+
+    if (!nrfx_is_in_ram(buf)) {
+        return SYS_EINVAL;
+    }
 
     last_op = !(flags & BUS_F_NOSTOP);
 

--- a/hw/mcu/nordic/nrf5340/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_spi.c
@@ -26,6 +26,7 @@
 #include <mcu/nrf5340_hal.h>
 #include <nrf.h>
 #include <nrfx_config.h>
+#include <nrfx_common.h>
 
 #define SPIM_TXD_MAXCNT_MAX 0xffff
 
@@ -961,7 +962,11 @@ hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int len)
     rc = EINVAL;
     NRF5340_HAL_SPI_RESOLVE(spi_num, spi);
 
-    if ((spi->txrx_cb_func == NULL) || (len == 0)) {
+    if ((spi->txrx_cb_func == NULL) || (len == 0) || !nrfx_is_in_ram(txbuf)) {
+        goto err;
+    }
+
+    if (rxbuf != NULL && !nrfx_is_in_ram(rxbuf)) {
         goto err;
     }
 

--- a/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
@@ -691,7 +691,7 @@ hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int len)
     }
 
     if (rxbuf != NULL && !nrfx_is_in_ram(rxbuf)) {
-        return SYS_EINVAL;
+        return EINVAL;
     }
 
 #if MYNEWT_VAL(SPI_0_MASTER)

--- a/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
@@ -25,6 +25,7 @@
 #include <hal/hal_spi.h>
 #include <mcu/nrf5340_net_hal.h>
 #include <nrf.h>
+#include <nrfx_common.h>
 
 #if MYNEWT_VAL(SPI_0_MASTER) || MYNEWT_VAL(SPI_0_SLAVE)
 
@@ -685,8 +686,12 @@ hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int len)
 {
     struct nrf5340_net_hal_spi *spi = &nrf5340_net_hal_spi0;
 
-    if (spi_num != 0 || (spi->txrx_cb_func == NULL) || (len == 0)) {
+    if (spi_num != 0 || (spi->txrx_cb_func == NULL) || (len == 0) || !nrfx_is_in_ram(txbuf)) {
         return EINVAL;
+    }
+
+    if (rxbuf != NULL && !nrfx_is_in_ram(rxbuf)) {
+        return SYS_EINVAL;
     }
 
 #if MYNEWT_VAL(SPI_0_MASTER)


### PR DESCRIPTION
Add checks to confirm that the buffer points to a location in RAM given that easyDMA can only access RAM locations