### PR TITLE
baselibc: Add option to have thread-safe heap

### DIFF
--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -27,3 +27,6 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
 pkg.req_apis:
     - console
+
+pkg.init.BASELIBC_THREAD_SAFE_HEAP_ALLOCATION:
+    baselibc_init: 0

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -36,3 +36,8 @@ syscfg.defs:
             It is still possible to use C++ code when this is set to 0 but
             global variable can be in wrong state.
         value: 1
+
+    BASELIBC_THREAD_SAFE_HEAP_ALLOCATION:
+        description: >
+            Set to 1 if project requires malloc/calloc/free to be thread safe.
+        value: 0


### PR DESCRIPTION
baselibc has option to lock the heap so malloc/free/calloc can be called from multi-threaded application.

This adds implementation of this using os_mutex.
When BASELIBC_THREAD_SAFE_HEAP_ALLOCATION is set to 1 baselibc has package initialization functions that puts locking functionality in place.

For now to preserve compatibility this functionality is not enabled by default leaving heap allocation
not thread unsafe.