### PR TITLE
Flash autoconfigure updates

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -85,6 +85,8 @@ struct qspi_flash_config {
 extern const struct qspi_flash_config rdids[];
 extern const int qspi_flash_config_array_size;
 
+const struct qspi_flash_config *da1469x_qspi_get_config(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -430,6 +430,9 @@ qspi_read_rdid(const struct hal_flash *dev)
     int i;
     uint32_t result;
 
+    da1469x_qspi_mode_manual(dev);
+    da1469x_qspi_wait_busy(dev);
+
     /* Issue a read rdid command (0x9F) and get 24 bit response */
     QSPIC->QSPIC_CTRLBUS_REG = QSPIC_QSPIC_CTRLBUS_REG_QSPIC_EN_CS_Msk;
     da1469x_qspi_write8(dev, 0x9f);
@@ -454,7 +457,6 @@ da1469x_hff_mcu_custom_init(const struct hal_flash *dev)
     uint32_t primask;
 
     __HAL_DISABLE_INTERRUPTS(primask);
-    da1469x_qspi_mode_manual(dev);
 
     /* detect flash device and use correct configuration */
     config = qspi_read_rdid(dev);


### PR DESCRIPTION
This set of patches fixes an issue with Gigadevice flash when issuing rdid reads.  The second patch adds an export of the RDID information so that it can be used by other application code.  This is especially useful if special actions need to be taken based on the detected flash identification.