### PR TITLE
mgmt: Fix package dependency

### DIFF
--- a/test/crash_test/pkg.yml
+++ b/test/crash_test/pkg.yml
@@ -28,9 +28,8 @@ pkg.req_apis.CRASH_TEST_CLI:
     - console
 pkg.deps.CRASH_TEST_MGMT:
     - "@apache-mynewt-core/mgmt/mgmt"
-
-pkg.deps.CRASH_TEST_MGMT:
     - "@apache-mynewt-core/encoding/json"
+    - "@apache-mynewt-mcumgr/cborattr"
 
 pkg.init:
     crash_test_init: 'MYNEWT_VAL(CRASH_TEST_SYSINIT_STAGE)'


### PR DESCRIPTION
There were two sections pkg.deps.CRASH_TEST_MGMT:
in such case only second section is used by newt tool.

cborattr/cborattr.h was included but cborattr package was
not specified.