### PR TITLE
MbedTLS: Suppress gcc 10 warning

### DIFF
--- a/crypto/mbedtls/pkg.yml
+++ b/crypto/mbedtls/pkg.yml
@@ -25,5 +25,7 @@ pkg.keywords:
     - ssl
     - tls
 
-pkg.cflags: '-DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h>'
+pkg.cflags:
+    - '-DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h>'
+    - -Wno-maybe-uninitialized
 pkg.cflags.TEST: -DTEST


### PR DESCRIPTION
Debug build compiled with gcc 10.x (arm and riscv) produces
warning:
repos/apache-mynewt-core/crypto/mbedtls/src/hmac_drbg.c:134:11: error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  134 |     return( ret );

This warning is incorrect and now is suppressed.