### PR TITLE
bsp/p-nucleo-wb55-dongle: Update BUTTON_1 in bootloader

### DIFF
--- a/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
@@ -91,10 +91,10 @@ hal_bsp_core_dump(int *area_cnt)
     return dump_cfg;
 }
 
+#if MYNEWT_VAL(BUTTON_1_AS_STM32_DFU)
 void
 boot_preboot(void)
 {
-#if MYNEWT_VAL(BUTTON_1_AS_STM32_DFU) >= 0
     hal_gpio_init_in(BUTTON_1, HAL_GPIO_PULL_UP);
     os_cputime_delay_usecs(100);
     if (hal_gpio_read(BUTTON_1) == 0) {
@@ -102,8 +102,8 @@ boot_preboot(void)
         stm32_start_bootloader();
     }
     hal_gpio_deinit(BUTTON_1);
-#endif
 }
+#endif
 
 static void
 dongle_soft_reset(void *arg)


### PR DESCRIPTION
When BUTTON_1_AS_STM32_DFU is set (that should be used only in bootloaer)
hal_bsp redirect execution to STM32 DFU bootloader to allow writing
bootloader or application.
Function boot_preboot was defined always even if functionality was not enabled.
This prevented alternative boot_preboot() functionality that can be provided
by other package.
Now hal_bsp.c only provides boot_preboot() when BUTTON_1_AS_STM32_DFU is set.