### PR TITLE
Add p-nucleo-wb55-usbdongle bsp

### DIFF
--- a/hw/bsp/p-nucleo-wb55-usbdongle/boot-p-nucleo-wb55.ld
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/boot-p-nucleo-wb55.ld
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx)       : ORIGIN = 0x08000000, LENGTH = 24K
+  RAM (rwx)        : ORIGIN = 0x20000000, LENGTH = 192K
+  RAM_SHARED (rwx) : ORIGIN = 0x20030000, LENGTH = 10K
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/p-nucleo-wb55-usbdongle/bsp.yml
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/bsp.yml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.name: "P-NUCLEO-WB55-USBDongle"
+bsp.url: https://www.st.com/en/evaluation-tools/p-nucleo-wb55.html
+bsp.maker: "STMicroelectronics"
+bsp.arch: cortex_m4
+bsp.compiler: compiler/arm-none-eabi-m4
+bsp.linkerscript:
+    - "hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32wbxx/stm32wb55.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/p-nucleo-wb55-usbdongle/boot-p-nucleo-wb55.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32wbxx/stm32wb55.ld"
+bsp.downloadscript: "hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_download.sh"
+bsp.debugscript: "hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_debug.sh"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x08000000
+            size: 24kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x08010000
+            size:  216kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x08046000
+            size: 216kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x0807c000
+            size: 16kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x08006000
+            size: 24kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x0800c000
+            size: 16kB

