### PR TITLE
tinyusb: Fix COMPATIBILITY_FEATURE_REQUEST handling

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -300,7 +300,11 @@ bool
 tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, const tusb_control_request_t *request)
 {
     if (request->wIndex == 0x04 && request->bRequest == COMPATIBILITY_FEATURE_REQUEST) {
-        return tud_control_xfer(rhport, request, (void *)&windows_compat_id, 40);
+        if (stage == CONTROL_STAGE_SETUP) {
+            return tud_control_xfer(rhport, request, (void *)&windows_compat_id, 40);
+        } else {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Transfer on control point was started regardless of stage.
Transfer should only be started in CONTROL_STAGE_SETUP in other
stages function should return true.

Despite incorrect behavior NRF5x based MCUs were working fine,
but DA1469x was not.