### PR TITLE
hw/ipc_nrf5340: Add support for reseting Network Core

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -41,6 +41,12 @@ typedef void (*ipc_nrf5340_recv_cb)(int channel, void *user_data);
 void ipc_nrf5340_init(void);
 
 /**
+ * Reset IPC and NetCore. Can be used to re-sync with Network Core without
+ * restarting Application Core.
+ */
+void ipc_nrf5340_reset(void);
+
+/**
  * Enable reception on specified IPC channel. Calling with NULL callback
  * disables reception.
  *

--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -338,6 +338,30 @@ ipc_nrf5340_init(void)
 }
 #endif
 
+#if MYNEWT_VAL(MCU_APP_CORE)
+void
+ipc_nrf5340_reset(void)
+{
+    int i;
+
+    /* TODO  do we need some reset callback for IPC users? */
+    /* TODO Should we sync this with send ? */
+
+    /* Make sure network core if off when we reset IPC */
+    NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Hold;
+
+    memset(shms, 0, sizeof(shms));
+
+    for (i = 0; i < IPC_MAX_CHANS; ++i) {
+        shms[i].buf = shms_bufs[i];
+        shms[i].buf_size = IPC_BUF_SIZE;
+    }
+
+    /* Start Network Core */
+    NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+}
+#endif
+
 void
 ipc_nrf5340_recv(int channel, ipc_nrf5340_recv_cb cb, void *user_data)
 {


### PR DESCRIPTION
This allows application core to reset Network core and re-sync IPC
state.