### PR TITLE
hw/drivers/flash/spiflash: add P25Q32H chip

### DIFF
--- a/hw/drivers/flash/spiflash/chips/syscfg.yml
+++ b/hw/drivers/flash/spiflash/chips/syscfg.yml
@@ -506,3 +506,6 @@ syscfg.defs:
     SPIFLASH_XM25QH32B:
         description: Add support for XM25QH32B
         value: 0
+    SPIFLASH_P25Q32H:
+        description: Add support for P25Q32H
+        value: 0

--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -127,6 +127,7 @@ struct spiflash_chip {
 #define JEDEC_MFC_ADESTO            0x1F
 #define JEDEC_MFC_EON               0x1C
 #define JEDEC_MFC_XTX               0x0B
+#define JEDEC_MFC_PUYA              0x85
 
 #define FLASH_CAPACITY_256KBIT      0x09
 #define FLASH_CAPACITY_512KBIT      0x10

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -86,6 +86,8 @@ static void spiflash_release_power_down_generic(struct spiflash_dev *dev) __attr
     STD_FLASH_CHIP(name, JEDEC_MFC_EON, typ, cap, spiflash_release_power_down_generic)
 #define XTX_CHIP(name, typ, cap) \
     STD_FLASH_CHIP(name, JEDEC_MFC_XTX, typ, cap, spiflash_release_power_down_generic)
+#define PUYA_CHIP(name, typ, cap) \
+    STD_FLASH_CHIP(name, JEDEC_MFC_PUYA, typ, cap, spiflash_release_power_down_generic)
 
 static struct spiflash_chip supported_chips[] = {
 #if MYNEWT_VAL(SPIFLASH_MANUFACTURER) && MYNEWT_VAL(SPIFLASH_MEMORY_TYPE) && MYNEWT_VAL(SPIFLASH_MEMORY_CAPACITY)
@@ -581,6 +583,9 @@ static struct spiflash_chip supported_chips[] = {
 #endif
 #if MYNEWT_VAL(SPIFLASH_XM25QH32B)
     MICRON_CHIP(XM25QH32B, 0x40, FLASH_CAPACITY_32MBIT),
+#endif
+#if MYNEWT_VAL(SPIFLASH_P25Q32H)
+    PUYA_CHIP(P25Q32H, 0x60, FLASH_CAPACITY_32MBIT),
 #endif
 
     { {0} },


### PR DESCRIPTION
Similar to #2582 , this adds support for the P25Q32H SPI NOR flash chip found in some P8(b) smartwatch variants. 

Datasheet: https://www.puyasemi.com/uploadfiles/2018/08/201808071524332433.pdf , see p. 70 for IDs.