### PR TITLE
stm32/spi: Fix uninitialized return value

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -912,13 +912,12 @@ uint16_t hal_spi_tx_val(int spi_num, uint16_t val)
 {
     int rc;
     struct stm32_hal_spi *spi;
-    uint16_t retval;
+    uint16_t retval = 0xFFFF;
     int len;
     int sr;
 
     STM32_HAL_SPI_RESOLVE(spi_num, spi);
     if (spi->slave) {
-        retval = -1;
         goto err;
     }
     if (spi->handle.Init.DataSize == SPI_DATASIZE_8BIT) {


### PR DESCRIPTION
if STM32_HAL_SPI_RESOLVE() fails code jumps to err: where retval is uninitialized.

```c
uint16_t hal_spi_tx_val(int spi_num, uint16_t val) {
...
    uint16_t retval;
...
    STM32_HAL_SPI_RESOLVE(spi_num, spi);
...
err:
    return retval;
}
```