### PR TITLE
baselibc: Prevent calloc recursion

### DIFF
--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -30,3 +30,6 @@ pkg.req_apis:
 
 pkg.init.BASELIBC_THREAD_SAFE_HEAP_ALLOCATION:
     baselibc_init: 0
+
+pkg.cflags:
+    - -fno-builtin-malloc


### PR DESCRIPTION
When optimization is above O1 compilers recognizes sequences:
   p = malloc(n);
   memset(p, 0, n);
and turns them into calloc calls.
Unfortunately this sequence is actually in baselibc implementation of calloc so compiler just optimizes this sequence and calls calloc recursively or jumps to the beginning resulting in infinite loops.

To break this circle baselibc is build with option -fno-builtin-malloc