### PR TITLE
mempool: Fix check for duplicate free

### DIFF
--- a/kernel/os/src/os_mempool.c
+++ b/kernel/os/src/os_mempool.c
@@ -401,6 +401,7 @@ os_memblock_put(struct os_mempool *mp, void *block_addr)
     os_error_t ret;
 #if MYNEWT_VAL(OS_MEMPOOL_CHECK)
     struct os_memblock *block;
+    int sr;
 #endif
 
     os_trace_api_u32x2(OS_TRACE_ID_MEMBLOCK_PUT, (uint32_t)mp,
@@ -419,9 +420,12 @@ os_memblock_put(struct os_mempool *mp, void *block_addr)
     /*
      * Check for duplicate free.
      */
+    OS_ENTER_CRITICAL(sr);
     SLIST_FOREACH(block, mp, mb_next) {
         assert(block != (struct os_memblock *)block_addr);
     }
+    OS_EXIT_CRITICAL(sr);
+
 #endif
     /* If this is an extended mempool with a put callback, call the callback
      * instead of freeing the block directly.


### PR DESCRIPTION
When OS_MEMPOOL_CHECK was set to 1, code tried to
verify that block is not already in free list.
If during iteration over free list, memory block
was taken from the pool (from interrupt or higher
priority task) and already filled with data
mb_next could point to anything resulting in
MPU or hard fault exception.

Now critical section is added to prevent list
modification during check.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>