### PR TITLE
README: Remove deleted apps from Sample Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,29 +145,12 @@ In addition to some of the core packages, there are also some sample
 applications that show how to instantiate the Apache Mynewt system.  These
 sample applications are located in the `apps/` directory.  They include:
 
-* [boot](https://github.com/apache/mynewt-core/tree/master/apps/boot):
-  Project to build the bootloader for test platforms.
-* [blinky](https://github.com/apache/mynewt-core/tree/master/apps/blinky): The
-  minimal packages to build the OS, and blink a LED!
 * [slinky](https://github.com/apache/mynewt-core/tree/master/apps/slinky): A
   slightly more complex project that includes the console and shell libraries.
-* [blecent](https://github.com/apache/mynewt-core/tree/master/apps/blecent): A basic central device with no user interface.  This
-application scans for a peripheral that supports the alert notification
-service (ANS).  Upon discovering such a peripheral, blecent connects and
-performs a characteristic read, characteristic write, and notification subscription.
-* [blehci](https://github.com/apache/mynewt-core/tree/master/apps/blehci): Implements a BLE controller-only application.  A separate
-host-only implementation, such as Linux's BlueZ, can interface with this
-application via HCI over UART.
-* [bleprph](https://github.com/apache/mynewt-core/tree/master/apps/bleprph): An
-  implementation of a minimal BLE peripheral.
-* [btshell](https://github.com/apache/mynewt-core/tree/master/apps/btshell): Shell interface to the Apache Mynewt Bluetooth stack.
 * [bleuart](https://github.com/apache/mynewt-core/tree/master/apps/bleuart):
 Implements a simple BLE peripheral that supports the Nordic
 UART / Serial Port Emulation service
 (https://developer.nordicsemi.com/nRF5_SDK/nRF51_SDK_v8.x.x/doc/8.0.0/s110/html/a00072.html).
-* [test](https://github.com/apache/mynewt-core/tree/master/apps/test): Test
-  project which can be compiled either with the simulator, or on a per-architecture basis.
-  Test will run all the package's unit tests.
 
 # Getting Help
 


### PR DESCRIPTION
Updated readme with the  deleted apps : 
Below is the list of commits that removed the respected apps : 

Commit &nbsp;&nbsp; | Apps Removed
1c1df506cef5678d3118f55288cb4cd437fbd478 | blecent, bleprph, blehci, btshell 
540ee189c90d66b86af52aae3d0d9cc31021281b | boot                                           
3469f91bba3b5ccb42f7011bab38aba676b9df07 | test
33cdc60bc6e78e786c879c0b5dd59a5d80369ee8 | blinky