### PR TITLE
hw/mcu: Fix cmac build on Windows

### DIFF
--- a/hw/mcu/dialog/cmac/pkg.yml
+++ b/hw/mcu/dialog/cmac/pkg.yml
@@ -31,3 +31,5 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/mcu/dialog"
     - "@apache-mynewt-nimble/nimble/drivers/dialog_cmac"
+
+pkg.cflags: -I@apache-mynewt-core/kernel

--- a/hw/mcu/dialog/cmac/src/arch/cortex_m0_cmac/os_arch_arm.c
+++ b/hw/mcu/dialog/cmac/src/arch/cortex_m0_cmac/os_arch_arm.c
@@ -20,8 +20,7 @@
 #include "mcu/mcu.h"
 #include "hal/hal_os_tick.h"
 #include "os/os_arch_cmac.h"
-/* XXX fix this... */
-#include "../../../../../../apache-mynewt-core/kernel/os/src/os_priv.h"
+#include "os/src/os_priv.h"
 
 /* Initial program status register */
 #define INITIAL_xPSR    0x01000000


### PR DESCRIPTION
Having include ../../../../../../apache-mynewt-core... in
os_arch_arm.c breaks build on Windows.

Adding include path to package seems to fix the problem.

```sh
Executing scripts/create_cmac_bin.sh
Target successfully built: targets/dialog_cmac
Executing scripts/build_libcmac.sh
Building target @apache-mynewt-nimble/targets/dialog_cmac
Error: CreateFile h\:\work\mynewt\repos\apache-mynewt-core\kernel\os\src\os_priv.h: The filename, directory name, or volume label syntax is incorrect.
```