### PR TITLE
libc/baselibc: Add specialized memset for RISCV

### DIFF
--- a/libc/baselibc/src/memset.c
+++ b/libc/baselibc/src/memset.c
@@ -66,6 +66,16 @@ void *memset(void *dst, int c, size_t n)
                   :
                   : "r3", "r4", "memory"
                  );
+#elif defined(__riscv)
+    (void)q;
+    asm volatile ("   add %[len], %[len], %[dst]            \n"
+                  "   j 2f                                  \n"
+                  "1: sb %[val], (%[dst])                   \n"
+                  "   addi %[dst], %[dst], 1                \n"
+                  "2: bne %[len], %[dst], 1b                \n"
+                  : [dst] "+r" (dst), [val] "+r" (c), [len] "+r" (n)
+                  :
+                  :);
 #else
 	while (n--) {
 		*q++ = c;


### PR DESCRIPTION
Code is slightly more efficient then one generated by default. It is replaced however because when "speed" profile is selected default loop
    while (n--) {
         *q++ = c;
    }
is recognized as candidate for memset and recursive call to same function is generated like that:
void *memset(void *dst, int c, size_t n)
{
204022ee:	1141                	addi	sp,sp,-16
204022f0:	c422                	sw	s0,8(sp)
204022f2:	c606                	sw	ra,12(sp)
204022f4:	842a                	mv	s0,a0
#else
	while (n--) {
204022f6:	c601                	beqz	a2,204022fe <memset+0x10>
		*q++ = c;
204022f8:	0ff5f593          	zext.b	a1,a1
204022fc:	3fcd                	jal	204022ee <memset>  !!!!!!!!!!! recursive call
	}
#endif