### PR TITLE
uncrustify: Don't use deprecated config

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -678,7 +678,7 @@ sp_try_brace                    = ignore   # ignore/add/remove/force
 sp_getset_brace                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
-sp_word_brace                   = add      # ignore/add/remove/force
+sp_word_brace_init_list         = add      # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for a namespace. Default=Add
 sp_word_brace_ns                = add      # ignore/add/remove/force


### PR DESCRIPTION
Use sp_word_brace_init_lst instead of sp_word_brace