### PR TITLE
hw/ipc_nrf5340: Add support for HCI IPC transport

### DIFF
--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340.h
@@ -151,6 +151,10 @@ uint16_t ipc_nrf5340_consume(int channel, uint16_t len);
  */
 void ipc_nrf5340_set_net_core_restart_cb(void (*on_restart)(void));
 
+#if MYNEWT_PKG_apache_mynewt_nimble__nimble_transport_common_hci_ipc
+volatile struct hci_ipc_shm *ipc_nrf5340_hci_shm_get(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340_priv.h
+++ b/hw/drivers/ipc_nrf5340/include/ipc_nrf5340/ipc_nrf5340_priv.h
@@ -21,6 +21,9 @@
 #define _HW_DRIVERS_IPC_NRF5340_PRIV_H
 
 #include <stdint.h>
+#if MYNEWT_PKG_apache_mynewt_nimble__nimble_transport_common_hci_ipc
+#include <nimble/transport/hci_ipc.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,8 +49,8 @@ struct ipc_shared {
         APP_AND_NET_RUNNING,
         NET_RESTARTED,
     } ipc_state;
-#if MYNEWT_VAL(BLE_TRANSPORT_INT_FLOW_CTL)
-    uint8_t acl_from_ll_count;
+#if MYNEWT_PKG_apache_mynewt_nimble__nimble_transport_common_hci_ipc
+    volatile struct hci_ipc_shm hci_shm;
 #endif
 };
 


### PR DESCRIPTION
This adds structure required for HCI IPC transport to shared memory. Since HCI IPC transport implements generic flow control for HCI over IPC, we can remove "old" flow control code.