### PR TITLE
net/ip/native_socks: Fix build on with -Werror=stringop-overflow

### DIFF
--- a/net/ip/native_sockets/src/native_sock.c
+++ b/net/ip/native_sockets/src/native_sock.c
@@ -196,7 +196,7 @@ native_sock_mn_addr_to_addr(struct mn_sockaddr *ms, struct sockaddr *sa,
         sun->sun_len = sizeof(*sun);
 #endif
         sun->sun_path[0] = '\0';
-        strncat(sun->sun_path, msun->msun_path, sizeof sun->sun_path);
+        strncat(sun->sun_path, msun->msun_path, sizeof(sun->sun_path) - 1);
         if (strcmp(sun->sun_path, msun->msun_path) != 0) {
             /* Path too long. */
             return MN_EINVAL;


### PR DESCRIPTION
Werror=stringop-overflow= seems to be now enabled by default on GCC 11.

repos/apache-mynewt-core/net/ip/native_sockets/src/native_sock.c: In
    function ‘native_sock_mn_addr_to_addr’:
repos/apache-mynewt-core/net/ip/native_sockets/src/native_sock.c:199:9:
    error: ‘strncat’ specified bound 108 equals destination size
    [-Werror=stringop-overflow=]
  199 |         strncat(sun->sun_path, msun->msun_path,
                        sizeof sun->sun_path);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors