### PR TITLE
tinyusb: Add TinyUSB loging

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -49,7 +49,7 @@ extern "C" {
 #else
 #define CFG_TUSB_OS                 OPT_OS_MYNEWT
 #endif
-#define CFG_TUSB_DEBUG              0
+#define CFG_TUSB_DEBUG              MYNEWT_VAL(CFG_TUSB_DEBUG)
 
 /* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
  * Tinyusb use follows macros to declare transferring memory so that they can be put

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -171,3 +171,13 @@ syscfg.defs:
         description: >
             Interface number associated with USBD_WINDOWS_COMP_ID.
         value: 0
+
+    CFG_TUSB_DEBUG:
+        description: >
+            When set to value > 0 enables TinyUSB logs and redirects them to Mynewt console.
+            It activates logs created by TU_LOG1, TU_LOG2, TU_LOG3
+        range: 0..3
+        value: 0
+
+syscfg.restrictions:
+    - '(CFG_TUSB_DEBUG == 0) || (USBD_STACK_SIZE >= 400)'


### PR DESCRIPTION
TinyUSB provides logs that can be enabled in tusb_config.h

This provides syscfg value that can enable those logs when needed.

When logs are enabled due to printf usage USBD_STASK_SIZE need to be increased,
and maybe some other tasks stacks that call TinyUSB functions.
It is also recommended having UART baudrate set to 1000000 or higher.
Recommended additional settings for logs:
CONSOLE_UART: 1
CONSOLE_UART_BAUD: 1000000
CONSOLE_UART_TX_BUF_SIZE: 512