### PR TITLE
Add initial STM32H723ZG MCU support with external repos downloading

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -360,6 +360,9 @@ STM32F7xx
 STM32F7xx_HAL_Driver
 stm32f7xx
 
+# CMSIS Cortex-H7, STM32h7 - BSD License.
+stm32h7xx
+
 # LORA - BSD License
 lora
 
@@ -396,6 +399,11 @@ startup_STM32F429x.s
 stm32l1xx_hal_conf.h
 system_stm32l1xx.c
 startup_stm32l152xc.s
+
+# NUCLEO-H723ZG BSP - BSD License
+stm32h7xx_hal_conf.h
+system_stm32h7xx.c
+startup_stm32h723xx.s
 
 # NUCLEO-F767 BSP - BSD License
 startup_stm32f767xx.s

--- a/LICENSE
+++ b/LICENSE
@@ -328,6 +328,7 @@ these files in later releases.  These files are:
     * hw/mcu/stm/stm32wbxx/include/mcu/cmsis_nvic.h
     * hw/mcu/stm/stm32f1xx/include/mcu/cmsis_nvic.h
     * hw/mcu/stm/stm32f7xx/include/mcu/cmsis_nvic.h
+    * hw/mcu/stm/stm32h7xx/include/mcu/cmsis_nvic.h
 
 This product bundles parts of STM32 SDK by STMicroelectronics, which is
 available under the "3-clause BSD" license.  Bundled files are:
@@ -385,6 +386,13 @@ This product bundles parts of STM32CubeF3, which is available under the
     * hw/bsp/nucleo-f303k8/src/arch/cortex_m4/startup_stm32f303x8.s
     * hw/bsp/nucleo-f303re/include/bsp/stm32f3xx_hal_conf.h
     * hw/bsp/nucleo-f303re/src/arch/cortex_m4/startup_stm32f303xe.s
+
+This product bundles parts of STM32CubeH7, which is available under the
+"3-clause BSD" license.  Bundled files are:
+    * hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
+    * hw/mcu/stm/stm32h7xx/src/system_stm32h7xx.c
+    * hw/bsp/nucleo-h723zg/include/bsp/stm32h7xx_hal_conf.h
+    * hw/bsp/nucleo-h723zg/src/arch/cortex_m7/startup_stm32h723xx.s
 
 This product bundles parts of stm32l1xx, which is available under the
 "3-clause BSD" license.  Bundled files are:

--- a/hw/bsp/nucleo-h723zg/boot-nucleo-h723zg.ld
+++ b/hw/bsp/nucleo-h723zg/boot-nucleo-h723zg.ld
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  ITCM (xrw)       : ORIGIN = 0x00000000,   LENGTH = 64K
+  DTCM (xrw)       : ORIGIN = 0x20000000,   LENGTH = 128K
+  FLASH (rx)       : ORIGIN = 0x08000000,   LENGTH = 128K /* Bootloader area */
+  RAM  (xrw)       : ORIGIN = 0x24000000,   LENGTH = 320K /* AXI (128) + AXI/ITCM (192) */
+  RAM_D2  (xrw)    : ORIGIN = 0x30000000,   LENGTH = 32K  /* SRAM1 + SRMA2 */
+  RAM_D3  (xrw)    : ORIGIN = 0x38000000,   LENGTH = 16K  /* SRAM4 */
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/nucleo-h723zg/bsp.yml
+++ b/hw/bsp/nucleo-h723zg/bsp.yml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bsp.name: "NUCLEO-H723ZG"
+bsp.url: https://www.st.com/en/evaluation-tools/nucleo-h723zg.html
+bsp.maker: "STMicroelectronics"
+bsp.arch: cortex_m7
+bsp.compiler: compiler/arm-none-eabi-m7
+bsp.linkerscript:
+    - "hw/bsp/nucleo-h723zg/nucleo-h723zg.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32h7xx/stm32h723.ld"
+bsp.linkerscript.BOOT_LOADER.OVERWRITE:
+    - "hw/bsp/nucleo-h723zg/boot-nucleo-h723zg.ld"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32h7xx/stm32h723.ld"
+bsp.downloadscript: "hw/bsp/nucleo-h723zg/nucleo-h723zg_download.sh"
+bsp.debugscript: "hw/bsp/nucleo-h723zg/nucleo-h723zg_debug.sh"
+
+bsp.flash_map:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x08000000
+            size: 128kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x08020000
+            size: 256kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x08060000
+            size: 256kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x080A0000
+            size: 128kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x080C0000
+            size: 128kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x080E0000
+            size: 128kB
+
+        FLASH_AREA_SPI:
+            user_id: 2
+            device: 1
+            offset: 0x0
+            size: 128kB

--- a/hw/bsp/nucleo-h723zg/include/bsp/bsp.h
+++ b/hw/bsp/nucleo-h723zg/include/bsp/bsp.h
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef H_BSP_H
+#define H_BSP_H
+
+#include <inttypes.h>
+#include <mcu/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define special stackos sections */
+#define sec_data_core   __attribute__((section(".data.core")))
+#define sec_bss_core    __attribute__((section(".bss.core")))
+#define sec_bss_nz_core __attribute__((section(".bss.core.nz")))
+
+/* More convenient section placement macros. */
+#define bssnz_t         sec_bss_nz_core
+
+extern uint8_t _ram_start;
+extern uint8_t _dtcmram_start;
+extern uint8_t _itcmram_start;
+extern uint8_t _ram2_start;
+
+#define RAM_SIZE        (320 * 1024)
+#define RAM2_SIZE       (32 * 1024)
+#define RAM3_SIZE       (16 * 1024)
+#define DTCMRAM_SIZE    (128 * 1024)
+#define ITCMRAM_SIZE    (64 * 1024)
+
+/* LED pins */
+#define LED_1           MCU_GPIO_PORTB(0)
+#define LED_2           MCU_GPIO_PORTE(1)
+#define LED_3           MCU_GPIO_PORTB(14)
+
+#define LED_green       LED_1
+#define LED_blue        LED_2
+#define LED_red         LED_3
+
+#define LED_BLINK_PIN   LED_1
+
+/* BUTTON pins */
+#define BTN_USER_1      MCU_GPIO_PORTC(13)
+
+/* Button pin */
+#define BUTTON_1        BTN_USER_1
+
+/* Arduino pins */
+#define ARDUINO_PIN_D0      MCU_GPIO_PORTB(7)
+#define ARDUINO_PIN_D1      MCU_GPIO_PORTB(6)
+#define ARDUINO_PIN_D2      MCU_GPIO_PORTG(14)
+#define ARDUINO_PIN_D3      MCU_GPIO_PORTE(13)
+#define ARDUINO_PIN_D4      MCU_GPIO_PORTE(14)
+#define ARDUINO_PIN_D5      MCU_GPIO_PORTE(11)
+#define ARDUINO_PIN_D6      MCU_GPIO_PORTE(9)
+#define ARDUINO_PIN_D7      MCU_GPIO_PORTG(12)
+#define ARDUINO_PIN_D8      MCU_GPIO_PORTF(3)
+#define ARDUINO_PIN_D9      MCU_GPIO_PORTD(15)
+#define ARDUINO_PIN_D10     MCU_GPIO_PORTD(14)
+#define ARDUINO_PIN_D11     MCU_GPIO_PORTB(5)
+#define ARDUINO_PIN_D12     MCU_GPIO_PORTA(6)
+#define ARDUINO_PIN_D13     MCU_GPIO_PORTA(5)
+#define ARDUINO_PIN_A0      MCU_GPIO_PORTA(3)
+#define ARDUINO_PIN_A1      MCU_GPIO_PORTC(0)
+#define ARDUINO_PIN_A2      MCU_GPIO_PORTC(3)
+#define ARDUINO_PIN_A3      MCU_GPIO_PORTB(1)
+#define ARDUINO_PIN_A4      MCU_GPIO_PORTC(2)
+#define ARDUINO_PIN_A5      MCU_GPIO_PORTF(10)
+
+#define ARDUINO_PIN_RX      ARDUINO_PIN_D0
+#define ARDUINO_PIN_TX      ARDUINO_PIN_D1
+
+#define ARDUINO_PIN_SCL     MCU_GPIO_PORTB(8)
+#define ARDUINO_PIN_SDA     MCU_GPIO_PORTB(9)
+
+#define ARDUINO_PIN_SCK     ARDUINO_PIN_D13
+#define ARDUINO_PIN_MOSI    ARDUINO_PIN_D11
+#define ARDUINO_PIN_MISO    ARDUINO_PIN_D12
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H_BSP_H */

--- a/hw/bsp/nucleo-h723zg/include/bsp/stm32h7xx_hal_conf.h
+++ b/hw/bsp/nucleo-h723zg/include/bsp/stm32h7xx_hal_conf.h
@@ -1,0 +1,422 @@
+/**
+ ******************************************************************************
+ * @file    stm32h7xx_hal_conf_template.h
+ * @author  MCD Application Team
+ * @brief   HAL configuration template file.
+ *          This file should be copied to the application folder and renamed
+ *          to stm32h7xx_hal_conf.h.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32H7xx_HAL_CONF_H
+#define __STM32H7xx_HAL_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+ * @brief This is the list of modules to be used in the HAL driver
+ */
+#define HAL_MODULE_ENABLED
+#define HAL_ADC_MODULE_ENABLED
+#define HAL_CEC_MODULE_ENABLED
+#define HAL_COMP_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_CRC_MODULE_ENABLED
+#define HAL_CRYP_MODULE_ENABLED
+#define HAL_DAC_MODULE_ENABLED
+#define HAL_DCMI_MODULE_ENABLED
+#define HAL_DFSDM_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_DMA2D_MODULE_ENABLED
+#define HAL_ETH_MODULE_ENABLED
+#define HAL_EXTI_MODULE_ENABLED
+#define HAL_FDCAN_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_HASH_MODULE_ENABLED
+#define HAL_HCD_MODULE_ENABLED
+#define HAL_HRTIM_MODULE_ENABLED
+#define HAL_HSEM_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED
+#define HAL_IRDA_MODULE_ENABLED
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_JPEG_MODULE_ENABLED
+#define HAL_LPTIM_MODULE_ENABLED
+#define HAL_LTDC_MODULE_ENABLED
+#define HAL_MDIOS_MODULE_ENABLED
+#define HAL_MDMA_MODULE_ENABLED
+#define HAL_MMC_MODULE_ENABLED
+#define HAL_NAND_MODULE_ENABLED
+#define HAL_NOR_MODULE_ENABLED
+#define HAL_OPAMP_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_QSPI_MODULE_ENABLED
+#define HAL_RAMECC_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_RNG_MODULE_ENABLED
+#define HAL_RTC_MODULE_ENABLED
+#define HAL_SAI_MODULE_ENABLED
+#define HAL_SD_MODULE_ENABLED
+#define HAL_SDRAM_MODULE_ENABLED
+#define HAL_SMARTCARD_MODULE_ENABLED
+#define HAL_SMBUS_MODULE_ENABLED
+#define HAL_SPDIFRX_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED
+#define HAL_SRAM_MODULE_ENABLED
+#define HAL_SWPMI_MODULE_ENABLED
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+#define HAL_USART_MODULE_ENABLED
+#define HAL_WWDG_MODULE_ENABLED
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+ * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+ *        This value is used by the RCC HAL module to compute the system frequency
+ *        (when HSE is used as system clock source, directly or through the PLL).
+ */
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+ * @brief Internal  oscillator (CSI) default value.
+ *        This value is the default CSI value after Reset.
+ */
+#if !defined  (CSI_VALUE)
+#define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* CSI_VALUE */
+
+/**
+ * @brief Internal High Speed oscillator (HSI) value.
+ *        This value is used by the RCC HAL module to compute the system frequency
+ *        (when HSI is used as system clock source, directly or through the PLL).
+ */
+#if !defined  (HSI_VALUE)
+#define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+ * @brief External Low Speed oscillator (LSE) value.
+ *        This value is used by the UART, RTC HAL module to compute the system frequency
+ */
+#if !defined  (LSE_VALUE)
+#define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+
+#if !defined  (LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
+
+#if !defined  (LSI_VALUE)
+#define LSI_VALUE  ((uint32_t)32000)      /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                              The real value may vary depending on the variations
+                                              in voltage and temperature.*/
+
+/**
+ * @brief External clock source for I2S peripheral
+ *        This value is used by the I2S HAL module to compute the I2S clock source
+ *        frequency, this source is inserted directly through I2S_CKIN pad.
+ */
+#if !defined  (EXTERNAL_CLOCK_VALUE)
+#define EXTERNAL_CLOCK_VALUE    12288000U /*!< Value of the External clock in Hz*/
+#endif /* EXTERNAL_CLOCK_VALUE */
+
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+ * @brief This is the HAL system configuration section
+ */
+#define  VDD_VALUE                    3300UL /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)0x0F) /*!< tick interrupt priority */
+#define  USE_RTOS                     0
+#define  USE_SD_TRANSCEIVER           1U               /*!< use uSD Transceiver */
+#define  USE_SPI_CRC                  1U               /*!< use CRC in SPI */
+
+/* ########################### Ethernet Configuration ######################### */
+#define ETH_TX_DESC_CNT         4  /* number of Ethernet Tx DMA descriptors */
+#define ETH_RX_DESC_CNT         4  /* number of Ethernet Rx DMA descriptors */
+
+#define ETH_MAC_ADDR0    ((uint8_t)0x02)
+#define ETH_MAC_ADDR1    ((uint8_t)0x00)
+#define ETH_MAC_ADDR2    ((uint8_t)0x00)
+#define ETH_MAC_ADDR3    ((uint8_t)0x00)
+#define ETH_MAC_ADDR4    ((uint8_t)0x00)
+#define ETH_MAC_ADDR5    ((uint8_t)0x00)
+
+/* ########################## Assert Selection ############################## */
+/**
+ * @brief Uncomment the line below to expanse the "assert_param" macro in the
+ *        HAL drivers code
+ */
+/* #define USE_FULL_ASSERT    1 */
+
+
+/* Includes ------------------------------------------------------------------*/
+/**
+ * @brief Include module's header file
+ */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+#include "stm32h7xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+#include "stm32h7xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+#include "stm32h7xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+
+#ifdef HAL_MDMA_MODULE_ENABLED
+#include "stm32h7xx_hal_mdma.h"
+#endif /* HAL_MDMA_MODULE_ENABLED */
+
+#ifdef HAL_HASH_MODULE_ENABLED
+#include "stm32h7xx_hal_hash.h"
+#endif /* HAL_HASH_MODULE_ENABLED */
+
+#ifdef HAL_DCMI_MODULE_ENABLED
+#include "stm32h7xx_hal_dcmi.h"
+#endif /* HAL_DCMI_MODULE_ENABLED */
+
+#ifdef HAL_DMA2D_MODULE_ENABLED
+#include "stm32h7xx_hal_dma2d.h"
+#endif /* HAL_DMA2D_MODULE_ENABLED */
+
+#ifdef HAL_DFSDM_MODULE_ENABLED
+#include "stm32h7xx_hal_dfsdm.h"
+#endif /* HAL_DFSDM_MODULE_ENABLED */
+
+#ifdef HAL_ETH_MODULE_ENABLED
+#include "stm32h7xx_hal_eth.h"
+#endif /* HAL_ETH_MODULE_ENABLED */
+
+#ifdef HAL_EXTI_MODULE_ENABLED
+#include "stm32h7xx_hal_exti.h"
+#endif /* HAL_EXTI_MODULE_ENABLED */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+#include "stm32h7xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+#include "stm32h7xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_FDCAN_MODULE_ENABLED
+#include "stm32h7xx_hal_fdcan.h"
+#endif /* HAL_FDCAN_MODULE_ENABLED */
+
+#ifdef HAL_CEC_MODULE_ENABLED
+#include "stm32h7xx_hal_cec.h"
+#endif /* HAL_CEC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+#include "stm32h7xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+#include "stm32h7xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+#include "stm32h7xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+#include "stm32h7xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+#include "stm32h7xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+#ifdef HAL_HRTIM_MODULE_ENABLED
+#include "stm32h7xx_hal_hrtim.h"
+#endif /* HAL_HRTIM_MODULE_ENABLED */
+
+#ifdef HAL_HSEM_MODULE_ENABLED
+#include "stm32h7xx_hal_hsem.h"
+#endif /* HAL_HSEM_MODULE_ENABLED */
+
+#ifdef HAL_SRAM_MODULE_ENABLED
+#include "stm32h7xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+#include "stm32h7xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+#include "stm32h7xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+#include "stm32h7xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+#include "stm32h7xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+#include "stm32h7xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_JPEG_MODULE_ENABLED
+#include "stm32h7xx_hal_jpeg.h"
+#endif /* HAL_JPEG_MODULE_ENABLED */
+
+#ifdef HAL_MDIOS_MODULE_ENABLED
+#include "stm32h7xx_hal_mdios.h"
+#endif /* HAL_MDIOS_MODULE_ENABLED */
+
+
+#ifdef HAL_MMC_MODULE_ENABLED
+#include "stm32h7xx_hal_mmc.h"
+#endif /* HAL_MMC_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+#include "stm32h7xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_LTDC_MODULE_ENABLED
+#include "stm32h7xx_hal_ltdc.h"
+#endif /* HAL_LTDC_MODULE_ENABLED */
+
+#ifdef HAL_OPAMP_MODULE_ENABLED
+#include "stm32h7xx_hal_opamp.h"
+#endif /* HAL_OPAMP_MODULE_ENABLED */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+#include "stm32h7xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_QSPI_MODULE_ENABLED
+#include "stm32h7xx_hal_qspi.h"
+#endif /* HAL_QSPI_MODULE_ENABLED */
+
+#ifdef HAL_RAMECC_MODULE_ENABLED
+#include "stm32h7xx_hal_ramecc.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+#include "stm32h7xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+#include "stm32h7xx_hal_rtc.h"
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SAI_MODULE_ENABLED
+#include "stm32h7xx_hal_sai.h"
+#endif /* HAL_SAI_MODULE_ENABLED */
+
+#ifdef HAL_SD_MODULE_ENABLED
+#include "stm32h7xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */
+
+#ifdef HAL_SDRAM_MODULE_ENABLED
+#include "stm32h7xx_hal_sdram.h"
+#endif /* HAL_SDRAM_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+#include "stm32h7xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_SPDIFRX_MODULE_ENABLED
+#include "stm32h7xx_hal_spdifrx.h"
+#endif /* HAL_SPDIFRX_MODULE_ENABLED */
+
+#ifdef HAL_SWPMI_MODULE_ENABLED
+#include "stm32h7xx_hal_swpmi.h"
+#endif /* HAL_SWPMI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+#include "stm32h7xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+#include "stm32h7xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+#include "stm32h7xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+#include "stm32h7xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+#include "stm32h7xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+#include "stm32h7xx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+#include "stm32h7xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+#include "stm32h7xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+#include "stm32h7xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+ * @brief  The assert_param macro is used for function's parameters check.
+ * @param  expr: If expr is false, it calls assert_failed function
+ *         which reports the name of the source file and the source
+ *         line number of the call that failed.
+ *         If expr is true, it returns no value.
+ * @retval None
+ */
+  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+void assert_failed(uint8_t * file, uint32_t line);
+#else
+#define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32H7xx_HAL_CONF_H */
+

