### PR TITLE
ublox-bmd-345: Enable PA/LNA by default

### DIFF
--- a/hw/bsp/ublox_bmd_345/pkg.yml
+++ b/hw/bsp/ublox_bmd_345/pkg.yml
@@ -40,3 +40,7 @@ pkg.deps:
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"
+
+# Use SKY66112 driver for now
+pkg.deps.BLE_CONTROLLER:
+    - "@apache-mynewt-nimble/nimble/drivers/plna/sky66112"

--- a/hw/bsp/ublox_bmd_345/src/hal_bsp.c
+++ b/hw/bsp/ublox_bmd_345/src/hal_bsp.c
@@ -102,13 +102,6 @@ hal_bsp_init(void)
     /* Make sure system clocks have started */
     hal_system_clock_start();
 
-#if MYNEWT_VAL(BSP_RFX2411_BYPASS_MODE)
-    /* Configure RFX2411 in bypass mode */
-    hal_gpio_init_out(37, 0);
-    hal_gpio_init_out(38, 0);
-    hal_gpio_init_out(36, 1);
-#endif
-
     /* Create all available nRF52840 peripherals */
     nrf52_periph_create();
 }

--- a/hw/bsp/ublox_bmd_345/syscfg.yml
+++ b/hw/bsp/ublox_bmd_345/syscfg.yml
@@ -26,8 +26,7 @@ syscfg.defs:
     BSP_RFX2411_BYPASS_MODE:
         description: >
             Setup RFX2411 in bypass mode.
-            Set to 1 till proper driver is available.
-        value: 1
+        value: 0
 
 syscfg.vals:
     # Enable nRF52840 MCU
@@ -63,8 +62,18 @@ syscfg.vals:
     QSPI_PIN_DIO2: 22
     QSPI_PIN_DIO3: 23
 
+    # RFX2411 PLNA
+    BLE_LL_PA_GPIO: 37
+    BLE_LL_LNA_GPIO: 38
+    SKY66112_PIN_CPS: 36
+    SKY66112_PIN_SEL: 34
+
 syscfg.vals.!BOOT_LOADER:
     MCU_LFCLK_SOURCE: LFXO
+
+syscfg.vals.!BSP_RFX2411_BYPASS_MODE:
+    BLE_LL_PA: 1
+    BLE_LL_LNA: 1
 
 syscfg.vals.BLE_CONTROLLER:
     TIMER_0: 0


### PR DESCRIPTION
SKY66112 driver can be used to drive RFX2411 so lets use it instead of
hardcoded PA/LNA bypass code.