### PR TITLE
Fix nrf534 ipc with old boot

### DIFF
--- a/hw/bsp/nordic_pca10095_net/boot-nrf5340_net.ld
+++ b/hw/bsp/nordic_pca10095_net/boot-nrf5340_net.ld
@@ -20,7 +20,7 @@ MEMORY
 {
   FLASH (rx) : ORIGIN = 0x01000000, LENGTH = 0x4000
   RAM (rwx) : ORIGIN = 0x21000000, LENGTH = 0x10000
-  IPC (rw)  : ORIGIN = 0x20000400, LENGTH = 0
+  IPC (rw)  : ORIGIN = 0x20000400, LENGTH = 0x400
 }
 
 /* The bootloader does not contain an image header */

--- a/hw/bsp/nordic_pca10095_net/nrf5340_net.ld
+++ b/hw/bsp/nordic_pca10095_net/nrf5340_net.ld
@@ -20,6 +20,7 @@ MEMORY
 {
   FLASH (rx) : ORIGIN = 0x01008000, LENGTH = 0x30000
   RAM (rwx) : ORIGIN = 0x21000000, LENGTH = 0x10000
+  IPC (rw)  : ORIGIN = 0x20000400, LENGTH = 0x400
 }
 
 /* This linker script is used for images and thus contains an image header */

--- a/hw/drivers/ipc_nrf5340/syscfg.yml
+++ b/hw/drivers/ipc_nrf5340/syscfg.yml
@@ -48,6 +48,16 @@ syscfg.defs:
             eg "LED_1, LED_2" or "1, 2". Further GPIO configuration should be
             done by Network Core.
         value: ""
+    IPC_NRF5340_PRE_TRUSTZONE_NETCORE_BOOT:
+        description: >
+            Set this to one only in case of the bootloader predates TrustZone
+            changes. With ARM TrusZone support added NRF_IPC_NS block is used
+            for both secure and non-secure application. Pre-TrustZone code
+            was always running in secure mode and network core code always
+            accessed NRF_IP_S (including code that is running in bootloader).
+            NRF_IP_S->GPMEM[] was used to pass address of net core application
+            image to net bootloader.
+        value: 0
 
 syscfg.restrictions:
     - "!BSP_NRF5340 || BSP_NRF5340_NET_ENABLE"

--- a/hw/mcu/nordic/nrf5340/nrf5340.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340.ld
@@ -137,6 +137,14 @@ SECTIONS
         . = ALIGN(4);
     } > RAM
 
+    /* Section for app-net cores IPC */
+    .ipc 0x20000400 (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.ipc)
+        . = ALIGN(4);
+    } > RAM
+
     /* This section will be zeroed by RTT package init */
     .rtt (NOLOAD):
     {

--- a/hw/mcu/nordic/nrf5340_net/nrf5340_net.ld
+++ b/hw/mcu/nordic/nrf5340_net/nrf5340_net.ld
@@ -130,6 +130,12 @@ SECTIONS
         . = ALIGN(4);
     } > RAM
 
+    /* Section for app-net cores IPC */
+    .ipc (NOLOAD):
+    {
+        *(.ipc)
+    } > IPC
+
     /* This section will be zeroed by RTT package init */
     .rtt (NOLOAD):
     {


### PR DESCRIPTION
IPC and virtual flash configuration was changed to be TrustZone non-secure friendly.
Those modification broke compatibility with existing net core bootloader.
This restores compatibility with old bootloader.

To enable old bootloader compatibility app core application have to be compiled with
`IPC_NRF5340_PRE_TRUSTZONE_NETCORE_BOOT: 1`
