### PR TITLE
hw/drivers/nrf53_ipc: Add API to retrieve pointer to data buffer

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -105,6 +105,17 @@ uint16_t ipc_nrf5340_read_om(int channel, struct os_mbuf *om, uint16_t len);
 uint16_t ipc_nrf5340_available(int channel);
 
 /**
+ * Returns number of continuous data bytes available in IPC ring buffer with
+ * pointer to that data. Should be used only from ipc_nrf5340_recv_cb context.
+ *
+ * @param channel     IPC channel number
+ * @param dptr        Pointer to data buffer
+ *
+ * @return            Number of bytes available in IPC ring buffer
+ */
+uint16_t ipc_nrf5340_available_buf(int channel, void **dptr);
+
+/**
  * Consumes data from IPC ring buffer without copying. Should be used only
  * from ipc_nrf5340_recv_cb context.
  *

--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -453,6 +453,24 @@ ipc_nrf5340_available(int channel)
 }
 
 uint16_t
+ipc_nrf5340_available_buf(int channel, void **dptr)
+{
+    struct ipc_shm *shm = &shms[channel];
+    uint16_t head = shm->head;
+    uint16_t tail = shm->tail;
+
+    *dptr = &shm->buf[tail];
+
+    if (head > tail) {
+        return head - tail;
+    } else if (head < tail) {
+        return IPC_BUF_SIZE - tail;
+    }
+
+    return 0;
+}
+
+uint16_t
 ipc_nrf5340_consume(int channel, uint16_t len)
 {
     assert(channel < IPC_MAX_CHANS);


### PR DESCRIPTION
This allows to read directly from an IPC flat buffer instead of reading
to a buffer.