### PR TITLE
tinyusb: Device descriptor configuration update

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
+++ b/hw/usb/tinyusb/std_descriptors/src/std_descriptors.c
@@ -167,23 +167,9 @@ const tusb_desc_device_t desc_device = {
     .bDescriptorType    = TUSB_DESC_DEVICE,
     .bcdUSB             = USB_BCD,
 
-#if CFG_TUD_BTH
-    .bDeviceClass       = TUD_BT_APP_CLASS,
-    .bDeviceSubClass    = TUD_BT_APP_SUBCLASS,
-    .bDeviceProtocol    = TUD_BT_PROTOCOL_PRIMARY_CONTROLLER,
-#elif CFG_TUD_CDC
-    /*
-     * Use Interface Association Descriptor (IAD) for CDC
-     * As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
-     */
-    .bDeviceClass       = TUSB_CLASS_MISC,
-    .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol    = MISC_PROTOCOL_IAD,
-#else
-    .bDeviceClass       = 0x00,
-    .bDeviceSubClass    = 0x00,
-    .bDeviceProtocol    = 0x00,
-#endif
+    .bDeviceClass       = MYNEWT_VAL(USBD_DEVICE_CLASS),
+    .bDeviceSubClass    = MYNEWT_VAL(USBD_DEVICE_SUBCLASS),
+    .bDeviceProtocol    = MYNEWT_VAL(USBD_DEVICE_PROTOCOL),
 
     .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 

--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -61,6 +61,27 @@ syscfg.defs:
     USBD_PRODUCT_STRING:
         description: Device friendly name
         value: '"Dev device"'
+    USBD_COMPOSITE_DEVICE:
+        description: >
+            When set to 1 device descriptor will have values assigned to
+            composite device. Device class = 0xFE, subclasss = 2,
+            protocol = 1.
+        value: 0
+    USBD_DEVICE_CLASS:
+        description: >
+            Device class that will be reported in device descriptors.
+            If 0 (preferred) class is specified in interface only.
+            Can be 0xFF for vendor specific.
+        value: 0
+    USBD_DEVICE_SUBCLASS:
+        description: >
+            Device sub class that will be reported in device descriptors.
+            If USBD_DEVICE_CLASS is 0 this also has to be 0.
+        value: 0
+    USBD_DEVICE_PROTOCOL:
+        description: >
+            Device class protocol that will be reported in device descriptors.
+        value: 0
     USBD_CDC:
         description: Enable CDC device function in TinyUSB stack (other then console or hci).
         value:
@@ -208,3 +229,8 @@ syscfg.defs:
 
 syscfg.restrictions:
     - '(CFG_TUSB_DEBUG == 0) || (USBD_STACK_SIZE >= 400)'
+
+syscfg.vals.USBD_COMPOSITE_DEVICE:
+    USBD_DEVICE_CLASS: TUSB_CLASS_MISC
+    USBD_DEVICE_SUBCLASS: MISC_SUBCLASS_COMMON
+    USBD_DEVICE_PROTOCOL: MISC_PROTOCOL_IAD


### PR DESCRIPTION
Device descriptor was set to composite only when CDC was used. Now user can specify class/subclass/protocol for device descriptor in syscfg.
If USBD_COMPOSITE_DEVICE is selected class/subclass/protocol are set according to composit device specification.

This allow to have BTH with MSC and CDC at the same time.