### PR TITLE
pic32: Change default cache mode to write-through

### DIFF
--- a/kernel/os/src/arch/pic32/stubs/pic32_init_cache.S
+++ b/kernel/os/src/arch/pic32/stubs/pic32_init_cache.S
@@ -55,7 +55,7 @@
 #endif
 
 /* Set __PIC32_CACHE_MODE to the desired coherency attribute */
-#define __PIC32_CACHE_MODE _CACHE_WRITEBACK_WRITEALLOCATE
+#define __PIC32_CACHE_MODE _CACHE_WRITETHROUGH_WRITEALLOCATE
 
 /* ==================================== */
 #define Index_Store_Tag_I 0x08


### PR DESCRIPTION
Write-back-allocate, while slightly more efficient, makes finding some errors very hard to find, when place of crash is connected to actual invalid address by cache line only.

Write-back-allocate is not really working correct with LWIP stack where frames from ETH PHY are received by DMA no CPU. This problem may be addressed later, for now code switches to write-through.