### PR TITLE
ci: Speed up builds on Windows

### DIFF
--- a/.github/test_build_blinky.sh
+++ b/.github/test_build_blinky.sh
@@ -44,7 +44,7 @@ for bsp in ${BSPS}; do
     newt target create -s $target
     newt target set -s $target bsp="@apache-mynewt-core/hw/bsp/$bsp"
     newt target set -s $target app="apps/blinky"
-    newt build -q $target
+    newt build -j 64 -q $target
 
     rc=$?
     [[ $rc -ne 0 ]] && EXIT_CODE=$rc

--- a/.github/test_build_blinky.sh
+++ b/.github/test_build_blinky.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/.github/windows_newtrc.yml
+++ b/.github/windows_newtrc.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Skip operations that are not essential for build but can be potentially
+# git-intensive which means they are painfully slow on Windows.
+skip_newt_compat: 1
+skip_syscfg_repo_hash: 1

--- a/.github/workflows/build_blinky.yml
+++ b/.github/workflows/build_blinky.yml
@@ -46,6 +46,12 @@ jobs:
         run: |
              go version
              go get mynewt.apache.org/newt/newt@latest
+      - name: Tune newt settings on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+             mkdir ~/.newt
+             cp .github/windows_newtrc.yml ~/.newt/newtrc.yml
       - name: Setup Blinky project
         run: |
              cp .github/project.yml project.yml
@@ -53,4 +59,5 @@ jobs:
              git clone https://github.com/apache/mynewt-blinky.git /tmp/blinky
              cp -r /tmp/blinky/apps/blinky/ apps/blinky
       - name: Build Blinky
-        run: bash .github/test_build_blinky.sh
+        shell: bash
+        run: .github/test_build_blinky.sh

--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -42,10 +42,17 @@ jobs:
              go version
              go get mynewt.apache.org/newt/newt@latest
       - name: Setup project
+        shell: bash
         run: |
              cp .github/project.yml project.yml
              newt upgrade --shallow=1
              cp -r .github/targets ci_targets
+      - name: Tune newt settings on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+             mkdir ~/.newt
+             cp .github/windows_newtrc.yml ~/.newt/newtrc.yml
       - name: Build targets
         shell: bash
         run: ls ci_targets | xargs -n1 sh -c 'echo "Testing $0"; newt build -q $0'


### PR DESCRIPTION
Skip newt operations that are not essential for build but can be potentially git-intensive which means they are painfully slow on Windows.