### PR TITLE
console: Fix internals console history

### DIFF
--- a/sys/console/full/history_log/pkg.yml
+++ b/sys/console/full/history_log/pkg.yml
@@ -27,6 +27,7 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
 
 pkg.init:
     console_history_pkg_init: 'MYNEWT_VAL(CONSOLE_HISTORY_LOG_SYSINIT_STAGE)'

--- a/sys/console/full/history_log/src/history_log.c
+++ b/sys/console/full/history_log/src/history_log.c
@@ -123,8 +123,8 @@ move(const char *p, history_find_type_t search_type)
     }
 }
 
-static history_handle_t
-console_history_add_to_cache(const char *line)
+static int
+console_history_add_to_cache(const char *line, history_handle_t *entry)
 {
     char *cache_end = history_cache + history_ptr;
     /* Let p1 point to last null-terminator */
@@ -227,7 +227,10 @@ console_history_add_to_cache(const char *line)
         p1 = NEXT_PTR(p1);
     }
 
-    return result;
+    if (entry) {
+        *entry = result;
+    }
+    return 0;
 }
 
 /*
@@ -246,24 +249,24 @@ history_cache_from_log(struct log *log, struct log_offset *log_offset,
     if (hdr->ue_module == MYNEWT_VAL(CONSOLE_HISTORY_LOG_MODULE)) {
         log_read_body(log, dptr, line, 0, len);
         line[len] = '\0';
-        (void)console_history_add_to_cache(line);
+        (void)console_history_add_to_cache(line, NULL);
     }
 
     return 0;
 }
 
-history_handle_t
-console_history_add(const char *line)
+int
+console_history_add(const char *line, history_handle_t *entry)
 {
-    history_handle_t added_line;
+    int rc;
 
-    added_line = console_history_add_to_cache(line);
+    rc = console_history_add_to_cache(line, entry);
 
-    if (added_line > 0 && history_log) {
+    if (rc == 0 && history_log) {
         log_printf(history_log, MYNEWT_VAL(CONSOLE_HISTORY_LOG_MODULE),
                    LOG_LEVEL_MAX, line);
     }
-    return added_line;
+    return rc;
 }
 
 int

--- a/sys/console/full/history_ram/src/history_ram.c
+++ b/sys/console/full/history_ram/src/history_ram.c
@@ -133,8 +133,8 @@ console_hist_move_to_head(char *line)
     return true;
 }
 
-history_handle_t
-console_history_add(const char *line)
+int
+console_history_add(const char *line, history_handle_t *entry)
 {
     struct console_hist *sh = &console_hist;
     char buf[MYNEWT_VAL(CONSOLE_MAX_INPUT_LEN)];
@@ -142,11 +142,15 @@ console_history_add(const char *line)
 
     len = trim_whitespace(line, buf, sizeof(buf));
     if (len == 0) {
-        return 0;
+        return SYS_EINVAL;
+    }
+
+    if (entry) {
+        *entry = 0;
     }
 
     if (console_hist_move_to_head(buf)) {
-        return 1;
+        return SYS_EALREADY;
     }
 
     strcpy(sh->lines[sh->head], buf);
@@ -154,7 +158,7 @@ console_history_add(const char *line)
     if (!console_hist_is_full()) {
         sh->count++;
     }
-    return 1;
+    return SYS_EOK;
 }
 
 /**

--- a/sys/console/full/include/console/history.h
+++ b/sys/console/full/include/console/history.h
@@ -44,12 +44,13 @@ typedef intptr_t history_handle_t;
  * Implemented by history provider.
  *
  * @param line text to add to history
+ * @param entry pointer to variable that will receive history entry
  *
- * @return handle to new entry added to history
+ * @return SYS_EOK - if line was added
  *         SYS_EINVAL - line was empty or null
  *         SYS_EALREADY - line was already at the end of history
  */
-history_handle_t console_history_add(const char *line);
+int console_history_add(const char *line, history_handle_t *entry);
 
 /**
  * Finds element in history.

--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -1187,7 +1187,7 @@ console_handle_char(uint8_t byte)
                 console_filter_out('\n');
             }
             if (!MYNEWT_VAL_CHOICE(CONSOLE_HISTORY, none)) {
-                console_history_add(input->line);
+                console_history_add(input->line, NULL);
                 history_line = 0;
                 if (MYNEWT_VAL(CONSOLE_HISTORY_AUTO_SEARCH)) {
                     trailing_selection = 0;


### PR DESCRIPTION
history_handle_t type was used to store pointer or result.
Code assumed that pointer will always be positive and error code
would be SYS_xxx so they would be negative.
For PIC32 RAM addresses start from 0x80000000 sot they were always
negative.

This removes double meaning of history_handle_t and some functions return
error codes separately from found history entries.

There is no change in history handling logic just arguments and return values reworked.