### PR TITLE
pic32: Assign shadow register sets to interrupts

### DIFF
--- a/kernel/os/src/arch/pic32/asm/ctx.S
+++ b/kernel/os/src/arch/pic32/asm/ctx.S
@@ -95,10 +95,12 @@
     # disable co-precessor 1 on return from context switch
     ins     k0, $0, _CP0_STATUS_CU1_POSITION, _CP0_STATUS_CU1_LENGTH
     sw      k0, CTX_STATUS(sp)
+#if defined(PRISS) && (__PIC32_SRS_SET_COUNT == 8)
     # enable interrupts with higher priority
     ins     k0, $0, _CP0_STATUS_EXL_POSITION, _CP0_STATUS_EXL_LENGTH
     ori     k0, k0, 1 << _CP0_STATUS_IPL_POSITION
     mtc0    k0, _CP0_STATUS
+#endif
     .set pop
 .endm
 

--- a/kernel/os/src/arch/pic32/os_arch_pic32.c
+++ b/kernel/os/src/arch/pic32/os_arch_pic32.c
@@ -196,6 +196,18 @@ os_arch_os_init(void)
         /* vector spacing 0x20  */
         _CP0_SET_INTCTL(_CP0_GET_INTCTL() | (1 << _CP0_INTCTL_VS_POSITION));
 
+#if defined(PRISS) && (__PIC32_SRS_SET_COUNT == 8)
+        /*
+         * Assign Shadow Register Sets to interrupts:
+         * Interrupt level 0 - (normal execution) SRS 0
+         * Interrupt level 1 - (SW0 - context switch) also SRS 0
+         * Interrupts level 2-7 - SRS 2-7
+         */
+        PRISS = 0x76543200;
+        /* Assign exceptions to SRS 1 */
+        _CP0_SET_SRSCTL((_CP0_GET_SRSCTL() & ~_CP0_SRSCTL_ESS_MASK) | (1 << _CP0_SRSCTL_ESS_POSITION));
+#endif
+
         /* Stop core timer while debugger stops */
         _CP0_BIC_DEBUG(_CP0_DEBUG_COUNTDM_MASK);
 


### PR DESCRIPTION
All interrupts used same register set and that made interrupt code take more time since more registers needed to be save.

Commit 808115b9530b059ff9b6a12fc5b988f87e540710 enabled interrupts at some point during context switch and while interrupts were enabled isr code for interrupt or exception that would be handled (Coprocessor Unusable exception) would use k0 and k1 without storing it first. This leads to difficult to find hard faults.

One way to fix it would be to not enable interrupts during context switch but this change just assigns SRS to interrupts and exception so k0 and k1 will not get clobbered during context switch.

For pic32mx just not enable interrupt during context switch since they don't have enough SRS.