### PR TITLE
mcu/nrf5340: Increase interrupt stack size

### DIFF
--- a/hw/mcu/nordic/nrf5340/startup/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/startup/syscfg.yml
@@ -22,7 +22,7 @@ syscfg.defs:
             Stack size (in bytes) to use in startup code.
             For bootloader it's main stack, for application this stack is used by interrupts
             and exceptions.
-        value: 512
+        value: 768
 
 syscfg.vals.BOOT_LOADER:
     # MCUboot code uses a lot of stack

--- a/hw/mcu/nordic/nrf5340_net/startup/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/startup/syscfg.yml
@@ -22,7 +22,7 @@ syscfg.defs:
             Stack size (in bytes) to use in startup code.
             For bootloader it's main stack, for application this stack is used by interrupts
             and exceptions.
-        value: 512
+        value: 768
 
 syscfg.vals.BOOT_LOADER:
     # MCUboot code uses a lot of stack


### PR DESCRIPTION
512 bytes seems to be insufficient for interrupt stack.
Stack increased to 768 bytes.