### PR TITLE
tinyusb/stm32wb55: Fix MCU type

### DIFF
--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/include/tusb_hw.h
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/include/tusb_hw.h
@@ -20,7 +20,7 @@
 #ifndef __TUSB_HW_H__
 #define __TUSB_HW_H__
 
-#define CFG_TUSB_MCU OPT_MCU_STM32WB55
+#define CFG_TUSB_MCU OPT_MCU_STM32WB
 
 #include <syscfg/syscfg.h>
 


### PR DESCRIPTION
CFG_TUSB_MCU should be set to OPT_MCU_STM32WB.
OPT_TUSB_STM32SB55 was originally proposed in TinyUSB pull request
but it was changed to version without 55