### PR TITLE
hal: Modify hal_system_restart

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_system_start.c
@@ -52,17 +52,22 @@ void
 hal_system_restart(void *img_start)
 {
     int i;
-    int sr;
 
     /*
-     * Disable interrupts, and leave the disabled.
-     * They get re-enabled when system starts coming back again.
+     * NOTE: on reset, PRIMASK should have global interrupts enabled so
+     * the code disables interrupts, clears the interrupt enable bits,
+     * clears any pending interrupts, then enables global interrupts
+     * so processor looks like state it would be in if it reset.
      */
-    __HAL_DISABLE_INTERRUPTS(sr);
+    __disable_irq();
     for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
         NVIC->ICER[i] = 0xffffffff;
     }
-    (void)sr;
+
+    for (i = 0; i < sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0]); i++) {
+        NVIC->ICPR[i] = 0xffffffff;
+    }
+    __enable_irq();
 
     hal_system_start(img_start);
 }

--- a/hw/mcu/nordic/nrf52xxx/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_system_start.c
@@ -52,17 +52,22 @@ void
 hal_system_restart(void *img_start)
 {
     int i;
-    int sr;
 
     /*
-     * Disable interrupts, and leave the disabled.
-     * They get re-enabled when system starts coming back again.
+     * NOTE: on reset, PRIMASK should have global interrupts enabled so
+     * the code disables interrupts, clears the interrupt enable bits,
+     * clears any pending interrupts, then enables global interrupts
+     * so processor looks like state it would be in if it reset.
      */
-    __HAL_DISABLE_INTERRUPTS(sr);
+    __disable_irq();
     for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
         NVIC->ICER[i] = 0xffffffff;
     }
-    (void)sr;
+
+    for (i = 0; i < sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0]); i++) {
+        NVIC->ICPR[i] = 0xffffffff;
+    }
+    __enable_irq();
 
     hal_system_start(img_start);
 }

--- a/hw/mcu/nordic/nrf5340/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_system_start.c
@@ -193,17 +193,22 @@ void
 hal_system_restart(void *img_start)
 {
     int i;
-    int sr;
 
     /*
-     * Disable interrupts, and leave the disabled.
-     * They get re-enabled when system starts coming back again.
+     * NOTE: on reset, PRIMASK should have global interrupts enabled so
+     * the code disables interrupts, clears the interrupt enable bits,
+     * clears any pending interrupts, then enables global interrupts
+     * so processor looks like state it would be in if it reset.
      */
-    __HAL_DISABLE_INTERRUPTS(sr);
+    __disable_irq();
     for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
         NVIC->ICER[i] = 0xffffffff;
     }
-    (void)sr;
+
+    for (i = 0; i < sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0]); i++) {
+        NVIC->ICPR[i] = 0xffffffff;
+    }
+    __enable_irq();
 
     hal_system_start(img_start);
 }

--- a/hw/mcu/nordic/nrf5340_net/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_system_start.c
@@ -52,17 +52,22 @@ void
 hal_system_restart(void *img_start)
 {
     int i;
-    int sr;
 
     /*
-     * Disable interrupts, and leave the disabled.
-     * They get re-enabled when system starts coming back again.
+     * NOTE: on reset, PRIMASK should have global interrupts enabled so
+     * the code disables interrupts, clears the interrupt enable bits,
+     * clears any pending interrupts, then enables global interrupts
+     * so processor looks like state it would be in if it reset.
      */
-    __HAL_DISABLE_INTERRUPTS(sr);
+    __disable_irq();
     for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
         NVIC->ICER[i] = 0xffffffff;
     }
-    (void)sr;
+
+    for (i = 0; i < sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0]); i++) {
+        NVIC->ICPR[i] = 0xffffffff;
+    }
+    __enable_irq();
 
     hal_system_start(img_start);
 }

--- a/hw/mcu/nordic/nrf91xx/src/hal_system_start.c
+++ b/hw/mcu/nordic/nrf91xx/src/hal_system_start.c
@@ -52,17 +52,22 @@ void
 hal_system_restart(void *img_start)
 {
     int i;
-    int sr;
 
     /*
-     * Disable interrupts, and leave the disabled.
-     * They get re-enabled when system starts coming back again.
+     * NOTE: on reset, PRIMASK should have global interrupts enabled so
+     * the code disables interrupts, clears the interrupt enable bits,
+     * clears any pending interrupts, then enables global interrupts
+     * so processor looks like state it would be in if it reset.
      */
-    __HAL_DISABLE_INTERRUPTS(sr);
+    __disable_irq();
     for (i = 0; i < sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0]); i++) {
         NVIC->ICER[i] = 0xffffffff;
     }
-    (void)sr;
+
+    for (i = 0; i < sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0]); i++) {
+        NVIC->ICPR[i] = 0xffffffff;
+    }
+    __enable_irq();
 
     hal_system_start(img_start);
 }


### PR DESCRIPTION
Two changes to the code: clear ICPR register (to clear any pending interrupts) and also leave global interrupts enabled when calling hal_system_start. The idea behind this change is that the cortex-M has global interrupts enabled on reset and that this should be the state when the system is restarted.

For now, I only modified the code in the hw/mcu/dialog directory to have a discussion regarding this change in case folks object. I am not sure why there is a both a hal_system_start and hal_system_restart function but given there were two I decided to change restart only. It appears that mcuboot for mynewt calls hal_system_start and it should probably call hal_system_restart or we should abandon hal_system_restart and have hal_system_start clear ICER and ICPR and leave primask with interrupts enabled.