### PR TITLE
hw/mcu/dialog: hal_spi update clock selection

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_spi.c
+++ b/hw/mcu/dialog/da1469x/src/hal_spi.c
@@ -304,20 +304,18 @@ hal_spi_config(int spi_num, struct hal_spi_settings *settings)
 
     assert(settings->data_order == HAL_SPI_MSB_FIRST);
 
-    switch (settings->baudrate) {
-    case 16000:
+    if (settings->baudrate >= 16000) {
+        /* Set 16 MHz */
         ctrl_reg |= (2U << SPI_SPI_CTRL_REG_SPI_CLK_Pos);
-        break;
-    case 8000:
+    } else if (settings->baudrate >= 8000) {
+        /* Set 8 MHz */
         ctrl_reg |= (1U << SPI_SPI_CTRL_REG_SPI_CLK_Pos);
-        break;
-    case 4000:
+    } else if (settings->baudrate > 4000) {
+        /* Set 4 MHz */
         ctrl_reg |= (0U << SPI_SPI_CTRL_REG_SPI_CLK_Pos);
-        break;
-    default:
+    } else {
         /* Slowest possibly clock, divider 14, 2.28MHz */
         ctrl_reg |= (3U << SPI_SPI_CTRL_REG_SPI_CLK_Pos);
-        break;
     }
 
     switch (settings->data_mode) {


### PR DESCRIPTION
It is possible to setup 16/8/4 and 2.28 MHz SPI clock. However for 16/8/4 MHZ clock was set only if baudrate had exactly correct value in other cases clock would defalt to slowest 2.28 Mhz.

With this change clock is selected to have highest value that not exceeds requested baudrate.

With this change it is easier to set baudare that is specific to device that is connected to SPI.
For example if SPI device supports up to 10 MHZ user could just pass this value in syscfg.yml and this could possibly be used for different MCUs that have different capabilities without needed to have separate clock values for different MCU. This strategy of rounding down is already used in ST MCUs and hifive1.