### PR TITLE
hw/ipc_nrf5340: Add network core crash notification

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -109,6 +109,15 @@ uint16_t ipc_nrf5340_available(int channel);
  */
 uint16_t ipc_nrf5340_consume(int channel, uint16_t len);
 
+/**
+ * Set function to be called when net core restarts.
+ *
+ * Note: Function will be called from IPC interrupt context.
+ *
+ * @param on_crash - function to be called
+ */
+void ipc_nrf5340_set_net_core_restart_cb(void (*on_restart)(void));
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340_priv.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340_priv.h
@@ -40,6 +40,12 @@ struct ipc_shared {
     uint8_t ipc_channel_count;
     /* Array of shared memories used for IPC */
     struct ipc_shm *ipc_shms;
+    /* Set by netcore during IPC initialization */
+    volatile enum {
+        APP_WAITS_FOR_NET,
+        APP_AND_NET_RUNNING,
+        NET_RESTARTED,
+    } ipc_state;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
So far reset of net core that was not initiated by
app core was silently ignored.
It could lead to synchronization loose of IPC or
higher layers.

Now net core restart notification can be propagated
to app core and that information can be used or
simply logged.