### PR TITLE
hw/ipc_nrf5340: Adjust default number of enabled channels

### DIFF
--- a/hw/drivers/ipc_nrf5340/syscfg.yml
+++ b/hw/drivers/ipc_nrf5340/syscfg.yml
@@ -20,7 +20,7 @@ syscfg.defs:
     IPC_NRF5340_CHANNELS:
         description: >
             Number of enabled IPC channels
-        value: 2
+        value: 5
         range: 1..16
 
     IPC_NRF5340_BUF_SZ:
@@ -61,3 +61,6 @@ syscfg.defs:
 
 syscfg.restrictions:
     - "!BSP_NRF5340 || BSP_NRF5340_NET_ENABLE"
+
+syscfg.vals.BSP_NRF5340_NET:
+    IPC_NRF5340_CHANNELS: 16


### PR DESCRIPTION
Increase default on Application core to 5 to cover "default" BLE
usecase: 2x for HCI, 2x for Virtual Flash and 1x for Keep Alive.

Increase default on Network core to 16 (max) since on that core only
"struct ipc_channel" is kept in RAM (rest is on Application core) and
true number of channels is read from AppCore IPC config in runtime.