### PR TITLE
hw/mcu/nordic: Bump main stack for nRF53

### DIFF
--- a/hw/mcu/nordic/nrf5340/startup/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/startup/syscfg.yml
@@ -22,7 +22,7 @@ syscfg.defs:
             Stack size (in bytes) to use in startup code.
             For bootloader it's main stack, for application this stack is used by interrupts
             and exceptions.
-        value: 432
+        value: 512
 
 syscfg.vals.BOOT_LOADER:
     # MCUboot code uses a lot of stack

--- a/hw/mcu/nordic/nrf5340_net/startup/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/startup/syscfg.yml
@@ -22,7 +22,7 @@ syscfg.defs:
             Stack size (in bytes) to use in startup code.
             For bootloader it's main stack, for application this stack is used by interrupts
             and exceptions.
-        value: 432
+        value: 512
 
 syscfg.vals.BOOT_LOADER:
     # MCUboot code uses a lot of stack


### PR DESCRIPTION
H4 over IPC requires a bit more stack.