### PR TITLE
sensors: LIS2DW12 allow shell usage with bus driver

### DIFF
--- a/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
+++ b/hw/drivers/sensors/lis2dw12/src/lis2dw12_shell.c
@@ -40,12 +40,25 @@ static struct shell_cmd lis2dw12_shell_cmd_struct = {
     .sc_cmd_func = lis2dw12_shell_cmd
 };
 
-static struct sensor_itf g_sensor_itf = {
-    .si_type = MYNEWT_VAL(LIS2DW12_SHELL_ITF_TYPE),
-    .si_num = MYNEWT_VAL(LIS2DW12_SHELL_ITF_NUM),
-    .si_cs_pin = MYNEWT_VAL(LIS2DW12_SHELL_CSPIN),
-    .si_addr = MYNEWT_VAL(LIS2DW12_SHELL_ITF_ADDR)
-};
+static struct sensor_itf *g_sensor_itf;
+static struct lis2dw12 *g_lis2dw12;
+
+static int
+lis2dw12_shell_open_device(void)
+{
+    if (g_sensor_itf) {
+        return 0;
+    }
+
+    g_lis2dw12 = (struct lis2dw12 *)os_dev_open(MYNEWT_VAL(LIS2DW12_SHELL_DEV_NAME),
+                                                1000, NULL);
+    if (g_lis2dw12) {
+        g_sensor_itf = &g_lis2dw12->sensor.s_itf;
+        return 0;
+    }
+
+    return SYS_ENODEV;
+}
 
 static int
 lis2dw12_shell_err_too_many_args(char *cmd_name)
@@ -100,7 +113,7 @@ lis2dw12_shell_cmd_read_chipid(int argc, char **argv)
     int rc;
     uint8_t chipid;
 
-    rc = lis2dw12_read8(&g_sensor_itf, LIS2DW12_REG_WHO_AM_I, &chipid);
+    rc = lis2dw12_read8(g_sensor_itf, LIS2DW12_REG_WHO_AM_I, &chipid);
     if (rc) {
         goto err;
     }
@@ -138,12 +151,12 @@ lis2dw12_shell_cmd_read(int argc, char **argv)
 
     while(samples--) {
 
-        rc = lis2dw12_get_fs(&g_sensor_itf, &fs);
+        rc = lis2dw12_get_fs(g_sensor_itf, &fs);
         if (rc) {
             return rc;
         }
         
-        rc = lis2dw12_get_data(&g_sensor_itf, fs,&x, &y, &z);
+        rc = lis2dw12_get_data(g_sensor_itf, fs,&x, &y, &z);
         if (rc) {
             console_printf("Read failed: %d\n", rc);
             return rc;
@@ -167,7 +180,7 @@ static void lis2dw12_shell_dump_reg(const char *name, uint8_t addr)
     uint8_t val = 0;
     int rc;
 
-    rc = lis2dw12_read8(&g_sensor_itf, addr, &val);
+    rc = lis2dw12_read8(g_sensor_itf, addr, &val);
     if (rc == 0) {
         console_printf("0x%02X (%s): 0x%02X\n", addr, name, val);
     } else {
@@ -236,7 +249,7 @@ lis2dw12_shell_cmd_peek(int argc, char **argv)
         return lis2dw12_shell_err_invalid_arg(argv[2]);
     }
 
-    rc = lis2dw12_read8(&g_sensor_itf, reg, &value);
+    rc = lis2dw12_read8(g_sensor_itf, reg, &value);
     if (rc) {
         console_printf("peek failed %d\n", rc);
     }else{
@@ -269,7 +282,7 @@ lis2dw12_shell_cmd_poke(int argc, char **argv)
         return lis2dw12_shell_err_invalid_arg(argv[3]);
     }
 
-    rc = lis2dw12_write8(&g_sensor_itf, reg, value);
+    rc = lis2dw12_write8(g_sensor_itf, reg, value);
     if (rc) {
         console_printf("poke failed %d\n", rc);
     }else{
@@ -285,7 +298,7 @@ lis2dw12_shell_cmd_test(int argc, char **argv)
     int rc;
     int result;
 
-    rc = lis2dw12_run_self_test(&g_sensor_itf, &result);
+    rc = lis2dw12_run_self_test(g_sensor_itf, &result);
     if (rc) {
         goto err;
     }
@@ -308,6 +321,11 @@ lis2dw12_shell_cmd(int argc, char **argv)
         return lis2dw12_shell_help();
     }
 
+    if (lis2dw12_shell_open_device()) {
+        console_printf("Error: device not found \"%s\"\n",
+                       MYNEWT_VAL(LIS2DW12_SHELL_DEV_NAME));
+        return 0;
+    }
     /* Read command (get a new data sample) */
     if (argc > 1 && strcmp(argv[1], "r") == 0) {
         return lis2dw12_shell_cmd_read(argc, argv);

--- a/hw/drivers/sensors/lis2dw12/syscfg.yml
+++ b/hw/drivers/sensors/lis2dw12/syscfg.yml
@@ -26,18 +26,34 @@ syscfg.defs:
     LIS2DW12_INT1_CFG_ACTIVE:
         description: 'Set 0 for active-low, 1 for active-high'
         value: 1
+    LIS2DW12_SHELL_DEV_NAME:
+        description: >
+            Device name for lis2dw12 device used in shell
+        value: '"lis2dw12_0"'
     LIS2DW12_SHELL_ITF_NUM:
-        description: 'Shell interface number for the LIS2DW12'
+        description: >
+            This is no longer used.
+            LIS2DW12_SHELL_DEV_NAME points to device that will be used by shell.
         value: 0
+        defunct: 1
     LIS2DW12_SHELL_ITF_TYPE:
-        description: 'Shell interface type for the LIS2DW12'
-        value: 1
+        description: >
+            This is no longer used.
+            LIS2DW12_SHELL_DEV_NAME points to device that will be used by shell.
+        value: 0
+        defunct: 1
     LIS2DW12_SHELL_CSPIN:
-        description: 'CS pin for LIS2DW12'
-        value : -1
+        description: >
+            This is no longer used.
+            LIS2DW12_SHELL_DEV_NAME points to device that will be used by shell.
+        value: 0
+        defunct: 1
     LIS2DW12_SHELL_ITF_ADDR:
-        description: 'Slave address for LIS2DW12'
-        value : 0x18
+        description: >
+            This is no longer used.
+            LIS2DW12_SHELL_DEV_NAME points to device that will be used by shell.
+        value: 0
+        defunct: 1
     LIS2DW12_CLI:
         description: 'Enable shell support for the LIS2DW12'
         value: 0


### PR DESCRIPTION
Shell functionality was limited to non bus driver build due
to sensor_itf usage.

Now shell opens existing device (default "lis2dw12_0") that
is used for communication.

Shell interface configuration for accelerometer is now marked as defunc,
and new LIS2DW_SHELL_DEV_NAME is added to point out to existing
device.