### PR TITLE
tinyusb: include bsp.h in FAT View

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <os/endian.h>
+#include <bsp/bsp.h>
 #include <sysflash/sysflash.h>
 #include <hal/hal_gpio.h>
 #include <os/util.h>


### PR DESCRIPTION
With this inclusion it is possible to use pin
defined in bsp.h (i.e. BUTTON_1) as pin for enabling
MSC FAT View in bootloader.