### PR TITLE
tinyusb: Allow for several CDC interfaces

### DIFF
--- a/hw/usb/tinyusb/cdc/include/cdc/cdc.h
+++ b/hw/usb/tinyusb/cdc/include/cdc/cdc.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __CDC_H__
+#define __CDC_H__
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <class/cdc/cdc_device.h>
+
+struct cdc_itf;
+typedef struct cdc_itf cdc_itf_t;
+
+struct cdc_callbacks {
+    /* Invoked when received new data */
+    void (*cdc_rx_cb)(cdc_itf_t *itf);
+
+    /* Invoked when received `wanted_char` */
+    void (*cdc_rx_wanted_cb)(cdc_itf_t *itf, char wanted_char);
+
+    /* Invoked when space becomes available in TX buffer */
+    void (*cdc_tx_complete_cb)(cdc_itf_t *itf);
+
+    /* Invoked when line state DTR & RTS are changed via SET_CONTROL_LINE_STATE */
+    void (*cdc_line_state_cb)(cdc_itf_t *itf, bool dtr, bool rts);
+
+    /* Invoked when line coding is change via SET_LINE_CODING */
+    void (*cdc_line_coding_cb)(cdc_itf_t *itf, cdc_line_coding_t const *p_line_coding);
+
+    /* Invoked when received send break */
+    void (*cdc_send_break_cb)(cdc_itf_t *itf, uint16_t duration_ms);
+};
+
+struct cdc_itf {
+    const struct cdc_callbacks *callbacks;
+    uint8_t cdc_num;
+};
+
+uint8_t cdc_itf_add(cdc_itf_t *cdc_ift);
+
+#endif /* __CDC_H__ */

--- a/hw/usb/tinyusb/cdc/pkg.yml
+++ b/hw/usb/tinyusb/cdc/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/usb/tinyusb/cdc
+pkg.description: USB CDC.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - usb
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/usb/tinyusb"
+    - "@tinyusb/tinyusb"

--- a/hw/usb/tinyusb/cdc/src/cdc.c
+++ b/hw/usb/tinyusb/cdc/src/cdc.c
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <cdc/cdc.h>
+
+static cdc_itf_t *cdc_itfs[CFG_TUD_CDC];
+static uint8_t cdc_itf_count;
+
+/* Invoked when received new data */
+void
+tud_cdc_rx_cb(uint8_t itf)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_rx_cb) {
+        cdc_itf->callbacks->cdc_rx_cb(cdc_itf);
+    }
+}
+
+/* Invoked when received `wanted_char` */
+void
+tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_rx_wanted_cb) {
+        cdc_itf->callbacks->cdc_rx_wanted_cb(cdc_itf, wanted_char);
+    }
+}
+
+/* Invoked when space becomes available in TX buffer */
+void
+tud_cdc_tx_complete_cb(uint8_t itf)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_tx_complete_cb) {
+        cdc_itf->callbacks->cdc_tx_complete_cb(cdc_itf);
+    }
+}
+
+/* Invoked when line state DTR & RTS are changed via SET_CONTROL_LINE_STATE */
+void
+tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_line_state_cb) {
+        cdc_itf->callbacks->cdc_line_state_cb(cdc_itf, dtr, rts);
+    }
+}
+
+/* Invoked when line coding is change via SET_LINE_CODING */
+void
+tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const *p_line_coding)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_line_coding_cb) {
+        cdc_itf->callbacks->cdc_line_coding_cb(cdc_itf, p_line_coding);
+    }
+}
+
+/* Invoked when received send break */
+void
+tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms)
+{
+    cdc_itf_t *cdc_itf = cdc_itfs[itf];
+
+    if (cdc_itf->callbacks->cdc_send_break_cb) {
+        cdc_itf->callbacks->cdc_send_break_cb(cdc_itf, duration_ms);
+    }
+}
+
+uint8_t
+cdc_itf_add(cdc_itf_t *cdc_itf)
+{
+    int sr;
+
+    assert(cdc_itf_count < CFG_TUD_CDC);
+
+    OS_ENTER_CRITICAL(sr);
+    cdc_itfs[cdc_itf_count] = cdc_itf;
+    cdc_itf->cdc_num = cdc_itf_count++;
+    OS_EXIT_CRITICAL(sr);
+
+    return cdc_itf->cdc_num;
+}

