### PR TITLE
tinyusb: USB function enable rework

### DIFF
--- a/hw/usb/tinyusb/cdc_console/syscfg.yml
+++ b/hw/usb/tinyusb/cdc_console/syscfg.yml
@@ -23,6 +23,7 @@ syscfg.defs:
         value: '"Mynewt console"'
 
 syscfg.vals:
+    USBD_CDC: 1
 
 syscfg.restrictions:
     - "USBD_CDC"

--- a/hw/usb/tinyusb/dfu/syscfg.yml
+++ b/hw/usb/tinyusb/dfu/syscfg.yml
@@ -101,6 +101,9 @@ syscfg.defs:
         description: 'Minimum level for the DFU log.'
         value: 1
 
+syscfg.vals:
+    USBD_DFU: 1
+
 syscfg.logs:
     USBD_DFU_LOG:
         module: MYNEWT_VAL(USBD_DFU_LOG_MODULE)

--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -72,15 +72,35 @@ extern "C" {
 #define CFG_TUD_ENDPOINT0_SIZE   MYNEWT_VAL(USBD_EP0_SIZE)
 
 /* ------------- CLASS ------------- */
+#if MYNEWT_VAL(USBD_CDC)
 #define CFG_TUD_CDC              MYNEWT_VAL(USBD_CDC)
+#else
+#define CFG_TUD_CDC              0
+#endif
+#if MYNEWT_VAL(USBD_HID)
 #define CFG_TUD_HID              MYNEWT_VAL(USBD_HID)
+#else
+#define CFG_TUD_HID              0
+#endif
+#if MYNEWT_VAL(USBD_MSC)
+#define CFG_TUD_MSC              MYNEWT_VAL(USBD_MSC)
+#else
 #define CFG_TUD_MSC              0
+#endif
 #define CFG_TUD_MIDI             0
 #define CFG_TUD_VENDOR           0
 #define CFG_TUD_USBTMC           0
 #define CFG_TUD_DFU_RT           0
+#if MYNEWT_VAL(USBD_DFU)
 #define CFG_TUD_DFU              MYNEWT_VAL(USBD_DFU)
+#else
+#define CFG_TUD_DFU              0
+#endif
+#if MYNEWT_VAL(USBD_BTH)
 #define CFG_TUD_BTH              MYNEWT_VAL(USBD_BTH)
+#else
+#define CFG_TUD_BTH              0
+#endif
 
 /* Minimal number for alternative interfaces that is recognized by Windows as Bluetooth radio controller */
 #define CFG_TUD_BTH_ISO_ALT_COUNT 2

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -62,24 +62,24 @@ syscfg.defs:
         description: Device friendly name
         value: '"Dev device"'
     USBD_CDC:
-        description: Enable CDC device
-        value: 0
+        description: Enable CDC device function in TinyUSB stack.
+        value:
     USBD_HID:
-        description: Enable HID device
-        value: 0
+        description: Enable HID device function in TinyUSB stack.
+        value:
     USBD_MSC:
-        description: Enable MSC device
-        value: 0
+        description: Enable MSC device function in TinyUSB stack.
+        value:
     USBD_BTH:
-        description: Enable BT HCI device
-        value: 0
+        description: Enable BT HCI device function in TinyUSB stack.
+        value:
     USBD_DFU:
         description: >
             Enable DFU interface in TinyUSB.  This adds USB descriptor to
             USB configuration.  It does not add TinyUSB callbacks implementation,
             if standard implementation exposing SLOT1 is required USB_DFU_STD can
             be additionally specified.
-        value: 0
+        value:
     USBD_DFU_STD:
         description: >
             Add Mynewt standard DFU interface implementation.


### PR DESCRIPTION
USB function in TinyUSB stack is enabled by one of the following
definitions: CFG_TUD_CDC, CFG_TUD_HID, CFG_TUD_MSC, CFG_TUD_MIDI,
CFG_TUD_MSC, CFG_TUD_VENDOR, CFG_TUD_USBTMC, CFG_TUD_DFU_RT, CFG_TUD_DFU,
USBD_BTH need to be set to non-zero value.

So far some of those could be set in syscfg (definition were provided
in std_descriptors package). Following syscfg values were there:
USBD_HID, USBD_CDC, USBD_MSC, USBD_DFU, UDBD_BTH.

In order to enable standard functionality two things had to be set.
For example to have USB console one had to include hw/usb/tinyusb/cdc_console
(this could be done by settings CONSOLE_USB: 1) and separate settings in
target or application was needed USBD_CDC: 1.
For BT one had to set BLE_TRANSPORT_HS: usb and USBD_BTH: 1.

Now that any package can overwrite setting that is defined but no set
it is possible to for package that implements some USB functionality
to enabled it in TinyUSB stack.

This change leaves all previously defined USBD_xxx: values to not defined
and packages can just enabled it when they are included.

There is no need to have USBD_CDC: 1 when CONSOLE_USB: 1 is present.
For BTH separate commit will go to nimble repository.