--- a/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/bsp.h
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/bsp.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+#include <mcu/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stack sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+#define sec_bss_nz_core __attribute__((section(".bss.core.nz")))
+
+/* More convenient section placement macros. */
+#define bssnz_t         sec_bss_nz_core
+
+extern uint8_t _ram_start;
+
+#define RAM_SIZE            (192 * 1024)
+
+/* LED pins */
+#define LED_1               MCU_GPIO_PORTA(4)
+#define LED_2               MCU_GPIO_PORTB(0)
+#define LED_3               MCU_GPIO_PORTB(1)
+#define LED_RED             LED_3
+#define LED_GREEN           LED_2
+#define LED_BLUE            LED_1
+#define LED_BLINK_PIN       LED_1
+
+/* Button pins */
+#define BUTTON_1            MCU_GPIO_PORTA(10)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
@@ -1,0 +1,351 @@
+/**
+  ******************************************************************************
+  * @file    stm32wbxx_hal_conf.h
+  * @author  MCD Application Team
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32WBxx_HAL_CONF_H
+#define __STM32WBxx_HAL_CONF_H
+
+#include <syscfg/syscfg.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver
+  */
+#define HAL_MODULE_ENABLED
+/*#define HAL_ADC_MODULE_ENABLED   */
+/*#define HAL_COMP_MODULE_ENABLED   */
+/*#define HAL_CRC_MODULE_ENABLED   */
+/*#define HAL_HSEM_MODULE_ENABLED   */
+/*#define HAL_IPCC_MODULE_ENABLED   */
+/*#define HAL_IRDA_MODULE_ENABLED   */
+/*#define HAL_LCD_MODULE_ENABLED   */
+/*#define HAL_LPTIM_MODULE_ENABLED   */
+/*#define HAL_PCD_MODULE_ENABLED   */
+/*#define HAL_PKA_MODULE_ENABLED   */
+/*#define HAL_QSPI_MODULE_ENABLED   */
+#define HAL_RTC_MODULE_ENABLED
+/*#define HAL_SAI_MODULE_ENABLED   */
+/*#define HAL_SMBUS_MODULE_ENABLED   */
+/*#define HAL_SMARTCARD_MODULE_ENABLED   */
+/*#define HAL_TSC_MODULE_ENABLED   */
+/*#define HAL_UART_MODULE_ENABLED   */
+/*#define HAL_USART_MODULE_ENABLED   */
+/*#define HAL_WWDG_MODULE_ENABLED   */
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_RNG_MODULE_ENABLED
+#define HAL_CRYP_MODULE_ENABLED
+
+#define USE_HAL_ADC_REGISTER_CALLBACKS       0u
+#define USE_HAL_COMP_REGISTER_CALLBACKS      0u
+#define USE_HAL_CRYP_REGISTER_CALLBACKS      0u
+#define USE_HAL_I2C_REGISTER_CALLBACKS       0u
+#define USE_HAL_IRDA_REGISTER_CALLBACKS      0u
+#define USE_HAL_LPTIM_REGISTER_CALLBACKS     0u
+#define USE_HAL_PCD_REGISTER_CALLBACKS       0u
+#define USE_HAL_PKA_REGISTER_CALLBACKS       0u
+#define USE_HAL_QSPI_REGISTER_CALLBACKS      0u
+#define USE_HAL_RNG_REGISTER_CALLBACKS       0u
+#define USE_HAL_RTC_REGISTER_CALLBACKS       0u
+#define USE_HAL_SAI_REGISTER_CALLBACKS       0u
+#define USE_HAL_SMARTCARD_REGISTER_CALLBACKS 0u
+#define USE_HAL_SMBUS_REGISTER_CALLBACKS     0u
+#define USE_HAL_SPI_REGISTER_CALLBACKS       0u
+#define USE_HAL_TIM_REGISTER_CALLBACKS       0u
+#define USE_HAL_TSC_REGISTER_CALLBACKS       0u
+#define USE_HAL_UART_REGISTER_CALLBACKS      0u
+#define USE_HAL_USART_REGISTER_CALLBACKS     0u
+#define USE_HAL_WWDG_REGISTER_CALLBACKS      0u
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE    32000000U             /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Multiple Speed oscillator (MSI) default value.
+  *        This value is the default MSI range value after Reset.
+  */
+#if !defined  (MSI_VALUE)
+  #define MSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* MSI_VALUE */
+
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL).
+  */
+#if !defined  (HSI_VALUE)
+#define HSI_VALUE    16000000U            /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @brief Internal Low Speed oscillator (LSI1) value.
+  */
+#if !defined  (LSI1_VALUE)
+ #define LSI1_VALUE  ((uint32_t)32000)       /*!< LSI1 Typical Value in Hz*/
+#endif /* LSI1_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.*/
+/**
+  * @brief Internal Low Speed oscillator (LSI2) value.
+  */
+#if !defined  (LSI2_VALUE)
+ #define LSI2_VALUE  ((uint32_t)32000)       /*!< LSI2 Typical Value in Hz*/
+#endif /* LSI2_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.*/
+
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  *        This value is used by the UART, RTC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+#define LSE_VALUE    32768U               /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+/**
+  * @brief Internal Multiple Speed oscillator (HSI48) default value.
+  *        This value is the default HSI48 range value after Reset.
+  */
+#if !defined (HSI48_VALUE)
+  #define HSI48_VALUE    ((uint32_t)48000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI48_VALUE */
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT    5000U      /*!< Time out for LSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief External clock source for SAI1 peripheral
+  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
+  *        frequency.
+  */
+#if !defined (EXTERNAL_SAI1_CLOCK_VALUE)
+  #define EXTERNAL_SAI1_CLOCK_VALUE    ((uint32_t)2097000) /*!< Value of the SAI1 External clock source in Hz*/
+#endif /* EXTERNAL_SAI1_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */
+
+#define  VDD_VALUE                    3300U   /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            0U      /*!< tick interrupt priority */
+#define  USE_RTOS                     0U
+#define  PREFETCH_ENABLE              MYNEWT_VAL(STM32_FLASH_PREFETCH_ENABLE)
+#define  INSTRUCTION_CACHE_ENABLE     MYNEWT_VAL(STM32_INSTRUCTION_CACHE_ENABLE)
+#define  DATA_CACHE_ENABLE            MYNEWT_VAL(STM32_DATA_CACHE_ENABLE)
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1U */
+
+/* ################## SPI peripheral configuration ########################## */
+
+/* CRC FEATURE: Use to activate CRC feature inside HAL SPI Driver
+ * Activated: CRC code is present inside driver
+ * Deactivated: CRC code cleaned from driver
+ */
+
+#define USE_SPI_CRC                   0U
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file
+  */
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32wbxx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32wbxx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+  #include "stm32wbxx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32wbxx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32wbxx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32wbxx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32wbxx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32wbxx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_HSEM_MODULE_ENABLED
+  #include "stm32wbxx_hal_hsem.h"
+#endif /* HAL_HSEM_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32wbxx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_IPCC_MODULE_ENABLED
+ #include "stm32wbxx_hal_ipcc.h"
+#endif /* HAL_IPCC_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32wbxx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32wbxx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LCD_MODULE_ENABLED
+ #include "stm32wbxx_hal_lcd.h"
+#endif /* HAL_LCD_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+  #include "stm32wbxx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+  #include "stm32wbxx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_PKA_MODULE_ENABLED
+  #include "stm32wbxx_hal_pka.h"
+#endif /* HAL_PKA_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32wbxx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_QSPI_MODULE_ENABLED
+ #define USE_HAL_QSPI_REGISTER_CALLBACKS 0U
+ #include "stm32wbxx_hal_qspi.h"
+#endif /* HAL_QSPI_MODULE_ENABLED */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32wbxx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+  #include "stm32wbxx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32wbxx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+ #include "stm32wbxx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32wbxx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+ #include "stm32wbxx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32wbxx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32wbxx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+  #include "stm32wbxx_hal_tsc.h"
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32wbxx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32wbxx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32wbxx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param expr If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed.
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+#define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32WBxx_HAL_CONF_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55.ld
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55.ld
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx)       : ORIGIN = 0x08010000, LENGTH = 216K /* First image slot. */
+  RAM (rwx)        : ORIGIN = 0x20000000, LENGTH = 192K
+  RAM_SHARED (rwx) : ORIGIN = 0x20030000, LENGTH = 10K
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_debug.sh
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_debug.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+#
+. $CORE_PATH/hw/scripts/stlink.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+
+stlink_debug

