### PR TITLE
dfu: Add auto confirm with timeout

### DIFF
--- a/hw/usb/tinyusb/dfu/pkg.yml
+++ b/hw/usb/tinyusb/dfu/pkg.yml
@@ -32,3 +32,6 @@ pkg.deps:
     - "@tinyusb/tinyusb"
     - "@apache-mynewt-core/mgmt/imgmgr"
     - "@mcuboot/boot/bootutil"
+
+pkg.init.USBD_DFU_AUTO_CONFIRM:
+    dfu_init: 'MYNEWT_VAL(USBD_DFU_SYSINIT_STAGE)'

--- a/hw/usb/tinyusb/dfu/src/dfu.c
+++ b/hw/usb/tinyusb/dfu/src/dfu.c
@@ -40,6 +40,7 @@
 #if MYNEWT_VAL(USBD_DFU_RESET_AFTER_DOWNLOAD)
 
 struct os_callout delayed_reset_callout;
+struct os_callout auto_confirm_callout;
 
 void
 delayed_reset_cb(struct os_event *event)
@@ -184,4 +185,19 @@ boot_preboot(void)
     }
     hal_gpio_deinit(MYNEWT_VAL(USBD_DFU_BOOT_PIN));
 #endif
+}
+
+void
+auto_confirm_cb(struct os_event *event)
+{
+    img_mgmt_state_confirm();
+}
+
+void
+dfu_init(void)
+{
+    os_callout_init(&auto_confirm_callout, os_eventq_dflt_get(),
+                    auto_confirm_cb, NULL);
+
+    os_callout_reset(&auto_confirm_callout, OS_TICKS_PER_SEC * MYNEWT_VAL(USBD_DFU_AUTO_CONFIRM_TIME));
 }

--- a/hw/usb/tinyusb/dfu/syscfg.yml
+++ b/hw/usb/tinyusb/dfu/syscfg.yml
@@ -44,6 +44,14 @@ syscfg.defs:
         description: >
             Mark image as confirmed after download.
         value: 0
+    USBD_DFU_AUTO_CONFIRM:
+        description: >
+            Confirm image if it runs without crash for some time.
+        value: 0
+    USBD_DFU_AUTO_CONFIRM_TIME:
+        description: >
+            Time in seconds needed for automatic image confirmation.
+        value: 60
     USBD_DFU_BLOCK_WRITE_TIME:
         description: >
             Time in milliseconds needed for writing block to the device.
@@ -82,6 +90,10 @@ syscfg.defs:
             Set to 2 if boto pin needs internal pull-down resistor.
         value: 0
 
+    USBD_DFU_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for DFU functionality.
+        value: 1000
     USBD_DFU_LOG_MODULE:
         description: 'Numeric module ID to use for DFU log messages.'
         value: 43


### PR DESCRIPTION
To prevent bricking device image is confirm in software
after bootloader swap.
Decision when to confirm new software is left to the application.

This allows to add simple timer that will confirm new image
after it was executing for some time (60 s default).

Then user does not need to write own decision-making way if
simply running new image is enough.

Two syscfg values are added:
- USBD_DFU_AUTO_CONFIRM
- USBD_DFU_AUTO_CONFIRM_TIME