### PR TITLE
mcu/da1469x: Increase retained GPIO number

### DIFF
--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -41,7 +41,7 @@ syscfg.defs:
             If set to -1, power domain which controls GPIO pins will be
             always active and thus retaining and restoring of GPIO pins
             state is disabled.
-        value: 4
+        value: 32
     MCU_GPIO_MAX_IRQ:
         description: >
             Maximum number of GPIO interrupts that can be configured at


### PR DESCRIPTION
MCU_GPIO_RETAINABLE_NUM default value 4 is optimized to reduce
RAM usage.
Unfortunately it leads very difficult problems.
If BSP tries to configure more GPIO then system asserts at run time.
It is even harder if this happens in flash_loader.

This changes MCU_GPIO_RETAINABLE_NUM to 32 by default