--- a/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_download.sh
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/p-nucleo-wb55_download.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/common.sh
+common_file_to_load
+
+if [ "$BOOT_LOADER" -o "$MFG_IMAGE" ]; then
+  STM32_Programmer_CLI -c port=usb1 -d $FILE_NAME $FLASH_OFFSET
+else
+  cp $FILE_NAME $FILE_NAME.bin
+  STM32_Programmer_CLI -c port=usb1 -d $FILE_NAME.bin $FLASH_OFFSET
+  rm $FILE_NAME.bin
+fi

--- a/hw/bsp/p-nucleo-wb55-usbdongle/pkg.yml
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/pkg.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bsp/p-nucleo-wb55-usbdongle
+pkg.type: bsp
+pkg.description: BSP definition for the P-NUCLEO-WB55-USBDongle board
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - stm32
+    - stm32wb
+    - nucleo
+
+pkg.cflags:
+    - -DSTM32WB55xx
+
+pkg.cflags.HARDFLOAT:
+    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/mcu/stm/stm32wbxx"
+    - "@apache-mynewt-core/libc/baselibc"

--- a/hw/bsp/p-nucleo-wb55-usbdongle/src/arch/cortex_m4/startup_stm32wb55xx_cm4.s
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/src/arch/cortex_m4/startup_stm32wb55xx_cm4.s
@@ -1,0 +1,445 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32wb55xx_cm4.s
+  * @author    MCD Application Team
+  * @brief     STM32WB55xx devices vector table GCC toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+
+  .section .text.Reset_Handler
+  .weak Reset_Handler
+  .type Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+
+/* Copy the data segment initializers from flash to SRAM */
+  ldr r0, =_sdata
+  ldr r1, =_edata
+  ldr r2, =_sidata
+  movs r3, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc CopyDataInit
+
+/* Zero fill the bss segment. */
+  ldr r2, =_sbss
+  ldr r4, =_ebss
+  movs r3, #0
+  b LoopFillZerobss
+
+FillZerobss:
+  str  r3, [r2]
+  adds r2, r2, #4
+
+LoopFillZerobss:
+  cmp r2, r4
+  bcc FillZerobss
+
+/* Zero fill the CoreBSS segment. */
+  ldr r2, =__corebss_start__
+  ldr r4, =__corebss_end__
+  movs r3, #0
+  b LoopFillZeroCoreBss
+
+FillZeroCoreBss:
+  str  r3, [r2]
+  adds r2, r2, #4
+
+LoopFillZeroCoreBss:
+  cmp r2, r4
+  bcc FillZeroCoreBss
+
+  ldr r0, =__HeapBase
+  ldr r1, =__HeapLimit
+  bl  _sbrkInit
+
+/* Call the clock system intitialization function.*/
+  bl SystemInit
+/* Call the application s entry point.*/
+  bl _start
+
+LoopForever:
+  b LoopForever
+
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval None
+*/
+  .section .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M4.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+  .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+g_pfnVectors:
+  .globl __isr_vector
+__isr_vector:
+  .word _estack
+  .word Reset_Handler
+  .word NMI_Handler
+  .word HardFault_Handler
+  .word MemManage_Handler
+  .word BusFault_Handler
+  .word UsageFault_Handler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word SVC_Handler
+  .word DebugMon_Handler
+  .word 0
+  .word PendSV_Handler
+  .word SysTick_Handler
+  .word WWDG_IRQHandler
+  .word PVD_PVM_IRQHandler
+  .word TAMP_STAMP_LSECSS_IRQHandler
+  .word RTC_WKUP_IRQHandler
+  .word FLASH_IRQHandler
+  .word RCC_IRQHandler
+  .word EXTI0_IRQHandler
+  .word EXTI1_IRQHandler
+  .word EXTI2_IRQHandler
+  .word EXTI3_IRQHandler
+  .word EXTI4_IRQHandler
+  .word DMA1_Channel1_IRQHandler
+  .word DMA1_Channel2_IRQHandler
+  .word DMA1_Channel3_IRQHandler
+  .word DMA1_Channel4_IRQHandler
+  .word DMA1_Channel5_IRQHandler
+  .word DMA1_Channel6_IRQHandler
+  .word DMA1_Channel7_IRQHandler
+  .word ADC1_IRQHandler
+  .word USB_HP_IRQHandler
+  .word USB_LP_IRQHandler
+  .word C2SEV_PWR_C2H_IRQHandler
+  .word COMP_IRQHandler
+  .word EXTI9_5_IRQHandler
+  .word TIM1_BRK_IRQHandler
+  .word TIM1_UP_TIM16_IRQHandler
+  .word TIM1_TRG_COM_TIM17_IRQHandler
+  .word TIM1_CC_IRQHandler
+  .word TIM2_IRQHandler
+  .word PKA_IRQHandler
+  .word I2C1_EV_IRQHandler
+  .word I2C1_ER_IRQHandler
+  .word I2C3_EV_IRQHandler
+  .word I2C3_ER_IRQHandler
+  .word SPI1_IRQHandler
+  .word SPI2_IRQHandler
+  .word USART1_IRQHandler
+  .word LPUART1_IRQHandler
+  .word SAI1_IRQHandler
+  .word TSC_IRQHandler
+  .word EXTI15_10_IRQHandler
+  .word RTC_Alarm_IRQHandler
+  .word CRS_IRQHandler
+  .word PWR_SOTF_BLEACT_802ACT_RFPHASE_IRQHandler
+  .word IPCC_C1_RX_IRQHandler
+  .word IPCC_C1_TX_IRQHandler
+  .word HSEM_IRQHandler
+  .word LPTIM1_IRQHandler
+  .word LPTIM2_IRQHandler
+  .word LCD_IRQHandler
+  .word QUADSPI_IRQHandler
+  .word AES1_IRQHandler
+  .word AES2_IRQHandler
+  .word RNG_IRQHandler
+  .word FPU_IRQHandler
+  .word DMA2_Channel1_IRQHandler
+  .word DMA2_Channel2_IRQHandler
+  .word DMA2_Channel3_IRQHandler
+  .word DMA2_Channel4_IRQHandler
+  .word DMA2_Channel5_IRQHandler
+  .word DMA2_Channel6_IRQHandler
+  .word DMA2_Channel7_IRQHandler
+  .word DMAMUX1_OVR_IRQHandler
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+  .weak  NMI_Handler
+  .thumb_set NMI_Handler,Default_Handler
+
+  .weak  HardFault_Handler
+  .thumb_set HardFault_Handler,Default_Handler
+
+  .weak  MemManage_Handler
+  .thumb_set MemManage_Handler,Default_Handler
+
+  .weak  BusFault_Handler
+  .thumb_set BusFault_Handler,Default_Handler
+
+  .weak  UsageFault_Handler
+  .thumb_set UsageFault_Handler,Default_Handler
+
+  .weak  SVC_Handler
+  .thumb_set SVC_Handler,Default_Handler
+
+  .weak  DebugMon_Handler
+  .thumb_set DebugMon_Handler,Default_Handler
+
+  .weak  PendSV_Handler
+  .thumb_set PendSV_Handler,Default_Handler
+
+  .weak  SysTick_Handler
+  .thumb_set SysTick_Handler,Default_Handler
+
+  .weak  WWDG_IRQHandler
+  .thumb_set WWDG_IRQHandler,Default_Handler
+
+  .weak  PVD_PVM_IRQHandler
+  .thumb_set PVD_PVM_IRQHandler,Default_Handler
+
+  .weak  TAMP_STAMP_LSECSS_IRQHandler
+  .thumb_set TAMP_STAMP_LSECSS_IRQHandler,Default_Handler
+
+  .weak  RTC_WKUP_IRQHandler
+  .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+  .weak  FLASH_IRQHandler
+  .thumb_set FLASH_IRQHandler,Default_Handler
+
+  .weak  RCC_IRQHandler
+  .thumb_set RCC_IRQHandler,Default_Handler
+
+  .weak  EXTI0_IRQHandler
+  .thumb_set EXTI0_IRQHandler,Default_Handler
+
+  .weak  EXTI1_IRQHandler
+  .thumb_set EXTI1_IRQHandler,Default_Handler
+
+  .weak  EXTI2_IRQHandler
+  .thumb_set EXTI2_IRQHandler,Default_Handler
+
+  .weak  EXTI3_IRQHandler
+  .thumb_set EXTI3_IRQHandler,Default_Handler
+
+  .weak  EXTI4_IRQHandler
+  .thumb_set EXTI4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel1_IRQHandler
+  .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel2_IRQHandler
+  .thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel3_IRQHandler
+  .thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel4_IRQHandler
+  .thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel5_IRQHandler
+  .thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel6_IRQHandler
+  .thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel7_IRQHandler
+  .thumb_set DMA1_Channel7_IRQHandler,Default_Handler
+
+  .weak  ADC1_IRQHandler
+  .thumb_set ADC1_IRQHandler,Default_Handler
+
+  .weak  USB_HP_IRQHandler
+  .thumb_set USB_HP_IRQHandler,Default_Handler
+
+  .weak  USB_LP_IRQHandler
+  .thumb_set USB_LP_IRQHandler,Default_Handler
+
+  .weak  C2SEV_PWR_C2H_IRQHandler
+  .thumb_set C2SEV_PWR_C2H_IRQHandler,Default_Handler
+
+  .weak  COMP_IRQHandler
+  .thumb_set COMP_IRQHandler,Default_Handler
+
+  .weak  EXTI9_5_IRQHandler
+  .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+  .weak  TIM1_BRK_IRQHandler
+  .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+  .weak  TIM1_UP_TIM16_IRQHandler
+  .thumb_set TIM1_UP_TIM16_IRQHandler,Default_Handler
+
+  .weak  TIM1_TRG_COM_TIM17_IRQHandler
+  .thumb_set TIM1_TRG_COM_TIM17_IRQHandler,Default_Handler
+
+  .weak  TIM1_CC_IRQHandler
+  .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+  .weak  TIM2_IRQHandler
+  .thumb_set TIM2_IRQHandler,Default_Handler
+
+  .weak  PKA_IRQHandler
+  .thumb_set PKA_IRQHandler,Default_Handler
+
+  .weak  I2C1_EV_IRQHandler
+  .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+  .weak  I2C1_ER_IRQHandler
+  .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+  .weak  I2C3_EV_IRQHandler
+  .thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+  .weak  I2C3_ER_IRQHandler
+  .thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+  .weak  SPI1_IRQHandler
+  .thumb_set SPI1_IRQHandler,Default_Handler
+
+  .weak  SPI2_IRQHandler
+  .thumb_set SPI2_IRQHandler,Default_Handler
+
+  .weak  USART1_IRQHandler
+  .thumb_set USART1_IRQHandler,Default_Handler
+
+  .weak  LPUART1_IRQHandler
+  .thumb_set LPUART1_IRQHandler,Default_Handler
+
+  .weak  SAI1_IRQHandler
+  .thumb_set SAI1_IRQHandler,Default_Handler
+
+  .weak  TSC_IRQHandler
+  .thumb_set TSC_IRQHandler,Default_Handler
+
+  .weak  EXTI15_10_IRQHandler
+  .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+  .weak  RTC_Alarm_IRQHandler
+  .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+  .weak  CRS_IRQHandler
+  .thumb_set CRS_IRQHandler,Default_Handler
+
+  .weak  PWR_SOTF_BLEACT_802ACT_RFPHASE_IRQHandler
+  .thumb_set PWR_SOTF_BLEACT_802ACT_RFPHASE_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_RX_IRQHandler
+  .thumb_set IPCC_C1_RX_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_TX_IRQHandler
+  .thumb_set IPCC_C1_TX_IRQHandler,Default_Handler
+
+  .weak  HSEM_IRQHandler
+  .thumb_set HSEM_IRQHandler,Default_Handler
+
+  .weak  LPTIM1_IRQHandler
+  .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+  .weak  LPTIM2_IRQHandler
+  .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+  .weak  LCD_IRQHandler
+  .thumb_set LCD_IRQHandler,Default_Handler
+
+  .weak  QUADSPI_IRQHandler
+  .thumb_set QUADSPI_IRQHandler,Default_Handler
+
+  .weak  AES1_IRQHandler
+  .thumb_set AES1_IRQHandler,Default_Handler
+
+  .weak  AES2_IRQHandler
+  .thumb_set AES2_IRQHandler,Default_Handler
+
+  .weak  RNG_IRQHandler
+  .thumb_set RNG_IRQHandler,Default_Handler
+
+  .weak  FPU_IRQHandler
+  .thumb_set FPU_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel1_IRQHandler
+  .thumb_set DMA2_Channel1_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel2_IRQHandler
+  .thumb_set DMA2_Channel2_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel3_IRQHandler
+  .thumb_set DMA2_Channel3_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel4_IRQHandler
+  .thumb_set DMA2_Channel4_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel5_IRQHandler
+  .thumb_set DMA2_Channel5_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel6_IRQHandler
+  .thumb_set DMA2_Channel6_IRQHandler,Default_Handler
+
+  .weak  DMA2_Channel7_IRQHandler
+  .thumb_set DMA2_Channel7_IRQHandler,Default_Handler
+
+  .weak  DMAMUX1_OVR_IRQHandler
+  .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+
+#include "bsp/bsp.h"
+#include "os/mynewt.h"
+
+#include <hal/hal_bsp.h>
+#include <hal/hal_flash_int.h>
+#include <hal/hal_system.h>
+
+#include <stm32wb55xx.h>
+#include <stm32_common/stm32_hal.h>
+
+#if MYNEWT_VAL(ETH_0)
+#include <stm32_eth/stm32_eth.h>
+#include <stm32_eth/stm32_eth_cfg.h>
+#endif
+
+#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
+#include <pwm_stm32/pwm_stm32.h>
+#endif
+
+#if MYNEWT_VAL(UART_0)
+const struct stm32_uart_cfg os_bsp_uart0_cfg = {
+    .suc_uart = USART1,
+    .suc_rcc_reg = &RCC->APB2ENR,
+    .suc_rcc_dev = RCC_APB2ENR_USART1EN,
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+    .suc_pin_af = GPIO_AF7_USART1,
+    .suc_irqn = USART1_IRQn,
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+const struct stm32_hal_i2c_cfg os_bsp_i2c0_cfg = {
+    .hic_i2c = I2C1,
+    .hic_rcc_reg = &RCC->APB1ENR1,
+    .hic_rcc_dev = RCC_APB1ENR1_I2C1EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C1,
+    .hic_10bit = 0,
+    .hic_timingr = 0x00C0216C,            /* 400KHz at 64MHz */
+};
+#endif
+
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE,
+    },
+};
+
+extern const struct hal_flash stm32_flash_dev;
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    /*
+     * Internal flash mapped to id 0.
+     */
+    if (id != 0) {
+        return NULL;
+    }
+    return &stm32_flash_dev;
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+void
+boot_preboot(void)
+{
+#if MYNEWT_VAL(BUTTON_1_AS_STM32_DFU) >= 0
+    hal_gpio_init_in(BUTTON_1, HAL_GPIO_PULL_UP);
+    os_cputime_delay_usecs(100);
+    if (hal_gpio_read(BUTTON_1) == 0) {
+        hal_gpio_deinit(BUTTON_1);
+        stm32_start_bootloader();
+    }
+    hal_gpio_deinit(BUTTON_1);
+#endif
+}
+
+static void
+dongle_soft_reset(void *arg)
+{
+    os_cputime_delay_usecs(800000);
+    hal_system_reset();
+}
+
+void
+hal_bsp_init(void)
+{
+    stm32_periph_create();
+
+    if (MYNEWT_VAL(BUTTON_1_AS_RESET)) {
+        hal_gpio_irq_init(BUTTON_1, dongle_soft_reset, NULL, HAL_GPIO_TRIG_FALLING, HAL_GPIO_PULL_UP);
+    }
+}
+
+void
+hal_bsp_deinit(void)
+{
+    RCC->AHB1ENR = 0;
+    RCC->AHB2ENR = 0;
+    RCC->AHB3ENR = RCC_AHB3ENR_FLASHEN | RCC_AHB3ENR_HSEMEN;
+    RCC->APB1ENR1 = RCC_APB1ENR1_RTCAPBEN;
+    RCC->APB1ENR2 = 0;
+    RCC->APB2ENR = 0;
+    RCC->AHB1RSTR = 0x00011007;
+    RCC->AHB2RSTR = 0x0001209F;
+    RCC->AHB3RSTR = 0x021F1000;
+    RCC->APB1RSTR1 = 0x85A04201;
+    RCC->APB1RSTR2 = 0x00000021;
+    RCC->APB2RSTR = 0x00265800;
+
+    RCC->AHB1RSTR = 0;
+    RCC->AHB2RSTR = 0;
+    RCC->AHB3RSTR = 0;
+    RCC->APB1RSTR1 = 0;
+    RCC->APB1RSTR2 = 0;
+    RCC->APB2RSTR = 0;
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    /* Add any interrupt priorities configured by the bsp here */
+    return pri;
+}

