### PR TITLE
USB clock request for NRF52/NRF5340

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/mcu/mcu.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/mcu.h
@@ -62,6 +62,8 @@ extern "C" {
 
 #endif
 
+#include "nrf52_clock.h"
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_clock.h
+++ b/hw/mcu/nordic/nrf52xxx/include/mcu/nrf52_clock.h
@@ -43,6 +43,9 @@ int nrf52_clock_hfxo_request(void);
  */
 int nrf52_clock_hfxo_release(void);
 
+#define usb_clock_request() nrf52_clock_hfxo_request()
+#define usb_clock_release() nrf52_clock_hfxo_release()
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/nordic/nrf5340/include/mcu/mcu.h
+++ b/hw/mcu/nordic/nrf5340/include/mcu/mcu.h
@@ -46,6 +46,7 @@ extern "C" {
     "I#56=I2S0,I#58=IPC,I#59=QSPI,I#61=NFCT,I#63=GPIOTE1,I#67=QDEC0,"        \
     "I#68=QDEC1,I#70=USBD,I#71=USBREGULATOR,I#73=KMU,I#84=CRYPTOCELL"
 
+#include "nrf5340_clock.h"
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/nordic/nrf5340/include/mcu/nrf5340_clock.h
+++ b/hw/mcu/nordic/nrf5340/include/mcu/nrf5340_clock.h
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_NRF5340_CLOCK_
+#define H_NRF5340_CLOCK_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * Request HFXO clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: hfxo was already on. 1: hfxo was turned on.
+ */
+int nrf5340_clock_hfxo_request(void);
+
+/**
+ * Release the HFXO. This means that the caller no longer needs the HFXO to be
+ * turned on. Each call to release should have been preceded by a corresponding
+ * call to request the HFXO
+ *
+ *
+ * @return int 0: HFXO not stopped by this call (others using it) 1: HFXO
+ *         stopped.
+ */
+int nrf5340_clock_hfxo_release(void);
+
+/**
+ * Request HFCLK192M clock be turned on. Note that each request must have a
+ * corresponding release.
+ *
+ * @return int 0: HFCLK192M was already on. 1: HFCLK192M was turned on.
+ */
+int nrf5340_clock_hfclk192m_request(void);
+
+/**
+ * Release the HFCLK192M. This means that the caller no longer needs the HFCLK192M to be
+ * turned on. Each call to release should have been preceded by a corresponding
+ * call to request the HFCLK192M
+ *
+ *
+ * @return int 0: HFCLK192M not stopped by this call (others using it) 1: HFCLK192M
+ *         stopped.
+ */
+int nrf5340_clock_hfclk192m_release(void);
+
+#define usb_clock_request() nrf5340_clock_hfclk192m_request()
+#define usb_clock_release() nrf5340_clock_hfclk192m_release()
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_NRF5340_CLOCK_ */

--- a/hw/mcu/nordic/nrf5340/src/nrf5340_clock.c
+++ b/hw/mcu/nordic/nrf5340/src/nrf5340_clock.c
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include <stdint.h>
+#include "mcu/nrf5340_hal.h"
+#include "nrfx.h"
+#include "nrf_clock.h"
+
+static uint8_t nrf5340_clock_hfxo_refcnt;
+static uint8_t nrf5340_clock_hfclk192m_refcnt;
+
+int
+nrf5340_clock_hfxo_request(void)
+{
+    int started;
+    uint32_t ctx;
+
+    started = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf5340_clock_hfxo_refcnt < 0xff);
+    if (nrf5340_clock_hfxo_refcnt == 0) {
+        nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTART);
+        started = 1;
+    }
+    ++nrf5340_clock_hfxo_refcnt;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return started;
+}
+
+int
+nrf5340_clock_hfxo_release(void)
+{
+    int stopped;
+    uint32_t ctx;
+
+    stopped = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf5340_clock_hfxo_refcnt != 0);
+    --nrf5340_clock_hfxo_refcnt;
+    if (nrf5340_clock_hfxo_refcnt == 0) {
+        nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
+        stopped = 1;
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return stopped;
+}
+
+int
+nrf5340_clock_hfclk192m_request(void)
+{
+    int started;
+    uint32_t ctx;
+
+    started = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf5340_clock_hfclk192m_refcnt < 0xff);
+    if (nrf5340_clock_hfclk192m_refcnt == 0) {
+        nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLK192MSTART);
+        started = 1;
+    }
+    ++nrf5340_clock_hfclk192m_refcnt;
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return started;
+}
+
+int
+nrf5340_clock_hfclk192m_release(void)
+{
+    int stopped;
+    uint32_t ctx;
+
+    stopped = 0;
+    __HAL_DISABLE_INTERRUPTS(ctx);
+    assert(nrf5340_clock_hfclk192m_refcnt != 0);
+    --nrf5340_clock_hfclk192m_refcnt;
+    if (nrf5340_clock_hfclk192m_refcnt == 0) {
+        nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLK192MSTOP);
+        stopped = 1;
+    }
+    __HAL_ENABLE_INTERRUPTS(ctx);
+
+    return stopped;
+}


### PR DESCRIPTION
TinyUSB disables/enables HFXO clock when needed (on VBUS change).
When used with Mynewt it may happen that BLE decides that it no longer needs HFXO,
then it allows HFXO to be turned off while USB still requires it.

This PR primarily adds API that can be called from TinyUSB stack to request/release clock
that is shared with BLE.

NRF52/53 shares same driver on TinyUSB side so API for clock request is also provided for NRF5340.
For NRF53 HFCLK192M is used to generate 48MHZ USB clock hence usb_clock_request maps to
different function there.