### PR TITLE
hw/mcu/nrf5340: Enable cache by default

### DIFF
--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -113,7 +113,7 @@ syscfg.defs:
         description: >
             Enable instruction and data cache
             Default value is 0, so disabled.
-        value: 0
+        value: 1
 
     MCU_NRF5340_EN_APPROTECT_USERHANDLING:
         description: >


### PR DESCRIPTION
Does not really make sense to have it disabled by default since we are running from flash.