### PR TITLE
TinyUSB and external pull up on D+

### DIFF
--- a/hw/bsp/black_vet6/syscfg.yml
+++ b/hw/bsp/black_vet6/syscfg.yml
@@ -108,3 +108,5 @@ syscfg.vals:
     TIMER_0_TIM: 'TIM2'
     TIMER_1_TIM: 'TIM3'
     TIMER_2_TIM: 'TIM4'
+
+    USB_DP_HAS_EXTERNAL_PULL_UP: 1

--- a/hw/usb/tinyusb/stm32_fsdev/src/stm32_fsdev.c
+++ b/hw/usb/tinyusb/stm32_fsdev/src/stm32_fsdev.c
@@ -55,7 +55,11 @@ tinyusb_hardware_init(void)
      */
 #if MYNEWT_VAL(USB_DP_HAS_EXTERNAL_PULL_UP)
     hal_gpio_init_out(MCU_GPIO_PORTA(12), 0);
+#if MYNEWT_VAL(BOOT_LOADER)
+    os_cputime_delay_usecs(1000);
+#else
     os_time_delay(1);
+#endif
 #endif
     hal_gpio_init_af(MCU_GPIO_PORTA(12), 0, GPIO_NOPULL, GPIO_MODE_AF_PP);
 

--- a/hw/usb/tinyusb/synopsys/src/synopsys.c
+++ b/hw/usb/tinyusb/synopsys/src/synopsys.c
@@ -44,7 +44,11 @@ tinyusb_hardware_init(void)
     hal_gpio_init_af(MCU_GPIO_PORTA(11), GPIO_AF10_OTG_FS, GPIO_NOPULL, GPIO_MODE_AF_PP);
 #if MYNEWT_VAL(USB_DP_HAS_EXTERNAL_PULL_UP)
     hal_gpio_init_out(MCU_GPIO_PORTA(12), 0);
+#if MYNEWT_VAL(BOOT_LOADER)
+    os_cputime_delay_usecs(1000);
+#else
     os_time_delay(1);
+#endif
 #endif
     hal_gpio_init_af(MCU_GPIO_PORTA(12), GPIO_AF10_OTG_FS, GPIO_NOPULL, GPIO_MODE_AF_PP);
 


### PR DESCRIPTION
For black_vet6 USB_DP_HAS_EXTERNAL_PULL_UP is set to 1 to reflect hardware design.
Without this USB host may not noticed that device rebooted and re-enumeration is required

For ST based hardware (both synopsys or stm32_fsdev) external pullup handling was working in
mynewt OS but when USB was built into bootloader GPIO handling of D+ was to fast because
os_time_delay() did not work.
For bootloader case os_cpu_time_delay is used.