### PR TITLE
sys/console: Add default CONSOLE_IMPLEMENTATION value

### DIFF
--- a/sys/console/syscfg.yml
+++ b/sys/console/syscfg.yml
@@ -20,7 +20,7 @@ syscfg.defs:
     CONSOLE_IMPLEMENTATION:
         description: >
             Selects console implementation package full, minimal or stub.
-        value:
+        value: full
         choices:
             - full
             - minimal


### PR DESCRIPTION
Until now CONSOLE_IMPLEMENTATION had no default value, which was causing build errors when implementation package wasn't specified.