### PR TITLE
tinyusb: Add hardware initialization for PIC32MZ

### DIFF
--- a/hw/usb/tinyusb/pic32mz/include/tusb_hw.h
+++ b/hw/usb/tinyusb/pic32mz/include/tusb_hw.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TUSB_HW_H__
+#define __TUSB_HW_H__
+
+#define CFG_TUSB_MCU OPT_MCU_PIC32MZ
+
+#include <syscfg/syscfg.h>
+#include <stdbool.h>
+
+#if MYNEWT_VAL(USBD_HIGH_SPEED)
+#define CFG_TUSB_RHPORT0_SPEED  OPT_MODE_HIGH_SPEED
+#else
+#define CFG_TUSB_RHPORT0_SPEED  OPT_MODE_FULL_SPEED
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
+#define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)
+#else
+#define USBD_CDC_NOTIFY_EP      0x81
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP_SIZE)
+#define USBD_CDC_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_NOTIFY_EP_SIZE 0x08
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_OUT_EP)
+#define USBD_CDC_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_DATA_OUT_EP)
+#else
+#define USBD_CDC_DATA_OUT_EP    0x02
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_IN_EP)
+#define USBD_CDC_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_DATA_IN_EP)
+#else
+#define USBD_CDC_DATA_IN_EP     0x82
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_EP_SIZE)
+#define USBD_CDC_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_DATA_EP_SIZE)
+#else
+#define USBD_CDC_DATA_EP_SIZE   0x40
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP)
+#define USBD_HID_REPORT_EP      MYNEWT_VAL(USBD_HID_REPORT_EP)
+#else
+#define USBD_HID_REPORT_EP      0x83
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_SIZE)
+#define USBD_HID_REPORT_EP_SIZE MYNEWT_VAL(USBD_HID_REPORT_EP_SIZE)
+#else
+#define USBD_HID_REPORT_EP_SIZE 0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_INTERVAL)
+#define USBD_HID_REPORT_EP_INTERVAL MYNEWT_VAL(USBD_HID_REPORT_EP_INTERVAL)
+#else
+#define USBD_HID_REPORT_EP_INTERVAL 10
+#endif
+
+#endif

--- a/hw/usb/tinyusb/pic32mz/pkg.yml
+++ b/hw/usb/tinyusb/pic32mz/pkg.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/usb/tinyusb/pic32mz
+pkg.description: Hardware initialization for Tinyusb
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - usb
+    - tinyusb
+
+pkg.apis:
+    - TINYUSB_HW_INIT
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@tinyusb/tinyusb"

--- a/hw/usb/tinyusb/pic32mz/src/pic32mz.c
+++ b/hw/usb/tinyusb/pic32mz/src/pic32mz.c
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <xc.h>
+#include <mcu/mcu.h>
+#include <mcu/pic32.h>
+
+#include <device/usbd.h>
+
+void
+__attribute__((interrupt(IPL2AUTO), vector(_USB_VECTOR), no_fpu))
+USBD_IRQHandler(void)
+{
+    IFS4CLR = _IFS4_USBIF_MASK;
+    tud_int_handler(0);
+}
+
+void
+tinyusb_hardware_init(void)
+{
+    /* set interrupt priority */
+    IPC33CLR = _IPC33_USBIP_MASK;
+    IPC33SET = (2 << _IPC33_USBIP_POSITION); /* priority 2 */
+    /* set interrupt subpriority */
+    IPC33CLR = _IPC33_USBIS_MASK;
+    IPC33SET = (0 << _IPC33_USBIS_POSITION); /* subpriority 0 */
+
+    USBCRCONbits.USBIE = 0;
+    IFS4CLR = _IFS4_USBIF_MASK;
+    IEC4SET = _IEC4_USBIE_MASK;
+
+    /* Force device mode by overriding USB ID and settings it to 1 */
+    USBCRCONbits.PHYIDEN = 0;
+    USBCRCONbits.USBIDVAL = 1;
+    USBCRCONbits.USBIDOVEN = 1;
+}


### PR DESCRIPTION
This provides code for USB hardware initialization
including interrupt and ID pin force to device mode.