--- a/hw/bsp/nucleo-h723zg/nucleo-h723zg.cfg
+++ b/hw/bsp/nucleo-h723zg/nucleo-h723zg.cfg
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# New version of St-link
+source [find interface/stlink-v2-1.cfg]
+transport select hla_swd
+source [find target/stm32f7x.cfg]

--- a/hw/bsp/nucleo-h723zg/nucleo-h723zg.ld
+++ b/hw/bsp/nucleo-h723zg/nucleo-h723zg.ld
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script for STM32H723 when running from flash and using the bootloader */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  ITCM (xrw)       : ORIGIN = 0x00000000,   LENGTH = 64K
+  DTCM (xrw)       : ORIGIN = 0x20000000,   LENGTH = 128K
+  FLASH (rx)       : ORIGIN = 0x08020000,   LENGTH = 384K /* Image slot 1 */
+  RAM  (xrw)       : ORIGIN = 0x24000000,   LENGTH = 320K /* AXI (128) + AXI/ITCM (192) */
+  RAM_D2  (xrw)    : ORIGIN = 0x30000000,   LENGTH = 32K  /* SRAM1 + SRMA2 */
+  RAM_D3  (xrw)    : ORIGIN = 0x38000000,   LENGTH = 16K  /* SRAM4 */
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/nucleo-h723zg/nucleo-h723zg_debug.sh
+++ b/hw/bsp/nucleo-h723zg/nucleo-h723zg_debug.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - RESET set if target should be reset when attaching
+#  - NO_GDB set if we should not start gdb to debug
+#
+. $CORE_PATH/hw/scripts/stlink.sh
+
+FILE_NAME=$BIN_BASENAME.elf
+
+stlink_debug

--- a/hw/bsp/nucleo-h723zg/nucleo-h723zg_download.sh
+++ b/hw/bsp/nucleo-h723zg/nucleo-h723zg_download.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Called with following variables set:
+#  - CORE_PATH is absolute path to @apache-mynewt-core
+#  - BSP_PATH is absolute path to hw/bsp/bsp_name
+#  - BIN_BASENAME is the path to prefix to target binary,
+#    .elf appended to name is the ELF file
+#  - IMAGE_SLOT is the image slot to download to (for non-mfg-image, non-boot)
+#  - FEATURES holds the target features string
+#  - EXTRA_JTAG_CMD holds extra parameters to pass to jtag software
+#  - MFG_IMAGE is "1" if this is a manufacturing image
+#  - FLASH_OFFSET contains the flash offset to download to
+#  - BOOT_LOADER is set if downloading a bootloader
+
+. $CORE_PATH/hw/scripts/stlink.sh
+
+if [ "$MFG_IMAGE" ]; then
+    FLASH_OFFSET=0x08000000
+fi
+
+common_file_to_load
+stlink_load

--- a/hw/bsp/nucleo-h723zg/pkg.yml
+++ b/hw/bsp/nucleo-h723zg/pkg.yml
@@ -17,43 +17,23 @@
 # under the License.
 #
 
-pkg.name: hw/bus/drivers/spi_stm32
-pkg.description: SPI bus driver that uses ST HAL with interrupts and DMA
+pkg.name: hw/bsp/nucleo-h723zg
+pkg.type: bsp
+pkg.description: BSP definition for the stm32h723zg-nucleo board.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+    - stm32
+    - stm32h7
+    - nucleo
+
+pkg.cflags: -DSTM32H723xx -DUSE_FULL_LL_DRIVER
+
+pkg.cflags.HARDFLOAT:
+    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 pkg.deps:
-    - hw/bus
-    - hw/bus/drivers/spi_common
-
-pkg.deps.MCU_STM32F0:
-    - hw/bus/drivers/spi_stm32/stm32f0xx
-
-pkg.deps.MCU_STM32F1:
-    - hw/bus/drivers/spi_stm32/stm32f1xx
-
-pkg.deps.MCU_STM32F3:
-    - hw/bus/drivers/spi_stm32/stm32f3xx
-
-pkg.deps.MCU_STM32F4:
-    - hw/bus/drivers/spi_stm32/stm32f4xx
-
-pkg.deps.MCU_STM32F7:
-    - hw/bus/drivers/spi_stm32/stm32f7xx
-
-pkg.deps.MCU_STM32L0:
-    - hw/bus/drivers/spi_stm32/stm32l0xx
-
-pkg.deps.MCU_STM32L1:
-    - hw/bus/drivers/spi_stm32/stm32l1xx
-
-pkg.deps.MCU_STM32L4:
-    - hw/bus/drivers/spi_stm32/stm32l4xx
-
-pkg.deps.MCU_STM32WB:
-    - hw/bus/drivers/spi_stm32/stm32wbxx
-
-pkg.deps.MCU_STM32H7:
-    - hw/bus/drivers/spi_stm32/stm32h7xx
-    
+    - "@apache-mynewt-core/hw/mcu/stm/stm32h7xx"
+    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/hw/drivers/flash/spiflash"
+    - "@apache-mynewt-core/hw/bus/drivers/spi_hal"

