### PR TITLE
riscv: Fix initialized data

### DIFF
--- a/hw/bsp/hifive1/hifive1.ld
+++ b/hw/bsp/hifive1/hifive1.ld
@@ -128,14 +128,14 @@ SECTIONS
     PROVIDE( _data = . );
   } >ram AT>flash
 
-  .data          :
+  .data          :  ALIGN_WITH_INPUT
   {
     *(.ram_text, .ram_text.*)
     *(.data .data.*)
     *(.gnu.linkonce.d.*)
   } >ram AT>flash
 
-  .srodata        :
+  .srodata        : ALIGN_WITH_INPUT
   {
     PROVIDE( _gp = . + 0x800 );
     PROVIDE( __global_pointer$ = _gp);
@@ -146,7 +146,7 @@ SECTIONS
     *(.srodata .srodata.*)
   } >ram AT>flash
 
-  .sdata          :
+  .sdata          : ALIGN_WITH_INPUT
   {
     *(.sdata .sdata.*)
     *(.gnu.linkonce.s.*)


### PR DESCRIPTION
Startup script has only one loop that copies initialized data and
code that should execute from RAM.
It implies that variables in .data .ram_text .srodata .sdata and such
has same layout in flash and in RAM.
Those data are packed by default in flash so output sections
(.data .srodata .sdata) if they start with something that requires
alignment change may end up with wrong data being copied to
statically initialized data.
One way to prevent such case is to copy each output section in separate
loop. But it is also possibly to add output section attribute ALIGN_WITH_INPUT
and then linker will fill necessary space in flash image.