### PR TITLE
hw/drivers/flash/spiflash: Add option to ignore JEDEC ID

### DIFF
--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -1374,12 +1374,24 @@ spiflash_identify(struct spiflash_dev *dev)
          * different pins, or of different type.
          * It is unlikely that flash depended packaged will work correctly.
          */
-        assert(manufacturer == supported_chips[0].fc_jedec_id.ji_manufacturer &&
-               memory_type == supported_chips[0].fc_jedec_id.ji_type &&
-               capacity == supported_chips[0].fc_jedec_id.ji_capacity);
-        if (manufacturer != supported_chips[0].fc_jedec_id.ji_manufacturer ||
-            memory_type != supported_chips[0].fc_jedec_id.ji_type ||
-            capacity != supported_chips[0].fc_jedec_id.ji_capacity) {
+        assert(MYNEWT_VAL(SPIFLASH_IGNORE_MANUFACTURER) ||
+            manufacturer == supported_chips[0].fc_jedec_id.ji_manufacturer);
+        if (!(MYNEWT_VAL(SPIFLASH_IGNORE_MANUFACTURER) ||
+              manufacturer == supported_chips[0].fc_jedec_id.ji_manufacturer)) {
+            rc = -1;
+            goto err;
+        }
+        assert(MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_TYPE) ||
+            memory_type == supported_chips[0].fc_jedec_id.ji_type);
+        if (!(MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_TYPE) ||
+              memory_type == supported_chips[0].fc_jedec_id.ji_type)) {
+            rc = -1;
+            goto err;
+        }
+        assert(MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_CAPACITY) ||
+            capacity == supported_chips[0].fc_jedec_id.ji_capacity);
+        if (!(MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_CAPACITY) ||
+              capacity == supported_chips[0].fc_jedec_id.ji_capacity)) {
             rc = -1;
             goto err;
         }
@@ -1413,9 +1425,12 @@ spiflash_identify(struct spiflash_dev *dev)
             }
         }
         for (i = 0; supported_chips[i].fc_jedec_id.ji_manufacturer != 0; ++i) {
-            if (manufacturer ==  supported_chips[i].fc_jedec_id.ji_manufacturer &&
-                memory_type == supported_chips[i].fc_jedec_id.ji_type &&
-                capacity == supported_chips[i].fc_jedec_id.ji_capacity) {
+            if ((MYNEWT_VAL(SPIFLASH_IGNORE_MANUFACTURER) ||
+                 manufacturer == supported_chips[i].fc_jedec_id.ji_manufacturer) &&
+                (MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_TYPE) ||
+                 memory_type == supported_chips[i].fc_jedec_id.ji_type) &&
+                (MYNEWT_VAL(SPIFLASH_IGNORE_MEMORY_CAPACITY) ||
+                 capacity == supported_chips[i].fc_jedec_id.ji_capacity)) {
                 /* Device is supported */
                 dev->flash_chip = &supported_chips[i];
                 break;

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -68,13 +68,25 @@ syscfg.defs:
             values found in hw/drivers/flash/spiflash/chips/syscfg.yml should be
             set to 1 for desired chips.
         value: 0
+    SPIFLASH_IGNORE_MANUFACTURER:
+        description: >
+            Ignore the SpiFlash manufacturer as read by Read JEDEC ID command 9FH
+        value: 0
     SPIFLASH_MEMORY_TYPE:
         description: >
             Expected SpiFlash memory type as read by Read JEDEC ID command 9FH
         value: 0
+    SPIFLASH_IGNORE_MEMORY_TYPE:
+        description: >
+            Ignore SpiFlash memory type as read by Read JEDEC ID command 9FH
+        value: 0
     SPIFLASH_MEMORY_CAPACITY:
         description: >
             Expected SpiFlash memory capactity as read by Read JEDEC ID command 9FH
+        value: 0
+    SPIFLASH_IGNORE_MEMORY_CAPACITY:
+        description: >
+            Ignore SpiFlash memory capactity as read by Read JEDEC ID command 9FH
         value: 0
 
     SPIFLASH_READ_STATUS_INTERVAL:


### PR DESCRIPTION
This PR introduces three new **optional** configuration parameters: `SPIFLASH_IGNORE_MANUFACTURER`, `SPIFLASH_IGNORE_MEMORY_TYPE`, and `SPIFLASH_IGNORE_MEMORY_CAPACITY`. (Default: `0`).

These parameters selectively disable the whitelist checks of the SPI Flash JEDEC IDs.

### Rationale

I am currently [porting the InfiniTime OS](https://github.com/InfiniTimeOrg/InfiniTime/pull/1050) (written for the [PineTime smartwatch](https://www.pine64.org/pinetime/)) to a popular Chinese smartwatch series called "P8". `mynewt-core` is used for the bootloader.

These P8 watches come in a whole zoo of variants, each being compatible with the firmware but containing sometimes a bit different chips due to the silicon shortage and general chip availability on the global market. This is usually no problem to handle.

However, the SPI driver of `mynewt-core` enforces a strict whitelist on the reported SPI Flash JEDEC ID. I see how this is useful in normal applications where the hardware configuration is known in detail and compatibility has to be ensured, however this leads to my bootloader refusing to work on prior unknown / new smartwatch variants, bricking them.

In the past, others and I have added definitions for SPI IDs (e.g. #2798 , #2582 ), but I can't keep up with all the models and I don't want to brick any more watches due to a purely whitelisting (not technical) issue. 

I am open to suggestions, I think these optional configuration parameters would be quite useful to have.