### PR TITLE
Mbedtls GCM refresh

### DIFF
--- a/crypto/mbedtls/include/mbedtls/gcm.h
+++ b/crypto/mbedtls/include/mbedtls/gcm.h
@@ -285,6 +285,30 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
 
 /**
  * \brief           This function feeds an input buffer into an ongoing GCM
+ *                  encryption or decryption operation as additional data.
+ *                  This needs to be called before starting enc/dec
+ *                  operations.
+ *
+ *    `             The function expects input to be a multiple of 16
+ *                  Bytes. Only the last call before mbedtls_gcm_update() or
+ *                  mbedtls_gcm_finish() can be less than 16 Bytes.
+ *
+ *
+ * \param ctx       The GCM context.
+ * \param length    The length of the input data. This must be a multiple of
+ *                  16 except in the last call before mbedtls_gcm_finish().
+ * \param input     The buffer holding the input ADD.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_GCM_BAD_INPUT on failure.
+ */
+int mbedtls_gcm_update_add( mbedtls_gcm_context *ctx,
+                size_t length,
+                const unsigned char *input );
+
+
+/**
+ * \brief           This function feeds an input buffer into an ongoing GCM
  *                  encryption or decryption operation.
  *
  *    `             The function expects input to be a multiple of 16

--- a/crypto/mbedtls/include/mbedtls/gcm.h
+++ b/crypto/mbedtls/include/mbedtls/gcm.h
@@ -145,6 +145,14 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
                         unsigned int keybits );
 
 /**
+ * Same as above, but with preallocated memory for cipher algorithm context
+ */
+int mbedtls_gcm_setkey_noalloc( mbedtls_gcm_context *ctx,
+                                const mbedtls_cipher_info_t *cipher_info,
+                                const unsigned char *key,
+                                void *cipher_ctx);
+
+/**
  * \brief           This function performs GCM encryption or decryption of a buffer.
  *
  * \note            For encryption, the output buffer can be the same as the

--- a/crypto/mbedtls/src/gcm.c
+++ b/crypto/mbedtls/src/gcm.c
@@ -417,15 +417,31 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
         return( ret );
     }
 
-    ctx->add_len = add_len;
+    return mbedtls_gcm_update_add( ctx, add_len, add );
+}
+
+int mbedtls_gcm_update_add( mbedtls_gcm_context *ctx,
+                size_t add_len,
+                const unsigned char *add )
+{
+    const unsigned char *p;
+    size_t i;
+    size_t use_len;
+
+    if ( ctx->add_len & 15 )
+    {
+        return( MBEDTLS_ERR_GCM_BAD_INPUT );
+    }
+    ctx->add_len += add_len;
     p = add;
-    while( add_len > 0 )
+
+    while (add_len > 0)
     {
         use_len = ( add_len < 16 ) ? add_len : 16;
 
-        for( i = 0; i < use_len; i++ )
+        for( i = 0; i < use_len; i++ ) {
             ctx->buf[i] ^= p[i];
-
+        }
         gcm_mult( ctx, ctx->buf, ctx->buf );
 
         add_len -= use_len;


### PR DESCRIPTION
This set of changes adds back in a couple of GCM functions that we had been using but which were recently dropped during the mbedtls update.

Specifically these are the mbedtls_gcm_setkey_noalloc() and mbedtls_gcm_update_add() APIs.