### PR TITLE
stm32f7 dcache

### DIFF
--- a/hw/mcu/stm/stm32f7xx/src/clock_stm32f7xx.c
+++ b/hw/mcu/stm/stm32f7xx/src/clock_stm32f7xx.c
@@ -258,17 +258,5 @@ SystemClock_Config(void)
 #if PREFETCH_ENABLE
     __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
 #endif
-
-    /*
-     * These are flash instruction and data caches, not the be confused with
-     * MCU caches.
-     */
-#if INSTRUCTION_CACHE_ENABLE
-    __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
-#endif
-
-#if DATA_CACHE_ENABLE
-    __HAL_FLASH_DATA_CACHE_ENABLE();
-#endif
 }
 #endif

--- a/hw/mcu/stm/stm32f7xx/src/clock_stm32f7xx.c
+++ b/hw/mcu/stm/stm32f7xx/src/clock_stm32f7xx.c
@@ -54,6 +54,9 @@ SystemClock_Config(void)
     SCB_EnableICache();
 #endif
 
+#if MYNEWT_VAL(STM32_ENABLE_DCACHE)
+    SCB_EnableDCache();
+#endif
     /*
      * Enable Power Control clock
      */

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -133,7 +133,7 @@ SECTIONS
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);
-    } > RAM
+    } > DTCM
 
     .coredata :
     {

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -133,7 +133,7 @@ SECTIONS
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);
-    } > RAM
+    } > DTCM
 
     .coredata :
     {

--- a/hw/mcu/stm/stm32f7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f7xx/syscfg.yml
@@ -31,6 +31,10 @@ syscfg.defs:
         description: Enable instruction caching
         value: 1
 
+    STM32_ENABLE_DCACHE:
+        description: Enable instruction caching
+        value: 0
+
     STM32_CLOCK_VOLTAGESCALING_CONFIG:
         description: Voltage scale
         value: 0


### PR DESCRIPTION
- Some inapplicable leftover from STM32F4 removed
- Added DCache enabler
- vector table moved to DTCM due to apparent NVIC problem with cached SRAM1