### PR TITLE
kernel/os: Add t_mutex and t_sem fields

### DIFF
--- a/kernel/os/include/os/os_task.h
+++ b/kernel/os/include/os/os_task.h
@@ -114,7 +114,11 @@ struct os_task {
     void *t_arg;
 
     /** Current object task is waiting on, either a semaphore or mutex */
-    void *t_obj;
+    union {
+        void *t_obj;
+        struct os_mutex *t_mutex;
+        struct os_sem *t_sem;
+    };
 
     /** Default sanity check for this task */
     struct os_sanity_check t_sanity_check;


### PR DESCRIPTION
t_obj points to semaphore or mutex while task is waiting now t_obj is field in union along with t_mutex and t_sem it just makes debugging easier since IDE can show mutex or semaphore without need to case in GDB console