--- a/hw/bsp/nucleo-h723zg/src/arch/cortex_m7/startup_stm32h723xx.s
+++ b/hw/bsp/nucleo-h723zg/src/arch/cortex_m7/startup_stm32h723xx.s
@@ -1,0 +1,773 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32h723xx.s
+  * @author    MCD Application Team
+  * @brief     STM32H723xx Devices vector table for GCC based toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m7
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+  .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+  ldr   sp, =_estack      /* set stack pointer */
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs  r1, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr  r3, =_sidata
+  ldr  r3, [r3, r1]
+  str  r3, [r0, r1]
+  adds  r1, r1, #4
+
+LoopCopyDataInit:
+  ldr  r0, =_sdata
+  ldr  r3, =_edata
+  adds  r2, r0, r1
+  cmp  r2, r3
+  bcc  CopyDataInit
+
+  ldr  r2, =_sbss
+  b  LoopFillZerobss
+
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs  r3, #0
+  str  r3, [r2], #4
+
+LoopFillZerobss:
+  ldr  r3, = _ebss
+  cmp  r2, r3
+  bcc  FillZerobss
+
+/*
+ * mynewt specific corebss clearing.
+ */
+  ldr   r2, =__corebss_start__
+  b     LoopFillZeroCoreBss
+
+/* Zero fill the bss segment. */
+FillZeroCoreBss:
+  movs  r3, #0
+  str   r3, [r2], #4
+
+LoopFillZeroCoreBss:
+  ldr   r3, =__corebss_end__
+  cmp   r2, r3
+  bcc   FillZeroCoreBss
+
+  ldr   r0, =__HeapBase
+  ldr   r1, =__HeapLimit
+  bl    _sbrkInit
+
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+/* Call the libc entry point.*/
+  bl  _start
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ * @param  None
+ * @retval None
+*/
+  .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M. Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+*******************************************************************************/
+  .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+g_pfnVectors:
+  .globl __isr_vector
+__isr_vector:
+  .word  _estack
+  .word  Reset_Handler
+
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  MemManage_Handler
+  .word  BusFault_Handler
+  .word  UsageFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTick_Handler
+
+  /* External Interrupts */
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */
+  .word     PVD_AVD_IRQHandler                /* PVD/AVD through EXTI Line detection */
+  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */
+  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */
+  .word     FLASH_IRQHandler                  /* FLASH                        */
+  .word     RCC_IRQHandler                    /* RCC                          */
+  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */
+  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */
+  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */
+  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */
+  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */
+  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */
+  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */
+  .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */
+  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */
+  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */
+  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */
+  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */
+  .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */
+  .word     FDCAN1_IT0_IRQHandler             /* FDCAN1 interrupt line 0      */
+  .word     FDCAN2_IT0_IRQHandler             /* FDCAN2 interrupt line 0      */
+  .word     FDCAN1_IT1_IRQHandler             /* FDCAN1 interrupt line 1      */
+  .word     FDCAN2_IT1_IRQHandler             /* FDCAN2 interrupt line 1      */
+  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */
+  .word     TIM1_BRK_IRQHandler               /* TIM1 Break interrupt         */
+  .word     TIM1_UP_IRQHandler                /* TIM1 Update interrupt        */
+  .word     TIM1_TRG_COM_IRQHandler           /* TIM1 Trigger and Commutation interrupt */
+  .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */
+  .word     TIM2_IRQHandler                   /* TIM2                         */
+  .word     TIM3_IRQHandler                   /* TIM3                         */
+  .word     TIM4_IRQHandler                   /* TIM4                         */
+  .word     I2C1_EV_IRQHandler                /* I2C1 Event                   */
+  .word     I2C1_ER_IRQHandler                /* I2C1 Error                   */
+  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */
+  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */
+  .word     SPI1_IRQHandler                   /* SPI1                         */
+  .word     SPI2_IRQHandler                   /* SPI2                         */
+  .word     USART1_IRQHandler                 /* USART1                       */
+  .word     USART2_IRQHandler                 /* USART2                       */
+  .word     USART3_IRQHandler                 /* USART3                       */
+  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */
+  .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */
+  .word     0                                 /* Reserved                     */
+  .word     TIM8_BRK_TIM12_IRQHandler         /* TIM8 Break and TIM12         */
+  .word     TIM8_UP_TIM13_IRQHandler          /* TIM8 Update and TIM13        */
+  .word     TIM8_TRG_COM_TIM14_IRQHandler     /* TIM8 Trigger and Commutation and TIM14 */
+  .word     TIM8_CC_IRQHandler                /* TIM8 Capture Compare         */
+  .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */
+  .word     FMC_IRQHandler                    /* FMC                          */
+  .word     SDMMC1_IRQHandler                 /* SDMMC1                       */
+  .word     TIM5_IRQHandler                   /* TIM5                         */
+  .word     SPI3_IRQHandler                   /* SPI3                         */
+  .word     UART4_IRQHandler                  /* UART4                        */
+  .word     UART5_IRQHandler                  /* UART5                        */
+  .word     TIM6_DAC_IRQHandler               /* TIM6 and DAC1&2 underrun errors */
+  .word     TIM7_IRQHandler                   /* TIM7                         */
+  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */
+  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */
+  .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */
+  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */
+  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */
+  .word     ETH_IRQHandler                    /* Ethernet                     */
+  .word     ETH_WKUP_IRQHandler               /* Ethernet Wakeup through EXTI line */
+  .word     FDCAN_CAL_IRQHandler              /* FDCAN calibration unit interrupt*/
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */
+  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */
+  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */
+  .word     USART6_IRQHandler                 /* USART6                       */
+  .word     I2C3_EV_IRQHandler                /* I2C3 event                   */
+  .word     I2C3_ER_IRQHandler                /* I2C3 error                   */
+  .word     OTG_HS_EP1_OUT_IRQHandler         /* USB OTG HS End Point 1 Out   */
+  .word     OTG_HS_EP1_IN_IRQHandler          /* USB OTG HS End Point 1 In    */
+  .word     OTG_HS_WKUP_IRQHandler            /* USB OTG HS Wakeup through EXTI */
+  .word     OTG_HS_IRQHandler                 /* USB OTG HS                   */
+  .word     DCMI_PSSI_IRQHandler              /* DCMI, PSSI                   */
+  .word     0                                 /* Reserved                     */
+  .word     RNG_IRQHandler                    /* Rng                          */
+  .word     FPU_IRQHandler                    /* FPU                          */
+  .word     UART7_IRQHandler                  /* UART7                        */
+  .word     UART8_IRQHandler                  /* UART8                        */
+  .word     SPI4_IRQHandler                   /* SPI4                         */
+  .word     SPI5_IRQHandler                   /* SPI5                         */
+  .word     SPI6_IRQHandler                   /* SPI6                         */
+  .word     SAI1_IRQHandler                   /* SAI1                         */
+  .word     LTDC_IRQHandler                   /* LTDC                         */
+  .word     LTDC_ER_IRQHandler                /* LTDC error                   */
+  .word     DMA2D_IRQHandler                  /* DMA2D                        */
+  .word     0                                 /* Reserved                     */
+  .word     OCTOSPI1_IRQHandler               /* OCTOSPI1                     */
+  .word     LPTIM1_IRQHandler                 /* LPTIM1                       */
+  .word     CEC_IRQHandler                    /* HDMI_CEC                     */
+  .word     I2C4_EV_IRQHandler                /* I2C4 Event                   */
+  .word     I2C4_ER_IRQHandler                /* I2C4 Error                   */
+  .word     SPDIF_RX_IRQHandler               /* SPDIF_RX                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DMAMUX1_OVR_IRQHandler            /* DMAMUX1 Overrun interrupt    */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DFSDM1_FLT0_IRQHandler            /* DFSDM Filter0 Interrupt      */
+  .word     DFSDM1_FLT1_IRQHandler            /* DFSDM Filter1 Interrupt      */
+  .word     DFSDM1_FLT2_IRQHandler            /* DFSDM Filter2 Interrupt      */
+  .word     DFSDM1_FLT3_IRQHandler            /* DFSDM Filter3 Interrupt      */
+  .word     0                                 /* Reserved                     */
+  .word     SWPMI1_IRQHandler                 /* Serial Wire Interface 1 global interrupt */
+  .word     TIM15_IRQHandler                  /* TIM15 global Interrupt          */
+  .word     TIM16_IRQHandler                  /* TIM16 global Interrupt          */
+  .word     TIM17_IRQHandler                  /* TIM17 global Interrupt          */
+  .word     MDIOS_WKUP_IRQHandler             /* MDIOS Wakeup  Interrupt         */
+  .word     MDIOS_IRQHandler                  /* MDIOS global Interrupt          */
+  .word     0                                 /* Reserved                        */
+  .word     MDMA_IRQHandler                   /* MDMA global Interrupt           */
+  .word     0                                 /* Reserved                        */
+  .word     SDMMC2_IRQHandler                 /* SDMMC2 global Interrupt         */
+  .word     HSEM1_IRQHandler                  /* HSEM1 global Interrupt          */
+  .word     0                                 /* Reserved                        */
+  .word     ADC3_IRQHandler                   /* ADC3 global Interrupt           */
+  .word     DMAMUX2_OVR_IRQHandler            /* DMAMUX Overrun interrupt        */
+  .word     BDMA_Channel0_IRQHandler          /* BDMA Channel 0 global Interrupt */
+  .word     BDMA_Channel1_IRQHandler          /* BDMA Channel 1 global Interrupt */
+  .word     BDMA_Channel2_IRQHandler          /* BDMA Channel 2 global Interrupt */
+  .word     BDMA_Channel3_IRQHandler          /* BDMA Channel 3 global Interrupt */
+  .word     BDMA_Channel4_IRQHandler          /* BDMA Channel 4 global Interrupt */
+  .word     BDMA_Channel5_IRQHandler          /* BDMA Channel 5 global Interrupt */
+  .word     BDMA_Channel6_IRQHandler          /* BDMA Channel 6 global Interrupt */
+  .word     BDMA_Channel7_IRQHandler          /* BDMA Channel 7 global Interrupt */
+  .word     COMP1_IRQHandler                  /* COMP1 global Interrupt          */
+  .word     LPTIM2_IRQHandler                 /* LP TIM2 global interrupt        */
+  .word     LPTIM3_IRQHandler                 /* LP TIM3 global interrupt        */
+  .word     LPTIM4_IRQHandler                 /* LP TIM4 global interrupt        */
+  .word     LPTIM5_IRQHandler                 /* LP TIM5 global interrupt        */
+  .word     LPUART1_IRQHandler                /* LP UART1 interrupt              */
+  .word     0                                 /* Reserved                        */
+  .word     CRS_IRQHandler                    /* Clock Recovery Global Interrupt */
+  .word     ECC_IRQHandler                    /* ECC diagnostic Global Interrupt */
+  .word     SAI4_IRQHandler                   /* SAI4 global interrupt           */
+  .word     DTS_IRQHandler                    /* Digital Temperature Sensor  interrupt */
+  .word     0                                 /* Reserved                              */
+  .word     WAKEUP_PIN_IRQHandler             /* Interrupt for all 6 wake-up pins      */
+  .word     OCTOSPI2_IRQHandler               /* OCTOSPI2 Interrupt       */
+  .word     0                                 /* Reserved                 */
+  .word     0                                 /* Reserved                 */
+  .word     FMAC_IRQHandler                   /* FMAC Interrupt           */
+  .word     CORDIC_IRQHandler                 /* CORDIC Interrupt         */
+  .word     UART9_IRQHandler                  /* UART9 Interrupt          */
+  .word     USART10_IRQHandler                /* UART10 Interrupt         */
+  .word     I2C5_EV_IRQHandler                /* I2C5 Event Interrupt     */
+  .word     I2C5_ER_IRQHandler                /* I2C5 Error Interrupt     */
+  .word     FDCAN3_IT0_IRQHandler             /* FDCAN3 interrupt line 0  */
+  .word     FDCAN3_IT1_IRQHandler             /* FDCAN3 interrupt line 1  */
+  .word     TIM23_IRQHandler                  /* TIM23 global interrupt   */
+  .word     TIM24_IRQHandler                  /* TIM24 global interrupt   */
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+
+   .weak      MemManage_Handler
+   .thumb_set MemManage_Handler,Default_Handler
+
+   .weak      BusFault_Handler
+   .thumb_set BusFault_Handler,Default_Handler
+
+   .weak      UsageFault_Handler
+   .thumb_set UsageFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler
+
+   .weak      WWDG_IRQHandler
+   .thumb_set WWDG_IRQHandler,Default_Handler
+
+   .weak      PVD_AVD_IRQHandler
+   .thumb_set PVD_AVD_IRQHandler,Default_Handler
+
+   .weak      TAMP_STAMP_IRQHandler
+   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+
+   .weak      RTC_WKUP_IRQHandler
+   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+   .weak      FLASH_IRQHandler
+   .thumb_set FLASH_IRQHandler,Default_Handler
+
+   .weak      RCC_IRQHandler
+   .thumb_set RCC_IRQHandler,Default_Handler
+
+   .weak      EXTI0_IRQHandler
+   .thumb_set EXTI0_IRQHandler,Default_Handler
+
+   .weak      EXTI1_IRQHandler
+   .thumb_set EXTI1_IRQHandler,Default_Handler
+
+   .weak      EXTI2_IRQHandler
+   .thumb_set EXTI2_IRQHandler,Default_Handler
+
+   .weak      EXTI3_IRQHandler
+   .thumb_set EXTI3_IRQHandler,Default_Handler
+
+   .weak      EXTI4_IRQHandler
+   .thumb_set EXTI4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream0_IRQHandler
+   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream1_IRQHandler
+   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream2_IRQHandler
+   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream3_IRQHandler
+   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream4_IRQHandler
+   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream5_IRQHandler
+   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream6_IRQHandler
+   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+
+   .weak      ADC_IRQHandler
+   .thumb_set ADC_IRQHandler,Default_Handler
+
+   .weak      FDCAN1_IT0_IRQHandler
+   .thumb_set FDCAN1_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN2_IT0_IRQHandler
+   .thumb_set FDCAN2_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN1_IT1_IRQHandler
+   .thumb_set FDCAN1_IT1_IRQHandler,Default_Handler
+
+   .weak      FDCAN2_IT1_IRQHandler
+   .thumb_set FDCAN2_IT1_IRQHandler,Default_Handler
+
+   .weak      EXTI9_5_IRQHandler
+   .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+   .weak      TIM1_BRK_IRQHandler
+   .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+   .weak      TIM1_UP_IRQHandler
+   .thumb_set TIM1_UP_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_IRQHandler
+   .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
+
+   .weak      TIM1_CC_IRQHandler
+   .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+   .weak      TIM2_IRQHandler
+   .thumb_set TIM2_IRQHandler,Default_Handler
+
+   .weak      TIM3_IRQHandler
+   .thumb_set TIM3_IRQHandler,Default_Handler
+
+   .weak      TIM4_IRQHandler
+   .thumb_set TIM4_IRQHandler,Default_Handler
+
+   .weak      I2C1_EV_IRQHandler
+   .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+   .weak      I2C1_ER_IRQHandler
+   .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+   .weak      I2C2_EV_IRQHandler
+   .thumb_set I2C2_EV_IRQHandler,Default_Handler
+
+   .weak      I2C2_ER_IRQHandler
+   .thumb_set I2C2_ER_IRQHandler,Default_Handler
+
+   .weak      SPI1_IRQHandler
+   .thumb_set SPI1_IRQHandler,Default_Handler
+
+   .weak      SPI2_IRQHandler
+   .thumb_set SPI2_IRQHandler,Default_Handler
+
+   .weak      USART1_IRQHandler
+   .thumb_set USART1_IRQHandler,Default_Handler
+
+   .weak      USART2_IRQHandler
+   .thumb_set USART2_IRQHandler,Default_Handler
+
+   .weak      USART3_IRQHandler
+   .thumb_set USART3_IRQHandler,Default_Handler
+
+   .weak      EXTI15_10_IRQHandler
+   .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+   .weak      RTC_Alarm_IRQHandler
+   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+   .weak      TIM8_BRK_TIM12_IRQHandler
+   .thumb_set TIM8_BRK_TIM12_IRQHandler,Default_Handler
+
+   .weak      TIM8_UP_TIM13_IRQHandler
+   .thumb_set TIM8_UP_TIM13_IRQHandler,Default_Handler
+
+   .weak      TIM8_TRG_COM_TIM14_IRQHandler
+   .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+
+   .weak      TIM8_CC_IRQHandler
+   .thumb_set TIM8_CC_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream7_IRQHandler
+   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+
+   .weak      FMC_IRQHandler
+   .thumb_set FMC_IRQHandler,Default_Handler
+
+   .weak      SDMMC1_IRQHandler
+   .thumb_set SDMMC1_IRQHandler,Default_Handler
+
+   .weak      TIM5_IRQHandler
+   .thumb_set TIM5_IRQHandler,Default_Handler
+
+   .weak      SPI3_IRQHandler
+   .thumb_set SPI3_IRQHandler,Default_Handler
+
+   .weak      UART4_IRQHandler
+   .thumb_set UART4_IRQHandler,Default_Handler
+
+   .weak      UART5_IRQHandler
+   .thumb_set UART5_IRQHandler,Default_Handler
+
+   .weak      TIM6_DAC_IRQHandler
+   .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+
+   .weak      TIM7_IRQHandler
+   .thumb_set TIM7_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream0_IRQHandler
+   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream1_IRQHandler
+   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream2_IRQHandler
+   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream3_IRQHandler
+   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream4_IRQHandler
+   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+
+   .weak      ETH_IRQHandler
+   .thumb_set ETH_IRQHandler,Default_Handler
+
+   .weak      ETH_WKUP_IRQHandler
+   .thumb_set ETH_WKUP_IRQHandler,Default_Handler
+
+   .weak      FDCAN_CAL_IRQHandler
+   .thumb_set FDCAN_CAL_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream5_IRQHandler
+   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream6_IRQHandler
+   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream7_IRQHandler
+   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+
+   .weak      USART6_IRQHandler
+   .thumb_set USART6_IRQHandler,Default_Handler
+
+   .weak      I2C3_EV_IRQHandler
+   .thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+   .weak      I2C3_ER_IRQHandler
+   .thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_OUT_IRQHandler
+   .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_IN_IRQHandler
+   .thumb_set OTG_HS_EP1_IN_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_WKUP_IRQHandler
+   .thumb_set OTG_HS_WKUP_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_IRQHandler
+   .thumb_set OTG_HS_IRQHandler,Default_Handler
+
+   .weak      DCMI_PSSI_IRQHandler
+   .thumb_set DCMI_PSSI_IRQHandler,Default_Handler
+
+   .weak      RNG_IRQHandler
+   .thumb_set RNG_IRQHandler,Default_Handler
+
+   .weak      FPU_IRQHandler
+   .thumb_set FPU_IRQHandler,Default_Handler
+
+   .weak      UART7_IRQHandler
+   .thumb_set UART7_IRQHandler,Default_Handler
+
+   .weak      UART8_IRQHandler
+   .thumb_set UART8_IRQHandler,Default_Handler
+
+   .weak      SPI4_IRQHandler
+   .thumb_set SPI4_IRQHandler,Default_Handler
+
+   .weak      SPI5_IRQHandler
+   .thumb_set SPI5_IRQHandler,Default_Handler
+
+   .weak      SPI6_IRQHandler
+   .thumb_set SPI6_IRQHandler,Default_Handler
+
+   .weak      SAI1_IRQHandler
+   .thumb_set SAI1_IRQHandler,Default_Handler
+
+   .weak      LTDC_IRQHandler
+   .thumb_set LTDC_IRQHandler,Default_Handler
+
+   .weak      LTDC_ER_IRQHandler
+   .thumb_set LTDC_ER_IRQHandler,Default_Handler
+
+   .weak      DMA2D_IRQHandler
+   .thumb_set DMA2D_IRQHandler,Default_Handler
+
+   .weak      OCTOSPI1_IRQHandler
+   .thumb_set OCTOSPI1_IRQHandler,Default_Handler
+
+   .weak      LPTIM1_IRQHandler
+   .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+   .weak      CEC_IRQHandler
+   .thumb_set CEC_IRQHandler,Default_Handler
+
+   .weak      I2C4_EV_IRQHandler
+   .thumb_set I2C4_EV_IRQHandler,Default_Handler
+
+   .weak      I2C4_ER_IRQHandler
+   .thumb_set I2C4_ER_IRQHandler,Default_Handler
+
+   .weak      SPDIF_RX_IRQHandler
+   .thumb_set SPDIF_RX_IRQHandler,Default_Handler
+
+   .weak      DMAMUX1_OVR_IRQHandler
+   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT0_IRQHandler
+   .thumb_set DFSDM1_FLT0_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT1_IRQHandler
+   .thumb_set DFSDM1_FLT1_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT2_IRQHandler
+   .thumb_set DFSDM1_FLT2_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT3_IRQHandler
+   .thumb_set DFSDM1_FLT3_IRQHandler,Default_Handler
+
+   .weak      SWPMI1_IRQHandler
+   .thumb_set SWPMI1_IRQHandler,Default_Handler
+
+   .weak      TIM15_IRQHandler
+   .thumb_set TIM15_IRQHandler,Default_Handler
+
+   .weak      TIM16_IRQHandler
+   .thumb_set TIM16_IRQHandler,Default_Handler
+
+   .weak      TIM17_IRQHandler
+   .thumb_set TIM17_IRQHandler,Default_Handler
+
+   .weak      MDIOS_WKUP_IRQHandler
+   .thumb_set MDIOS_WKUP_IRQHandler,Default_Handler
+
+   .weak      MDIOS_IRQHandler
+   .thumb_set MDIOS_IRQHandler,Default_Handler
+
+   .weak      MDMA_IRQHandler
+   .thumb_set MDMA_IRQHandler,Default_Handler
+
+   .weak      SDMMC2_IRQHandler
+   .thumb_set SDMMC2_IRQHandler,Default_Handler
+
+   .weak      HSEM1_IRQHandler
+   .thumb_set HSEM1_IRQHandler,Default_Handler
+
+   .weak      ADC3_IRQHandler
+   .thumb_set ADC3_IRQHandler,Default_Handler
+
+   .weak      DMAMUX2_OVR_IRQHandler
+   .thumb_set DMAMUX2_OVR_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel0_IRQHandler
+   .thumb_set BDMA_Channel0_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel1_IRQHandler
+   .thumb_set BDMA_Channel1_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel2_IRQHandler
+   .thumb_set BDMA_Channel2_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel3_IRQHandler
+   .thumb_set BDMA_Channel3_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel4_IRQHandler
+   .thumb_set BDMA_Channel4_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel5_IRQHandler
+   .thumb_set BDMA_Channel5_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel6_IRQHandler
+   .thumb_set BDMA_Channel6_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel7_IRQHandler
+   .thumb_set BDMA_Channel7_IRQHandler,Default_Handler
+
+   .weak      COMP1_IRQHandler
+   .thumb_set COMP1_IRQHandler,Default_Handler
+
+   .weak      LPTIM2_IRQHandler
+   .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+   .weak      LPTIM3_IRQHandler
+   .thumb_set LPTIM3_IRQHandler,Default_Handler
+
+   .weak      LPTIM4_IRQHandler
+   .thumb_set LPTIM4_IRQHandler,Default_Handler
+
+   .weak      LPTIM5_IRQHandler
+   .thumb_set LPTIM5_IRQHandler,Default_Handler
+
+   .weak      LPUART1_IRQHandler
+   .thumb_set LPUART1_IRQHandler,Default_Handler
+
+   .weak      CRS_IRQHandler
+   .thumb_set CRS_IRQHandler,Default_Handler
+
+   .weak      ECC_IRQHandler
+   .thumb_set ECC_IRQHandler,Default_Handler
+
+   .weak      SAI4_IRQHandler
+   .thumb_set SAI4_IRQHandler,Default_Handler
+
+   .weak      DTS_IRQHandler
+   .thumb_set DTS_IRQHandler,Default_Handler
+
+   .weak      WAKEUP_PIN_IRQHandler
+   .thumb_set WAKEUP_PIN_IRQHandler,Default_Handler
+
+   .weak      OCTOSPI2_IRQHandler
+   .thumb_set OCTOSPI2_IRQHandler,Default_Handler
+
+   .weak      FMAC_IRQHandler
+   .thumb_set FMAC_IRQHandler,Default_Handler
+
+   .weak      CORDIC_IRQHandler
+   .thumb_set CORDIC_IRQHandler,Default_Handler
+
+   .weak      UART9_IRQHandler
+   .thumb_set UART9_IRQHandler,Default_Handler
+
+   .weak      USART10_IRQHandler
+   .thumb_set USART10_IRQHandler,Default_Handler
+
+   .weak      I2C5_EV_IRQHandler
+   .thumb_set I2C5_EV_IRQHandler,Default_Handler
+
+   .weak      I2C5_ER_IRQHandler
+   .thumb_set I2C5_ER_IRQHandler,Default_Handler
+
+   .weak      FDCAN3_IT0_IRQHandler
+   .thumb_set FDCAN3_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN3_IT1_IRQHandler
+   .thumb_set FDCAN3_IT1_IRQHandler,Default_Handler
+
+   .weak      TIM23_IRQHandler
+   .thumb_set TIM23_IRQHandler,Default_Handler
+
+   .weak      TIM24_IRQHandler
+   .thumb_set TIM24_IRQHandler,Default_Handler
+
+

