### PR TITLE
Ambiq Apollo3: Utilize ram buffer to handle flash to flash memory writes

### DIFF
--- a/hw/mcu/ambiq/apollo3/src/hal_flash.c
+++ b/hw/mcu/ambiq/apollo3/src/hal_flash.c
@@ -93,7 +93,7 @@ apollo3_flash_write_odd(const struct hal_flash *dev, uint32_t address,
 
 static int
 apollo3_flash_write_default(const struct hal_flash *dev, uint32_t address,
-    const void *src, uint32_t num_bytes) 
+                            const void *src, uint32_t num_bytes)
 {
     const uint8_t *u8p;
     int lead_size;
@@ -170,7 +170,7 @@ done:
 
 static int
 apollo3_flash_write(const struct hal_flash *dev, uint32_t address,
-    const void *src, uint32_t num_bytes)
+                    const void *src, uint32_t num_bytes)
 {
     int rc = 0;
     uint32_t offset = 0;
@@ -178,11 +178,12 @@ apollo3_flash_write(const struct hal_flash *dev, uint32_t address,
     uint8_t ram_buf[MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE)];
 
     /* Handle in the default manner if src data is already in ram */
-    if((uint32_t)src > apollo3_flash_dev.hf_size - apollo3_flash_dev.hf_base_addr) {
+    if ((uint32_t)src > apollo3_flash_dev.hf_size - apollo3_flash_dev.hf_base_addr) {
         rc = apollo3_flash_write_default(dev, address, src, num_bytes);
     } else {
-        while(num_bytes) {
-            chunk_len = num_bytes > MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) ? MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) : num_bytes;
+        while (num_bytes) {
+            chunk_len = num_bytes >
+                        MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) ? MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) : num_bytes;
             memcpy(ram_buf, src+offset, chunk_len);
             rc = apollo3_flash_write_default(dev, address+offset, ram_buf, chunk_len);
 

--- a/hw/mcu/ambiq/apollo3/src/hal_flash.c
+++ b/hw/mcu/ambiq/apollo3/src/hal_flash.c
@@ -92,8 +92,8 @@ apollo3_flash_write_odd(const struct hal_flash *dev, uint32_t address,
 }
 
 static int
-apollo3_flash_write(const struct hal_flash *dev, uint32_t address,
-    const void *src, uint32_t num_bytes)
+apollo3_flash_write_default(const struct hal_flash *dev, uint32_t address,
+    const void *src, uint32_t num_bytes) 
 {
     const uint8_t *u8p;
     int lead_size;
@@ -165,6 +165,32 @@ apollo3_flash_write(const struct hal_flash *dev, uint32_t address,
 
 done:
     __HAL_ENABLE_INTERRUPTS(sr);
+    return rc;
+}
+
+static int
+apollo3_flash_write(const struct hal_flash *dev, uint32_t address,
+    const void *src, uint32_t num_bytes)
+{
+    int rc = 0;
+    uint32_t offset = 0;
+    uint32_t chunk_len;
+    uint8_t ram_buf[MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE)];
+
+    /* Handle in the default manner if src data is already in ram */
+    if((uint32_t)src > apollo3_flash_dev.hf_size - apollo3_flash_dev.hf_base_addr) {
+        rc = apollo3_flash_write_default(dev, address, src, num_bytes);
+    } else {
+        while(num_bytes) {
+            chunk_len = num_bytes > MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) ? MYNEWT_VAL(FLASH_INTERMEDIARY_BUF_SIZE) : num_bytes;
+            memcpy(ram_buf, src+offset, chunk_len);
+            rc = apollo3_flash_write_default(dev, address+offset, ram_buf, chunk_len);
+
+            num_bytes -= chunk_len;
+            offset += chunk_len;
+        }
+    }
+
     return rc;
 }
 

--- a/hw/mcu/ambiq/apollo3/syscfg.yml
+++ b/hw/mcu/ambiq/apollo3/syscfg.yml
@@ -26,6 +26,14 @@ syscfg.defs:
     MCU_APOLLO3:
         value: 1
 
+    FLASH_INTERMEDIARY_BUF_SIZE:
+        description: >
+            In order to write data located on flash to another location on flash
+            they have to be read first. This is the size of buffer used to read
+            data before writing, i.e. each such transfer will be split into
+            chunks of this size. Buffer is created on stack.
+        value: 128
+
     UART_0:
         description: 'Whether to enable UART0'
         value: 1


### PR DESCRIPTION
Ambiq's internal flash writing functionality does not allow for direct flash to flash memory transfers. This change handles situations like that by transferring to an intermediary ram buffer.