### PR TITLE
tinyusb/cdc: Add fifo size configuration option

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -85,9 +85,17 @@ extern "C" {
 /* Minimal number for alternative interfaces that is recognized by Windows as Bluetooth radio controller */
 #define CFG_TUD_BTH_ISO_ALT_COUNT 2
 
-/*  CDC FIFO size of TX and RX */
+#if MYNEWT_VAL(USBD_CDC_RX_BUFSIZE)
+#define CFG_TUD_CDC_RX_BUFSIZE   MYNEWT_VAL(USBD_CDC_RX_BUFSIZE)
+#else
 #define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
+
+#if MYNEWT_VAL(USBD_CDC_TX_BUFSIZE)
+#define CFG_TUD_CDC_TX_BUFSIZE   MYNEWT_VAL(USBD_CDC_TX_BUFSIZE)
+#else
 #define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
 
 /* HID buffer size Should be sufficient to hold ID (if any) + Data */
 #define CFG_TUD_HID_BUFSIZE      16

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -91,7 +91,7 @@ syscfg.defs:
         description: CDC data out endpoint number
         value:
     USBD_CDC_DATA_IN_EP:
-        description: CDC data out endpoint number
+        description: CDC data in endpoint number
         value:
     USBD_CDC_DATA_EP_SIZE:
         description: CDC data endpoint size
@@ -101,6 +101,12 @@ syscfg.defs:
         value:
     USBD_CDC_NOTIFY_EP_SIZE:
         description: CDC notify endpoint size
+        value:
+    USBD_CDC_RX_BUFSIZE:
+        description: CDC endpoint OUT FIFO size
+        value:
+    USBD_CDC_TX_BUFSIZE:
+        description: CDC endpoint IN FIFO size
         value:
 
     USBD_CDC_DESCRIPTOR_STRING:


### PR DESCRIPTION
So far CDC RX/TX fifo size was matching endpoint size.
Now it is possible to specify those in syscfg.yml.
This can improve console logging.
Default FIFO sizes remain unchanged.