### PR TITLE
bsp/hifive1: Add missing include

### DIFF
--- a/hw/bsp/hifive1/include/bsp/bsp.h
+++ b/hw/bsp/hifive1/include/bsp/bsp.h
@@ -19,6 +19,8 @@
 #ifndef __HIFIVE_BSP_H
 #define __HIFIVE_BSP_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
bsp.h use uint8_t without including stdint.h.
For most cases it will work since bsp.h is likely to be
included later then some other headers.
If it is first include file compilation will fail:
Error: In file included from repos/apache-mynewt-core/apps/slinky/src/led.c:22:
repos/apache-mynewt-core/hw/bsp/hifive1/include/bsp/bsp.h:121:8: error: unknown type name 'uint8_t'
 extern uint8_t _ram_start;

Now required header is explicitly included.