### PR TITLE
apps/blesplit: Remove transport ram dependency

### DIFF
--- a/apps/blesplit/pkg.yml
+++ b/apps/blesplit/pkg.yml
@@ -38,7 +38,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
     - "@apache-mynewt-nimble/nimble/host/store/config"
-    - "@apache-mynewt-nimble/nimble/transport/ram"
+    - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/id"
     - "@apache-mynewt-core/sys/log/full"


### PR DESCRIPTION
Dependency to nimble/transport/ram changed to nimble/transport

This change is needed for https://github.com/apache/mynewt-nimble/pull/1101
travis uses this target