### PR TITLE
bsp/pca100121: Init on board pins

### DIFF
--- a/hw/bsp/nordic_pca10121/include/bsp/bsp.h
+++ b/hw/bsp/nordic_pca10121/include/bsp/bsp.h
@@ -55,6 +55,9 @@ extern uint8_t _ram_start;
 #define BUTTON_3            4
 #define BUTTON_4            6
 #define BUTTON_5            5
+#define BUTTON_VOL_DOWN     BUTTON_1
+#define BUTTON_VOL_UP       BUTTON_2
+#define BUTTON_PLAY         BUTTON_3
 
 /* Arduino pins */
 #define ARDUINO_PIN_D0      41
@@ -87,6 +90,13 @@ extern uint8_t _ram_start;
 #define ARDUINO_PIN_SCK     ARDUINO_PIN_D13
 #define ARDUINO_PIN_MOSI    ARDUINO_PIN_D11
 #define ARDUINO_PIN_MISO    ARDUINO_PIN_D12
+
+/* Other on board pin selection */
+
+#define PCA100121_SDCARD_CS_PIN         11
+#define PCA100121_CS47L63_CS_PIN        17
+#define PCA100121_CS47L63_RESET_PIN     18
+#define PCA100121_HW_CODEC_ON_BOARD_PIN 21
 
 #ifdef __cplusplus
 }

--- a/hw/bsp/nordic_pca10121/src/hal_bsp.c
+++ b/hw/bsp/nordic_pca10121/src/hal_bsp.c
@@ -29,6 +29,7 @@
 #include <mcu/nrf5340_hal.h>
 #include <mcu/nrf5340_periph.h>
 #include <bsp/bsp.h>
+#include "hal/hal_gpio.h"
 
 /*
  * What memory to include in coredump.
@@ -95,6 +96,21 @@ hal_bsp_init(void)
 {
     /* Make sure system clocks have started */
     hal_system_clock_start();
+
+    /* SDCard CS, (active low), default to 1 */
+    hal_gpio_init_out(PCA100121_SDCARD_CS_PIN, 1);
+
+    /* CS47L63 CS, (active low), default to 1 */
+    hal_gpio_init_out(PCA100121_CS47L63_CS_PIN, 1);
+
+    /* CS47L63 Reset pin, keep low at start */
+    hal_gpio_init_out(PCA100121_CS47L63_RESET_PIN, 0);
+
+    /* Select HW codec:
+     * 0 - on board HW codec
+     * 1 - pins routed to external header
+     */
+    hal_gpio_init_out(PCA100121_HW_CODEC_ON_BOARD_PIN, 0);
 
     /* Create all available nRF5340 peripherals */
     nrf5340_periph_create();


### PR DESCRIPTION
SD card and CS47L63 codec share SPI this make sure that both CS pins are high at start so unused peripheral does not interfere with used one.
CS47L63 is kept in reset till it's used.
CS47L63 on board is used instead of one possibly connected to external connector.