### PR TITLE
hw/drivers/adc_nrf52: Prevent NULL pointer access

### DIFF
--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -163,10 +163,10 @@ nrf52_adc_open(struct os_dev *odev, uint32_t wait, void *arg)
     }
 
     if (++(dev->ad_ref_cnt) == 1) {
+        global_adc_dev = dev;
         init_instance_unconf();
         NVIC_SetPriority(SAADC_IRQn, 0);
         NVIC_EnableIRQ(SAADC_IRQn);
-        global_adc_dev = dev;
 
         if (adc_config) {
             switch (adc_config->resolution) {


### PR DESCRIPTION
Assign the device pointer before un-configuring ADC instance. This prevents `global_adc_dev` from being NULL inside `channel_unconf()` via `init_instance_unconf()`