### PR TITLE
os/kernel: Fix os_sched_sleep when task switch is locked

### DIFF
--- a/kernel/os/src/os_sched.c
+++ b/kernel/os/src/os_sched.c
@@ -180,6 +180,9 @@ os_sched_sleep(struct os_task *t, os_time_t nticks)
 {
     struct os_task *entry;
 
+    if (os_sched_lock_count) {
+        return 0;
+    }
     entry = NULL;
 
     TAILQ_REMOVE(&g_os_run_list, t, t_os_list);


### PR DESCRIPTION
When os_sched_sleep() was called from task that previously disabled scheduler (using os_sched_suspend()) current task was put in sleep queue and continue to execute while not being marked as ready.
If task called os_sched_sleep() again g_os_sleep_list and g_os_run_list get mixed resulting in idle task being active all the time.

Now os_sched_sleep() does not modify task list when scheduling is locked. It means that os_delay() will not not put task to sleep and will exit immediately.