### PR TITLE
coremark: Compute number of iteration automatically by default

### DIFF
--- a/apps/coremark/syscfg.yml
+++ b/apps/coremark/syscfg.yml
@@ -19,7 +19,7 @@
 syscfg.defs:
     COREMARK_ITERATIONS:
         description: Number of iterations to run
-        value: 200
+        value: 0
 
 syscfg.vals.HARDFLOAT:
     FLOAT_USER: 1


### PR DESCRIPTION
Default value 200 for COREMARK_ITERATIONS is not good enough for most BSP/MCUs.
Making default value 0 makes coremark pre-compute number of iterations needed for 10-20s of benchmark time.

this change will make most (maybe all) BSP work out of the box.