### PR TITLE
sensors/lsm6dsl: add tilt function

### DIFF
--- a/hw/drivers/sensors/lsm6dsl/include/lsm6dsl/lsm6dsl.h
+++ b/hw/drivers/sensors/lsm6dsl/include/lsm6dsl/lsm6dsl.h
@@ -120,10 +120,10 @@ struct lsm6dsl_tilt_settings {
 
 struct lsm6dsl_tap_settings {
     /* Axis enabled bitmask */
-    uint8_t en_x: 1;
-    uint8_t en_y: 1;
-    uint8_t en_z: 1;
-    uint8_t en_dtap: 1;
+    uint8_t en_x : 1;
+    uint8_t en_y : 1;
+    uint8_t en_z : 1;
+    uint8_t en_dtap : 1;
 
     /* Threshold for tap recognition */
     int8_t tap_ths;

--- a/hw/drivers/sensors/lsm6dsl/include/lsm6dsl/lsm6dsl.h
+++ b/hw/drivers/sensors/lsm6dsl/include/lsm6dsl/lsm6dsl.h
@@ -107,6 +107,17 @@ struct lsm6dsl_ff_settings {
     free_fall_threshold_t free_fall_ths;
 };
 
+struct lsm6dsl_tilt_settings {
+    uint8_t en_rel_tilt;
+    uint8_t en_wrist_tilt;
+    /* Timer for latency. 1LSB = 40ms */
+    uint8_t tilt_lat;
+    /* Threshold for Tilt function 1LSB = 15.626 mg*/
+    uint8_t tilt_ths;
+    /* A_WRIST_TILT_Mask reg (z pos and neg)*/
+    uint8_t tilt_axis_mask;
+};
+
 struct lsm6dsl_tap_settings {
     /* Axis enabled bitmask */
     uint8_t en_x: 1;
@@ -165,6 +176,9 @@ struct int_src_regs {
     uint8_t tap_src;
     uint8_t d6d_src;
     uint8_t status_reg;
+    uint8_t func_src1;
+    uint8_t func_src2;
+    uint8_t wrist_tilt_ia;
 };
 
 struct lsm6dsl_cfg {
@@ -177,6 +191,7 @@ struct lsm6dsl_cfg {
     struct lsm6dsl_orientation_settings orientation;
     struct lsm6dsl_wk_settings wk;
     struct lsm6dsl_ff_settings ff;
+    struct lsm6dsl_tilt_settings tilt;
 
     /* Event notification config */
     struct lsm6dsl_notif_cfg *notify_cfg;

--- a/hw/drivers/sensors/lsm6dsl/src/lsm6dsl.c
+++ b/hw/drivers/sensors/lsm6dsl/src/lsm6dsl.c
@@ -1028,7 +1028,7 @@ lsm6dsl_get_wake_up(struct lsm6dsl *lsm6dsl, struct lsm6dsl_wk_settings *wk)
 
 int
 lsm6dsl_set_tilt(struct lsm6dsl *lsm6dsl,
-                        const struct lsm6dsl_tilt_settings *cfg)
+                 const struct lsm6dsl_tilt_settings *cfg)
 {
     int rc;
     uint8_t en_mask;
@@ -1041,7 +1041,8 @@ lsm6dsl_set_tilt(struct lsm6dsl *lsm6dsl,
             return rc;
         }
         if (cfg->en_wrist_tilt) {
-            rc = lsm6dsl_write_reg(lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, LSM6DSL_FUNC_CFG_ACCESS_MASK | LSM6DSL_SHUB_REG_ACCESS_MASK);
+            rc = lsm6dsl_write_reg(lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG,
+                                   LSM6DSL_FUNC_CFG_ACCESS_MASK | LSM6DSL_SHUB_REG_ACCESS_MASK);
             if (rc) {
                 return rc;
             }
@@ -2213,35 +2214,35 @@ lsm6dsl_inc_notif_stats(sensor_event_type_t event)
 {
 #if MYNEWT_VAL(LSM6DSL_NOTIF_STATS)
     switch (event) {
-        case SENSOR_EVENT_TYPE_SINGLE_TAP:
-            STATS_INC(g_lsm6dsl_stats, single_tap_notify);
-            break;
-        case SENSOR_EVENT_TYPE_DOUBLE_TAP:
-            STATS_INC(g_lsm6dsl_stats, double_tap_notify);
-            break;
-        case SENSOR_EVENT_TYPE_ORIENT_CHANGE:
-            STATS_INC(g_lsm6dsl_stats, orientation_notify);
-            break;
-        case SENSOR_EVENT_TYPE_SLEEP:
-            STATS_INC(g_lsm6dsl_stats, sleep_notify);
-            break;
-        case SENSOR_EVENT_TYPE_WAKEUP:
-            STATS_INC(g_lsm6dsl_stats, wakeup_notify);
-            break;
-        case SENSOR_EVENT_TYPE_FREE_FALL:
-            STATS_INC(g_lsm6dsl_stats, free_fall_notify);
-            break;
-        case SENSOR_EVENT_TYPE_TILT_CHANGE:
-            STATS_INC(g_lsm6dsl_stats, rel_tilt_notify);
-            break;
-        case SENSOR_EVENT_TYPE_TILT_POS:
-            STATS_INC(g_lsm6dsl_stats, abs_tilt_pos_notify);
-            break;
-        case SENSOR_EVENT_TYPE_TILT_NEG:
-            STATS_INC(g_lsm6dsl_stats, abs_tilt_neg_notify);
-            break;
-        default:
-            break;
+    case SENSOR_EVENT_TYPE_SINGLE_TAP:
+        STATS_INC(g_lsm6dsl_stats, single_tap_notify);
+        break;
+    case SENSOR_EVENT_TYPE_DOUBLE_TAP:
+        STATS_INC(g_lsm6dsl_stats, double_tap_notify);
+        break;
+    case SENSOR_EVENT_TYPE_ORIENT_CHANGE:
+        STATS_INC(g_lsm6dsl_stats, orientation_notify);
+        break;
+    case SENSOR_EVENT_TYPE_SLEEP:
+        STATS_INC(g_lsm6dsl_stats, sleep_notify);
+        break;
+    case SENSOR_EVENT_TYPE_WAKEUP:
+        STATS_INC(g_lsm6dsl_stats, wakeup_notify);
+        break;
+    case SENSOR_EVENT_TYPE_FREE_FALL:
+        STATS_INC(g_lsm6dsl_stats, free_fall_notify);
+        break;
+    case SENSOR_EVENT_TYPE_TILT_CHANGE:
+        STATS_INC(g_lsm6dsl_stats, rel_tilt_notify);
+        break;
+    case SENSOR_EVENT_TYPE_TILT_POS:
+        STATS_INC(g_lsm6dsl_stats, abs_tilt_pos_notify);
+        break;
+    case SENSOR_EVENT_TYPE_TILT_NEG:
+        STATS_INC(g_lsm6dsl_stats, abs_tilt_neg_notify);
+        break;
+    default:
+        break;
     }
 #endif /* LSM6DSL_NOTIF_STATS */
 }

--- a/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_priv.h
+++ b/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_priv.h
@@ -37,7 +37,7 @@ extern "C" {
 #define LSM6DSL_FUNC_CFG_ACCESS_REG     0x01
 
 #define LSM6DSL_FUNC_CFG_ACCESS_MASK    0x80
-#define LSM6DSL_SHUB_REG_ACCESS_MASK    0x40
+#define LSM6DSL_SHUB_REG_ACCESS_MASK    0x20
 
 /*
  * FIFO control register 1
@@ -650,6 +650,25 @@ extern "C" {
 #define LSM6DSL_SENSORHUB17_REG         0x51
 #define LSM6DSL_SENSORHUB18_REG         0x52
 
+/*
+ * FUNC_SRC1 register
+ */
+#define LSM6DSL_FUNC_SRC1_REG             0x53
+#define LSM6DSL_SENSORHUB_END_OP_MASK     0x01
+#define LSM6DSL_SI_END_OP_MASK            0x02
+#define LSM6DSL_HI_FAI_MASKL              0x04
+#define LSM6DSL_STEP_OVERFLOW_MASK        0x08
+#define LSM6DSL_STEP_DETECTED_MASK        0x10
+#define LSM6DSL_TILT_IA_MASK              0x20
+#define LSM6DSL_SIGN_MOTION_IA_MASK       0x40
+#define LSM6DSL_STEP_COUNT_DELTA_IA_MASK  0x80
+
+/*
+ * FUNC_SRC2 register
+ */
+#define LSM6DSL_FUNC_SRC2_REG             0x54
+#define LSM6DSL_WRIST_TILT_IA_MASK        0x01
+
 /* Bank A registers */
 #define LSM6DSL_SLV0_ADD_REG            0x02
 #define LSM6DSL_SLV0_SUBADD_REG         0x03
@@ -689,6 +708,14 @@ extern "C" {
 #define LSM6DSL_A_WRIST_TILT_LAT_REG    0x50
 #define LSM6DSL_A_WRIST_TILT_THS_REG    0x54
 #define LSM6DSL_A_WRIST_TILT_MASK_REG   0x59
+
+#define LSM6DSL_A_WRIST_TILT_IA_REG     0x55
+#define LSM6DSL_A_WRIST_TILT_XPOS_MASK  0x80
+#define LSM6DSL_A_WRIST_TILT_XNEG_MASK  0x40
+#define LSM6DSL_A_WRIST_TILT_YPOS_MASK  0x20
+#define LSM6DSL_A_WRIST_TILT_YNEG_MASK  0x10
+#define LSM6DSL_A_WRIST_TILT_ZPOS_MASK  0x08
+#define LSM6DSL_A_WRIST_TILT_ZNEG_MASK  0x04
 
 #define LSM6DSL_MAX_FIFO_DEPTH          2048
 

--- a/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_shell.c
+++ b/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_shell.c
@@ -80,6 +80,21 @@ static const reg_name_t reg_name[] = {
     { .addr = 0x5f, .regname = "MD2_CFG" },
 };
 
+/* Human readable register map for bankA */
+static const reg_name_t reg_name_banka[] = {
+    { .addr = 0x0f, .regname = "CONFIG_PEDO_THS_MIN" },
+    { .addr = 0x13, .regname = "SM_THS" },
+    { .addr = 0x14, .regname = "PEDO_DEB_REG" },
+    { .addr = 0x15, .regname = "STEP_COUNT_DELTA" },
+};
+
+/* Human readable register map for bankB */
+static const reg_name_t reg_name_bankb[] = {
+    { .addr = 0x50, .regname = "A_WRIST_TILT_LAT" },
+    { .addr = 0x54, .regname = "A_WRIST_TILT_THS" },
+    { .addr = 0x59, .regname = "A_WRIST_TILT_Mask" },
+};
+
 static struct shell_cmd lsm6dsl_shell_cmd_struct = {
     .sc_cmd = "lsm6dsl",
     .sc_cmd_func = lsm6dsl_shell_cmd
@@ -171,6 +186,44 @@ lsm6dsl_shell_cmd_dump(int argc, char **argv)
                 console_printf("%-22s(0x%02X) = 0x%02X\n",
                                reg_name[i].regname, reg_name[i].addr, value);
             }
+        }
+
+        /* Bank A */
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, LSM6DSL_FUNC_CFG_ACCESS_MASK);
+        if (rc) {
+            return rc;
+        }
+        for (i = 0; i < ARRAY_SIZE(reg_name_banka); i++) {
+            rc = lsm6dsl_read(g_lsm6dsl, reg_name_banka[i].addr, &value, 1);
+            if (rc) {
+                console_printf("dump failed %d\n", rc);
+            } else if (all || value != 0){
+                console_printf("%-22s(0x%02X) = 0x%02X\n",
+                               reg_name_banka[i].regname, reg_name_banka[i].addr, value);
+            }
+        }
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, 0);
+        if (rc) {
+            return rc;
+        }
+
+        /* Bank B */
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, LSM6DSL_FUNC_CFG_ACCESS_MASK | LSM6DSL_SHUB_REG_ACCESS_MASK);
+        if (rc) {
+            return rc;
+        }
+        for (i = 0; i < ARRAY_SIZE(reg_name_bankb); i++) {
+            rc = lsm6dsl_read(g_lsm6dsl, reg_name_bankb[i].addr, &value, 1);
+            if (rc) {
+                console_printf("dump failed %d\n", rc);
+            } else if (all || value != 0){
+                console_printf("%-22s(0x%02X) = 0x%02X\n",
+                               reg_name_bankb[i].regname, reg_name_bankb[i].addr, value);
+            }
+        }
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, 0);
+        if (rc) {
+            return rc;
         }
     } else {
         sreg = parse_ll_bounds(argv[2], 0x02, 0x7F, &rc);

--- a/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_shell.c
+++ b/hw/drivers/sensors/lsm6dsl/src/lsm6dsl_shell.c
@@ -182,14 +182,15 @@ lsm6dsl_shell_cmd_dump(int argc, char **argv)
             rc = lsm6dsl_read(g_lsm6dsl, reg_name[i].addr, &value, 1);
             if (rc) {
                 console_printf("dump failed %d\n", rc);
-            } else if (all || value != 0){
+            } else if (all || value != 0) {
                 console_printf("%-22s(0x%02X) = 0x%02X\n",
                                reg_name[i].regname, reg_name[i].addr, value);
             }
         }
 
         /* Bank A */
-        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, LSM6DSL_FUNC_CFG_ACCESS_MASK);
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG,
+                               LSM6DSL_FUNC_CFG_ACCESS_MASK);
         if (rc) {
             return rc;
         }