--- a/hw/bsp/nucleo-h723zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-h723zg/src/hal_bsp.c
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+
+#include "bsp/bsp.h"
+#include "os/mynewt.h"
+#include "spiflash/spiflash.h"
+
+#include <hal/hal_bsp.h>
+#include <hal/hal_flash_int.h>
+#include <hal/hal_system.h>
+
+#include <stm32h723xx.h>
+#include <stm32_common/stm32_hal.h>
+#include <bus/drivers/spi_common.h>
+
+#if MYNEWT_VAL(ETH_0)
+#include <stm32_eth/stm32_eth.h>
+#include <stm32_eth/stm32_eth_cfg.h>
+#endif
+
+#if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
+#include <pwm_stm32/pwm_stm32.h>
+#endif
+
+#if MYNEWT_VAL(PWM_0)
+struct stm32_pwm_conf os_bsp_pwm0_cfg = {
+    .tim = TIM3,
+    .irq = TIM3_IRQn,
+};
+#endif
+#if MYNEWT_VAL(PWM_1)
+struct stm32_pwm_conf os_bsp_pwm1_cfg = {
+    .tim = TIM4,
+    .irq = TIM4_IRQn,
+};
+#endif
+#if MYNEWT_VAL(PWM_2)
+struct stm32_pwm_conf os_bsp_pwm2_cfg = {
+    .tim = TIM12,
+    .irq = TIM8_BRK_TIM12_IRQn,
+};
+#endif
+
+const uint32_t stm32_flash_sectors[] = {
+    0x08000000,     /* 128kB */
+    0x08020000,     /* 128kB */
+    0x08040000,     /* 128kB */
+    0x08060000,     /* 128kB */
+    0x08080000,     /* 128kB */
+    0x080a0000,     /* 128kB */
+    0x080c0000,     /* 128kB */
+    0x080e0000,     /* 128kB */
+    0x08100000,     /* End of flash */
+};
+
+#define SZ (sizeof(stm32_flash_sectors) / sizeof(stm32_flash_sectors[0]))
+static_assert(MYNEWT_VAL(STM32_FLASH_NUM_AREAS) + 1 == SZ,
+        "STM32_FLASH_NUM_AREAS does not match flash sectors");
+
+#if MYNEWT_VAL(UART_0)
+const struct stm32_uart_cfg os_bsp_uart0_cfg = {
+    .suc_uart = USART3,
+    .suc_rcc_reg = &RCC->APB1LENR,
+    .suc_rcc_dev = RCC_APB1LENR_USART3EN,
+    .suc_pin_tx = MYNEWT_VAL(UART_0_PIN_TX),
+    .suc_pin_rx = MYNEWT_VAL(UART_0_PIN_RX),
+    .suc_pin_rts = MYNEWT_VAL(UART_0_PIN_RTS),
+    .suc_pin_cts = MYNEWT_VAL(UART_0_PIN_CTS),
+    .suc_pin_af = GPIO_AF7_USART3,
+    .suc_irqn = USART3_IRQn,
+};
+#endif
+
+#if MYNEWT_VAL(I2C_0)
+/*
+ * The PB8 and PB9 pins are connected through jumpers in the board to
+ * both ADC_IN and I2C pins. To enable I2C functionality SB147/SB157 need
+ * to be removed (they are the default connections) and SB138/SB143 need
+ * to be shorted.
+ */
+const struct stm32_hal_i2c_cfg os_bsp_i2c0_cfg = {
+    .hic_i2c = I2C1,
+    .hic_rcc_reg = &RCC->APB1LENR,
+    .hic_rcc_dev = RCC_APB1LENR_I2C1EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_0_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_0_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C1,
+    .hic_10bit = 0,
+    .hic_timingr = 0xA0303048,  /* 100kHz at 544 MHz system clock */
+};
+#endif
+
+#if MYNEWT_VAL(I2C_1)
+const struct stm32_hal_i2c_cfg os_bsp_i2c1_cfg = {
+    .hic_i2c = I2C2,
+    .hic_rcc_reg = &RCC->APB1LENR,
+    .hic_rcc_dev = RCC_APB1LENR_I2C2EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_1_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_1_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C2,
+    .hic_10bit = 0,
+    .hic_timingr = 0xA0303048,  /* 100kHz at 544 MHz system clock */
+};
+#endif
+
+#if MYNEWT_VAL(I2C_2)
+const struct stm32_hal_i2c_cfg os_bsp_i2c2_cfg = {
+    .hic_i2c = I2C3,
+    .hic_rcc_reg = &RCC->APB1LENR,
+    .hic_rcc_dev = RCC_APB1LENR_I2C3EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_2_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_2_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C3,
+    .hic_10bit = 0,
+    .hic_timingr = 0xA0303048,  /* 100kHz at 544 MHz system clock */
+};
+#endif
+
+#if MYNEWT_VAL(I2C_3)
+const struct stm32_hal_i2c_cfg os_bsp_i2c3_cfg = {
+    .hic_i2c = I2C4,
+    .hic_rcc_reg = &RCC->APB4ENR,
+    .hic_rcc_dev = RCC_APB4ENR_I2C4EN,
+    .hic_pin_sda = MYNEWT_VAL(I2C_3_PIN_SDA),
+    .hic_pin_scl = MYNEWT_VAL(I2C_3_PIN_SCL),
+    .hic_pin_af = GPIO_AF4_I2C4,
+    .hic_10bit = 0,
+    .hic_timingr = 0xA0303048,  /* 100kHz at 544 MHz system clock */
+};
+#endif
+
+#if MYNEWT_VAL(ETH_0)
+const struct stm32_eth_cfg os_bsp_eth0_cfg = {
+    /*
+     * PORTA
+     *   PA1 - ETH_RMII_REF_CLK
+     *   PA2 - ETH_RMII_MDIO
+     *   PA7 - ETH_RMII_CRS_DV
+     */
+    .sec_port_mask[0] = (1 << 1) | (1 << 2) | (1 << 7),
+
+    /*
+     * PORTB
+     *   PB13 - ETH_RMII_TXD1
+     */
+    .sec_port_mask[1] = (1 << 13),
+
+    /*
+     * PORTC
+     *   PC1 - ETH_RMII_MDC
+     *   PC4 - ETH_RMII_RXD0
+     *   PC5 - ETH_RMII_RXD1
+     */
+    .sec_port_mask[2] = (1 << 1) | (1 << 4) | (1 << 5),
+
+    /*
+     * PORTG
+     *   PG11 - ETH_RMII_TXEN
+     *   PG13 - ETH_RMII_TXD0
+     */
+    .sec_port_mask[6] = (1 << 11) | (1 << 13),
+    .sec_phy_type = LAN_8742_RMII,
+    .sec_phy_irq = -1
+};
+#endif
+
+/* FIXME */
+static const struct hal_bsp_mem_dump dump_cfg[] = {
+    [0] = {
+        .hbmd_start = &_ram_start,
+        .hbmd_size = RAM_SIZE,
+    },
+    [1] = {
+        .hbmd_start = &_dtcmram_start,
+        .hbmd_size = DTCMRAM_SIZE,
+    },
+    [2] = {
+        .hbmd_start = &_itcmram_start,
+        .hbmd_size = ITCMRAM_SIZE,
+    },
+};
+
+extern const struct hal_flash stm32_flash_dev;
+
+#if MYNEWT_VAL(SPIFLASH)
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+struct bus_spi_node_cfg flash_spi_cfg = {
+    .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
+    .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
+    .mode = BUS_SPI_MODE_0,
+    .data_order = HAL_SPI_MSB_FIRST,
+    .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
+};
+#endif
+#endif
+
+static const struct hal_flash *flash_devs[] = {
+    [0] = &stm32_flash_dev,
+#if MYNEWT_VAL(SPIFLASH)
+    [1] = &spiflash_dev.hal,
+#endif
+};
+
+const struct hal_flash *
+hal_bsp_flash_dev(uint8_t id)
+{
+    if (id >= ARRAY_SIZE(flash_devs)) {
+        return NULL;
+    }
+
+    return flash_devs[id];
+}
+
+const struct hal_bsp_mem_dump *
+hal_bsp_core_dump(int *area_cnt)
+{
+    *area_cnt = sizeof(dump_cfg) / sizeof(dump_cfg[0]);
+    return dump_cfg;
+}
+
+void
+hal_bsp_init(void)
+{
+    int rc;
+    (void)rc;
+
+    stm32_periph_create();
+
+#if MYNEWT_VAL(SPIFLASH) && MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    rc = spiflash_create_spi_dev(&spiflash_dev.dev,
+                                 MYNEWT_VAL(BSP_FLASH_SPI_NAME), &flash_spi_cfg);
+    assert(rc == 0);
+#endif
+}
+
+void
+hal_bsp_deinit(void)
+{
+}
+
+/**
+ * Returns the configured priority for the given interrupt. If no priority
+ * configured, return the priority passed in
+ *
+ * @param irq_num
+ * @param pri
+ *
+ * @return uint32_t
+ */
+uint32_t
+hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
+{
+    /* Add any interrupt priorities configured by the bsp here */
+    return pri;
+}

--- a/hw/bsp/nucleo-h723zg/syscfg.yml
+++ b/hw/bsp/nucleo-h723zg/syscfg.yml
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB.'
+        value: 1024
+
+    STM32_FLASH_NUM_AREAS:
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value: 8
+
+    BSP_FLASH_SPI_BUS:
+        description: 'bus name SPIFLASH is connected to'
+        value: '"spi0"'
+
+    BSP_FLASH_SPI_NAME:
+        description: 'SPIFLASH device name'
+        value: '"spiflash0"'
+
+syscfg.vals:
+    REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
+    CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
+    NFFS_FLASH_AREA: FLASH_AREA_NFFS
+    COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
+    STM32_CLOCK_VOLTAGESCALING_CONFIG: 'PWR_REGULATOR_VOLTAGE_SCALE0'
+    STM32_CLOCK_HSI: 1
+    STM32_CLOCK_HSE: 0
+    STM32_CLOCK_HSE_BYPASS: 0
+    STM32_CLOCK_PLL_PLLM: 4
+    STM32_CLOCK_PLL_PLLN: 34
+    STM32_CLOCK_PLL_PLLP: 1
+    STM32_CLOCK_PLL_PLLQ: 4
+    STM32_CLOCK_PLL_PLLR: 2
+    STM32_CLOCK_ENABLE_OVERDRIVE: 0
+    STM32_CLOCK_AHB_DIVIDER: 'RCC_HCLK_DIV2'
+    STM32_CLOCK_APB1_DIVIDER: 'RCC_APB1_DIV4'
+    STM32_CLOCK_APB2_DIVIDER: 'RCC_APB2_DIV2'
+    STM32_CLOCK_APB3_DIVIDER: 'RCC_APB3_DIV2'
+    STM32_CLOCK_APB4_DIVIDER: 'RCC_APB4_DIV2'
+    STM32_CLOCK_PLLRGE: 'RCC_PLL1VCIRANGE_3'
+    STM32_FLASH_LATENCY: 'FLASH_LATENCY_3'
+    STM32_ENABLE_ICACHE: 0
+    UART_0_PIN_TX: 'MCU_GPIO_PORTD(8)'
+    UART_0_PIN_RX: 'MCU_GPIO_PORTD(9)'
+    SPI_0_PIN_SS: 'MCU_GPIO_PORTD(14)'
+    SPI_0_PIN_SCK: 'MCU_GPIO_PORTA(5)'
+    SPI_0_PIN_MISO: 'MCU_GPIO_PORTA(6)'
+    SPI_0_PIN_MOSI: 'MCU_GPIO_PORTB(5)'
+    I2C_0_PIN_SCL: 'MCU_GPIO_PORTB(8)'
+    I2C_0_PIN_SDA: 'MCU_GPIO_PORTB(9)'
+    I2C_1_PIN_SCL: 'MCU_GPIO_PORTF(1)'
+    I2C_1_PIN_SDA: 'MCU_GPIO_PORTF(0)'
+    I2C_2_PIN_SCL: 'MCU_GPIO_PORTA(8)'
+    I2C_2_PIN_SDA: 'MCU_GPIO_PORTC(9)'
+    I2C_3_PIN_SCL: 'MCU_GPIO_PORTD(12)'
+    I2C_3_PIN_SDA: 'MCU_GPIO_PORTD(13)'
+    TIMER_0_TIM: 'TIM12'
+    TIMER_1_TIM: 'TIM13'
+    TIMER_2_TIM: 'TIM14'

--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -613,7 +613,11 @@ spi_stm32_configure(struct bus_dev *bdev, struct bus_node *bnode)
     if (prescaler > 7) {
         rc = SYS_EINVAL;
     } else {
+#if MYNEWT_VAL(MCU_STM32H7)
+        dd->hspi.Init.BaudRatePrescaler = prescaler << SPI_CFG1_MBR_Pos;
+#else
         dd->hspi.Init.BaudRatePrescaler = prescaler << SPI_CR1_BR_Pos;
+#endif
         dd->hspi.Init.CLKPolarity = (node->mode == BUS_SPI_MODE_0 || node->mode == BUS_SPI_MODE_1) ?
                                     SPI_POLARITY_LOW : SPI_POLARITY_HIGH;
         dd->hspi.Init.CLKPhase = (node->mode == BUS_SPI_MODE_0 || node->mode == BUS_SPI_MODE_2) ?
@@ -846,7 +850,7 @@ bus_spi_stm32_dev_init_func(struct os_dev *odev, void *arg)
             __HAL_RCC_DMA2_CLK_ENABLE();
 #endif
         }
-#ifdef DMAMUX1
+#ifdef __HAL_RCC_DMAMUX1_CLK_ENABLE
         __HAL_RCC_DMAMUX1_CLK_ENABLE();
 #endif
 

