### PR TITLE
Make Mynewt 1.10 release depend on mcuboot 1.7.2

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -124,7 +124,7 @@ repo.deps:
             mynewt_1_7_0_tag: 1.3.1
             mynewt_1_8_0_tag: 1.5.0
             mynewt_1_9_0_tag: 1.7.2
-            mynewt_1_10_0_tag: 1.9.0
+            mynewt_1_10_0_tag: 1.7.2
 
     apache-mynewt-mcumgr:
         type: github


### PR DESCRIPTION
Mcuboot 1.8 and newer have issues in test framework affecting
'newt test all'