### PR TITLE
hw/bsp: Update Sky66112 package path for uBlox BMD345

### DIFF
--- a/hw/bsp/ublox_bmd_345/pkg.yml
+++ b/hw/bsp/ublox_bmd_345/pkg.yml
@@ -43,4 +43,4 @@ pkg.deps.SOFT_PWM:
 
 # Use SKY66112 driver for now
 pkg.deps.BLE_CONTROLLER:
-    - "@apache-mynewt-nimble/nimble/drivers/plna/sky66112"
+    - "@apache-mynewt-nimble/nimble/drivers/fem/sky66112"


### PR DESCRIPTION
This was recently renamed from plna to fem.