--- a/hw/bus/drivers/spi_stm32/stm32h7xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32h7xx/include/spidmacfg.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32h7xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Stream_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_RX_CHANNEL(dma, st, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _spi ## spi_num ## _rx;
+
+#define SPI_DMA_TX_CHANNEL(dma, st, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _spi ## spi_num ## _tx;
+
+SPI_DMA_RX_CHANNEL(1, 1, 1);
+SPI_DMA_RX_CHANNEL(1, 2, 1);
+SPI_DMA_RX_CHANNEL(1, 3, 1);
+SPI_DMA_RX_CHANNEL(1, 4, 1);
+SPI_DMA_RX_CHANNEL(1, 5, 1);
+SPI_DMA_RX_CHANNEL(1, 6, 1);
+SPI_DMA_RX_CHANNEL(1, 7, 1);
+SPI_DMA_RX_CHANNEL(2, 1, 1);
+SPI_DMA_RX_CHANNEL(2, 2, 1);
+SPI_DMA_RX_CHANNEL(2, 3, 1);
+SPI_DMA_RX_CHANNEL(2, 4, 1);
+SPI_DMA_RX_CHANNEL(2, 5, 1);
+SPI_DMA_RX_CHANNEL(2, 6, 1);
+SPI_DMA_RX_CHANNEL(2, 7, 1);
+
+SPI_DMA_RX_CHANNEL(1, 1, 2);
+SPI_DMA_RX_CHANNEL(1, 2, 2);
+SPI_DMA_RX_CHANNEL(1, 3, 2);
+SPI_DMA_RX_CHANNEL(1, 4, 2);
+SPI_DMA_RX_CHANNEL(1, 5, 2);
+SPI_DMA_RX_CHANNEL(1, 6, 2);
+SPI_DMA_RX_CHANNEL(1, 7, 2);
+SPI_DMA_RX_CHANNEL(2, 1, 2);
+SPI_DMA_RX_CHANNEL(2, 2, 2);
+SPI_DMA_RX_CHANNEL(2, 3, 2);
+SPI_DMA_RX_CHANNEL(2, 4, 2);
+SPI_DMA_RX_CHANNEL(2, 5, 2);
+SPI_DMA_RX_CHANNEL(2, 6, 2);
+SPI_DMA_RX_CHANNEL(2, 7, 2);
+
+SPI_DMA_TX_CHANNEL(1, 1, 1);
+SPI_DMA_TX_CHANNEL(1, 2, 1);
+SPI_DMA_TX_CHANNEL(1, 3, 1);
+SPI_DMA_TX_CHANNEL(1, 4, 1);
+SPI_DMA_TX_CHANNEL(1, 5, 1);
+SPI_DMA_TX_CHANNEL(1, 6, 1);
+SPI_DMA_TX_CHANNEL(1, 7, 1);
+SPI_DMA_TX_CHANNEL(2, 1, 1);
+SPI_DMA_TX_CHANNEL(2, 2, 1);
+SPI_DMA_TX_CHANNEL(2, 3, 1);
+SPI_DMA_TX_CHANNEL(2, 4, 1);
+SPI_DMA_TX_CHANNEL(2, 5, 1);
+SPI_DMA_TX_CHANNEL(2, 6, 1);
+SPI_DMA_TX_CHANNEL(2, 7, 1);
+
+SPI_DMA_TX_CHANNEL(1, 1, 2);
+SPI_DMA_TX_CHANNEL(1, 2, 2);
+SPI_DMA_TX_CHANNEL(1, 3, 2);
+SPI_DMA_TX_CHANNEL(1, 4, 2);
+SPI_DMA_TX_CHANNEL(1, 5, 2);
+SPI_DMA_TX_CHANNEL(1, 6, 2);
+SPI_DMA_TX_CHANNEL(1, 7, 2);
+SPI_DMA_TX_CHANNEL(2, 1, 2);
+SPI_DMA_TX_CHANNEL(2, 2, 2);
+SPI_DMA_TX_CHANNEL(2, 3, 2);
+SPI_DMA_TX_CHANNEL(2, 4, 2);
+SPI_DMA_TX_CHANNEL(2, 5, 2);
+SPI_DMA_TX_CHANNEL(2, 6, 2);
+SPI_DMA_TX_CHANNEL(2, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32h7xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32h7xx/pkg.yml
@@ -17,43 +17,12 @@
 # under the License.
 #
 
-pkg.name: hw/bus/drivers/spi_stm32
-pkg.description: SPI bus driver that uses ST HAL with interrupts and DMA
+pkg.name: hw/bus/drivers/spi_stm32/stm32h7xx
+pkg.description: STM32H7 specific part of STM32 SPI driver
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
     - hw/bus
-    - hw/bus/drivers/spi_common
-
-pkg.deps.MCU_STM32F0:
-    - hw/bus/drivers/spi_stm32/stm32f0xx
-
-pkg.deps.MCU_STM32F1:
-    - hw/bus/drivers/spi_stm32/stm32f1xx
-
-pkg.deps.MCU_STM32F3:
-    - hw/bus/drivers/spi_stm32/stm32f3xx
-
-pkg.deps.MCU_STM32F4:
-    - hw/bus/drivers/spi_stm32/stm32f4xx
-
-pkg.deps.MCU_STM32F7:
-    - hw/bus/drivers/spi_stm32/stm32f7xx
-
-pkg.deps.MCU_STM32L0:
-    - hw/bus/drivers/spi_stm32/stm32l0xx
-
-pkg.deps.MCU_STM32L1:
-    - hw/bus/drivers/spi_stm32/stm32l1xx
-
-pkg.deps.MCU_STM32L4:
-    - hw/bus/drivers/spi_stm32/stm32l4xx
-
-pkg.deps.MCU_STM32WB:
-    - hw/bus/drivers/spi_stm32/stm32wbxx
-
-pkg.deps.MCU_STM32H7:
-    - hw/bus/drivers/spi_stm32/stm32h7xx
-    
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32h7xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32h7xx/src/spidmacfg.c
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32h7xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, st, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _spi ## spi_num ## _rx = { \
+        st,                                                                  \
+        DMA ## dma ## _Stream ## st ## _IRQn,                               \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Stream ## st,                                \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _RX,                   \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, st, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _stream ## st ## _spi ## spi_num ## _tx = { \
+        st,                                            \
+        DMA ## dma ## _Stream ## st ## _IRQn,                                    \
+        stm32_dma ## dma ## _ ## st ## _irq_handler,                        \
+        .regs = DMA ## dma ## _Stream ## st,                                     \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _TX,                   \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 2, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 4, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 5, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 6, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 7, 1);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 1, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 2, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 3, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 4, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 5, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 6, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(2, 7, 2);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 1, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 3, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 5, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 6, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 7, 1);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 1, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 2, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 3, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 4, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 5, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 6, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(2, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32h7xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32h7xx/syscfg.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_stream1_spi1_rx
+    SPI1_TX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_stream2_spi1_tx
+    SPI2_RX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_stream3_spi2_rx
+    SPI2_TX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_stream4_spi2_tx

--- a/hw/mcu/stm/stm32_common/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32_common/src/hal_gpio.c
@@ -837,7 +837,7 @@ hal_gpio_irq_enable(int pin)
     mask = GPIO_MASK(pin);
 
     __HAL_DISABLE_INTERRUPTS(ctx);
-#if MYNEWT_VAL(MCU_STM32L4) || MYNEWT_VAL(MCU_STM32WB)
+#if MYNEWT_VAL(MCU_STM32L4) || MYNEWT_VAL(MCU_STM32WB) || MYNEWT_VAL(MCU_STM32H7)
     EXTI->IMR1 |= mask;
 #else
     EXTI->IMR |= mask;
@@ -859,7 +859,7 @@ hal_gpio_irq_disable(int pin)
 
     mask = GPIO_MASK(pin);
     __HAL_DISABLE_INTERRUPTS(ctx);
-#if MYNEWT_VAL(MCU_STM32L4) || MYNEWT_VAL(MCU_STM32WB)
+#if MYNEWT_VAL(MCU_STM32L4) || MYNEWT_VAL(MCU_STM32WB) || MYNEWT_VAL(MCU_STM32H7)
     EXTI->IMR1 |= mask;
 #else
     EXTI->IMR &= ~mask;

--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -394,10 +394,12 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
     /*
      * Keep clocking debug even when CPU is sleeping, stopped or in standby.
      */
-#if !MYNEWT_VAL(MCU_STM32F0)
-    DBGMCU->CR |= (DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY);
-#else
+#if MYNEWT_VAL(MCU_STM32F0)
     DBGMCU->CR |= (DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY);
+#elif MYNEWT_VAL(MCU_STM32H7)
+    DBGMCU->CR |= (DBGMCU_CR_DBG_SLEEPD1 | DBGMCU_CR_DBG_STOPD1 | DBGMCU_CR_DBG_STANDBYD1);
+#else
+    DBGMCU->CR |= (DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY);
 #endif
 }
 

--- a/hw/mcu/stm/stm32_common/src/hal_timer.c
+++ b/hw/mcu/stm/stm32_common/src/hal_timer.c
@@ -262,9 +262,31 @@ stm32_hw_setup(int num, TIM_TypeDef *regs)
         __HAL_RCC_TIM11_CLK_ENABLE();
     }
 #endif
+#ifdef TIM12
+    if (regs == TIM12) {
+        stm32_tmr_reg_irq(TIM8_BRK_TIM12_IRQn, func);
+        __HAL_RCC_TIM12_CLK_ENABLE();
+    }
+#endif
+#ifdef TIM13
+    if (regs == TIM13) {
+        stm32_tmr_reg_irq(TIM8_UP_TIM13_IRQn, func);
+        __HAL_RCC_TIM13_CLK_ENABLE();
+    }
+#endif
+#ifdef TIM14
+    if (regs == TIM14) {
+#if MYNEWT_VAL(MCU_STM32F0)
+        stm32_tmr_reg_irq(TIM14_IRQn, func);
+#else
+        stm32_tmr_reg_irq(TIM8_TRG_COM_TIM14_IRQn, func);
+#endif
+        __HAL_RCC_TIM14_CLK_ENABLE();
+    }
+#endif
 #ifdef TIM15
     if (regs == TIM15) {
-#if MYNEWT_VAL(MCU_STM32F0)
+#if MYNEWT_VAL(MCU_STM32F0) || MYNEWT_VAL(MCU_STM32H7)
         stm32_tmr_reg_irq(TIM15_IRQn, func);
 #else
         stm32_tmr_reg_irq(TIM1_BRK_TIM15_IRQn, func);
@@ -274,7 +296,7 @@ stm32_hw_setup(int num, TIM_TypeDef *regs)
 #endif
 #ifdef TIM16
     if (regs == TIM16) {
-#if MYNEWT_VAL(MCU_STM32F0)
+#if MYNEWT_VAL(MCU_STM32F0) || MYNEWT_VAL(MCU_STM32H7)
         stm32_tmr_reg_irq(TIM16_IRQn, func);
 #else
         stm32_tmr_reg_irq(TIM1_UP_TIM16_IRQn, func);
@@ -284,7 +306,7 @@ stm32_hw_setup(int num, TIM_TypeDef *regs)
 #endif
 #ifdef TIM17
     if (regs == TIM17) {
-#if MYNEWT_VAL(MCU_STM32F0)
+#if MYNEWT_VAL(MCU_STM32F0) || MYNEWT_VAL(MCU_STM32H7)
         stm32_tmr_reg_irq(TIM17_IRQn, func);
 #else
         stm32_tmr_reg_irq(TIM1_TRG_COM_TIM17_IRQn, func);

--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -134,12 +134,17 @@ static struct hal_uart_irq uart_irqs[3];
 
 #if !MYNEWT_VAL(STM32_HAL_UART_HAS_SR)
 #  define STATUS(x)     ((x)->ISR)
+#if MYNEWT_VAL(MCU_STM32H7)
+#  define RXNE          USART_ISR_RXNE_RXFNE
+#  define TXE           USART_ISR_TXE_TXFNF
+#else
 #  define RXNE          USART_ISR_RXNE
 #  define TXE           USART_ISR_TXE
+#endif
 #  define TC            USART_ISR_TC
 #  define RXDR(x)       ((x)->RDR)
 #  define TXDR(x)       ((x)->TDR)
-#if MYNEWT_VAL(MCU_STM32WB)
+#if MYNEWT_VAL(MCU_STM32WB) || MYNEWT_VAL(MCU_STM32H7)
 #  define BAUD(x,y)     UART_DIV_SAMPLING16((x), (y), UART_PRESCALER_DIV1)
 #else
 #  define BAUD(x,y)     UART_DIV_SAMPLING16((x), (y))

--- a/hw/mcu/stm/stm32_common/src/hal_watchdog.c
+++ b/hw/mcu/stm/stm32_common/src/hal_watchdog.c
@@ -19,6 +19,7 @@
 
 #include "hal/hal_watchdog.h"
 #include "mcu/stm32_hal.h"
+#include "syscfg/syscfg.h"
 
 IWDG_HandleTypeDef g_wdt_cfg;
 
@@ -36,7 +37,11 @@ hal_watchdog_init(uint32_t expire_msecs)
         return -1;
     }
 
+#if MYNEWT_VAL(MCU_STM32H7)
+    g_wdt_cfg.Instance = IWDG1;
+#else
     g_wdt_cfg.Instance = IWDG;
+#endif
     g_wdt_cfg.Init.Prescaler = IWDG_PRESCALER_256;
     g_wdt_cfg.Init.Reload = reload;
     STM32_HAL_WATCHDOG_CUSTOM_INIT(&g_wdt_cfg);
@@ -47,7 +52,11 @@ hal_watchdog_init(uint32_t expire_msecs)
 void
 hal_watchdog_enable(void)
 {
+#if MYNEWT_VAL(MCU_STM32H7)
+    __HAL_DBGMCU_FREEZE_IWDG1();
+#else
     __HAL_DBGMCU_FREEZE_IWDG();
+#endif
     HAL_IWDG_Init(&g_wdt_cfg);
 }
 

--- a/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
+++ b/hw/mcu/stm/stm32_common/src/stm32_driver_mod_spi.c
@@ -43,6 +43,11 @@ HAL_StatusTypeDef HAL_SPI_QueueTransmit(SPI_HandleTypeDef *hspi, uint8_t *pData,
 #error "This MCU currently does not support SPI slave"
 #endif
 
+#if !MYNEWT_VAL(MCU_STM32H7)
+#define RXDR DR
+#define TXDR DR
+#endif
+
 /* XXX: This is copied from stm32l1xx_hal_spi_ex.c because it is a __weak
  * symbol defined in stm32l1xx_hal_spi.c that is overriden but due to our
  * archive process seems to not link correctly. Copying here enables the
@@ -112,6 +117,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
 }
 #endif
 
+#if !MYNEWT_VAL(MCU_STM32H7)
 static HAL_StatusTypeDef
 SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout, uint32_t Tickstart)
 {
@@ -139,6 +145,7 @@ SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t S
 
   return HAL_OK;
 }
+#endif
 
 #if !SPI_HAS_FIFO
 static HAL_StatusTypeDef
@@ -161,12 +168,21 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
 
   while ((hspi->Instance->SR & Fifo) != State)
   {
+#if MYNEWT_VAL(MCU_STM32H7)
+    if ((Fifo == SPI_SR_RXPLVL) && (State == SPI_RX_FIFO_0PACKET))
+    {
+      tmpreg = *((__IO uint8_t *)&hspi->Instance->RXDR);
+      /* To avoid GCC warning */
+      UNUSED(tmpreg);
+    }
+#else
     if ((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
     {
       tmpreg = *((__IO uint8_t *)&hspi->Instance->DR);
       /* To avoid GCC warning */
       UNUSED(tmpreg);
     }
+#endif
 
     if (Timeout != HAL_MAX_DELAY)
     {
@@ -195,6 +211,14 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
 
 static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout, uint32_t Tickstart)
 {
+#if MYNEWT_VAL(MCU_STM32H7)
+  /* Control if the TX fifo is empty */
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_TXC, SPI_SR_TXC, Timeout, Tickstart) != HAL_OK)
+  {
+    SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_FLAG);
+    return HAL_TIMEOUT;
+  }
+#else
   /* Control if the TX fifo is empty */
   if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FTLVL, SPI_FTLVL_EMPTY, Timeout, Tickstart) != HAL_OK)
   {
@@ -208,6 +232,7 @@ static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_FLAG);
     return HAL_TIMEOUT;
   }
+#endif
 
   /* Control if the RX fifo is empty */
   if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, Timeout, Tickstart) != HAL_OK)
@@ -220,12 +245,21 @@ static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_
 
 static HAL_StatusTypeDef SPI_EndTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout, uint32_t Tickstart)
 {
+#if MYNEWT_VAL(MCU_STM32H7)
+  /* Control if the TX fifo is empty */
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_TXC, SPI_SR_TXC, Timeout, Tickstart) != HAL_OK)
+  {
+    SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_FLAG);
+    return HAL_TIMEOUT;
+  }
+#else
   /* Control if the TX fifo is empty */
   if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FTLVL, SPI_FTLVL_EMPTY, Timeout, Tickstart) != HAL_OK)
   {
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_FLAG);
     return HAL_TIMEOUT;
   }
+#endif
   return HAL_OK;
 }
 #endif
