### PR TITLE
pic32 flash access fixes

### DIFF
--- a/hw/mcu/microchip/pic32mz/src/hal_flash.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_flash.c
@@ -22,6 +22,7 @@
 #include <hal/hal_flash_int.h>
 #include <mcu/mips_hal.h>
 #include <string.h>
+#include <sys/kmem.h>
 
 #define VIRT_TO_PHY(ADDRESS)   (unsigned int)((int)(ADDRESS) & 0x1FFFFFFF)
 #define PHY_TO_VIRT(ADDRESS)   (unsigned int)((int)(ADDRESS) | 0x80000000)
@@ -100,7 +101,7 @@ pic32mz_flash_read(const struct hal_flash *dev, uint32_t address,
                    void *dst, uint32_t num_bytes)
 {
     (void)dev;
-    memcpy(dst, (void *)PHY_TO_VIRT(address), num_bytes);
+    memcpy(dst, (void *)PA_TO_KVA1(address), num_bytes);
     return 0;
 }
 


### PR DESCRIPTION
This fixes:
- unaligned address writes that are not needed (FCB uses unaligned writes).
- writes that are not multiply of 4 are now allowed
- flash read uses uncached segment to avoid wrong data read after writes (CRC failure in FCB usage)
