### PR TITLE
tinyusb: Setup pic32mz USB interrupt automatically

### DIFF
--- a/hw/mcu/microchip/pic32mz/syscfg.yml
+++ b/hw/mcu/microchip/pic32mz/syscfg.yml
@@ -17,6 +17,9 @@
 #
 
 syscfg.defs:
+    MCU_PIC32MZ:
+        description: MCUs are of PIC32MZ family.
+        value: 1
     MCU_FLASH_MIN_WRITE_SIZE:
         description: >
             Specifies the required alignment for internal flash writes.

--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -52,6 +52,8 @@ pkg.deps.MCU_STM32F1:
     - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
 pkg.deps.'(MCU_TARGET == "DA14691" || MCU_TARGET == "DA14695" || MCU_TARGET == "DA14697" || MCU_TARGET == "DA14699")':
     - "@apache-mynewt-core/hw/usb/tinyusb/da146xx"
+pkg.deps.MCU_PIC32MZ:
+    - "@apache-mynewt-core/hw/usb/tinyusb/pic32mz"
 pkg.deps.USBD_DFU_STD:
     - "@apache-mynewt-core/hw/usb/tinyusb/dfu"
 pkg.req_apis:


### PR DESCRIPTION
When hw/usb/tinyusb package is included for pic32mz based build,
it will automatically pull pic32mz glue package that will
setup interrupt.

This is done same way as for other MCUs