### PR TITLE
apps/coremark: Fix output when HARDFLOAT is on

### DIFF
--- a/apps/coremark/syscfg.yml
+++ b/apps/coremark/syscfg.yml
@@ -20,3 +20,6 @@ syscfg.defs:
     COREMARK_ITERATIONS:
         description: Number of iterations to run
         value: 200
+
+syscfg.vals.HARDFLOAT:
+    FLOAT_USER: 1


### PR DESCRIPTION
When **HARDFLOAT** is 1 (usually done in compiler.yml) coremark application
uses floating point for calculations and prints.
**baselibc** version of `printf` does not support `%f` if **FLOAT_USER** is not enabled.
It results in missing information about iterations and total time

```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 1520
Total time (secs):
Iterations/Sec   :
Iterations       : 1000
Compiler version : GCC10.3.1 20210621 (release)
Compiler flags   :
Memory location  : STACK
seedcrc          : 0xe9f5
```

To fix this **FLOAT_USER** is set to 1 in syscfg.yml when **HARDFLOAT** is 1.