### PR TITLE
da1469x: hal_flash: Autodetect and configure flash

### DIFF
--- a/hw/bsp/dialog_da14695-dk-usb/src/hal_bsp.c
+++ b/hw/bsp/dialog_da14695-dk-usb/src/hal_bsp.c
@@ -50,8 +50,7 @@ const struct qspi_flash_config rdids[] = {
     { .id = 0xc22536,                       /* macronix */
       .cmda = 0xa8a500eb,
       .cmdb = 0x66,
-      .qe = {1, {0x40}},
-    },
+      .qe = {1, {0x40}},},
 };
 
 const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);

--- a/hw/bsp/dialog_da14695-dk-usb/src/hal_bsp.c
+++ b/hw/bsp/dialog_da14695-dk-usb/src/hal_bsp.c
@@ -27,6 +27,7 @@
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_periph.h"
 #include "bsp/bsp.h"
+#include <os/util.h>
 
 static const struct hal_bsp_mem_dump dump_cfg[] = {
     [0] = {
@@ -40,6 +41,21 @@ static const struct hal_bsp_mem_dump dump_cfg[] = {
  * Most probably it should be generated and stored somewhere in OTP.
  */
 static char hw_id[] = "DA1469X_HW_ID";
+
+/*
+ * Configure empty RDIDs for use by flash init.
+ */
+#if MYNEWT_VAL(RAM_RESIDENT)
+const struct qspi_flash_config rdids[] = {
+    { .id = 0xc22536,                       /* macronix */
+      .cmda = 0xa8a500eb,
+      .cmdb = 0x66,
+      .qe = {1, {0x40}},
+    },
+};
+
+const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);
+#endif
 
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -27,6 +27,7 @@
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_periph.h"
 #include "bsp/bsp.h"
+#include <os/util.h>
 
 static const struct hal_bsp_mem_dump dump_cfg[] = {
     [0] = {

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -47,7 +47,14 @@ static char hw_id[] = "DA1469X_HW_ID";
  * Configure empty RDIDs for use by flash init.
  */
 #if MYNEWT_VAL(RAM_RESIDENT)
-const struct qspi_flash_config rdids[] = {};
+const struct qspi_flash_config rdids[] = {
+    { .id = 0xc22536,                       /* macronix */
+      .cmda = 0xa8a500eb,
+      .cmdb = 0x66,
+      .qe = {1, {0x40}},
+    },
+};
+
 const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);
 #endif
 

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -46,7 +46,7 @@ static char hw_id[] = "DA1469X_HW_ID";
  * Configure empty RDIDs for use by flash init.
  */
 #if MYNEWT_VAL(RAM_RESIDENT)
-const struct qspi_flash_config rdids[] = 0;
+const struct qspi_flash_config rdids[] = {};
 const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);
 #endif
 

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -51,8 +51,7 @@ const struct qspi_flash_config rdids[] = {
     { .id = 0xc22536,                       /* macronix */
       .cmda = 0xa8a500eb,
       .cmdb = 0x66,
-      .qe = {1, {0x40}},
-    },
+      .qe = {1, {0x40}},},
 };
 
 const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);

