### PR TITLE
sys/console: Reset text attributes on init

### DIFF
--- a/sys/console/full/src/console.c
+++ b/sys/console/full/src/console.c
@@ -368,6 +368,7 @@ console_init_terminal(void)
 {
     if (MYNEWT_VAL(CONSOLE_PROMPT_STICKY) && !terminal_initialized) {
         console_write_str(CSI "!p"
+                          CSI "0m"
                           CSI "1;999r"
                           CSI "999;1H\n\n"
                           CSI "A"


### PR DESCRIPTION
When console has colors (for now only for software cursor) color or other text attributes can be changed from the default when device reboots.
Now escape sequnce to restore default text attributes is added to first time initialization of console.