@@ -348,20 +382,20 @@ static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
 static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 {
   if (hspi->Init.Mode == SPI_MODE_MASTER) {
-    *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->DR);
+    *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->RXDR);
     hspi->RxXferCount--;
   } else {
     //FIXME: this block below is probably not required...
 #if SPI_HAS_FIFO
     /* Receive data in packing mode */
     if (hspi->RxXferCount > 1U) {
-      *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->DR;
+      *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->RXDR;
       hspi->pRxBuffPtr += sizeof(uint16_t);
       hspi->RxXferCount -= 2U;
     } else {
       /* Receive data in 8 Bit mode */
 #endif
-      *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->DR);
+      *hspi->pRxBuffPtr++ = *((__IO uint8_t *)&hspi->Instance->RXDR);
       hspi->RxXferCount--;
 #if SPI_HAS_FIFO
     }
@@ -393,7 +427,7 @@ static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   /* Transmit data in packing Bit mode */
   if (hspi->TxXferCount >= 2U)
   {
-    hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+    hspi->Instance->TXDR = *((uint16_t *)hspi->pTxBuffPtr);
     hspi->pTxBuffPtr += sizeof(uint16_t);
     hspi->TxXferCount -= 2U;
   }
@@ -401,7 +435,7 @@ static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   else
   {
 #endif
-    *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+    *(__IO uint8_t *)&hspi->Instance->TXDR = (*hspi->pTxBuffPtr++);
     hspi->TxXferCount--;
 #if SPI_HAS_FIFO
   }
