### PR TITLE
i2s_nrfx: Add Audio clock support

### DIFF
--- a/hw/mcu/nordic/nrf5340/include/nrfx_config.h
+++ b/hw/mcu/nordic/nrf5340/include/nrfx_config.h
@@ -234,7 +234,7 @@
 // <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver.
 //==========================================================
 #ifndef NRFX_CLOCK_ENABLED
-#define NRFX_CLOCK_ENABLED 0
+#define NRFX_CLOCK_ENABLED 1
 #endif
 // <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF clock source.
 


### PR DESCRIPTION
NRF5340 has dedicated audio clock that allows for more precise audio frequencies then 32MHz oscillator only.

NRF5340 also supports 32 bits sample slots.

This add support ACLK.
For this to work NRFX_CLOCK_ENABLED must be enabled to allows usage of clock related nrfx api.