--- a/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
+++ b/hw/bsp/dialog_da1469x-dk-pro/src/hal_bsp.c
@@ -41,6 +41,15 @@ static const struct hal_bsp_mem_dump dump_cfg[] = {
  */
 static char hw_id[] = "DA1469X_HW_ID";
 
+
+/*
+ * Configure empty RDIDs for use by flash init.
+ */
+#if MYNEWT_VAL(RAM_RESIDENT)
+const struct qspi_flash_config rdids[] = 0;
+const int qspi_flash_config_array_size = ARRAY_SIZE(rdids);
+#endif
+
 const struct hal_flash *
 hal_bsp_flash_dev(uint8_t id)
 {

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -70,6 +70,21 @@ struct da1469x_hal_spi_cfg {
     int8_t pin_ss;
 };
 
+struct qspi_qe_config {
+    uint8_t length;
+    uint8_t bytes[2];
+};
+
+struct qspi_flash_config {
+    uint32_t id;
+    uint32_t cmda;
+    uint32_t cmdb;
+    struct qspi_qe_config qe;
+};
+
+extern const struct qspi_flash_config rdids[];
+extern const int qspi_flash_config_array_size;
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -398,7 +398,8 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
 
 #if MYNEWT_VAL(RAM_RESIDENT)
 
-static void qspi_qe_enable(const struct hal_flash *dev, const struct qspi_qe_config *config)
+static void
+qspi_qe_enable(const struct hal_flash *dev, const struct qspi_qe_config *config)
 {
     int i;
 
@@ -424,7 +425,8 @@ static void qspi_qe_enable(const struct hal_flash *dev, const struct qspi_qe_con
     QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
 }
 
-static const struct qspi_flash_config *qspi_read_rdid(const struct hal_flash *dev)
+static const struct qspi_flash_config *
+qspi_read_rdid(const struct hal_flash *dev)
 {
     int i;
     uint32_t result;
@@ -483,7 +485,7 @@ da1469x_hff_mcu_custom_init(const struct hal_flash *dev)
 #endif
 
 static int
-    da1469x_hff_init(const struct hal_flash *dev)
+da1469x_hff_init(const struct hal_flash *dev)
 {
 #if MYNEWT_VAL(RAM_RESIDENT)
     da1469x_hff_mcu_custom_init(dev);

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -397,31 +397,6 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
 }
 
 #if MYNEWT_VAL(RAM_RESIDENT)
-struct qspi_qe_config {
-    uint8_t length;
-    uint8_t bytes[2];
-};
-
-struct qspi_flash_config {
-    uint32_t id;
-    uint32_t cmda;
-    uint32_t cmdb;
-    struct qspi_qe_config qe;
-};
-
-static const struct qspi_flash_config rdids[] =
-{
-    { .id = 0xc86015,                       /* gigaflash */
-      .cmda = 0xa82000eb,
-      .cmdb = 0x66,
-      .qe = {2, {0x0, 0x2}},
-    },
-    { .id = 0xc22535,                       /* macronix */
-      .cmda = 0xa8a500eb,
-      .cmdb = 0x66,
-      .qe = {1, {0x40}},
-    },
-};
 
 static void qspi_qe_enable(const struct hal_flash *dev, const struct qspi_qe_config *config)
 {
@@ -462,7 +437,7 @@ static const struct qspi_flash_config *qspi_read_rdid(const struct hal_flash *de
     result |= da1469x_qspi_read8(dev);
     QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
 
-    for (i = 0; i < ARRAY_SIZE(rdids); i++) {
+    for (i = 0; i < qspi_flash_config_array_size; i++) {
         if (result == rdids[i].id) {
             return &rdids[i];
         }

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -24,6 +24,7 @@
 #include "mcu/da1469x_hal.h"
 #include "hal/hal_flash_int.h"
 #include "mcu/mcu.h"
+#include <os/util.h>
 #include <stdbool.h>
 
 #define CODE_QSPI_INLINE    __attribute__((always_inline)) inline
@@ -395,27 +396,113 @@ da1469x_hff_sector_info(const struct hal_flash *dev, int idx,
     return 0;
 }
 
-#if MYNEWT_VAL(MCU_QSPIC_APP_CFG)
+#if MYNEWT_VAL(RAM_RESIDENT)
+struct qspi_qe_config {
+    uint8_t length;
+    uint8_t bytes[2];
+};
+
+struct qspi_flash_config {
+    uint32_t id;
+    uint32_t cmda;
+    uint32_t cmdb;
+    struct qspi_qe_config qe;
+};
+
+static const struct qspi_flash_config rdids[] =
+{
+    { .id = 0xc86015,                       /* gigaflash */
+      .cmda = 0xa82000eb,
+      .cmdb = 0x66,
+      .qe = {2, {0x0, 0x2}},
+    },
+    { .id = 0xc22535,                       /* macronix */
+      .cmda = 0xa8a500eb,
+      .cmdb = 0x66,
+      .qe = {1, {0x40}},
+    },
+};
+
+static void qspi_qe_enable(const struct hal_flash *dev, const struct qspi_qe_config *config)
+{
+    int i;
+
+    /*
+     * Write some number of bytes to the status register of the QSPI device.
+     * Targeting QE enable bit
+     */
+
+    da1469x_qspi_mode_manual(dev);
+    da1469x_qspi_wait_busy(dev);
+    da1469x_qspi_cmd_enable_write(dev);
+
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
+
+    /* Write status register command 0x1 */
+    da1469x_qspi_write8(dev, 0x01);
+
+    /* data to write out to register */
+    for (i = 0; i < config->length; i++) {
+        da1469x_qspi_write8(dev, config->bytes[i]);
+    }
+
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
+}
+
+static const struct qspi_flash_config *qspi_read_rdid(const struct hal_flash *dev)
+{
+    int i;
+    uint32_t result;
+
+    /* Issue a read rdid command (0x9F) and get 24 bit response */
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
+    da1469x_qspi_write8(dev, 0x9f);
+    result = da1469x_qspi_read8(dev) << 16;
+    result |= da1469x_qspi_read8(dev) << 8;
+    result |= da1469x_qspi_read8(dev);
+    QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_DIS_CS_Msk;
+
+    for (i = 0; i < ARRAY_SIZE(rdids); i++) {
+        if (result == rdids[i].id) {
+            return &rdids[i];
+        }
+    }
+
+    return NULL;
+}
+
 static sec_text_ram_core void
 da1469x_hff_mcu_custom_init(const struct hal_flash *dev)
 {
+    const struct qspi_flash_config *config = NULL;
     uint32_t primask;
-    uint32_t ctrlmode_reg = QSPIC->QSPIC_CTRLMODE_REG;
+
     __HAL_DISABLE_INTERRUPTS(primask);
     da1469x_qspi_mode_manual(dev);
-#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDA_INIT_VAL)
-    QSPIC->QSPIC_BURSTCMDA_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDA_INIT_VAL);
-#endif
-#if defined (MYNEWT_VAL_MCU_QSPIC_BURSTCMDB_INIT_VAL)
-    QSPIC->QSPIC_BURSTCMDB_REG = MYNEWT_VAL(MCU_QSPIC_BURSTCMDB_INIT_VAL);
-#endif
-#if defined (MYNEWT_VAL_MCU_QSPIC_CTRLMODE_INIT_VAL)
-    QSPIC->QSPIC_CTRLMODE_REG = MYNEWT_VAL(MCU_QSPIC_CTRLMODE_INIT_VAL);
-#endif
-    if (ctrlmode_reg & QSPIC_QSPIC_CTRLMODE_REG_QSPIC_AUTO_MD_Msk) {
-        /* restore auto mode */
-        da1469x_qspi_mode_auto(dev);
-    }
+
+    /* detect flash device and use correct configuration */
+    config = qspi_read_rdid(dev);
+    assert(config);
+
+    QSPIC->QSPIC_BURSTCMDA_REG = config->cmda;
+    QSPIC->QSPIC_BURSTCMDB_REG = config->cmdb;
+
+    /* provision attached QSPI device for proper quad operation */
+    qspi_qe_enable(dev, &config->qe);
+
+    /*
+     * Set auto mode, read pipe delay to 0x7, read pipe enable
+     * negative edge on received data, and IO2/3 output level 1
+     * and disable IO2/3 output enable
+     */
+    QSPIC->QSPIC_CTRLMODE_REG = QSPIC_QSPIC_CTRLMODE_REG_QSPIC_AUTO_MD_Msk |
+                                QSPIC_QSPIC_CTRLMODE_REG_QSPIC_CLK_MD_Msk |
+                                QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO2_DAT_Msk |
+                                QSPIC_QSPIC_CTRLMODE_REG_QSPIC_IO3_DAT_Msk |
+                                QSPIC_QSPIC_CTRLMODE_REG_QSPIC_RXD_NEG_Msk |
+                                QSPIC_QSPIC_CTRLMODE_REG_QSPIC_RPIPE_EN_Msk |
+                                (0x7 << QSPIC_QSPIC_CTRLMODE_REG_QSPIC_PCLK_MD_Pos);
+
     __HAL_ENABLE_INTERRUPTS(primask);
 }
 #endif
@@ -423,7 +510,7 @@ da1469x_hff_mcu_custom_init(const struct hal_flash *dev)
 static int
     da1469x_hff_init(const struct hal_flash *dev)
 {
-#if MYNEWT_VAL(MCU_QSPIC_APP_CFG)
+#if MYNEWT_VAL(RAM_RESIDENT)
     da1469x_hff_mcu_custom_init(dev);
 #endif
     return 0;

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -24,7 +24,6 @@
 #include "mcu/da1469x_hal.h"
 #include "hal/hal_flash_int.h"
 #include "mcu/mcu.h"
-#include <os/util.h>
 #include <stdbool.h>
 
 #define CODE_QSPI_INLINE    __attribute__((always_inline)) inline

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -173,30 +173,6 @@ syscfg.defs:
             data before writing, i.e. each such transfer will be split into
             chunks of this size. Buffer is created on stack.
         value: 128
-    MCU_QSPIC_APP_CFG:
-        description: >
-            Enable application initialization of QSPIC settings. Syscfg values that
-            are defined for QSPIC_BURSTCMDA_REG, QSPIC_BURSTCMDB_REG or
-            QSPIC_CTRLMODE_REG will be applied by hal_flash_init.
-        value: 0
-    MCU_QSPIC_BURSTCMDA_INIT_VAL:
-        description: >
-            MCU initialization value for QSPIC_BURSTCMDA_REG
-        value: ''
-        restrictions:
-        - (MCU_QSPIC_APP_CFG)
-    MCU_QSPIC_BURSTCMDB_INIT_VAL:
-        description: >
-            MCU initialization value for QSPIC_BURSTCMDB_REG
-        value: ''
-        restrictions:
-        - (MCU_QSPIC_APP_CFG)
-    MCU_QSPIC_CTRLMODE_INIT_VAL:
-        description: >
-            MCU initialization value for QSPIC_CTRLMODE_REG
-        value: ''
-        restrictions:
-        - (MCU_QSPIC_APP_CFG)
     MCU_DEEP_SLEEP_QSPIC_QUAD_DISABLE:
         description: >
             Enable disabling quad mode when entering deep sleep


### PR DESCRIPTION
This patch adds in auto-detection and configuration of Gigadevice and Macronix
flash devices based on the manufacturer and device ID.  The intent in this is to
allow for a single binary to work on devices with different flash.

Normally, the flash is initialized by the ROM bootloader on the device.  However, if the image being loaded is RAM_RESIDENT, that header will not exist and the ROM bootloader will not provision the device to have a working flash configuration.

Signed-off-by: Andy Gross <andy.gross@juul.com>