--- a/hw/usb/tinyusb/cdc_console/pkg.yml
+++ b/hw/usb/tinyusb/cdc_console/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb/cdc"
     - "@tinyusb/tinyusb"
 
 pkg.init:

--- a/hw/usb/tinyusb/cdc_console/src/cdc_console.c
+++ b/hw/usb/tinyusb/cdc_console/src/cdc_console.c
@@ -20,6 +20,7 @@
 #include <os/mynewt.h>
 
 #include <class/cdc/cdc_device.h>
+#include <cdc/cdc.h>
 
 #include <console/console.h>
 #include <bsp/bsp.h>
@@ -27,6 +28,12 @@
 static struct os_event rx_receive_event;
 static struct os_event tx_flush_event;
 static bool connected;
+
+static const struct cdc_callbacks console_cdc_callback;
+
+cdc_itf_t console_cdc_itf = {
+    .callbacks = &console_cdc_callback
+};
 
 static void
 cdc_schedule_tx_flush(void)
@@ -39,11 +46,11 @@ cdc_write(int c)
 {
     uint32_t written;
 
-    written = tud_cdc_write_char(c);
-    if (tud_cdc_write_available() == 0) {
-        tud_cdc_write_flush();
+    written = tud_cdc_n_write_char(console_cdc_itf.cdc_num, c);
+    if (tud_cdc_n_write_available(console_cdc_itf.cdc_num) == 0) {
+        tud_cdc_n_write_flush(console_cdc_itf.cdc_num);
         if (written == 0) {
-            tud_cdc_write_char(c);
+            tud_cdc_n_write_char(console_cdc_itf.cdc_num, c);
         }
     }
 }
@@ -72,11 +79,11 @@ static void
 tx_flush_ev_cb(struct os_event *ev)
 {
 #if MYNEWT_VAL(USBD_CDC_TX_BUFSIZE)
-    if (connected && tud_cdc_write_available() < CFG_TUD_CDC_TX_BUFSIZE) {
+    if (connected && tud_cdc_n_write_available(console_cdc_itf.cdc_num) < CFG_TUD_CDC_TX_BUFSIZE) {
 #else
-    if (connected && tud_cdc_write_available() < USBD_CDC_DATA_EP_SIZE) {
+    if (connected && tud_cdc_n_write_available(console_cdc_itf.cdc_num) < USBD_CDC_DATA_EP_SIZE) {
 #endif
-        if (tud_cdc_write_flush() == 0) {
+        if (tud_cdc_n_write_flush(console_cdc_itf.cdc_num) == 0) {
             /*
              * Previous data not sent yet.
              * There is no data sent notification in tinyusb/cdc, retry flush later.
@@ -100,8 +107,8 @@ rx_ev_cb(struct os_event *ev)
         }
     }
 
-    while (tud_cdc_available()) {
-        console_rejected_char = tud_cdc_read_char();
+    while (tud_cdc_n_available(console_cdc_itf.cdc_num)) {
+        console_rejected_char = tud_cdc_n_read_char(console_cdc_itf.cdc_num);
         if (console_rejected_char >= 0) {
             ret = console_handle_char(console_rejected_char);
             if (ret < 0) {
@@ -115,9 +122,12 @@ rx_ev_cb(struct os_event *ev)
     console_rejected_char = -1;
 }
 
-void
-tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
+static void
+cdc_console_line_state_cb(cdc_itf_t *itf, bool dtr, bool rts)
 {
+    (void)itf;
+    (void)rts;
+
     if (dtr != connected) {
         connected = dtr;
         cdc_schedule_tx_flush();
@@ -125,20 +135,23 @@ tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
 }
 
 /* Invoked when CDC interface received data from host */
-void
-tud_cdc_rx_cb(uint8_t itf)
+static void
+cdc_console_rx_cb(cdc_itf_t *itf)
 {
+    (void)itf;
     os_eventq_put(os_eventq_dflt_get(), &rx_receive_event);
 }
 
-void
-tud_cdc_line_coding_cb(uint8_t itf, const cdc_line_coding_t *p_line_coding)
+static void
+cdc_console_line_coding_cb(cdc_itf_t *itf, const cdc_line_coding_t *p_line_coding)
 {
+    (void)itf;
 }
 
-void
-tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char)
+static void
+cdc_console_rx_wanted_cb(cdc_itf_t *itf, char wanted_char)
 {
+    (void)itf;
 }
 
 int
@@ -147,11 +160,23 @@ usb_cdc_console_pkg_init(void)
     rx_receive_event.ev_cb = rx_ev_cb;
     tx_flush_event.ev_cb = tx_flush_ev_cb;
 
+    cdc_itf_add(&console_cdc_itf);
+
     return 0;
 }
 
 int
 usb_cdc_console_is_init(void)
 {
-    return (int)tud_cdc_connected();
+    return (int)tud_cdc_n_connected(console_cdc_itf.cdc_num);
 }
+
+static const struct cdc_callbacks console_cdc_callback = {
+    .cdc_rx_cb = cdc_console_rx_cb,
+    .cdc_line_coding_cb = cdc_console_line_coding_cb,
+    .cdc_line_state_cb = cdc_console_line_state_cb,
+    .cdc_rx_wanted_cb = cdc_console_rx_wanted_cb,
+    .cdc_send_break_cb = NULL,
+    .cdc_tx_complete_cb = NULL,
+};
+

--- a/hw/usb/tinyusb/cdc_console/syscfg.yml
+++ b/hw/usb/tinyusb/cdc_console/syscfg.yml
@@ -18,12 +18,12 @@
 #
 
 syscfg.defs:
-    USBD_CDC_DECRIPTOR_STRING:
-        description: String for CDC interface
+    USBD_CDC_CONSOLE_DECRIPTOR_STRING:
+        description: String for CDC/Console interface
         value: '"Mynewt console"'
 
 syscfg.vals:
-    USBD_CDC: 1
+    USBD_CDC_CONSOLE: 1
 
 syscfg.restrictions:
-    - "USBD_CDC"
+    - "USBD_CDC_CONSOLE"

--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -72,11 +72,54 @@ extern "C" {
 #define CFG_TUD_ENDPOINT0_SIZE   MYNEWT_VAL(USBD_EP0_SIZE)
 
 /* ------------- CLASS ------------- */
-#if MYNEWT_VAL(USBD_CDC)
-#define CFG_TUD_CDC              MYNEWT_VAL(USBD_CDC)
+/*
+ * If CDC_CONSOLE does not have specific values for endpoint configuration,
+ * use values for unspecified CDC
+ */
+#if defined(MYNEWT_VAL_USBD_CDC_CONSOLE_NOTIFY_EP_SIZE)
+#define USBD_CDC_CONSOLE_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_CONSOLE_NOTIFY_EP_SIZE)
 #else
-#define CFG_TUD_CDC              0
+#define USBD_CDC_CONSOLE_NOTIFY_EP_SIZE USBD_CDC_NOTIFY_EP_SIZE
 #endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_CONSOLE_NOTIFY_EP)
+#define USBD_CDC_CONSOLE_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_CONSOLE_NOTIFY_EP)
+#else
+#define USBD_CDC_CONSOLE_NOTIFY_EP      USBD_CDC_NOTIFY_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_CONSOLE_DATA_OUT_EP)
+#define USBD_CDC_CONSOLE_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_CONSOLE_DATA_OUT_EP)
+#else
+#define USBD_CDC_CONSOLE_DATA_OUT_EP    USBD_CDC_DATA_OUT_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_CONSOLE_DATA_IN_EP)
+#define USBD_CDC_CONSOLE_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_CONSOLE_DATA_IN_EP)
+#else
+#define USBD_CDC_CONSOLE_DATA_IN_EP     USBD_CDC_DATA_IN_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_CONSOLE_DATA_EP_SIZE)
+#define USBD_CDC_CONSOLE_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_CONSOLE_DATA_EP_SIZE)
+#else
+#define USBD_CDC_CONSOLE_DATA_EP_SIZE   USBD_CDC_DATA_EP_SIZE
+#endif
+
+#if MYNEWT_VAL(USBD_CDC)
+#define CFG_CDC                  MYNEWT_VAL(USBD_CDC)
+#else
+#define CFG_CDC                  0
+#endif
+
+#if MYNEWT_VAL(CONSOLE_USB)
+#define CFG_CDC_CONSOLE          MYNEWT_VAL(CONSOLE_USB)
+#else
+#define CFG_CDC_CONSOLE          0
+#endif
+
+#define CFG_TUD_CDC              ((CFG_CDC) + (CFG_CDC_CONSOLE))
+
 #if MYNEWT_VAL(USBD_HID)
 #define CFG_TUD_HID              MYNEWT_VAL(USBD_HID)
 #else

--- a/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
+++ b/hw/usb/tinyusb/std_descriptors/include/tusb_config.h
@@ -106,6 +106,41 @@ extern "C" {
 #define USBD_CDC_CONSOLE_DATA_EP_SIZE   USBD_CDC_DATA_EP_SIZE
 #endif
 
+/*
+ * If CDC_HCI does not have specific values for endpoint configuration,
+ * use values for unspecified CDC
+ */
+#if defined(MYNEWT_VAL_USBD_CDC_HCI_NOTIFY_EP)
+#define USBD_CDC_HCI_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_HCI_NOTIFY_EP)
+#else
+#define USBD_CDC_HCI_NOTIFY_EP      USBD_BTH_EVENT_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_HCI_NOTIFY_EP_SIZE)
+#define USBD_CDC_HCI_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_HCI_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_HCI_NOTIFY_EP_SIZE USBD_CDC_NOTIFY_EP_SIZE
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_HCI_DATA_OUT_EP)
+#define USBD_CDC_HCI_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_HCI_DATA_OUT_EP)
+#else
+#define USBD_CDC_HCI_DATA_OUT_EP    USBD_BTH_DATA_OUT_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_HCI_DATA_IN_EP)
+#define USBD_CDC_HCI_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_HCI_DATA_IN_EP)
+#else
+#define USBD_CDC_HCI_DATA_IN_EP     USBD_BTH_DATA_IN_EP
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_HCI_DATA_EP_SIZE)
+#define USBD_CDC_HCI_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_HCI_DATA_EP_SIZE)
+#else
+#define USBD_CDC_HCI_DATA_EP_SIZE   USBD_CDC_DATA_EP_SIZE
+#endif
+
+
 #if MYNEWT_VAL(USBD_CDC)
 #define CFG_CDC                  MYNEWT_VAL(USBD_CDC)
 #else
@@ -118,7 +153,13 @@ extern "C" {
 #define CFG_CDC_CONSOLE          0
 #endif
 
-#define CFG_TUD_CDC              ((CFG_CDC) + (CFG_CDC_CONSOLE))
+#if MYNEWT_VAL(USBD_CDC_HCI)
+#define CFG_CDC_HCI              MYNEWT_VAL(USBD_CDC_HCI)
+#else
+#define CFG_CDC_HCI              0
+#endif
+
+#define CFG_TUD_CDC              ((CFG_CDC) + (CFG_CDC_CONSOLE) + (CFG_CDC_HCI))
 
 #if MYNEWT_VAL(USBD_HID)
 #define CFG_TUD_HID              MYNEWT_VAL(USBD_HID)

--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -53,6 +53,11 @@ enum usb_desc_ix {
 #else
 #define CDC_CONSOLE_IF_STR_IX   0
 #endif
+#if defined MYNEWT_VAL_USBD_CDC_HCI_DESCRIPTOR_STRING
+    CDC_HCI_IF_STR_IX,
+#else
+#define CDC_HCI_IF_STR_IX   0
+#endif
 #if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
     MSC_IF_STR_IX,
 #else
@@ -272,6 +277,11 @@ enum {
     ITF_NUM_CDC_CONSOLE_DATA,
 #endif
 
+#if CFG_CDC_HCI
+    ITF_NUM_CDC_HCI,
+    ITF_NUM_CDC_HCI_DATA,
+#endif
+
 #if CFG_TUD_MSC
     ITF_NUM_MSC,
 #endif
@@ -290,6 +300,7 @@ enum {
 #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + \
                              CFG_CDC * TUD_CDC_DESC_LEN + \
                              CFG_CDC_CONSOLE * TUD_CDC_DESC_LEN + \
+                             CFG_CDC_HCI * TUD_CDC_DESC_LEN + \
                              CFG_TUD_MSC * TUD_MSC_DESC_LEN + \
                              CFG_TUD_HID * TUD_HID_DESC_LEN + \
                              CFG_TUD_BTH * TUD_BTH_DESC_LEN + \
@@ -311,6 +322,12 @@ const uint8_t desc_configuration[] = {
     TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_CONSOLE, CDC_CONSOLE_IF_STR_IX, USBD_CDC_CONSOLE_NOTIFY_EP,
                        USBD_CDC_CONSOLE_NOTIFY_EP_SIZE, USBD_CDC_CONSOLE_DATA_OUT_EP, USBD_CDC_CONSOLE_DATA_IN_EP,
                        (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 512 : USBD_CDC_CONSOLE_DATA_EP_SIZE),
+#endif
+
+#if CFG_CDC_HCI
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_HCI, CDC_HCI_IF_STR_IX, USBD_CDC_HCI_NOTIFY_EP, USBD_CDC_HCI_NOTIFY_EP_SIZE,
+                       USBD_CDC_HCI_DATA_OUT_EP, USBD_CDC_HCI_DATA_IN_EP,
+                       (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 512 : USBD_CDC_HCI_DATA_EP_SIZE),
 #endif
 
 #if CFG_CDC
@@ -357,6 +374,9 @@ const char *string_desc_arr[] = {
 #endif
 #if defined MYNEWT_VAL_USBD_CDC_CONSOLE_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_CDC_CONSOLE_DESCRIPTOR_STRING),
+#endif
+#if defined MYNEWT_VAL_USBD_CDC_HCI_DESCRIPTOR_STRING
+    MYNEWT_VAL(USBD_CDC_HCI_DESCRIPTOR_STRING),
 #endif
 #if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_MSC_DESCRIPTOR_STRING),

--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -39,10 +39,34 @@
 #define CONFIG_NUM 1
 #endif
 
-#define CDC_IF_STR_IX (MYNEWT_VAL(USBD_CDC_DESCRIPTOR_STRING) == NULL ? 0 : 4)
-#define MSC_IF_STR_IX (MYNEWT_VAL(USBD_MSC_DESCRIPTOR_STRING) == NULL ? 0 : 5)
-#define HID_IF_STR_IX (MYNEWT_VAL(USBD_HID_DESCRIPTOR_STRING) == NULL ? 0 : 6)
-#define BTH_IF_STR_IX (MYNEWT_VAL(USBD_BTH_DESCRIPTOR_STRING) == NULL ? 0 : 7)
+enum usb_desc_ix {
+    USB_DESC_IX_SERIAL_NUMBER   = 1,
+    USB_DESC_IX_VENDOR          = 2,
+    USB_DESC_IX_PRODUCT         = 3,
+#if defined MYNEWT_VAL_USBD_CDC_DESCRIPTOR_STRING
+    CDC_IF_STR_IX,
+#else
+#define CDC_IF_STR_IX 0
+#endif
+#if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
+    MSC_IF_STR_IX,
+#else
+#define MSC_IF_STR_IX   0
+#endif
+#if defined MYNEWT_VAL_USBD_HID_DESCRIPTOR_STRING
+    HID_IF_STR_IX,
+#else
+#define HID_IF_STR_IX   0
+#endif
+#if defined MYNEWT_VAL_USBD_BTH_DESCRIPTOR_STRING
+    BTH_IF_STR_IX,
+#else
+#define BTH_IF_STR_IX   0
+#endif
+#if defined MYNEWT_VAL_USBD_DFU_SLOT_NAME
+    DFU_SLOT_NAME_IF_STR_IX,
+#endif
+};
 
 #if MYNEWT_VAL(USBD_CONFIGURATION_SELF_POWERED)
 #define SELF_POWERED_OPT    TUSB_DESC_CONFIG_ATT_SELF_POWERED
@@ -290,7 +314,8 @@ const uint8_t desc_configuration[] = {
 #endif
 
 #if CFG_TUD_DFU
-    TUD_DFU_DESCRIPTOR(ITF_NUM_DFU, 1, 8, DFU_ATTR_CAN_DOWNLOAD, CFG_TUD_DFU_DETACH_TIMEOUT, CFG_TUD_DFU_XFER_BUFSIZE),
+    TUD_DFU_DESCRIPTOR(ITF_NUM_DFU, 1, DFU_SLOT_NAME_IF_STR_IX, DFU_ATTR_CAN_DOWNLOAD,
+                       CFG_TUD_DFU_DETACH_TIMEOUT, CFG_TUD_DFU_XFER_BUFSIZE),
 #endif
 };
 
@@ -310,14 +335,20 @@ tud_descriptor_configuration_cb(uint8_t index)
 const char *string_desc_arr[] = {
     MYNEWT_VAL(USBD_VENDOR_STRING),
     MYNEWT_VAL(USBD_PRODUCT_STRING),
+#if defined MYNEWT_VAL_USBD_CDC_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_CDC_DESCRIPTOR_STRING),
+#endif
+#if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_MSC_DESCRIPTOR_STRING),
+#endif
+#if defined MYNEWT_VAL_USBD_HID_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_HID_DESCRIPTOR_STRING),
+#endif
+#if defined MYNEWT_VAL_USBD_BTH_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_BTH_DESCRIPTOR_STRING),
+#endif
 #if defined MYNEWT_VAL_USBD_DFU_SLOT_NAME
     MYNEWT_VAL(USBD_DFU_SLOT_NAME),
-#else
-    NULL,
 #endif
 };
 
@@ -400,14 +431,16 @@ tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     } else if (index - 2 < ARRAY_SIZE(string_desc_arr)) {
         str = string_desc_arr[index - 2];
 
-        char_num = strlen(str);
-        assert(char_num <= ARRAY_SIZE(desc_string) - 1);
-        if (char_num > ARRAY_SIZE(desc_string) - 1) {
-            char_num = ARRAY_SIZE(desc_string) - 1;
-        }
+        if (str) {
+            char_num = strlen(str);
+            assert(char_num <= ARRAY_SIZE(desc_string) - 1);
+            if (char_num > ARRAY_SIZE(desc_string) - 1) {
+                char_num = ARRAY_SIZE(desc_string) - 1;
+            }
 
-        for (i = 0; i < char_num; ++i) {
-            desc_string[1 + i] = str[i];
+            for (i = 0; i < char_num; ++i) {
+                desc_string[1 + i] = str[i];
+            }
         }
     }
 

--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -48,6 +48,11 @@ enum usb_desc_ix {
 #else
 #define CDC_IF_STR_IX 0
 #endif
+#if defined MYNEWT_VAL_USBD_CDC_CONSOLE_DESCRIPTOR_STRING
+    CDC_CONSOLE_IF_STR_IX,
+#else
+#define CDC_CONSOLE_IF_STR_IX   0
+#endif
 #if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
     MSC_IF_STR_IX,
 #else
@@ -257,9 +262,14 @@ enum {
 #endif
 #endif
 
-#if CFG_TUD_CDC
+#if CFG_CDC
     ITF_NUM_CDC,
     ITF_NUM_CDC_DATA,
+#endif
+
+#if CFG_CDC_CONSOLE
+    ITF_NUM_CDC_CONSOLE,
+    ITF_NUM_CDC_CONSOLE_DATA,
 #endif
 
 #if CFG_TUD_MSC
@@ -278,7 +288,8 @@ enum {
 };
 
 #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + \
-                             CFG_TUD_CDC * TUD_CDC_DESC_LEN + \
+                             CFG_CDC * TUD_CDC_DESC_LEN + \
+                             CFG_CDC_CONSOLE * TUD_CDC_DESC_LEN + \
                              CFG_TUD_MSC * TUD_MSC_DESC_LEN + \
                              CFG_TUD_HID * TUD_HID_DESC_LEN + \
                              CFG_TUD_BTH * TUD_BTH_DESC_LEN + \
@@ -296,7 +307,13 @@ const uint8_t desc_configuration[] = {
                        0, 9, 17, 25, 33, 49),
 #endif
 
-#if CFG_TUD_CDC
+#if CFG_CDC_CONSOLE
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_CONSOLE, CDC_CONSOLE_IF_STR_IX, USBD_CDC_CONSOLE_NOTIFY_EP,
+                       USBD_CDC_CONSOLE_NOTIFY_EP_SIZE, USBD_CDC_CONSOLE_DATA_OUT_EP, USBD_CDC_CONSOLE_DATA_IN_EP,
+                       (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 512 : USBD_CDC_CONSOLE_DATA_EP_SIZE),
+#endif
+
+#if CFG_CDC
     TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, CDC_IF_STR_IX, USBD_CDC_NOTIFY_EP, USBD_CDC_NOTIFY_EP_SIZE,
                        USBD_CDC_DATA_OUT_EP, USBD_CDC_DATA_IN_EP,
                        (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 512 : USBD_CDC_DATA_EP_SIZE),
@@ -337,6 +354,9 @@ const char *string_desc_arr[] = {
     MYNEWT_VAL(USBD_PRODUCT_STRING),
 #if defined MYNEWT_VAL_USBD_CDC_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_CDC_DESCRIPTOR_STRING),
+#endif
+#if defined MYNEWT_VAL_USBD_CDC_CONSOLE_DESCRIPTOR_STRING
+    MYNEWT_VAL(USBD_CDC_CONSOLE_DESCRIPTOR_STRING),
 #endif
 #if defined MYNEWT_VAL_USBD_MSC_DESCRIPTOR_STRING
     MYNEWT_VAL(USBD_MSC_DESCRIPTOR_STRING),

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -62,7 +62,10 @@ syscfg.defs:
         description: Device friendly name
         value: '"Dev device"'
     USBD_CDC:
-        description: Enable CDC device function in TinyUSB stack.
+        description: Enable CDC device function in TinyUSB stack (other then console or hci).
+        value:
+    USBD_CDC_CONSOLE:
+        description: Enable CDC device function for console in TinyUSB stack.
         value:
     USBD_HID:
         description: Enable HID device function in TinyUSB stack.

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -111,19 +111,19 @@ syscfg.defs:
 
     USBD_CDC_DESCRIPTOR_STRING:
         description: String for CDC interface
-        value: NULL
+        value:
 
     USBD_MSC_DESCRIPTOR_STRING:
         description: String for MSC interface
-        value: NULL
+        value:
 
     USBD_HID_DESCRIPTOR_STRING:
         description: String for HID interface
-        value: NULL
+        value:
 
     USBD_BTH_DESCRIPTOR_STRING:
         description: String for BT descriptor
-        value: NULL
+        value:
 
     USBD_HID_REPORT_EP:
         description: HID report endpoint number


### PR DESCRIPTION
This adds way to have several CDC interfaces (COM ports or /dev/ttyACMx devices) on one USB devices.
This will allow to have USB console with other serial based interface like HCI over serial connection.

cdc package is added that routes TinyUSB CDC devices callbacks to multiply interface implementations.

Some USB string descriptor handling is also updated so string indices for interfaces and DFU slot are no longer hardcode.

This also adds standard descriptor for CDC HCI that can be used by future nimble transport.