### PR TITLE
hw/mcu/dialog: Fix OTP settings when using 96MHz clock

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_otp.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_otp.c
@@ -120,7 +120,18 @@ da1469x_otp_init(void)
     da1469x_otp_set_mode(OTPC_MODE_STBY);
 
     /* set clk timing */
-    OTPC->OTPC_TIM1_REG = 0x0999101f;  /* 32 MHz default */
+    switch (SystemCoreClock) {
+    default:
+        /* Unsupported sys_clk value, fall-through to default 32MHz */
+        assert(0);
+    case 32000000:
+        OTPC->OTPC_TIM1_REG = 0x0999101f;
+        break;
+    case 96000000:
+        OTPC->OTPC_TIM1_REG = 0x0999515f;
+        break;
+    }
+
     OTPC->OTPC_TIM2_REG = 0xa4040409;
 
     /* Disable OTP clock */

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -21,6 +21,7 @@
 #include "syscfg/syscfg.h"
 #include "mcu/da1469x_clock.h"
 #include "mcu/da1469x_lpclk.h"
+#include "mcu/da1469x_otp.h"
 #include "mcu/da1469x_pd.h"
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
@@ -113,6 +114,8 @@ hal_system_clock_start(void)
 #if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, PLL96)
     da1469x_clock_pll_wait_to_lock();
     da1469x_clock_sys_pll_switch();
+    /* Need to re-initialize OTP for 96MHz */
+    da1469x_otp_init();
 #endif
 #if MYNEWT_VAL_CHOICE(MCU_SYSCLK_SOURCE, XTAL32M)
     /* Switch to XTAL32M and disable RC32M */


### PR DESCRIPTION
Different timing settings shall be used in OTP configuration if system
clock is set to 96MHz to ensure proper operation.