### PR TITLE
nrf5340: avoid have 2 interrupts for each IPC message

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -21,6 +21,7 @@
 #define _HW_DRIVERS_IPC_NRF5340_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,6 +70,21 @@ void ipc_nrf5340_recv(int channel, ipc_nrf5340_recv_cb cb, void *user_data);
  * @return            0 on success and negative error on failure
  */
 int ipc_nrf5340_send(int channel, const void *data, uint16_t len);
+
+/**
+ * Sends data over specified IPC channel. IPC uses ring buffer for data passing.
+ * If IPC_NRF5340_BLOCKING_WRITE is not enable and there is not enough space to
+ * store data SYS_ENOMEM error is returned.
+ *
+ * @param channel     IPC channel number to send on
+ * @param data        Data to be sent over IPC. If this is NULL only signal is
+ *                    sent
+ * @param len         Data length
+ * @param last        If this is the last send, so other side can be notified
+ *
+ * @return            0 on success and negative error on failure
+ */
+int ipc_nrf5340_write(int channel, const void *data, uint16_t len, bool last);
 
 /**
  * Reads data from IPC ring buffer to specified flat buffer. Should be used only

--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -392,6 +392,12 @@ ipc_nrf5340_recv(int channel, ipc_nrf5340_recv_cb cb, void *user_data)
 int
 ipc_nrf5340_send(int channel, const void *data, uint16_t len)
 {
+    return ipc_nrf5340_write(channel, data, len, true);
+}
+
+int
+ipc_nrf5340_write(int channel, const void *data, uint16_t len, bool last)
+{
     struct ipc_shm *shm;
     uint16_t frag_len;
     uint16_t space;
@@ -417,7 +423,9 @@ ipc_nrf5340_send(int channel, const void *data, uint16_t len)
 
             frag_len = min(len, space);
             ipc_nrf5340_shm_write(shm, data, frag_len);
-            NRF_IPC->TASKS_SEND[channel] = 1;
+            if (last || len > space) {
+                NRF_IPC->TASKS_SEND[channel] = 1;
+            }
 
             data += frag_len;
             len -= frag_len;


### PR DESCRIPTION
The Nimble IPC messages are written in 2 parts: the cmd byte and the rest.
It is unneccesary to already interrupt the other core for the first byte,
since it will be interrupted by the 2nd write already.
(a 2nd patch to Nimble will use this new function)