### PR TITLE
bus/spi_stm32: Fix SCK glitch for STM32H7

### DIFF
--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -624,6 +624,9 @@ spi_stm32_configure(struct bus_dev *bdev, struct bus_node *bnode)
                                  SPI_PHASE_1EDGE : SPI_PHASE_2EDGE;
         dd->hspi.Init.FirstBit = node->data_order == BUS_SPI_DATA_ORDER_MSB ?
                                  SPI_FIRSTBIT_MSB : SPI_FIRSTBIT_LSB;
+#if defined(SPI_MASTER_KEEP_IO_STATE_ENABLE)
+        dd->hspi.Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_ENABLE;
+#endif
     }
     if (HAL_OK != HAL_SPI_Init(&dd->hspi)) {
         rc = SYS_EINVAL;


### PR DESCRIPTION
When SPI_MASTER_KEEP_IO_STATE_ENABLE flag is not set for STM32H7, SPI SCK line can change state when SPI is re-configured. This change in SCK line can lead to broken SPI transmission.

Even when this will be set there is still issue in ST driver that can prevent correct transmission
https://github.com/STMicroelectronics/stm32h7xx_hal_driver/issues/35