### PR TITLE
fcb2 initialization fix

### DIFF
--- a/fs/fcb2/selftest/src/fcb_test.c
+++ b/fs/fcb2/selftest/src/fcb_test.c
@@ -108,13 +108,11 @@ fcb_test_cnt_elems_cb(struct fcb2_entry *loc, void *arg)
     return 0;
 }
 
-void
-fcb_tc_pretest(uint8_t sector_count)
+int
+fcb_tc_init_fcb(uint8_t sector_count)
 {
     struct fcb2 *fcb;
-    int rc = 0;
 
-    fcb_test_wipe();
     fcb = &test_fcb;
     memset(fcb, 0, sizeof(*fcb));
     fcb->f_sector_cnt = sector_count;
@@ -124,7 +122,16 @@ fcb_tc_pretest(uint8_t sector_count)
     test_fcb_ranges[0].fsr_flash_area.fa_size =
         test_fcb_ranges[0].fsr_sector_size * sector_count;
 
-    rc = fcb2_init(fcb);
+    return fcb2_init(fcb);
+}
+
+void
+fcb_tc_pretest(uint8_t sector_count)
+{
+    int rc = 0;
+
+    fcb_test_wipe();
+    rc = fcb_tc_init_fcb(sector_count);
     if (rc != 0) {
         printf("fcb_tc_pretest rc == %x, %d\n", rc, rc);
         TEST_ASSERT(rc == 0);

--- a/fs/fcb2/selftest/src/fcb_test.c
+++ b/fs/fcb2/selftest/src/fcb_test.c
@@ -143,6 +143,7 @@ TEST_CASE_DECL(fcb_test_empty_walk)
 TEST_CASE_DECL(fcb_test_append)
 TEST_CASE_DECL(fcb_test_append_too_big)
 TEST_CASE_DECL(fcb_test_append_fill)
+TEST_CASE_DECL(fcb_test_append_fill_small)
 TEST_CASE_DECL(fcb_test_reset)
 TEST_CASE_DECL(fcb_test_rotate)
 TEST_CASE_DECL(fcb_test_multiple_scratch)
@@ -157,6 +158,7 @@ TEST_SUITE(fcb_test_all)
     fcb_test_append();
     fcb_test_append_too_big();
     fcb_test_append_fill();
+    fcb_test_append_fill_small();
     fcb_test_reset();
     fcb_test_rotate();
     fcb_test_multiple_scratch();

--- a/fs/fcb2/selftest/src/fcb_test.h
+++ b/fs/fcb2/selftest/src/fcb_test.h
@@ -46,6 +46,8 @@ uint8_t fcb_test_append_data(int msg_len, int off);
 int fcb_test_data_walk_cb(struct fcb2_entry *loc, void *arg);
 int fcb_test_cnt_elems_cb(struct fcb2_entry *loc, void *arg);
 void fcb_tc_pretest(uint8_t sector_count);
+/* Inits fcb without wiping flash */
+int fcb_tc_init_fcb(uint8_t sector_count);
 
 #ifdef __cplusplus
 }

--- a/fs/fcb2/selftest/src/testcases/fcb_test_append_fill.c
+++ b/fs/fcb2/selftest/src/testcases/fcb_test_append_fill.c
@@ -78,4 +78,14 @@ TEST_CASE_SELF(fcb_test_append_fill)
     TEST_ASSERT(rc == 0);
     TEST_ASSERT(aa_separate.elem_cnts[0] == elem_cnts[0]);
     TEST_ASSERT(aa_separate.elem_cnts[1] == elem_cnts[1]);
+
+    /* Re-init FCB without clearing flash */
+    rc = fcb_tc_init_fcb(2);
+    TEST_ASSERT(rc == 0);
+    aa_together_cnts[0] = 0;
+    aa_together_cnts[1] = 0;
+    /* Walk again, number of elements should not changed */
+    rc = fcb2_walk(fcb, FCB2_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_together);
+    TEST_ASSERT(aa_together_cnts[0] == elem_cnts[0]);
+    TEST_ASSERT(aa_together_cnts[1] == elem_cnts[1]);
 }

--- a/fs/fcb2/selftest/src/testcases/fcb_test_append_fill_small.c
+++ b/fs/fcb2/selftest/src/testcases/fcb_test_append_fill_small.c
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "fcb_test.h"
+
+TEST_CASE_SELF(fcb_test_append_fill_small)
+{
+    struct fcb2 *fcb;
+    int rc;
+    int i;
+    struct fcb2_entry loc;
+    uint8_t test_data[1];
+    int elem_cnts[2] = {0, 0};
+    int aa_together_cnts[2];
+    struct append_arg aa_together = {
+        .elem_cnts = aa_together_cnts
+    };
+    int aa_separate_cnts[2];
+    struct append_arg aa_separate = {
+        .elem_cnts = aa_separate_cnts
+    };
+
+    fcb_tc_pretest(2);
+
+    fcb = &test_fcb;
+
+    for (i = 0; i < sizeof(test_data); i++) {
+        test_data[i] = fcb_test_append_data(sizeof(test_data), i);
+    }
+
+    while (1) {
+        rc = fcb2_append(fcb, sizeof(test_data), &loc);
+        if (rc == FCB2_ERR_NOSPACE) {
+            break;
+        }
+        if (loc.fe_sector == 0) {
+            elem_cnts[0]++;
+        } else if (loc.fe_sector == 1) {
+            elem_cnts[1]++;
+        } else {
+            TEST_ASSERT(0);
+        }
+
+        rc = fcb2_write(&loc, 0, test_data, sizeof(test_data));
+        TEST_ASSERT(rc == 0);
+
+        rc = fcb2_append_finish(&loc);
+        TEST_ASSERT(rc == 0);
+    }
+    TEST_ASSERT(elem_cnts[0] > 0);
+    TEST_ASSERT(elem_cnts[0] == elem_cnts[1]);
+
+    memset(&aa_together_cnts, 0, sizeof(aa_together_cnts));
+    rc = fcb2_walk(fcb, FCB2_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_together);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(aa_together.elem_cnts[0] == elem_cnts[0]);
+    TEST_ASSERT(aa_together.elem_cnts[1] == elem_cnts[1]);
+
+    memset(&aa_separate_cnts, 0, sizeof(aa_separate_cnts));
+    rc = fcb2_walk(fcb, 0, fcb_test_cnt_elems_cb, &aa_separate);
+    TEST_ASSERT(rc == 0);
+    rc = fcb2_walk(fcb, 1, fcb_test_cnt_elems_cb, &aa_separate);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(aa_separate.elem_cnts[0] == elem_cnts[0]);
+    TEST_ASSERT(aa_separate.elem_cnts[1] == elem_cnts[1]);
+
+    /* Re-init FCB without clearing flash */
+    rc = fcb_tc_init_fcb(2);
+    TEST_ASSERT(rc == 0);
+    aa_together_cnts[0] = 0;
+    aa_together_cnts[1] = 0;
+    /* Walk again, number of elements should not changed */
+    rc = fcb2_walk(fcb, FCB2_SECTOR_OLDEST, fcb_test_cnt_elems_cb, &aa_together);
+    TEST_ASSERT(aa_together_cnts[0] == elem_cnts[0]);
+    TEST_ASSERT(aa_together_cnts[1] == elem_cnts[1]);
+}


### PR DESCRIPTION
When FCB was full and there was less free space that could be used < 6.
fcb2_init incorrectly returned error FCB2_ERR_CRC instead of FCB2_OK
It could lead to FCB being wiped if fcb2_init_flash_area() was used for fcb initialization.

Fixes #2756
