### PR TITLE
da1469x: Specify custom location of da1469x_flash_loader

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/syscfg.yml
@@ -51,6 +51,12 @@ syscfg.defs:
             - 331_O7_B
             - 331_O7_C
 
+    FLASH_LOADER_TARGET:
+        description: >
+            Flash loader target name. Used when da1469x bootloader is placed
+            in other folder than /targets.
+        value: 'targets/da1469x_flash_loader'
+
 syscfg.defs.BUS_DRIVER_PRESENT:
     BSP_FLASH_SPI_NAME:
         description: 'SPIFLASH device name'

--- a/hw/mcu/dialog/da1469x/scripts/dialog_da1469x-download_jlink.sh
+++ b/hw/mcu/dialog/da1469x/scripts/dialog_da1469x-download_jlink.sh
@@ -47,8 +47,8 @@ JLINK_LOG_FILE=.jlink_log
 
 # flash_loader build for this BSP
 if [ -z $FLASH_LOADER ]; then
-    FL_TGT=da1469x_flash_loader
-    FLASH_LOADER=$BIN_ROOT/targets/$FL_TGT/app/@apache-mynewt-core/apps/flash_loader/flash_loader.elf
+    FL_TGT=${MYNEWT_VAL_FLASH_LOADER_TARGET}
+    FLASH_LOADER=$BIN_ROOT/$FL_TGT/app/@apache-mynewt-core/apps/flash_loader/flash_loader.elf
 fi
 if [ ! -f $FLASH_LOADER ]; then
     FILE=${FLASH_LOADER##$(pwd)/}


### PR DESCRIPTION
User may now use the mynewt value FLASH_LOADER_TARGET in bootloader target
to specify the da1469x_flash_loader target location.