### PR TITLE
mempool: Fix OS_MEMPOOL_SIZE when OS_MEMPOOL_GUARD is on

### DIFF
--- a/kernel/os/include/os/os_mempool.h
+++ b/kernel/os/include/os/os_mempool.h
@@ -176,7 +176,7 @@ typedef __uint128_t os_membuf_t;
 #else
 #error "Unhandled `OS_ALIGNMENT` for `os_membuf_t`"
 #endif /* OS_ALIGNMENT == * */
-#define OS_MEMPOOL_SIZE(n,blksize)      ((((blksize) + ((OS_ALIGNMENT)-1)) / (OS_ALIGNMENT)) * (n))
+#define OS_MEMPOOL_SIZE(n,blksize)      (((OS_MEMPOOL_BLOCK_SZ(blksize) + ((OS_ALIGNMENT)-1)) / (OS_ALIGNMENT)) * (n))
 
 /** Calculates the number of bytes required to initialize a memory pool. */
 #define OS_MEMPOOL_BYTES(n,blksize)     \


### PR DESCRIPTION
OS_MEMPOOL_SIZE returned incorrect memory size for mpool buffer when
OS_MEMPOOL_GUARD was enabled.
OS_MEMPOOL_GUARD requires extra space between memory blocks and
OS_MEMPOOL_SIZE (and OS_MEMPOOL_BYTES) returned values that did not
include this extra space.
During os_mempool_init_internal() memory outside expected buffer
was clobbered.