### PR TITLE
da1469x: Add option to not disable watchdog on init

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_watchdog.c
+++ b/hw/mcu/dialog/da1469x/src/hal_watchdog.c
@@ -27,7 +27,10 @@ int
 hal_watchdog_init(uint32_t expire_msecs)
 {
     SYS_WDOG->WATCHDOG_CTRL_REG = SYS_WDOG_WATCHDOG_CTRL_REG_WDOG_FREEZE_EN_Msk;
+
+#if MYNEWT_VAL(MCU_WATCHDOG_DISABLE_ON_INIT)
     GPREG->SET_FREEZE_REG |= GPREG_SET_FREEZE_REG_FRZ_SYS_WDOG_Msk;
+#endif
 
 #if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
     g_hal_watchdog_reload_val = expire_msecs / 21;
@@ -40,7 +43,7 @@ hal_watchdog_init(uint32_t expire_msecs)
         /* wait */
     }
     SYS_WDOG->WATCHDOG_REG = g_hal_watchdog_reload_val;
-    
+
     return 0;
 }
 

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -454,6 +454,11 @@ syscfg.defs:
         restrictions:
             - '!GPADC_BATTERY'
 
+    MCU_WATCHDOG_DISABLE_ON_INIT:
+        description: >
+          'Disable watchdog on init'
+        value: 1
+
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
 


### PR DESCRIPTION
This patch adds a facility to control whether or not the Dialog watchdog is disabled when the hal_watchdog_init function is being called.  There are some use cases where the watchdog needs to remain running from a previous application or bootloader.

Signed-off-by: Andy Gross <andy.gross@juul.com>