### PR TITLE
dialog_da1469x-dk-pro: MIKROBUS and ARDUINO pin constants

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -47,12 +47,21 @@ extern uint8_t _ram_start;
 #define BUTTON_1        (6)     /* P0_6 */
 
 /* Arduino pins */
+#if MYNEWT_VAL_CHOICE(DA1469X_DK_PRO_REV, 331_O7_B)
 #define ARDUINO_PIN_D0      0
 #define ARDUINO_PIN_D1      1
 #define ARDUINO_PIN_D2      2
 #define ARDUINO_PIN_D3      3
 #define ARDUINO_PIN_D4      4
 #define ARDUINO_PIN_D5      5
+#else
+#define ARDUINO_PIN_D0      34
+#define ARDUINO_PIN_D1      35
+#define ARDUINO_PIN_D2      36
+#define ARDUINO_PIN_D3      37
+#define ARDUINO_PIN_D4      39
+#define ARDUINO_PIN_D5      40
+#endif
 #define ARDUINO_PIN_D6      17
 #define ARDUINO_PIN_D7      18
 #define ARDUINO_PIN_D8      19

--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -87,6 +87,37 @@ extern uint8_t _ram_start;
 #define ARDUINO_PIN_MOSI    ARDUINO_PIN_D11
 #define ARDUINO_PIN_MISO    ARDUINO_PIN_D12
 
+#define MIKROBUS_1_PIN_AN   41
+#define MIKROBUS_1_PIN_CS   20
+#define MIKROBUS_1_PIN_SCK  21
+#define MIKROBUS_1_PIN_MISO 24
+#define MIKROBUS_1_PIN_MOSI 25
+#define MIKROBUS_1_PIN_PWM  33
+#define MIKROBUS_1_PIN_INT  27
+#define MIKROBUS_1_PIN_RX   28
+#define MIKROBUS_1_PIN_TX   29
+#define MIKROBUS_1_PIN_SCL  30
+#define MIKROBUS_1_PIN_SDA  31
+
+#define MIKROBUS_2_PIN_AN   25
+#if MYNEWT_VAL_CHOICE(DA1469X_DK_PRO_REV, 331_O7_B)
+#define MIKROBUS_2_PIN_CS   0
+#define MIKROBUS_2_PIN_SCK  1
+#define MIKROBUS_2_PIN_MISO 2
+#define MIKROBUS_2_PIN_MOSI 3
+#else
+#define MIKROBUS_2_PIN_CS   34
+#define MIKROBUS_2_PIN_SCK  35
+#define MIKROBUS_2_PIN_MISO 36
+#define MIKROBUS_2_PIN_MOSI 37
+#endif
+#define MIKROBUS_2_PIN_PWM  38
+#define MIKROBUS_2_PIN_INT  39
+#define MIKROBUS_2_PIN_RX   40
+#define MIKROBUS_2_PIN_TX   17
+#define MIKROBUS_2_PIN_SCL  18
+#define MIKROBUS_2_PIN_SDA  19
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
@@ -42,6 +42,15 @@ syscfg.defs:
         description: 'Specifies AES key slot for OTP user data encryption and decryption'
         value: -1
 
+    DA1469X_DK_PRO_REV:
+        description: >
+            Indicates DA14695 Development Kit - Pro hardware revision number.
+            This is used to setup Arduino and Mikrobus pin settings.
+        value: 331_O7_C
+        choices:
+            - 331_O7_B
+            - 331_O7_C
+
 syscfg.defs.BUS_DRIVER_PRESENT:
     BSP_FLASH_SPI_NAME:
         description: 'SPIFLASH device name'


### PR DESCRIPTION
DK-PRO has two connectors for in MIKROBUS standard.
Change adds symbolic definition for both connectors.

This PR also adds DK PRO revision selectors that can be used to
choose correct board revision so Arduino and MIKROBUS pin
constants are correct.