### PR TITLE
tinyusb: Add hardware initialization for stm32wb55

### DIFF
--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -50,6 +50,8 @@ pkg.deps.MCU_STM32L4:
     - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
 pkg.deps.MCU_STM32F1:
     - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
+pkg.deps.MCU_STM32WB:
+    - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev/stm32wb55"
 pkg.deps.'(MCU_TARGET == "DA14691" || MCU_TARGET == "DA14695" || MCU_TARGET == "DA14697" || MCU_TARGET == "DA14699")':
     - "@apache-mynewt-core/hw/usb/tinyusb/da146xx"
 pkg.deps.MCU_PIC32MZ:

--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/include/tusb_hw.h
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/include/tusb_hw.h
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TUSB_HW_H__
+#define __TUSB_HW_H__
+
+#define CFG_TUSB_MCU OPT_MCU_STM32WB55
+
+#include <syscfg/syscfg.h>
+
+#define CFG_TUSB_RHPORT0_SPEED  OPT_MODE_FULL_SPEED
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
+#define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)
+#else
+#define USBD_CDC_NOTIFY_EP      0x81
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP_SIZE)
+#define USBD_CDC_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_NOTIFY_EP_SIZE 0x08
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_OUT_EP)
+#define USBD_CDC_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_DATA_OUT_EP)
+#else
+#define USBD_CDC_DATA_OUT_EP    0x01
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_IN_EP)
+#define USBD_CDC_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_DATA_IN_EP)
+#else
+#define USBD_CDC_DATA_IN_EP     0x82
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_EP_SIZE)
+#define USBD_CDC_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_DATA_EP_SIZE)
+#else
+#define USBD_CDC_DATA_EP_SIZE   0x40
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP)
+#define USBD_HID_REPORT_EP      MYNEWT_VAL(USBD_HID_REPORT_EP)
+#else
+#define USBD_HID_REPORT_EP      0x83
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_SIZE)
+#define USBD_HID_REPORT_EP_SIZE MYNEWT_VAL(USBD_HID_REPORT_EP_SIZE)
+#else
+#define USBD_HID_REPORT_EP_SIZE 0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_INTERVAL)
+#define USBD_HID_REPORT_EP_INTERVAL MYNEWT_VAL(USBD_HID_REPORT_EP_INTERVAL)
+#else
+#define USBD_HID_REPORT_EP_INTERVAL 10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_MSC_DATA_IN_EP)
+#define USBD_MSC_DATA_IN_EP     MYNEWT_VAL(USBD_MSC_DATA_IN_EP)
+#else
+#define USBD_MSC_DATA_IN_EP     0x86
+#endif
+
+#if defined(MYNEWT_VAL_USBD_MSC_DATA_OUT_EP)
+#define USBD_MSC_DATA_OUT_EP     MYNEWT_VAL(USBD_MSC_DATA_OUT_EP)
+#else
+#define USBD_MSC_DATA_OUT_EP     0x06
+#endif
+
+#endif

--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/pkg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/pkg.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/usb/tinyusb/stm32_fsdev/stm32wb55
+pkg.description: Hardware initialization for TinyUSB
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - usb
+    - tinyusb
+
+pkg.apis:
+    - TINYUSB_HW_INIT
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@tinyusb/tinyusb"

--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/src/stm32_fsdev.c
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/src/stm32_fsdev.c
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <mcu/mcu.h>
+
+#include <tusb.h>
+
+#include <mcu/stm32wb_bsp.h>
+#include <mcu/stm32wbxx_mynewt_hal.h>
+#include <bsp/stm32wbxx_hal_conf.h>
+
+static void
+USB_IRQHandler(void)
+{
+    tud_int_handler(0);
+}
+
+void
+tinyusb_hardware_init(void)
+{
+    HAL_PWREx_EnableVddUSB();
+
+    /* TinyUSB provides interrupt handler, here it is setup the mynewt way */
+    NVIC_SetVector(USB_HP_IRQn, (uint32_t)USB_IRQHandler);
+    NVIC_SetPriority(USB_HP_IRQn, 2);
+    NVIC_SetVector(USB_LP_IRQn, (uint32_t)USB_IRQHandler);
+    NVIC_SetPriority(USB_LP_IRQn, 2);
+
+    /*
+     * USB Pin Init
+     * PA11- DM, PA12- DP
+     */
+    hal_gpio_init_af(MCU_GPIO_PORTA(11), GPIO_AF10_USB, GPIO_NOPULL, GPIO_MODE_AF_PP);
+
+    /*
+     * Device needs external PULLUP, following two lines change DP to 0 for a while
+     * to indicated device connection.
+     */
+#if MYNEWT_VAL(USB_DP_HAS_EXTERNAL_PULL_UP)
+    hal_gpio_init_out(MCU_GPIO_PORTA(12), 0);
+#if MYNEWT_VAL(BOOT_LOADER)
+    os_cputime_delay_usecs(1000);
+#else
+    os_time_delay(1);
+#endif
+#endif
+    hal_gpio_init_af(MCU_GPIO_PORTA(12), GPIO_AF10_USB, GPIO_NOPULL, GPIO_MODE_AF_PP);
+
+    /*
+     * Enable USB clock
+     */
+    __HAL_RCC_USB_CLK_ENABLE();
+}

--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/syscfg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/syscfg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    USB_DP_HAS_EXTERNAL_PULL_UP:
+        description: >
+            Set this to 1 if hardware has external pull up resistor.
+            Setting this changes DP pin to 0 at startup for a fraction
+            then device is discovered by host.
+        value: 1
+


### PR DESCRIPTION
TinyUSB uses same driver for STM32WB55 as for STM32F1 but there
are differences in interrupts and power settings that call
for separate package.