### PR TITLE
tinyusb/msc_fat_view: Fix missing else in pre-processor

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
@@ -107,8 +107,11 @@ typedef uint32_t cluster_t;
 #endif
 #elif (MYNEWT_VAL(MSC_FAT_VIEW_DISK_SIZE) * 1024) < 2000000
 #error No space for huge file, increase MSC_FAT_VIEW_DISK_SIZE in syscfg
-#endif
+#else
 #define HUGE_FILE_SIZE          ((MYNEWT_VAL(MSC_FAT_VIEW_DISK_SIZE) * 1024) - 2000000)
+#endif
+#else
+#define HUGE_FILE_SIZE          0
 #endif
 
 struct TU_ATTR_PACKED boot_sector_start {


### PR DESCRIPTION
HUGE_FILE_SIZE could be re-defined due to missing else