### PR TITLE
iptest thread safe malloc

### DIFF
--- a/apps/iptest/syscfg.yml
+++ b/apps/iptest/syscfg.yml
@@ -41,3 +41,4 @@ syscfg.vals:
 
     ETH_0: 1
 
+    BASELIBC_THREAD_SAFE_HEAP_ALLOCATION: 1

--- a/net/ip/lwip_mn/lwipopts/syscfg.yml
+++ b/net/ip/lwip_mn/lwipopts/syscfg.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.restrictions:
+    # As long as MEM_LIBC_MALLOC is 1 this restriction applies
+    - 'BASELIBC_THREAD_SAFE_HEAP_ALLOCATION'


### PR DESCRIPTION
LwIP in default configuration specified by lwipopts.h uses malloc/calloc/free for
some allocations.
- To make sure that malloc is thread safe restriction is applied in syscfg for lwipopts package
- apps/iptest has this value set in syscfg
