### PR TITLE
Add stm32u5 stm32h7 repository to project.yml for CI

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -42,3 +42,31 @@ repository.apache-mynewt-mcumgr:
     vers: 0.0.0
     user: apache
     repo: mynewt-mcumgr
+
+repository.cmsis_device_u5:
+    type: github
+    branch: main
+    vers: v1.1.0-commit
+    user: STMicroelectronics
+    repo: cmsis_device_u5
+
+repository.stm32u5xx_hal_driver:
+    type: github
+    branch: main
+    vers: v1.1.0-commit
+    user: STMicroelectronics
+    repo: stm32u5xx_hal_driver
+
+repository.cmsis_device_h7:
+    type: github
+    branch: master
+    vers: v1.10.3-commit
+    user: STMicroelectronics
+    repo: cmsis_device_h7
+
+repository.stm32h7xx_hal_driver:
+    type: github
+    branch: master
+    vers: v1.11.1-commit
+    user: STMicroelectronics
+    repo: stm32h7xx_hal_driver


### PR DESCRIPTION
External repositiries needed by some BSP are not added to project.yml used for CI.