### PR TITLE
hw/bus: Extend SPI handle speed over 64MHz

### DIFF
--- a/hw/bus/drivers/spi_common/include/bus/drivers/spi_common.h
+++ b/hw/bus/drivers/spi_common/include/bus/drivers/spi_common.h
@@ -65,7 +65,7 @@ struct bus_spi_node_cfg {
     /** Data order */
     int data_order;
     /** SCK frequency to be used for node */
-    uint16_t freq;
+    uint32_t freq;
     /** Quirks to be applied for device */
     uint16_t quirks;
 };
@@ -75,7 +75,7 @@ struct bus_spi_node {
     int pin_cs;
     uint8_t mode;
     uint8_t data_order;
-    uint16_t freq;
+    uint32_t freq;
     uint16_t quirks;
 
 #if MYNEWT_VAL(BUS_DEBUG_OS_DEV)


### PR DESCRIPTION
With LCD over SPI it is possible to have clocks
around 100MHz while due to type chosen for freq
SPI was limited to around 64MHz.

Now type is extend to 32 bits to allow greater speeds.