### PR TITLE
bus/spi_apollo3: Fix SPI frequency setting

### DIFF
--- a/hw/bus/drivers/spi_apollo3/src/spi_apollo3.c
+++ b/hw/bus/drivers/spi_apollo3/src/spi_apollo3.c
@@ -107,7 +107,7 @@ bus_spi_configure(struct bus_dev *bdev, struct bus_node *bnode)
 
     spi_cfg.data_mode = node->mode;
     spi_cfg.data_order = node->data_order;
-    spi_cfg.baudrate = node->freq;
+    spi_cfg.baudrate = node->freq * 1000;
     /* XXX add support for other word sizes */
     spi_cfg.word_size = HAL_SPI_WORD_SIZE_8BIT;
 


### PR DESCRIPTION
bus_spi_node seems to keep SPI frequency in kHz while hal_spi_settings keeps it in Hz.

This just converts frequency to Hz before calling hal_spi_config.