### PR TITLE
stm32/spi: Init Instance in hal_spi_init

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -430,6 +430,41 @@ hal_spi_init(int spi_num, void *usercfg, uint8_t spi_type)
 
     spi->cfg = usercfg;
     spi->slave = (spi_type == HAL_SPI_TYPE_SLAVE);
+    switch (spi_num) {
+#if SPI_0_ENABLED
+    case 0:
+        spi->handle.Instance = SPI1;
+        break;
+#endif
+#if SPI_1_ENABLED
+    case 1:
+        spi->handle.Instance = SPI2;
+        break;
+#endif
+#if SPI_2_ENABLED
+    case 2:
+        spi->handle.Instance = SPI3;
+        break;
+#endif
+#if SPI_3_ENABLED
+    case 3:
+        spi->handle.Instance = SPI4;
+        break;
+#endif
+#if SPI_4_ENABLED
+    case 4:
+        spi->handle.Instance = SPI5;
+        break;
+#endif
+#if SPI_5_ENABLED
+    case 5:
+        spi->handle.Instance = SPI6;
+        break;
+#endif
+    default:
+        rc = -1;
+        goto err;
+    }
 
     return (0);
 err:
@@ -611,7 +646,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
         gpio.Alternate = GPIO_AF0_SPI1;
     #endif
 #endif
-        spi->handle.Instance = SPI1;
         break;
 #endif
 #if SPI_1_ENABLED
@@ -624,7 +658,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
         gpio.Alternate = GPIO_AF0_SPI2;
     #endif
 #endif
-        spi->handle.Instance = SPI2;
         break;
 #endif
 #if SPI_2_ENABLED
@@ -633,7 +666,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 #if !MYNEWT_VAL(MCU_STM32F1)
         gpio.Alternate = GPIO_AF6_SPI3;
 #endif
-        spi->handle.Instance = SPI3;
         break;
 #endif
 #if SPI_3_ENABLED
@@ -642,7 +674,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 #if !MYNEWT_VAL(MCU_STM32F1)
         gpio.Alternate = GPIO_AF5_SPI4;
 #endif
-        spi->handle.Instance = SPI4;
         break;
 #endif
 #if SPI_4_ENABLED
@@ -653,7 +684,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 #elif defined(GPIO_AF5_SPI5)
         gpio.Alternate = GPIO_AF5_SPI5;
 #endif
-        spi->handle.Instance = SPI5;
         break;
 #endif
 #if SPI_5_ENABLED
@@ -662,7 +692,6 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 #if !MYNEWT_VAL(MCU_STM32F1)
         gpio.Alternate = GPIO_AF5_SPI6;
 #endif
-        spi->handle.Instance = SPI6;
         break;
 #endif
    default:


### PR DESCRIPTION
This fixes the problem firmware update on STM32 devices with external flash that is enabled
in bootloader (most likely when second slot is in external flash as is configured for black_vet6,
but could happen also when both slots are in normal flash and spiflash is enabled in bootloader
for other reason).

spi->handle.Instance initiated to constant value (register address) It was done in hal_spi_config() so value was set every time this function was called which is not the main reason it is moved now to hal_spi_init().

Main reason is that in spiflash code call to hal_spi_disable() is made before first call to hal_spi_config() it can result in writes to addresses around 0 which most likely be internal flash address. It can result in exception if MPU is present and configured to block writes to this region. In other cases it can set error flag in flash register that is never cleared by ST HAL flash driver code HAL_FLASHEx_Erase() as is done in HAL_FLASHEx_Erase_IT(). This in turn prevents bootloader to swap images since during erase error is reported.
Erase function from STM HAL (at least for STMF4/7/2) could be fixed to do what HAL_FLASHEx_Erase_IT does with error flags. But for now just setup correctly Instance.