### PR TITLE
hw/bsp/dialog: Add missing #include

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -21,6 +21,7 @@
 #define H_BSP_H
 
 #include <stdint.h>
+#include <syscfg/syscfg.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Need to include syscfg.h since it uses MYNEWT_VAL_CHOICE().