### PR TITLE
riscv: Fix build warning

### DIFF
--- a/hw/bsp/hifive1/hifive1.ld
+++ b/hw/bsp/hifive1/hifive1.ld
@@ -130,6 +130,7 @@ SECTIONS
 
   .data          :
   {
+    *(.ram_text, .ram_text.*)
     *(.data .data.*)
     *(.gnu.linkonce.d.*)
   } >ram AT>flash

--- a/hw/mcu/sifive/fe310/src/hal_flash.c
+++ b/hw/mcu/sifive/fe310/src/hal_flash.c
@@ -70,7 +70,7 @@ fe310_flash_read(const struct hal_flash *dev, uint32_t address, void *dst,
     return 0;
 }
 
-static int __attribute((section(".data.fe310_flash_transmit")))
+static int __attribute((section(".ram_text.fe310_flash_transmit")))
 fe310_flash_transmit(uint8_t out_byte)
 {
     int in_byte;
@@ -86,7 +86,7 @@ fe310_flash_transmit(uint8_t out_byte)
     return in_byte;
 }
 
-static int __attribute((section(".data.fe310_flash_fifo_put")))
+static int __attribute((section(".ram_text.fe310_flash_fifo_put")))
 fe310_flash_fifo_put(uint8_t out_byte)
 {
     int went_out = 0;
@@ -105,7 +105,7 @@ fe310_flash_fifo_put(uint8_t out_byte)
     return went_out;
 }
 
-static int __attribute((section(".data.fe310_flash_fifo_write")))
+static int __attribute((section(".ram_text.fe310_flash_fifo_write")))
 fe310_flash_fifo_write(const uint8_t *ptr, int count)
 {
     int went_out = 0;
@@ -123,7 +123,7 @@ fe310_flash_fifo_write(const uint8_t *ptr, int count)
     return went_out;
 }
 
-static int __attribute((section(".data.fe310_flash_wait_till_ready")))
+static int __attribute((section(".ram_text.fe310_flash_wait_till_ready")))
 fe310_flash_wait_till_ready(void)
 {
     int status;
@@ -138,7 +138,7 @@ fe310_flash_wait_till_ready(void)
     return 0;
 }
 
-static int __attribute((section(".data.fe310_flash_write_enable")))
+static int __attribute((section(".ram_text.fe310_flash_write_enable")))
 fe310_flash_write_enable(void)
 {
     SPI0_REG(SPI_REG_CSMODE) = SPI_CSMODE_HOLD;
@@ -147,7 +147,7 @@ fe310_flash_write_enable(void)
     return 0;
 }
 
-static int  __attribute((section(".data.fe310_flash_write_page"))) __attribute((noinline))
+static int  __attribute((section(".ram_text.fe310_flash_write_page"))) __attribute((noinline))
 fe310_flash_write_page(const struct hal_flash *dev, uint32_t address,
                       const void *src, uint32_t num_bytes)
 {
@@ -232,7 +232,7 @@ fe310_flash_write(const struct hal_flash *dev, uint32_t address,
     return 0;
 }
 
-static int __attribute((section(".data.fe310_flash_erase_sector"))) __attribute((noinline))
+static int __attribute((section(".ram_text.fe310_flash_erase_sector"))) __attribute((noinline))
 fe310_flash_erase_sector(const struct hal_flash *dev, uint32_t sector_address)
 {
     int sr;


### PR DESCRIPTION
This eliminates following warning:

/tmp/ccfBOXIv.s: Assembler messages:
/tmp/ccfBOXIv.s:6: Warning: setting incorrect section attributes for .data.fe310_flash_transmit
/tmp/ccfBOXIv.s:41: Warning: setting incorrect section attributes for .data.fe310_flash_fifo_put
/tmp/ccfBOXIv.s:89: Warning: setting incorrect section attributes for .data.fe310_flash_fifo_write
/tmp/ccfBOXIv.s:145: Warning: setting incorrect section attributes for .data.fe310_flash_wait_till_ready
/tmp/ccfBOXIv.s:194: Warning: setting incorrect section attributes for .data.fe310_flash_write_enable
/tmp/ccfBOXIv.s:232: Warning: setting incorrect section attributes for .data.fe310_flash_write_page
/tmp/ccfBOXIv.s:419: Warning: setting incorrect section attributes for .data.fe310_flash_erase_sector

.data.XXXX section gets default attributes that are no executable
renaming .data to .ram_text fixes assembler warning
This requries change to linker script that now has to include .ram_text.XXXXX in data section
to work as it used to before change