### PR TITLE
nrf5340: Remove misleading comment

### DIFF
--- a/hw/mcu/nordic/nrf5340/nrf5340.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340.ld
@@ -165,13 +165,7 @@ SECTIONS
         __data_end__ = .;
     } > RAM AT > FLASH
 
-    /* Non-zeroed BSS.  This section is similar to BSS, with the following two
-     * caveats:
-     *    1. It does not get zeroed at init-time.
-     *    2. You cannot use it as source memory for EasyDMA.
-     *
-     * This section exists because of a hardware defect; see errata 33 and 34
-     * in nrf52 errata sheet.
+    /* Non-zeroed BSS.  This section is similar to BSS, but does not get zeroed at init-time.
      */
     .bssnz :
     {

--- a/hw/mcu/nordic/nrf5340/nrf5340_ram_resident.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340_ram_resident.ld
@@ -138,13 +138,7 @@ SECTIONS
         __data_end__ = .;
     } > RAM
 
-    /* Non-zeroed BSS.  This section is similar to BSS, with the following two
-     * caveats:
-     *    1. It does not get zeroed at init-time.
-     *    2. You cannot use it as source memory for EasyDMA.
-     *
-     * This section exists because of a hardware defect; see errata 33 and 34
-     * in nrf52 errata sheet.
+    /* Non-zeroed BSS.  This section is similar to BSS, but does not get zeroed at init-time.
      */
     .bssnz :
     {


### PR DESCRIPTION
Comment about erratas 33, 34 was valid only for first drop of NRF52832.
For NRF5340 erratas with those numbers exists but are not applicable here.
