### PR TITLE
tinyusb: Tickle watchdog in bootloader

### DIFF
--- a/hw/usb/tinyusb/src/tinyusb.c
+++ b/hw/usb/tinyusb/src/tinyusb.c
@@ -19,6 +19,7 @@
 
 
 #include <os/mynewt.h>
+#include <hal/hal_watchdog.h>
 #include <device/usbd.h>
 
 #include <tusb.h>
@@ -43,6 +44,9 @@ tinyusb_device_task(void *param)
     (void)param;
 
     while (1) {
+#if !MYNEWT_VAL(OS_SCHEDULING) && MYNEWT_VAL(WATCHDOG_INTERVAL)
+        hal_watchdog_tickle();
+#endif
         tud_task();
     }
 }


### PR DESCRIPTION
When TinyUSB was enabled in bootloader (for DFU) and Watchdog was
enabled device resets all the time because TinyUSB loop did not feed
watchdog.

Now for bootloader build watchdog is handled when tinyusb takes over.