@@ -197,7 +198,7 @@ lsm6dsl_shell_cmd_dump(int argc, char **argv)
             rc = lsm6dsl_read(g_lsm6dsl, reg_name_banka[i].addr, &value, 1);
             if (rc) {
                 console_printf("dump failed %d\n", rc);
-            } else if (all || value != 0){
+            } else if (all || value != 0) {
                 console_printf("%-22s(0x%02X) = 0x%02X\n",
                                reg_name_banka[i].regname, reg_name_banka[i].addr, value);
             }
@@ -208,7 +209,8 @@ lsm6dsl_shell_cmd_dump(int argc, char **argv)
         }
 
         /* Bank B */
-        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG, LSM6DSL_FUNC_CFG_ACCESS_MASK | LSM6DSL_SHUB_REG_ACCESS_MASK);
+        rc = lsm6dsl_write_reg(g_lsm6dsl, LSM6DSL_FUNC_CFG_ACCESS_REG,
+                               LSM6DSL_FUNC_CFG_ACCESS_MASK | LSM6DSL_SHUB_REG_ACCESS_MASK);
         if (rc) {
             return rc;
         }
@@ -216,7 +218,7 @@ lsm6dsl_shell_cmd_dump(int argc, char **argv)
             rc = lsm6dsl_read(g_lsm6dsl, reg_name_bankb[i].addr, &value, 1);
             if (rc) {
                 console_printf("dump failed %d\n", rc);
-            } else if (all || value != 0){
+            } else if (all || value != 0) {
                 console_printf("%-22s(0x%02X) = 0x%02X\n",
                                reg_name_bankb[i].regname, reg_name_bankb[i].addr, value);
             }

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -140,6 +140,12 @@ typedef enum {
     SENSOR_EVENT_TYPE_ORIENT_Y_H_CHANGE  = (1 << 14),
     /* Orientation Change Event in the Z H direction */
     SENSOR_EVENT_TYPE_ORIENT_Z_H_CHANGE  = (1 << 15),
+    /* Relative tilt Change Event */
+    SENSOR_EVENT_TYPE_TILT_CHANGE        = (1 << 16),
+    /* Absolute tilt Change Event in the positive direction */
+    SENSOR_EVENT_TYPE_TILT_POS           = (1 << 17),
+    /* Absolute tilt Change Event in the negative direction */
+    SENSOR_EVENT_TYPE_TILT_NEG           = (1 << 18),
 } sensor_event_type_t;
 
 


### PR DESCRIPTION
Adding absolute and relative tilt functionality.
Extending lsm6dsl_shell dump to include bankA and bankB registers.
Fixed LSM6DSL_SHUB_REG_ACCESS_MASK bit mask.