--- a/hw/bsp/p-nucleo-wb55-usbdongle/syscfg.yml
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/syscfg.yml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB.'
+        value: 1024
+    BUTTON_1_AS_RESET:
+        description: >
+            This USB dongle does not have physical Reset button.
+            When this value is set BUTTON_1 acts are reset button.
+        value: 0
+    BUTTON_1_AS_STM32_DFU:
+        description: >
+            When this value is set to 1. BUTTON_1 pressed during boot
+            enters STM32 DFU.
+        value: 0
+
+syscfg.vals.BUTTON_1_AS_STM32_DFU:
+    BOOT_PREBOOT: 1
+
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    STM32_CLOCK_VOLTAGESCALING_CONFIG: 'PWR_REGULATOR_VOLTAGE_SCALE1'
+    STM32_CLOCK_LSI1: 1
+    STM32_CLOCK_LSI2: 0
+    STM32_CLOCK_LSI2_CALIBRATION: 0
+    STM32_CLOCK_LSE: 0
+    STM32_CLOCK_LSE_BYPASS: 0
+    STM32_CLOCK_MSI: 1
+    STM32_CLOCK_MSI_CALIBRATION: 'RCC_MSICALIBRATION_DEFAULT'
+    STM32_CLOCK_MSI_CLOCK_RANGE: 'RCC_MSIRANGE_8'  # 16MHz
+    STM32_CLOCK_HSI: 0
+    STM32_CLOCK_HSI_CALIBRATION: 'RCC_HSICALIBRATION_DEFAULT'
+    STM32_CLOCK_HSI48: 0
+    STM32_CLOCK_HSE: 0
+    STM32_CLOCK_HSE_BYPASS: 0
+    STM32_CLOCK_HSEPRE: 1  # 32 / 2 = 16MHz
+    STM32_CLOCK_PLL_PLLM: 'RCC_PLLM_DIV1'  # 16MHz
+    STM32_CLOCK_PLL_PLLN: 12  # 16 * 12 = 192MHz
+    STM32_CLOCK_PLL_PLLP: 'RCC_PLLP_DIV12'  # 192 / 12 = 16MHz
+    STM32_CLOCK_PLL_PLLR: 'RCC_PLLR_DIV3'  # 192 / 3 = 64MHz
+    STM32_CLOCK_PLL_PLLQ: 'RCC_PLLQ_DIV4'  # 192 / 4 = 48MHz
+    STM32_CLOCK_AHB_DIVIDER: 'RCC_SYSCLK_DIV1'
+    STM32_CLOCK_APB1_DIVIDER: 'RCC_HCLK_DIV1'
+    STM32_CLOCK_APB2_DIVIDER: 'RCC_HCLK_DIV1'
+    STM32_CLOCK_AHBCLK2_DIVIDER: 'RCC_SYSCLK_DIV2'
+    STM32_CLOCK_AHBCLK4_DIVIDER: 'RCC_SYSCLK_DIV1'
+    STM32_FLASH_LATENCY: 'FLASH_LATENCY_3'
+    STM32_FLASH_PREFETCH_ENABLE: 1
+    STM32_INSTRUCTION_CACHE_ENABLE: 1
+    STM32_DATA_CACHE_ENABLE: 1
+    UART_0_PIN_TX: 'MCU_GPIO_PORTB(6)'
+    UART_0_PIN_RX: 'MCU_GPIO_PORTB(7)'
+    SPI_0_PIN_SS: 'MCU_GPIO_PORTA(4)'
+    SPI_0_PIN_SCK: 'MCU_GPIO_PORTA(5)'
+    SPI_0_PIN_MISO: 'MCU_GPIO_PORTA(6)'
+    SPI_0_PIN_MOSI: 'MCU_GPIO_PORTA(7)'
+    I2C_0_PIN_SCL: 'MCU_GPIO_PORTB(8)'
+    I2C_0_PIN_SDA: 'MCU_GPIO_PORTB(9)'
+    TIMER_0_TIM: 'TIM2'
+    TIMER_1_TIM: 'TIM16'
+    TIMER_2_TIM: 'TIM17'


### PR DESCRIPTION
USB dongle has same MCU as p-nucleo-wb55 and it differs from big board:
- No Arduino or morpho connectors
- only one button
- no debugger on board

BSP reflects pins and buttons differences.
It also changes download script to use STM DFU bootloader.
Also there are two configuration values that may be handy:
- BUTTON_1 can be configured to act as Reset pin that is not present
- BUTTON_1 can be used in bootloader to enter DFU mode when pressed during boot
(there is BOOT switch on board but it may be convenient to use BUTTON_1 as reset in application
and when still pressed as a way to enter STM32 DFU mode)