### PR TITLE
stm32f4: Enable prefetch for F405/F407/415/417

### DIFF
--- a/hw/mcu/stm/stm32f4xx/src/clock_stm32f4xx.c
+++ b/hw/mcu/stm/stm32f4xx/src/clock_stm32f4xx.c
@@ -275,8 +275,8 @@ SystemClock_Config(void)
 #if PREFETCH_ENABLE
 #if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || \
     defined(STM32F417xx)
-    /* RevA (prefetch must be off) or RevZ (prefetch can be on/off) */
-    if (HAL_GetREVID() == 0x1001) {
+    /* RevA (prefetch must be off see errata ES0182) */
+    if (HAL_GetREVID() != 0x1000) {
         __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
     }
 #else


### PR DESCRIPTION
Prefetch is not available only on Revision A.
Prefetch was enabled only for Revision Z.
Now revisions 1,2,4,Y also can have prefetch enabled.