### PR TITLE
stm32f4/f7 Fix PLL configuration

### DIFF
--- a/hw/mcu/stm/stm32f4xx/src/system_stm32f4xx.c
+++ b/hw/mcu/stm/stm32f4xx/src/system_stm32f4xx.c
@@ -124,8 +124,8 @@ SystemInit(void)
     /* Reset CFGR register */
     RCC->CFGR = 0x00000000;
 
-    /* Reset HSEON, CSSON and PLLON bits */
-    RCC->CR &= (uint32_t)0xFEF6FFFF;
+    /* Reset HSEON, CSSON PLLI2S and PLLON bits */
+    RCC->CR &= (uint32_t)0xFAF6FFFF;
 
     /* Reset PLLCFGR register */
     RCC->PLLCFGR = 0x24003010;

--- a/hw/mcu/stm/stm32f7xx/src/system_stm32f7xx.c
+++ b/hw/mcu/stm/stm32f7xx/src/system_stm32f7xx.c
@@ -104,8 +104,8 @@ void SystemInit(void)
     /* Reset CFGR register */
     RCC->CFGR = 0x00000000;
 
-    /* Reset HSEON, CSSON and PLLON bits */
-    RCC->CR &= (uint32_t)0xFEF6FFFF;
+    /* Reset HSEON, CSSON PLLI2S and PLLON bits */
+    RCC->CR &= (uint32_t)0xFAF6FFFF;
 
     /* Reset PLLCFGR register */
     RCC->PLLCFGR = 0x24003010;


### PR DESCRIPTION
SystemInit disabled few bits in CR register before every clock was
configured. This allows to configure PLL.

If PLLI2S was enabled before this function was called (could happen
if I2S was enabled in bootloader) PLL source could not be changed.
ST HAL function HAL_RCC_OscConfig() expect this bit to be cleared.

Following code from HAL will not update PLLSRC bit if PLLI2S in enabled
during call to this function.

/* Configure the main PLL clock source, multiplication and division factors. */
    WRITE_REG(RCC->PLLCFGR, (RCC_OscInitStruct->PLL.PLLSource                                            | \
                             RCC_OscInitStruct->PLL.PLLM                                                 | \
                             (RCC_OscInitStruct->PLL.PLLN << RCC_PLLCFGR_PLLN_Pos)             | \
                             (((RCC_OscInitStruct->PLL.PLLP >> 1U) - 1U) << RCC_PLLCFGR_PLLP_Pos) | \
                             (RCC_OscInitStruct->PLL.PLLQ << RCC_PLLCFGR_PLLQ_Pos)));

This clears PLLI2S bit in RCC_CR register to enable further configuration
of PLL from external oscillator (same bit is already cleared in L4 devices
in code provided by ST).