### PR TITLE
tinyusb: Add syscfg to include dfu standard package

### DIFF
--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -52,6 +52,7 @@ pkg.deps.MCU_STM32F1:
     - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
 pkg.deps.'(MCU_TARGET == "DA14691" || MCU_TARGET == "DA14695" || MCU_TARGET == "DA14697" || MCU_TARGET == "DA14699")':
     - "@apache-mynewt-core/hw/usb/tinyusb/da146xx"
-
+pkg.deps.USBD_DFU_STD:
+    - "@apache-mynewt-core/hw/usb/tinyusb/dfu"
 pkg.req_apis:
     - TINYUSB_HW_INIT

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -66,7 +66,17 @@ syscfg.defs:
         description: Enable BT HCI device
         value: 0
     USBD_DFU:
-        description: Enable DFU interface
+        description: >
+            Enable DFU interface in TinyUSB.  This adds USB descriptor to
+            USB configuration.  It does not add TinyUSB callbacks implementation,
+            if standard implementation exposing SLOT1 is required USB_DFU_STD can
+            be additionally specified.
+        value: 0
+    USBD_DFU_STD:
+        description: >
+            Add Mynewt standard DFU interface implementation.
+            It will include hw/tinyusb/dfu package with mynewt standard
+            DFU implementation.
         value: 0
 
     USBD_CDC_DATA_OUT_EP:


### PR DESCRIPTION
mynewt has default implementation of DFU over USB.
This implementation exposes SLOT0 or SLOT1.
Existing syscfg value USBD_DFU==1 includes DFU interface descriptor
and enabled TinyUSB stack part of implementation.
User had to provide own DFU application code or use hw/tinyusb/dfu
package.
New USBD_DFU_STD does inclusion of the package so it can
be easly turned on and off in targets.