### PR TITLE
stlink: Allow STM32_Programmer_CLI for flashing

### DIFF
--- a/hw/scripts/stlink.sh
+++ b/hw/scripts/stlink.sh
@@ -41,7 +41,11 @@ stlink_load () {
 
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
-    st-flash --reset write $FILE_NAME $FLASH_OFFSET
+    if [ "$STLINK_USE_STM32_PROGRAMMER_CLI" == 1 ] ; then
+      STM32_Programmer_CLI -c port=SWD -d $FILE_NAME $FLASH_OFFSET -rst
+    else
+      st-flash --reset write $FILE_NAME $FLASH_OFFSET
+    fi
     if [ $? -ne 0 ]; then
         exit 1
     fi


### PR DESCRIPTION
stlink: Allow STM32_Programmer_CLI for flashing

ST provides command line tool for flashing devices as a part of STM32CubeIDE.

In some cases this tool works better than currently used st-flash tool.
st-flash sometimes has problem detecting flash memory:

```
Error: Downloading bin/targets/nucleo-f411re-blinky/app/apps/blinky/blinky.img to 0x8020000
st-flash 1.7.0-11-ge662da0
2021-12-16T14:25:02 INFO common.c: stm32f411re: 128 KiB SRAM, 0 KiB flash in at least 16 KiB pages.
Unknown memory region
```

For same hardware setup ST provided tool has no problem (openocd also works fine but requires script selection).

When user sets environment variable `STLINK_USE_STM32_PROGRAMMER_CLI=1`,
**STM32_Programmer_CLI** will be used instead of st-flash tool.