### PR TITLE
github: Improve test targets build

### DIFF
--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -42,4 +42,4 @@ jobs:
              newt upgrade --shallow=1
              ln -s .github/targets ci_targets
       - name: Build targets
-        run: newt build `ls ci_targets/`
+        run: ls ci_targets | xargs -n1 sh -c 'echo "Testing $0"; newt build -q $0'


### PR DESCRIPTION
Don't fail on first error but try to build all targets. Also, make build less spammy, we care about errors only anyway.