### PR TITLE
mcu/nrf5340: Enable cache only from secure code

### DIFF
--- a/hw/mcu/nordic/nrf5340/src/hal_system.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_system.c
@@ -38,7 +38,9 @@ void
 hal_system_init(void)
 {
 #if MYNEWT_VAL(MCU_CACHE_ENABLED)
+#if MYNEWT_VAL(MCU_APP_SECURE) || MYNEWT_VAL(BOOT_LOADER)
     NRF_CACHE_S->ENABLE = 1;
+#endif
 #endif
 
 #if MYNEWT_VAL(MCU_DCDC_ENABLED)


### PR DESCRIPTION
This is allowed only from secure code (either application running in secure mode, or bootloader).