### PR TITLE
sys/log: Fix dangling pointer

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -920,12 +920,12 @@ log_walk_body_section(struct log *log, log_walk_body_func_t walk_body_func,
     };
     int rc;
 
-    log_offset->lo_arg = &lwba;
-
     if (!log->l_log->log_walk_sector) {
         rc = SYS_ENOTSUP;
         goto err;
     }
+
+    log_offset->lo_arg = &lwba;
 
     rc = log->l_log->log_walk_sector(log, log_walk_body_fn, log_offset);
     log_offset->lo_arg = lwba.arg;


### PR DESCRIPTION
GCC 12 reports following error:

Compiling repos/apache-mynewt-core/sys/log/full/src/log_level.c Error: repos/apache-mynewt-core/sys/log/full/src/log.c: In function
     'log_walk_body_section':
repos/apache-mynewt-core/sys/log/full/src/log.c:923:24: error: storing
    the address of local variable 'lwba' in '*log_offset.lo_arg'
    [-Werror=dangling-pointer=]
  923 |     log_offset->lo_arg = &lwba;
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~
repos/apache-mynewt-core/sys/log/full/src/log.c:917:30: note: 'lwba'
    declared here
  917 |     struct log_walk_body_arg lwba = {
      |                              ^~~~
repos/apache-mynewt-core/sys/log/full/src/log.c:917:30: note:
    'log_offset' declared here
cc1: all warnings being treated as errors