### PR TITLE
stm32: Add missing package when RTC is used for systick

### DIFF
--- a/hw/mcu/stm/stm32_common/pkg.yml
+++ b/hw/mcu/stm/stm32_common/pkg.yml
@@ -27,6 +27,8 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/cmsis-core"
+pkg.deps.OS_TICKS_USE_RTC:
+    - "@apache-mynewt-core/time/datetime"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"


### PR DESCRIPTION
When OS_TICKS_USE_RTC is 1 hal_os_tick.c includes datetime/datetime.h
but appropriate package was not added now it is added when required.