@@ -431,7 +465,7 @@ static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 {
   /* Receive data in 16 Bit mode */
-  *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+  *((uint16_t *)hspi->pRxBuffPtr) = hspi->Instance->RXDR;
   hspi->pRxBuffPtr += sizeof(uint16_t);
   hspi->RxXferCount--;
 
@@ -456,7 +490,7 @@ static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 {
   /* Transmit data in 16 Bit mode */
-  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->Instance->TXDR = *((uint16_t *)hspi->pTxBuffPtr);
   hspi->pTxBuffPtr += sizeof(uint16_t);
   hspi->TxXferCount--;
 
@@ -483,12 +517,12 @@ static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 #if SPI_HAS_FIFO
   /* Transmit data in packing Bit mode */
   if (hspi->TxXferCount >= 2U) {
-    hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+    hspi->Instance->TXDR = *((uint16_t *)hspi->pTxBuffPtr);
     hspi->pTxBuffPtr += sizeof(uint16_t);
     hspi->TxXferCount -= 2U;
   } else {
 #endif
-    *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+    *(__IO uint8_t *)&hspi->Instance->TXDR = (*hspi->pTxBuffPtr++);
     hspi->TxXferCount--;
 #if SPI_HAS_FIFO
   }
@@ -509,7 +543,7 @@ static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 {
   /* Transmit data in 16 Bit mode */
-  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->Instance->TXDR = *((uint16_t *)hspi->pTxBuffPtr);
   hspi->pTxBuffPtr += sizeof(uint16_t);
   hspi->TxXferCount--;
 
@@ -599,9 +633,15 @@ HAL_StatusTypeDef HAL_SPI_QueueTransmit(SPI_HandleTypeDef *hspi, uint8_t *pData,
 #endif
 
   /* MYNEWT: in slave mode write 1st byte to DR */
+#if MYNEWT_VAL(MCU_STM32H7)
+  if ((hspi->Instance->CFG2 & SPI_CFG2_MASTER) == 0) {
+      hspi->TxISR(hspi);
+  }
+#else
   if ((hspi->Instance->CR1 & SPI_CR1_MSTR) == 0) {
       hspi->TxISR(hspi);
   }
+#endif
 
 #if 0 /* MYNEWT: TODO */
   /* Check if the SPI is already enabled */
@@ -706,9 +746,15 @@ HAL_StatusTypeDef HAL_SPI_Slave_Queue_TransmitReceive(SPI_HandleTypeDef *hspi, u
   //__HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
 
   /* MYNEWT: in slave mode write 1st byte to DR */
+#if MYNEWT_VAL(MCU_STM32H7)
+  if ((hspi->Instance->CFG2 & SPI_CFG2_MASTER) == 0) {
+      hspi->TxISR(hspi);
+  }
+#else
   if ((hspi->Instance->CR1 & SPI_CR1_MSTR) == 0) {
       hspi->TxISR(hspi);
   }
+#endif
 
 #if 0
   /* Check if the SPI is already enabled */

--- a/hw/mcu/stm/stm32h7xx/include/mcu/cmsis_nvic.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/cmsis_nvic.h
@@ -1,0 +1,35 @@
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include <stdint.h>
+
+#if defined(STM32H723xx)
+ #define MCU_NUM_PERIPH_VECTORS 163
+#else
+ #error "Number of peripheral vectors not defined for this MCU."
+#endif
+
+#define NVIC_USER_IRQ_OFFSET  16
+#define NVIC_NUM_VECTORS      (16 + MCU_NUM_PERIPH_VECTORS)
+
+#include "stm32h723xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_Relocate(void);
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/mcu/stm/stm32h7xx/include/mcu/cortex_m7.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/cortex_m7.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_CORTEX_M7_H__
+#define __MCU_CORTEX_M7_H__
+
+#include "stm32h723xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void
+hal_debug_break(void)
+{
+    __BKPT(1);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_CORTEX_M7_H__ */

--- a/hw/mcu/stm/stm32h7xx/include/mcu/mcu.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/mcu.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_MCU_H_
+#define __MCU_MCU_H_
+
+#include <stm32_common/mcu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(STM32H723xx)
+#define STM32_SYSTEM_MEMORY     0x1FF00000
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_MCU_H_ */

--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32_hal.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32_hal.h
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef STM32_HAL_H
+#define STM32_HAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <mcu/cortex_m7.h>
+
+#include "stm32h7xx_hal.h"
+#include "stm32h7xx_hal_def.h"
+
+#include "stm32h7xx_mynewt_hal.h"
+
+/* hal_watchdog */
+#include "stm32h7xx_hal_iwdg.h"
+#define STM32_HAL_WATCHDOG_CUSTOM_INIT(x)           \
+    do {                                            \
+        (x)->Init.Window = IWDG_WINDOW_DISABLE;     \
+    } while (0)
+
+/* hal_system_start */
+#define STM32_HAL_FLASH_REMAP()
+
+/* hal_spi */
+#include "stm32h7xx.h"
+#include "stm32h7xx_hal_dma.h"
+#include "stm32h7xx_hal_spi.h"
+#include "stm32h7xx_hal_gpio.h"
+#include "stm32h7xx_hal_gpio_ex.h"
+#include "stm32h7xx_hal_rcc.h"
+
+struct stm32_hal_spi_cfg {
+    int ss_pin;                     /* for slave mode */
+    int sck_pin;
+    int miso_pin;
+    int mosi_pin;
+    int irq_prio;
+};
+
+/* hal_i2c */
+#include "stm32h7xx_hal_i2c.h"
+#include "mcu/stm32h7xx_mynewt_hal.h"
+
+/* hal_uart */
+#include "stm32h7xx_hal_uart.h"
+#include "mcu/stm32h7_bsp.h"
+
+/* hal_timer */
+#include "stm32h7xx_hal_tim.h"
+#include "stm32h7xx_ll_bus.h"
+#include "stm32h7xx_ll_tim.h"
+
+#define STM32_HAL_TIMER_MAX     (3)
+
+/* hw/drivers/trng */
+#include "stm32h7xx_hal_rng.h"
+
+/* hw/drivers/crypto */
+#include "stm32h7xx_hal_cryp.h"
+#include "stm32h7xx_hal_rcc_ex.h"
+
+/* hal_flash */
+#include "stm32h7xx_hal_def.h"
+#include "stm32h7xx_hal_flash.h"
+#include "stm32h7xx_hal_flash_ex.h"
+#define STM32_HAL_FLASH_INIT()        \
+    do {                              \
+        HAL_FLASH_Unlock();           \
+    } while (0)
+#define FLASH_PROGRAM_TYPE FLASH_TYPEPROGRAM_FLASHWORD
+#define STM32_HAL_FLASH_CLEAR_ERRORS()            \
+    do {                                          \
+        __HAL_FLASH_CLEAR_FLAG(FLASH_CCR_CLR_EOP |   \
+                FLASH_CCR_CLR_WRPERR   |             \
+                FLASH_CCR_CLR_PGSERR   |             \
+                FLASH_CCR_CLR_STRBERR  |             \
+                FLASH_CCR_CLR_INCERR   |             \
+                FLASH_CCR_CLR_OPERR    |             \
+                FLASH_CCR_CLR_RDPERR   |             \
+                FLASH_CCR_CLR_RDSERR   |             \
+                FLASH_CCR_CLR_SNECCERR |             \
+                FLASH_CCR_CLR_DBECCERR |             \
+                FLASH_CCR_CLR_CRCEND   |             \
+                FLASH_CCR_CLR_CRCRDERR);             \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32_HAL_H */

--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7_bsp.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7_bsp.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_STM32H7_BSP_H_
+#define __MCU_STM32H7_BSP_H_
+
+#include <hal/hal_gpio.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * BSP specific UART settings.
+ */
+struct stm32_uart_cfg {
+    USART_TypeDef *suc_uart;            /* UART dev registers */
+    volatile uint32_t *suc_rcc_reg;     /* RCC register to modify */
+    uint32_t suc_rcc_dev;               /* RCC device ID */
+    int8_t suc_pin_tx;                  /* pins for IO */
+    int8_t suc_pin_rx;
+    int8_t suc_pin_rts;
+    int8_t suc_pin_cts;
+    uint8_t suc_pin_af;                 /* AF selection for this */
+    IRQn_Type suc_irqn;                 /* NVIC IRQn */
+};
+
+/*
+ * Internal API for stm32f7xx mcu specific code.
+ */
+int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
+                     od);
+
+struct hal_flash;
+extern struct hal_flash stm32f7_flash_dev;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_STM32H7_BSP_H_ */

--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7xx_mynewt_hal.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __MCU_STM32H7_MYNEWT_HAL_H
+#define __MCU_STM32H7_MYNEWT_HAL_H
+
+#include "stm32h7xx.h"
+#include "stm32h7xx_hal_dma.h"
+#include "stm32h7xx_hal_gpio.h"
+#include "stm32h7xx_hal_i2c.h"
+#include "stm32h7xx_hal_spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Helper functions to enable/disable interrupts. */
+#define __HAL_DISABLE_INTERRUPTS(x)                     \
+    do {                                                \
+        x = __get_PRIMASK();                            \
+        __disable_irq();                                \
+    } while(0);
+
+#define __HAL_ENABLE_INTERRUPTS(x)                      \
+    do {                                                \
+        if (!x) {                                       \
+            __enable_irq();                             \
+        }                                               \
+    } while(0);
+
+
+int hal_gpio_init_stm(int pin, GPIO_InitTypeDef *cfg);
+int hal_gpio_deinit_stm(int pin, GPIO_InitTypeDef *cfg);
+
+struct stm32_hal_i2c_cfg {
+    I2C_TypeDef *hic_i2c;
+    volatile uint32_t *hic_rcc_reg;      /* RCC register to modify */
+    uint32_t hic_rcc_dev;                /* RCC device ID */
+    uint8_t hic_pin_sda;
+    uint8_t hic_pin_scl;
+    uint8_t hic_pin_af;
+    uint8_t hic_10bit;
+    uint32_t hic_timingr;               /* TIMINGR register */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MCU_STM32H7_MYNEWT_HAL_H */

--- a/hw/mcu/stm/stm32h7xx/pkg.yml
+++ b/hw/mcu/stm/stm32h7xx/pkg.yml
@@ -17,43 +17,35 @@
 # under the License.
 #
 
-pkg.name: hw/bus/drivers/spi_stm32
-pkg.description: SPI bus driver that uses ST HAL with interrupts and DMA
+pkg.name: hw/mcu/stm/stm32h7xx
+pkg.description: MCU definition for STM32H7 ARM Cortex-M7 chips.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
+    - stm32
+    - stm32h7
+
+pkg.type: sdk
+
+pkg.ign_files:
+    - ".*template.*"
+
+pkg.include_dirs:
+    - "@cmsis_device_h7/Include"
+    - "@stm32h7xx_hal_driver/Inc"
+
+pkg.src_dirs:
+    - "@cmsis_device_h7/Source/Templates/gcc"
+    - "@stm32h7xx_hal_driver/Src"
+    - "src"
+
+pkg.ign_dirs:
+    - "Device"
 
 pkg.deps:
-    - hw/bus
-    - hw/bus/drivers/spi_common
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/mcu/stm/stm32_common"
+    - "@apache-mynewt-core/hw/cmsis-core"
 
-pkg.deps.MCU_STM32F0:
-    - hw/bus/drivers/spi_stm32/stm32f0xx
-
-pkg.deps.MCU_STM32F1:
-    - hw/bus/drivers/spi_stm32/stm32f1xx
-
-pkg.deps.MCU_STM32F3:
-    - hw/bus/drivers/spi_stm32/stm32f3xx
-
-pkg.deps.MCU_STM32F4:
-    - hw/bus/drivers/spi_stm32/stm32f4xx
-
-pkg.deps.MCU_STM32F7:
-    - hw/bus/drivers/spi_stm32/stm32f7xx
-
-pkg.deps.MCU_STM32L0:
-    - hw/bus/drivers/spi_stm32/stm32l0xx
-
-pkg.deps.MCU_STM32L1:
-    - hw/bus/drivers/spi_stm32/stm32l1xx
-
-pkg.deps.MCU_STM32L4:
-    - hw/bus/drivers/spi_stm32/stm32l4xx
-
-pkg.deps.MCU_STM32WB:
-    - hw/bus/drivers/spi_stm32/stm32wbxx
-
-pkg.deps.MCU_STM32H7:
-    - hw/bus/drivers/spi_stm32/stm32h7xx
-    
+pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER || SPI_3_MASTER || SPI_4_MASTER || SPI_5_MASTER) && BUS_DRIVER_PRESENT':
+   - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"

--- a/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
+++ b/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
@@ -1,0 +1,246 @@
+/*
+ * <h2><center>&copy; COPYRIGHT 2016 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stm32h7xx_hal_pwr_ex.h"
+#include "stm32h7xx_hal.h"
+#include <assert.h>
+
+/*
+ * This allows an user to have a custom clock configuration by zeroing
+ * every possible clock source in the syscfg.
+ */
+#if MYNEWT_VAL(STM32_CLOCK_HSE) || MYNEWT_VAL(STM32_CLOCK_LSE) || \
+    MYNEWT_VAL(STM32_CLOCK_HSI) || MYNEWT_VAL(STM32_CLOCK_LSI)
+
+/*
+ * HSI is turned on by default, but can be turned off and use HSE instead.
+ */
+#if (((MYNEWT_VAL(STM32_CLOCK_HSE) != 0) + (MYNEWT_VAL(STM32_CLOCK_HSI) != 0)) < 1)
+#error "At least one of HSE or HSI clock source must be enabled"
+#endif
+
+void
+SystemClock_Config(void)
+{
+    RCC_OscInitTypeDef osc_init = {0};
+    RCC_ClkInitTypeDef clk_init = {0};
+    HAL_StatusTypeDef status;
+
+
+    /* Enable the MCU instruction cache */
+#if MYNEWT_VAL(STM32_ENABLE_ICACHE)
+    SCB_EnableICache();
+#endif
+
+    /*
+     *  Supply configuration update enable
+     */
+    HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
+
+    /*
+     * The voltage scaling allows optimizing the power consumption when the
+     * device is clocked below the maximum system frequency, to update the
+     * voltage scaling value regarding system frequency refer to product
+     * datasheet.
+     */
+    __HAL_PWR_VOLTAGESCALING_CONFIG(MYNEWT_VAL(STM32_CLOCK_VOLTAGESCALING_CONFIG));
+    while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+
+    osc_init.OscillatorType = RCC_OSCILLATORTYPE_NONE;
+
+    /*
+     * LSI is used to clock the independent watchdog and optionally the RTC.
+     * It can be disabled per user request, but is automatically enabled again
+     * when the IWDG is started.
+     *
+     * XXX currently the watchdog is not optional, so there's no point in
+     * disabling LSI through syscfg.
+     */
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_LSI;
+#if MYNEWT_VAL(STM32_CLOCK_LSI)
+    osc_init.LSIState = RCC_LSI_ON;
+#else
+    osc_init.LSIState = RCC_LSI_OFF;
+#endif
+
+    /*
+     * LSE is only used to clock the RTC.
+     */
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_LSE;
+#if (MYNEWT_VAL(STM32_CLOCK_LSE) == 0)
+    osc_init.LSEState = RCC_LSE_OFF;
+#elif MYNEWT_VAL(STM32_CLOCK_LSE_BYPASS)
+    osc_init.LSEState = RCC_LSE_BYPASS;
+#else
+    osc_init.LSEState = RCC_LSE_ON;
+#endif
+
+    /*
+     * HSE Oscillator (can be used as PLL, SYSCLK and RTC clock source)
+     */
+#if MYNEWT_VAL(STM32_CLOCK_HSE)
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_HSE;
+#if MYNEWT_VAL(STM32_CLOCK_HSE_BYPASS)
+    osc_init.HSEState = RCC_HSE_BYPASS;
+#else
+    osc_init.HSEState = RCC_HSE_ON;
+#endif
+#endif
+
+    /*
+     * HSI Oscillator (can be used as PLL and SYSCLK clock source). It is
+     * already turned on by default but a new calibration setting might be
+     * used. If the user chooses to turn it off, it must be turned off after
+     * SYSCLK was updated to use HSE/PLL.
+     */
+#if MYNEWT_VAL(STM32_CLOCK_HSI)
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_HSI;
+    osc_init.HSIState = RCC_HSI_ON;
+    /* HSI calibration is not optional when HSI is enabled */
+    osc_init.HSICalibrationValue = MYNEWT_VAL(STM32_CLOCK_HSI_CALIBRATION);
+
+#if MYNEWT_VAL(STM32_CLOCK_HSI) && \
+    !IS_RCC_HSICALIBRATION_VALUE(MYNEWT_VAL(STM32_CLOCK_HSI_CALIBRATION))
+#error "Invalid HSI calibration value"
+#endif
+#endif
+
+    /*
+     * Default to HSE as source, when both HSE and HSI are enabled.
+     *
+     * TODO: option to let the PLL turned off could be added, because
+     * both HSI and HSE can be used as SYSCLK source.
+     */
+    osc_init.PLL.PLLState = RCC_PLL_ON;
+#if MYNEWT_VAL(STM32_CLOCK_HSE)
+    osc_init.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+#else
+    osc_init.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+#endif
+
+#if !IS_RCC_PLLM_VALUE(MYNEWT_VAL(STM32_CLOCK_PLL_PLLM))
+#error "PLLM value is invalid"
+#endif
+
+#if !IS_RCC_PLLN_VALUE(MYNEWT_VAL(STM32_CLOCK_PLL_PLLN))
+#error "PLLN value is invalid"
+#endif
+
+#if !IS_RCC_PLLP_VALUE(MYNEWT_VAL(STM32_CLOCK_PLL_PLLP))
+#error "PLLP value is invalid"
+#endif
+
+#if !IS_RCC_PLLQ_VALUE(MYNEWT_VAL(STM32_CLOCK_PLL_PLLQ))
+#error "PLLQ value is invalid"
+#endif
+
+#if !IS_RCC_PLLR_VALUE(MYNEWT_VAL(STM32_CLOCK_PLL_PLLR))
+#error "PLLR value is invalid"
+#endif
+
+    osc_init.PLL.PLLM = MYNEWT_VAL(STM32_CLOCK_PLL_PLLM);
+    osc_init.PLL.PLLN = MYNEWT_VAL(STM32_CLOCK_PLL_PLLN);
+    osc_init.PLL.PLLP = MYNEWT_VAL(STM32_CLOCK_PLL_PLLP);
+    osc_init.PLL.PLLQ = MYNEWT_VAL(STM32_CLOCK_PLL_PLLQ);
+    osc_init.PLL.PLLR = MYNEWT_VAL(STM32_CLOCK_PLL_PLLR);
+
+    osc_init.PLL.PLLRGE = MYNEWT_VAL(STM32_CLOCK_PLLRGE);
+
+    status = HAL_RCC_OscConfig(&osc_init);
+    if (status != HAL_OK) {
+        assert(0);
+    }
+
+#if MYNEWT_VAL(STM32_CLOCK_ENABLE_OVERDRIVE)
+    /*
+     * Activate the Over-Drive mode
+     */
+    status = HAL_PWREx_EnableOverDrive();
+    if (status != HAL_OK) {
+        assert(0);
+    }
+#endif
+
+    /*
+     * Select PLL as system clock source and configure the HCLK, PCLK1 and
+     * PCLK2 clocks dividers. HSI and HSE are also valid system clock sources,
+     * although there is no much point in supporting them now.
+     */
+    clk_init.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                         RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2 |
+                         RCC_CLOCKTYPE_D3PCLK1 | RCC_CLOCKTYPE_D1PCLK1;
+    clk_init.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+
+#if !IS_RCC_HCLK(MYNEWT_VAL(STM32_CLOCK_AHB_DIVIDER))
+#error  "AHB clock divider is invalid"
+#endif
+
+#if !IS_RCC_PCLK1(MYNEWT_VAL(STM32_CLOCK_APB1_DIVIDER))
+#error "APB1 clock divider is invalid"
+#endif
+
+#if !IS_RCC_PCLK2(MYNEWT_VAL(STM32_CLOCK_APB2_DIVIDER))
+#error "APB2 clock divider is invalid"
+#endif
+
+    clk_init.AHBCLKDivider = MYNEWT_VAL(STM32_CLOCK_AHB_DIVIDER);
+    clk_init.APB1CLKDivider = MYNEWT_VAL(STM32_CLOCK_APB1_DIVIDER);
+    clk_init.APB2CLKDivider = MYNEWT_VAL(STM32_CLOCK_APB2_DIVIDER);
+    clk_init.APB3CLKDivider = MYNEWT_VAL(STM32_CLOCK_APB3_DIVIDER);
+    clk_init.APB4CLKDivider = MYNEWT_VAL(STM32_CLOCK_APB4_DIVIDER);
+
+#if !IS_FLASH_LATENCY(MYNEWT_VAL(STM32_FLASH_LATENCY))
+#error "Flash latency value is invalid"
+#endif
+
+    status = HAL_RCC_ClockConfig(&clk_init, MYNEWT_VAL(STM32_FLASH_LATENCY));
+    if (status != HAL_OK) {
+        assert(0);
+    }
+
+#if ((MYNEWT_VAL(STM32_CLOCK_HSI) == 0) || (MYNEWT_VAL(STM32_CLOCK_HSE) == 0))
+    /*
+     * Turn off HSE/HSI oscillator; this must be done at the end because
+     * SYSCLK source has to be updated first.
+     */
+    osc_init.OscillatorType = RCC_OSCILLATORTYPE_NONE;
+#if (MYNEWT_VAL(STM32_CLOCK_HSE) == 0)
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_HSE;
+    osc_init.HSEState = RCC_HSE_OFF;
+#endif
+#if (MYNEWT_VAL(STM32_CLOCK_HSI) == 0)
+    osc_init.OscillatorType |= RCC_OSCILLATORTYPE_HSI;
+    osc_init.HSIState = RCC_HSI_OFF;
+#endif
+    osc_init.PLL.PLLState = RCC_PLL_NONE;
+
+    status = HAL_RCC_OscConfig(&osc_init);
+    if (status != HAL_OK) {
+        assert(0);
+    }
+#endif
+}
+#endif

--- a/hw/mcu/stm/stm32h7xx/src/hal_reset_cause.c
+++ b/hw/mcu/stm/stm32h7xx/src/hal_reset_cause.c
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <hal/hal_system.h>
+
+#include "stm32h7xx_hal_def.h"
+
+enum hal_reset_reason
+hal_reset_cause(void)
+{
+    static enum hal_reset_reason reason;
+    uint32_t reg;
+
+    if (reason) {
+        return reason;
+    }
+
+    reg = RCC->RSR;
+    if (reg & RCC_RSR_WWDG1RSTF || reg & RCC_RSR_IWDG1RSTF) {
+        reason = HAL_RESET_WATCHDOG;
+    } else if (reg & RCC_RSR_SFTRSTF) {
+        reason = HAL_RESET_SOFT;
+    } else if (reg & RCC_RSR_PINRSTF) {
+        reason = HAL_RESET_PIN;
+    } else if (reg & RCC_RSR_BORRSTF) {
+        reason = HAL_RESET_BROWNOUT;
+    } else {
+        reason = HAL_RESET_POR;
+    }
+    RCC->RSR |= RCC_RSR_RMVF;
+    return reason;
+}

--- a/hw/mcu/stm/stm32h7xx/src/hal_timer_freq.c
+++ b/hw/mcu/stm/stm32h7xx/src/hal_timer_freq.c
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include "stm32h7xx_hal_rcc.h"
+
+static uint32_t
+stm32_hal_timer_abp_clk_div(uint32_t divider)
+{
+    switch (divider) {
+    case RCC_HCLK_DIV1:
+        return 1;
+    case RCC_HCLK_DIV2:
+        return 2;
+    case RCC_HCLK_DIV4:
+        return 4;
+    case RCC_HCLK_DIV8:
+        return 8;
+    case RCC_HCLK_DIV16:
+        return 16;
+    }
+    return 0;
+}
+
+uint32_t
+stm32_hal_timer_get_freq(void *timx)
+{
+    uintptr_t regs = (uintptr_t)timx;
+    RCC_ClkInitTypeDef clocks;
+    uint32_t flashLatency;
+    uint32_t freq = 0;
+    uint32_t div = 0;
+
+    HAL_RCC_GetClockConfig(&clocks, &flashLatency);
+
+    switch (regs) {
+#ifdef TIM1
+    case (uintptr_t)TIM1:
+#endif
+#ifdef TIM8
+    case (uintptr_t)TIM8:
+#endif
+#ifdef TIM15
+    case (uintptr_t)TIM15:
+#endif
+#ifdef TIM16
+    case (uintptr_t)TIM16:
+#endif
+#ifdef TIM17
+    case (uintptr_t)TIM17:
+#endif
+        freq = HAL_RCC_GetPCLK2Freq();
+        div = stm32_hal_timer_abp_clk_div(clocks.APB2CLKDivider);
+        break;
+
+#ifdef TIM2
+    case (uintptr_t)TIM2:
+#endif
+#ifdef TIM3
+    case (uintptr_t)TIM3:
+#endif
+#ifdef TIM4
+    case (uintptr_t)TIM4:
+#endif
+#ifdef TIM5
+    case (uintptr_t)TIM5:
+#endif
+#ifdef TIM6
+    case (uintptr_t)TIM6:
+#endif
+#ifdef TIM7
+    case (uintptr_t)TIM7:
+#endif
+
+#ifdef TIM12
+    case (uintptr_t)TIM12:
+#endif
+#ifdef TIM13
+    case (uintptr_t)TIM13:
+#endif
+#ifdef TIM14
+    case (uintptr_t)TIM14:
+#endif
+#ifdef TIM23
+    case (uintptr_t)TIM23:
+#endif
+#ifdef TIM24
+    case (uintptr_t)TIM24:
+#endif
+        freq = HAL_RCC_GetPCLK1Freq();
+        div = stm32_hal_timer_abp_clk_div(clocks.APB1CLKDivider);
+        break;
+
+    default:
+        assert(0);
+        return 0;
+    }
+
+    if (RCC_TIMPRES_ACTIVATED == READ_BIT(RCC->CFGR, RCC_CFGR_TIMPRE)) {
+        if (div > 2) {
+            return freq * 4;
+        }
+        return freq * div;
+    }
+
+    if (div > 1) {
+        return freq * 2;
+    }
+    return freq;
+}

--- a/hw/mcu/stm/stm32h7xx/src/system_stm32h7xx.c
+++ b/hw/mcu/stm/stm32h7xx/src/system_stm32h7xx.c
@@ -1,0 +1,440 @@
+/**
+ ******************************************************************************
+ * @file    system_stm32h7xx.c
+ * @author  MCD Application Team
+ * @brief   CMSIS Cortex-Mx Device Peripheral Access Layer System Source File.
+ *
+ *   This file provides two functions and one global variable to be called from
+ *   user application:
+ *      - SystemInit(): This function is called at startup just after reset and
+ *                      before branch to main program. This call is made inside
+ *                      the "startup_stm32h7xx.s" file.
+ *
+ *      - SystemCoreClock variable: Contains the core clock, it can be used
+ *                                  by the user application to setup the SysTick
+ *                                  timer or configure other parameters.
+ *
+ *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+ *                                 be called whenever the core clock is changed
+ *                                 during program execution.
+ *
+ *
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2017 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
+
+/** @addtogroup CMSIS
+ * @{
+ */
+
+/** @addtogroup stm32h7xx_system
+ * @{
+ */
+
+/** @addtogroup STM32H7xx_System_Private_Includes
+ * @{
+ */
+
+#include "bsp/stm32h7xx_hal_conf.h"
+#include "stm32h7xx.h"
+#include "mcu/cmsis_nvic.h"
+
+/* This variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+       Note: If you use this function to configure the system clock; then there
+             is no need to call the 2 first functions listed above, since SystemCoreClock
+             variable is updated automatically.
+ */
+uint32_t SystemCoreClock = 64000000;
+uint32_t SystemD2Clock = 64000000;
+const uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+/*
+ * XXX BSP specific
+ */
+void SystemClock_Config(void);
+
+/**
+ * @brief  Setup the microcontroller system
+ *         Initialize the Embedded Flash Interface, the PLL and update the
+ *         SystemFrequency variable.
+ * @param  None
+ * @retval None
+ */
+void
+SystemInit(void)
+{
+    /*
+     * FPU settings
+     */
+
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    /* set CP10 and CP11 Full Access */
+    SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));
+#endif
+
+    /*
+     * Reset the RCC clock configuration to the default reset state
+     */
+
+    /* Set HSION bit */
+    RCC->CR |= RCC_CR_HSION;
+
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000;
+
+    /* Reset HSEON, HSECSSON, CSION, HSI48ON, CSIKERON, PLL1ON, PLL2ON and PLL3ON bits */
+    RCC->CR &= 0xEAF6ED7FU;
+
+#if defined(D3_SRAM_BASE)
+    /* Reset D1CFGR register */
+    RCC->D1CFGR = 0x00000000;
+    /* Reset D2CFGR register */
+    RCC->D2CFGR = 0x00000000;
+    /* Reset D3CFGR register */
+    RCC->D3CFGR = 0x00000000;
+#else
+    /* Reset CDCFGR1 register */
+    RCC->CDCFGR1 = 0x00000000;
+    /* Reset CDCFGR2 register */
+    RCC->CDCFGR2 = 0x00000000;
+    /* Reset SRDCFGR register */
+    RCC->SRDCFGR = 0x00000000;
+#endif
+
+    /* Reset PLLCKSELR register */
+    RCC->PLLCKSELR = 0x02020200;
+
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x01FF0000;
+    /* Reset PLL1DIVR register */
+    RCC->PLL1DIVR = 0x01010280;
+    /* Reset PLL1FRACR register */
+    RCC->PLL1FRACR = 0x00000000;
+
+    /* Reset PLL2DIVR register */
+    RCC->PLL2DIVR = 0x01010280;
+
+    /* Reset PLL2FRACR register */
+
+    RCC->PLL2FRACR = 0x00000000;
+    /* Reset PLL3DIVR register */
+    RCC->PLL3DIVR = 0x01010280;
+
+    /* Reset PLL3FRACR register */
+    RCC->PLL3FRACR = 0x00000000;
+
+    /* Reset HSEBYP bit */
+    RCC->CR &= 0xFFFBFFFFU;
+
+    /* Configure System Clock */
+    SystemClock_Config();
+
+    /* Update SystemCoreClock global variable */
+    SystemCoreClockUpdate();
+
+    /* Relocate the vector table */
+    NVIC_Relocate();
+}
+
+/**
+ * @brief  Update SystemCoreClock variable according to Clock Register Values.
+ *         The SystemCoreClock variable contains the core clock (HCLK), it can
+ *         be used by the user application to setup the SysTick timer or configure
+ *         other parameters.
+ *
+ * @note   Each time the core clock (HCLK) changes, this function must be called
+ *         to update SystemCoreClock variable value. Otherwise, any configuration
+ *         based on this variable will be incorrect.
+ *
+ * @note   - The system frequency computed by this function is not the real
+ *           frequency in the chip. It is calculated based on the predefined
+ *           constant and the selected clock source:
+ *
+ *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(*)
+ *
+ *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(**)
+ *
+ *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**)
+ *             or HSI_VALUE(*) multiplied/divided by the PLL factors.
+ *
+ *         (*) HSI_VALUE is a constant defined in stm32f7xx_hal_conf.h file (default value
+ *             16 MHz) but the real value may vary depending on the variations
+ *             in voltage and temperature.
+ *
+ *         (**) HSE_VALUE is a constant defined in stm32f7xx_hal_conf.h file (default value
+ *              25 MHz), user has to ensure that HSE_VALUE is same as the real
+ *              frequency of the crystal used. Otherwise, this function may
+ *              have wrong result.
+ *
+ *         - The result of this function could be not correct when using fractional
+ *           value for HSE crystal.
+ */
+void
+SystemCoreClockUpdate(void)
+{
+    uint32_t pllp, pllsource, pllm, pllfracen, hsivalue, tmp;
+    uint32_t common_system_clock;
+    float_t fracn1, pllvco;
+
+
+    /* Get SYSCLK source -------------------------------------------------------*/
+
+    switch (RCC->CFGR & RCC_CFGR_SWS) {
+    case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
+        common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+        break;
+
+    case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
+        common_system_clock = CSI_VALUE;
+        break;
+
+    case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
+        common_system_clock = HSE_VALUE;
+        break;
+
+    case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
+
+        /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
+           SYSCLK = PLL_VCO / PLLR
+         */
+        pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
+        pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1)>> 4);
+        pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN)>>RCC_PLLCFGR_PLL1FRACEN_Pos);
+        fracn1 = (float_t)(uint32_t)(pllfracen* ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1)>> 3));
+
+        if (pllm != 0U) {
+            switch (pllsource) {
+            case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
+
+                hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+                pllvco = ((float_t)hsivalue / (float_t)pllm) *
+                         ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +
+                          (float_t)1);
+                break;
+
+            case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
+                pllvco = ((float_t)CSI_VALUE / (float_t)pllm) *
+                         ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +
+                          (float_t)1);
+                break;
+
+            case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
+                pllvco = ((float_t)HSE_VALUE / (float_t)pllm) *
+                         ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +
+                          (float_t)1);
+                break;
+
+            default:
+                hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+                pllvco = ((float_t)hsivalue / (float_t)pllm) *
+                         ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +
+                          (float_t)1);
+                break;
+            }
+            pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >>9) + 1U);
+            common_system_clock = (uint32_t)(float_t)(pllvco/(float_t)pllp);
+        } else {
+            common_system_clock = 0U;
+        }
+        break;
+
+    default:
+        common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+        break;
+    }
+
+    /* Compute SystemClock frequency --------------------------------------------------*/
+#if defined (RCC_D1CFGR_D1CPRE)
+    tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE)>> RCC_D1CFGR_D1CPRE_Pos];
+
+    /* common_system_clock frequency : CM7 CPU frequency  */
+    common_system_clock >>= tmp;
+
+    /* SystemD2Clock frequency : CM4 CPU, AXI and AHBs Clock frequency  */
+    SystemD2Clock =
+        (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE)>> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
+
+#else
+    tmp = D1CorePrescTable[(RCC->CDCFGR1 & RCC_CDCFGR1_CDCPRE)>> RCC_CDCFGR1_CDCPRE_Pos];
+
+    /* common_system_clock frequency : CM7 CPU frequency  */
+    common_system_clock >>= tmp;
+
+    /* SystemD2Clock frequency : AXI and AHBs Clock frequency  */
+    SystemD2Clock = (common_system_clock >>
+                     ((D1CorePrescTable[(RCC->CDCFGR1 & RCC_CDCFGR1_HPRE)>> RCC_CDCFGR1_HPRE_Pos]) & 0x1FU));
+
+#endif
+
+#if defined(DUAL_CORE) && defined(CORE_CM4)
+    SystemCoreClock = SystemD2Clock;
+#else
+    SystemCoreClock = common_system_clock;
+#endif /* DUAL_CORE && CORE_CM4 */
+}
+
+/*!< Uncomment the following line if you need to use external SDRAM mounted
+     on DK as data memory  */
+/* #define DATA_IN_ExtSDRAM */
+
+#if defined (DATA_IN_ExtSDRAM)
+/**
+ * @brief  Setup the external memory controller.
+ *         Called in startup_stm32f7xx.s before jump to main.
+ *         This function configures the external memories (SDRAM)
+ *         This SDRAM will be used as program data memory (including heap and stack).
+ * @param  None
+ * @retval None
+ */
+void
+SystemInit_ExtMemCtl(void)
+{
+    register uint32_t tmpreg = 0, timeout = 0xFFFF;
+    register __IO uint32_t index;
+
+    /* Enable GPIOC, GPIOD, GPIOE, GPIOF, GPIOG and GPIOH interface
+       clock */
+    RCC->AHB1ENR |= 0x000000FC;
+
+    /* Connect PCx pins to FMC Alternate function */
+    GPIOC->AFR[0] = 0x0000C000;
+    GPIOC->AFR[1] = 0x00000000;
+    /* Configure PCx pins in Alternate function mode */
+    GPIOC->MODER = 0x00000080;
+    /* Configure PCx pins speed to 50 MHz */
+    GPIOC->OSPEEDR = 0x00000080;
+    /* Configure PCx pins Output type to push-pull */
+    GPIOC->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PCx pins */
+    GPIOC->PUPDR = 0x00000040;
+
+    /* Connect PDx pins to FMC Alternate function */
+    GPIOD->AFR[0] = 0x000000CC;
+    GPIOD->AFR[1] = 0xCC000CCC;
+    /* Configure PDx pins in Alternate function mode */
+    GPIOD->MODER = 0xA02A000A;
+    /* Configure PDx pins speed to 50 MHz */
+    GPIOD->OSPEEDR = 0xA02A000A;
+    /* Configure PDx pins Output type to push-pull */
+    GPIOD->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PDx pins */
+    GPIOD->PUPDR = 0x50150005;
+
+    /* Connect PEx pins to FMC Alternate function */
+    GPIOE->AFR[0] = 0xC00000CC;
+    GPIOE->AFR[1] = 0xCCCCCCCC;
+    /* Configure PEx pins in Alternate function mode */
+    GPIOE->MODER = 0xAAAA800A;
+    /* Configure PEx pins speed to 50 MHz */
+    GPIOE->OSPEEDR = 0xAAAA800A;
+    /* Configure PEx pins Output type to push-pull */
+    GPIOE->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PEx pins */
+    GPIOE->PUPDR = 0x55554005;
+
+    /* Connect PFx pins to FMC Alternate function */
+    GPIOF->AFR[0] = 0x00CCCCCC;
+    GPIOF->AFR[1] = 0xCCCCC000;
+    /* Configure PFx pins in Alternate function mode */
+    GPIOF->MODER = 0xAA800AAA;
+    /* Configure PFx pins speed to 50 MHz */
+    GPIOF->OSPEEDR = 0xAA800AAA;
+    /* Configure PFx pins Output type to push-pull */
+    GPIOF->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PFx pins */
+    GPIOF->PUPDR = 0x55400555;
+
+    /* Connect PGx pins to FMC Alternate function */
+    GPIOG->AFR[0] = 0x00CC00CC;
+    GPIOG->AFR[1] = 0xC000000C;
+    /* Configure PGx pins in Alternate function mode */
+    GPIOG->MODER = 0x80020A0A;
+    /* Configure PGx pins speed to 50 MHz */
+    GPIOG->OSPEEDR = 0x80020A0A;
+    /* Configure PGx pins Output type to push-pull */
+    GPIOG->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PGx pins */
+    GPIOG->PUPDR = 0x40010505;
+
+    /* Connect PHx pins to FMC Alternate function */
+    GPIOH->AFR[0] = 0x00C0C000;
+    GPIOH->AFR[1] = 0x00000000;
+    /* Configure PHx pins in Alternate function mode */
+    GPIOH->MODER = 0x00000880;
+    /* Configure PHx pins speed to 50 MHz */
+    GPIOH->OSPEEDR = 0x00000880;
+    /* Configure PHx pins Output type to push-pull */
+    GPIOH->OTYPER = 0x00000000;
+    /* No pull-up, pull-down for PHx pins */
+    GPIOH->PUPDR = 0x00000440;
+
+    /* Enable the FMC interface clock */
+    RCC->AHB3ENR |= 0x00000001;
+
+    /* Configure and enable SDRAM bank1 */
+    FMC_Bank5_6->SDCR[0] = 0x00001954;
+    FMC_Bank5_6->SDTR[0] = 0x01115351;
+
+    /* SDRAM initialization sequence */
+    /* Clock enable command */
+    FMC_Bank5_6->SDCMR = 0x00000011;
+    tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+    while ((tmpreg != 0) && (timeout-- > 0)) {
+        tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+    }
+
+    /* Delay */
+    for (index = 0; index < 1000; index++) {
+        ;
+    }
+
+    /* PALL command */
+    FMC_Bank5_6->SDCMR = 0x00000012;
+    timeout = 0xFFFF;
+    while ((tmpreg != 0) && (timeout-- > 0)) {
+        tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+    }
+
+    /* Auto refresh command */
+    FMC_Bank5_6->SDCMR = 0x000000F3;
+    timeout = 0xFFFF;
+    while ((tmpreg != 0) && (timeout-- > 0)) {
+        tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+    }
+
+    /* MRD register program */
+    FMC_Bank5_6->SDCMR = 0x00044014;
+    timeout = 0xFFFF;
+    while ((tmpreg != 0) && (timeout-- > 0)) {
+        tmpreg = FMC_Bank5_6->SDSR & 0x00000020;
+    }
+
+    /* Set refresh count */
+    tmpreg = FMC_Bank5_6->SDRTR;
+    FMC_Bank5_6->SDRTR = (tmpreg | (0x0000050C<<1));
+
+    /* Disable write protection */
+    tmpreg = FMC_Bank5_6->SDCR[0];
+    FMC_Bank5_6->SDCR[0] = (tmpreg & 0xFFFFFDFF);
+
+    /*
+     * Disable the FMC bank1 (enabled after reset).
+     * This, prevents CPU speculation access on this bank which blocks the use of FMC during
+     * 24us. During this time the others FMC master (such as LTDC) cannot use it!
+     */
+    FMC_Bank1->BTCR[0] = 0x000030d2;
+}
+#endif /* DATA_IN_ExtSDRAM */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hw/mcu/stm/stm32h7xx/stm32h723.ld
+++ b/hw/mcu/stm/stm32h7xx/stm32h723.ld
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __coredata_start__
+ *   __coredata_end__
+ *   __corebss_start__
+ *   __corebss_end__
+ *   __ecoredata
+ *   __ecorebss
+ */
+ENTRY(Reset_Handler)
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    /* Reserve space at the start of the image for the header. */
+    .imghdr (NOLOAD):
+    {
+        . = . + _imghdr_size;
+    } > FLASH
+
+    __text = .;
+
+    .text :
+    {
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))
+        __isr_vector_end = .;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+
+    __exidx_end = .;
+
+    __etext = .;
+
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > DTCM
+
+    .coredata :
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(4);
+        __coredata_end__ = .;
+    } > RAM AT > FLASH
+
+    __ecoredata = __etext + SIZEOF(.coredata);
+
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        __data_start__ = _sdata;
+        *(vtable)
+        *(.data*)
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        _edata = .;
+        __data_end__ = _edata;
+
+    } > RAM AT > FLASH
+
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        *(.corebss*)
+        *(.bss.core.nz)
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } > RAM
+
+    . = ALIGN(8);
+    __HeapBase = .;
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+
+    _ram_start = ORIGIN(RAM);
+    _dtcmram_start = ORIGIN(DTCM);
+    _itcmram_start = ORIGIN(ITCM);
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    /* Set stack top to end of RAM; stack limit is bottom of stack */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check for RAM overflow */
+    ASSERT(__StackLimit >= __ecorebss, "RAM overflow!")
+}
+

