### PR TITLE
uncrustify: Fix typo in configuration

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -678,7 +678,7 @@ sp_try_brace                    = ignore   # ignore/add/remove/force
 sp_getset_brace                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
-sp_word_brace_init_list         = add      # ignore/add/remove/force
+sp_word_brace_init_lst          = add      # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for a namespace. Default=Add
 sp_word_brace_ns                = add      # ignore/add/remove/force


### PR DESCRIPTION
Should be sp_word_brace_init_lst.