### PR TITLE
ci: Fix targets build on Windows

### DIFF
--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -45,4 +45,5 @@ jobs:
              newt upgrade --shallow=1
              cp -r .github/targets ci_targets
       - name: Build targets
+        shell: bash
         run: ls ci_targets | xargs -n1 sh -c 'echo "Testing $0"; newt build -q $0'


### PR DESCRIPTION
We need to build from bash instead of windows shell.