--- a/hw/mcu/stm/stm32h7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32h7xx/syscfg.yml
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    MCU_FLASH_MIN_WRITE_SIZE:
+        description: >
+            Specifies the required alignment for internal flash writes.
+            Used internally by the newt tool.
+        value: 1
+
+    MCU_STM32H7:
+        description: MCUs are of STM32H7xx family
+        value: 1
+
+    STM32_ENABLE_ICACHE:
+        description: Enable instruction caching
+        value: 1
+
+    STM32_CLOCK_VOLTAGESCALING_CONFIG:
+        description: Voltage scale
+        value: 0
+
+    STM32_CLOCK_LSI:
+        description: Enable low-speed internal clock source
+        value: 1
+
+    STM32_CLOCK_LSE:
+        description: Enable low-speed external clock source (aka RTC xtal)
+        value: 0
+
+    STM32_CLOCK_LSE_BYPASS:
+        description: 0 for 32768 xtal; 1 for input clock
+        value: 0
+
+    STM32_CLOCK_HSE:
+        description: Enable high-speed external clock source
+        value: 0
+
+    STM32_CLOCK_HSE_BYPASS:
+        description: 0 for xtal; 1 for input clock
+        value: 0
+
+    STM32_CLOCK_HSI:
+        description: Enable high-speed internal clock source
+        value: 1
+
+    STM32_CLOCK_HSI_CALIBRATION:
+        description: HSI calibration value
+        value: 'RCC_HSICALIBRATION_DEFAULT'
+
+    STM32_CLOCK_PLL_PLLM:
+        description: PLL config M parameter
+        value: 0
+
+    STM32_CLOCK_PLL_PLLN:
+        description: PLL config N parameter
+        value: 0
+
+    STM32_CLOCK_PLL_PLLP:
+        description: PLL config P parameter
+        value: 0
+
+    STM32_CLOCK_PLL_PLLQ:
+        description: PLL config Q parameter
+        value: 0
+
+    STM32_CLOCK_PLL_PLLR:
+        description: PLL config R parameter
+        value: 0
+
+    STM32_CLOCK_PLLRGE:
+        description: PLL input frequency range
+        value: 0
+
+    STM32_CLOCK_ENABLE_OVERDRIVE:
+        description: Turn on over-drive mode (reach higher clock rates)
+        value: 0
+
+    STM32_CLOCK_AHB_DIVIDER:
+        description: AHB prescaler
+        value: 0
+
+    STM32_CLOCK_APB1_DIVIDER:
+        description: APB low-speed prescaler
+        value: 0
+
+    STM32_CLOCK_APB2_DIVIDER:
+        description: APB high-speed prescaler
+        value: 0
+
+    STM32_CLOCK_APB3_DIVIDER:
+        description: APB low-speed prescaler
+        value: 0
+
+    STM32_CLOCK_APB4_DIVIDER:
+        description: APB high-speed prescaler
+        value: 0
+
+    STM32_FLASH_LATENCY:
+        description: Number of wait-states
+        value: 0
+
+    STM32_HAL_SPI_HAS_FIFO:
+        description: This MCU has a SPI with FIFO
+        value: 1
+
+    STM32_HAL_I2C_HAS_CLOCKSPEED:
+        description: This MCU's I2C has no clock speed register (has TIMINGR)
+        value: 0
+
+    STM32_HAL_UART_HAS_SR:
+        description: This MCU's UART uses ISR register (not SR) for status.
+        value: 0
+
+    MCU_FLASH_ERASED_VAL:
+        description: Value read from erased flash.
+        value: 0xff


### PR DESCRIPTION
This adds initial Nucleo-H723ZG BSP and STM32H723ZG MCU support, but it uses new feature implemented to Newt, which is ability to download external repositories that do not contain project.yml file. This way we do not have to add hundreds of files from ST's repository to the core. In order for this to work you have to build Newt from this commit:
<https://github.com/m-gorecki/mynewt-newt/commit/4a9b494d14da5c860c1747ebecec6fc70952197a> and later add this to your project.yml file:

repository.cmsis_device_h7:
    type: github
    vers: 6dac8c24d7b38ab20806d27dd7d8285a6433b8f7-commit
    user: STMicroelectronics
    repo: cmsis_device_h7

repository.stm32h7xx_hal_driver:
    type: github
    vers: b716379524ba3549e4db11804889776ffeb239d1-commit
    user: STMicroelectronics
    repo: stm32h7xx_hal_driver

After doing so you can run "newt upgrade" and try it out.