### PR TITLE
hw/bus: Add duplex_write_read function to bus_dev_ops

### DIFF
--- a/hw/bus/drivers/spi_hal/src/spi_hal.c
+++ b/hw/bus/drivers/spi_hal/src/spi_hal.c
@@ -252,6 +252,34 @@ bus_spi_write_read(struct bus_dev *bdev, struct bus_node *bnode,
     return rc;
 }
 
+static int
+bus_spi_duplex_write_read(struct bus_dev *bdev, struct bus_node *bnode,
+                          const uint8_t *wbuf, uint8_t *rbuf, uint16_t length,
+                          os_time_t timeout, uint16_t flags)
+{
+    struct bus_spi_hal_dev *dev = (struct bus_spi_hal_dev *)bdev;
+    struct bus_spi_node *node = (struct bus_spi_node *)bnode;
+    int rc;
+
+    BUS_DEBUG_VERIFY_DEV(&dev->spi_dev);
+    BUS_DEBUG_VERIFY_NODE(node);
+
+    hal_gpio_write(node->pin_cs, 0);
+
+    rc = hal_spi_txrx_noblock(dev->spi_dev.cfg.spi_num, (uint8_t *)wbuf, rbuf, length);
+#if MYNEWT_VAL(SPI_HAL_USE_NOBLOCK)
+    if (rc == 0) {
+        os_sem_pend(&dev->sem, OS_TIMEOUT_NEVER);
+    }
+#endif
+
+    if (rc || !(flags & BUS_F_NOSTOP)) {
+        hal_gpio_write(node->pin_cs, 1);
+    }
+
+    return rc;
+}
+
 static int bus_spi_disable(struct bus_dev *bdev)
 {
     struct bus_spi_dev *spi_dev = (struct bus_spi_dev *)bdev;
@@ -275,6 +303,7 @@ static const struct bus_dev_ops bus_spi_ops = {
     .write = bus_spi_write,
     .disable = bus_spi_disable,
     .write_read = bus_spi_write_read,
+    .duplex_write_read = bus_spi_duplex_write_read,
 };
 
 int

--- a/hw/bus/include/bus/bus.h
+++ b/hw/bus/include/bus/bus.h
@@ -129,6 +129,27 @@ bus_node_write_read_transact(struct os_dev *node, const void  *wbuf,
                              os_time_t timeout, uint16_t flags);
 
 /**
+ * Perform write and read in duplex mode (SPI)
+ *
+ * Writes data to node and automatically reads response at the same time.
+ *
+ * The timeout parameter applies to complete transaction time.
+ *
+ * @param node     Node device object
+ * @param wbuf     Buffer with data to be written
+ * @param rbuf     Buffer to read data into
+ * @param length   Length of data to be written and read
+ * @param timeout  Operation timeout
+ * @param flags    Flags
+ *
+ * @return 0 on success, SYS_xxx on error
+ */
+int
+bus_node_duplex_write_read(struct os_dev *node, const void *wbuf,
+                           void *rbuf, uint16_t length,
+                           os_time_t timeout, uint16_t flags);
+
+/**
  * Read data from node
  *
  * This is simple version of bus_node_read() with default timeout and no flags.

--- a/hw/bus/include/bus/bus_driver.h
+++ b/hw/bus/include/bus/bus_driver.h
@@ -68,6 +68,10 @@ struct bus_dev_ops {
                        const uint8_t *wbuf, uint16_t wlength,
                        uint8_t *rbuf, uint16_t rlength,
                        os_time_t timeout,  uint16_t flags);
+    /* Duplex write and read */
+    int (* duplex_write_read)(struct bus_dev *bdev, struct bus_node *bnode,
+                              const uint8_t *wbuf, uint8_t *rbuf, uint16_t length,
+                              os_time_t timeout, uint16_t flags);
 };
 
 /**


### PR DESCRIPTION
Duplex of SPI was not covered in bus drivers.
This adds bus_node_duplex_write_read() function that
can be used with SPI drivers that support duplex mode.
For simplicity both buffers provided to function have same length.