### PR TITLE
pic32 use spi_hal bus driver for SPI

### DIFF
--- a/hw/mcu/microchip/pic32mz/include/mcu/mips_hal.h
+++ b/hw/mcu/microchip/pic32mz/include/mcu/mips_hal.h
@@ -36,13 +36,6 @@ struct mips_uart_cfg {
     uint8_t cts;
 };
 
-/* I/O pins for SPI, SS pin is not handled by the driver */
-struct mips_spi_cfg {
-    uint8_t mosi;
-    uint8_t miso;
-    uint8_t sck;
-};
-
 /* I/O pins for I2C, also set frequency */
 struct mips_i2c_cfg {
     uint8_t scl;

--- a/hw/mcu/microchip/pic32mz/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_spi.c
@@ -59,7 +59,7 @@ struct hal_spi {
     int                       rxcnt;
     hal_spi_txrx_cb           callback;
     void                      *arg;
-    const struct mips_spi_cfg *pins;
+    const struct hal_spi_hw_settings *pins;
     uint32_t                  con;
     uint32_t                  brg;
 };
@@ -225,9 +225,9 @@ hal_spi_config_pins(int spi_num, uint8_t mode)
 {
     int ret = 0;
 
-    if (hal_gpio_init_out(spis[spi_num].pins->mosi, 0) ||
-        hal_gpio_init_out(spis[spi_num].pins->sck, 1) ||
-        hal_gpio_init_in(spis[spi_num].pins->miso, HAL_GPIO_PULL_NONE)) {
+    if (hal_gpio_init_out(spis[spi_num].pins->pin_mosi, 0) ||
+        hal_gpio_init_out(spis[spi_num].pins->pin_sck, 1) ||
+        hal_gpio_init_in(spis[spi_num].pins->pin_miso, HAL_GPIO_PULL_NONE)) {
         return -1;
     }
 
@@ -238,52 +238,52 @@ hal_spi_config_pins(int spi_num, uint8_t mode)
     switch (mode) {
     case HAL_SPI_MODE0:
     case HAL_SPI_MODE1:
-        hal_gpio_write(spis[spi_num].pins->sck, 0);
+        hal_gpio_write(spis[spi_num].pins->pin_sck, 0);
         break;
     case HAL_SPI_MODE2:
     case HAL_SPI_MODE3:
-        hal_gpio_write(spis[spi_num].pins->sck, 1);
+        hal_gpio_write(spis[spi_num].pins->pin_sck, 1);
         break;
     }
 
     switch (spi_num) {
 #if MYNEWT_VAL(SPI_0_MASTER)
     case 0:
-        ret += pps_configure_output(spis[spi_num].pins->mosi, SDO1_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso, SDI1_IN_FUNC);
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi, SDO1_OUT_FUNC);
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso, SDI1_IN_FUNC);
         break;
 #endif
 #if MYNEWT_VAL(SPI_1_MASTER)
     case 1:
-        ret += pps_configure_output(spis[spi_num].pins->mosi, SDO2_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso, SDI2_IN_FUNC);
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi, SDO2_OUT_FUNC);
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso, SDI2_IN_FUNC);
         break;
 #endif
 #if MYNEWT_VAL(SPI_2_MASTER)
     case 2:
-        ret += pps_configure_output(spis[spi_num].pins->mosi, SDO3_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso, SDI3_IN_FUNC);
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi, SDO3_OUT_FUNC);
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso, SDI3_IN_FUNC);
         break;
 #endif
 #if MYNEWT_VAL(SPI_3_MASTER)
     case 3:
-        ret += pps_configure_output(spis[spi_num].pins->mosi, SDO4_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso, SDI4_IN_FUNC);
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi, SDO4_OUT_FUNC);
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso, SDI4_IN_FUNC);
         break;
 #endif
 #if defined(_SPI5) && MYNEWT_VAL(SPI_4_MASTER)
     case 4:
-        ret += pps_configure_output(spis[spi_num].pins->mosi,
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi,
                                     SDO5_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso,
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso,
                                    SDI5_IN_FUNC);
         break;
 #endif
 #if defined(_SPI6) && MYNEWT_VAL(SPI_5_MASTER)
     case 5:
-        ret += pps_configure_output(spis[spi_num].pins->mosi,
+        ret += pps_configure_output(spis[spi_num].pins->pin_mosi,
                                     SDO6_OUT_FUNC);
-        ret += pps_configure_input(spis[spi_num].pins->miso,
+        ret += pps_configure_input(spis[spi_num].pins->pin_miso,
                                    SDI6_IN_FUNC);
         break;
 #endif

--- a/hw/mcu/microchip/pic32mz/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_spi.c
@@ -705,3 +705,10 @@ hal_spi_abort(int spi_num)
 
     return 0;
 }
+
+int
+hal_spi_init_hw(uint8_t spi_num, uint8_t spi_type,
+                const struct hal_spi_hw_settings *cfg)
+{
+    return hal_spi_init(spi_num, (void *)cfg, spi_type);
+}

--- a/hw/mcu/microchip/pic32mz/src/pic32mz_periph.c
+++ b/hw/mcu/microchip/pic32mz/src/pic32mz_periph.c
@@ -30,6 +30,12 @@
 #include <mcu/mips_hal.h>
 #include <uart_hal/uart_hal.h>
 #include <bsp/bsp.h>
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include "bus/bus.h"
+#include "bus/drivers/spi_hal.h"
+#endif
+
 #if MYNEWT_VAL(ETH_0)
 #include <pic32_eth/pic32_eth.h>
 #endif
@@ -87,40 +93,40 @@ static const struct mips_uart_cfg uart_5_cfg = {
  * SPI_0
  *   SCK1  -> RD1
  */
-static const struct mips_spi_cfg spi_0_cfg = {
-    .mosi = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTD(1),
+static const struct hal_spi_hw_settings spi_0_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTD(1),
 };
 
 /*
  * SPI_1
  *   SCK2  -> RG6
  */
-static const struct mips_spi_cfg spi_1_cfg = {
-    .mosi = MYNEWT_VAL(SPI_1_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_1_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTG(6),
+static const struct hal_spi_hw_settings spi_1_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_1_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_1_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTG(6),
 };
 
 /*
  * SPI_2
  *   SCK3  -> B14
  */
-static const struct mips_spi_cfg spi_2_cfg = {
-    .mosi = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTB(14),
+static const struct hal_spi_hw_settings spi_2_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTB(14),
 };
 
 /*
  * SPI_3
  *   SCK4  -> RD10
  */
-static const struct mips_spi_cfg spi_3_cfg = {
-    .mosi = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTD(10),
+static const struct hal_spi_hw_settings spi_3_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTD(10),
 };
 
 #ifdef _SPI5_BASE_ADDRESS
@@ -128,10 +134,10 @@ static const struct mips_spi_cfg spi_3_cfg = {
  * SPI_4
  *   SCK5  -> RF13
  */
-static const struct mips_spi_cfg spi_4_cfg = {
-    .mosi = MYNEWT_VAL(SPI_4_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_4_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTF(13),
+static const struct hal_spi_hw_settings spi_4_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_4_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_4_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTF(13),
 };
 #endif
 
@@ -140,12 +146,64 @@ static const struct mips_spi_cfg spi_4_cfg = {
  * SPI_5
  *   SCK6  -> RD15
  */
-static const struct mips_spi_cfg spi_5_cfg = {
-    .mosi = MYNEWT_VAL(SPI_5_MASTER_PIN_MOSI),
-    .miso = MYNEWT_VAL(SPI_5_MASTER_PIN_MISO),
-    .sck = MCU_GPIO_PORTD(15),
+static const struct hal_spi_hw_settings spi_5_cfg = {
+    .pin_mosi = MYNEWT_VAL(SPI_5_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_5_MASTER_PIN_MISO),
+    .pin_sck = MCU_GPIO_PORTD(15),
 };
 #endif
+
+static const struct bus_spi_dev_cfg spi0_cfg = {
+    .spi_num = 0,
+    .pin_sck = MCU_GPIO_PORTD(1),
+    .pin_mosi = MYNEWT_VAL(SPI_0_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_0_MASTER_PIN_MISO),
+};
+static struct bus_spi_hal_dev spi0_bus;
+
+static const struct bus_spi_dev_cfg spi1_cfg = {
+    .spi_num = 1,
+    .pin_sck = MCU_GPIO_PORTG(6),
+    .pin_mosi = MYNEWT_VAL(SPI_1_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_1_MASTER_PIN_MISO),
+};
+static struct bus_spi_hal_dev spi1_bus;
+
+static const struct bus_spi_dev_cfg spi2_cfg = {
+    .spi_num = 2,
+    .pin_sck = MCU_GPIO_PORTB(14),
+    .pin_mosi = MYNEWT_VAL(SPI_2_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_2_MASTER_PIN_MISO),
+};
+static struct bus_spi_hal_dev spi2_bus;
+
+static const struct bus_spi_dev_cfg spi3_cfg = {
+    .spi_num = 3,
+    .pin_sck = MCU_GPIO_PORTD(10),
+    .pin_mosi = MYNEWT_VAL(SPI_3_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_3_MASTER_PIN_MISO),
+};
+static struct bus_spi_hal_dev spi3_bus;
+
+static const struct bus_spi_dev_cfg spi4_cfg = {
+    .spi_num = 4,
+#ifdef _SPI5_BASE_ADDRESS
+    .pin_sck = MCU_GPIO_PORTF(13),
+    .pin_mosi = MYNEWT_VAL(SPI_4_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_4_MASTER_PIN_MISO),
+#endif
+};
+static struct bus_spi_hal_dev spi4_bus;
+
+static const struct bus_spi_dev_cfg spi5_cfg = {
+    .spi_num = 5,
+#ifdef _SPI6_BASE_ADDRESS
+    .pin_sck = MCU_GPIO_PORTD(15),
+    .pin_mosi = MYNEWT_VAL(SPI_5_MASTER_PIN_MOSI),
+    .pin_miso = MYNEWT_VAL(SPI_5_MASTER_PIN_MISO),
+#endif
+};
+static struct bus_spi_hal_dev spi5_bus;
 
 /*
  * I2C_0 -> I2C1
@@ -320,7 +378,38 @@ static void
 pic32mz_periph_spi_devs(void)
 {
     int rc;
-
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+    if (MYNEWT_VAL(SPI_0_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi0",
+                                    &spi0_bus, (struct bus_spi_dev_cfg *)&spi0_cfg);
+        assert(rc == 0);
+    }
+    if (MYNEWT_VAL(SPI_1_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi1", &spi1_bus,
+                                    (struct bus_spi_dev_cfg *)&spi1_cfg);
+        assert(rc == 0);
+    }
+    if (MYNEWT_VAL(SPI_2_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi2", &spi2_bus,
+                                    (struct bus_spi_dev_cfg *)&spi2_cfg);
+        assert(rc == 0);
+    }
+    if (MYNEWT_VAL(SPI_3_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi3", &spi3_bus,
+                                    (struct bus_spi_dev_cfg *)&spi3_cfg);
+        assert(rc == 0);
+    }
+    if (MYNEWT_VAL(SPI_4_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi4", &spi4_bus,
+                                    (struct bus_spi_dev_cfg *)&spi4_cfg);
+        assert(rc == 0);
+    }
+    if (MYNEWT_VAL(SPI_5_MASTER)) {
+        rc = bus_spi_hal_dev_create("spi5", &spi5_bus,
+                                    (struct bus_spi_dev_cfg *)&spi5_cfg);
+        assert(rc == 0);
+    }
+#else
     if (MYNEWT_VAL(SPI_0_MASTER)) {
         rc = hal_spi_init(0, (void *)&spi_0_cfg, HAL_SPI_TYPE_MASTER);
         assert(rc == 0);
@@ -348,6 +437,7 @@ pic32mz_periph_spi_devs(void)
         rc = hal_spi_init(5, (void *)&spi_5_cfg, HAL_SPI_TYPE_MASTER);
         assert(rc == 0);
     }
+#endif
 #endif
 }
 


### PR DESCRIPTION
This is simple refactor of hal_spi so it can be used with spi_hal bus driver.

When bus driver bus/drivers/spi_hal is added to the target pic32mz_periph_create() function creates proper devices
so applications using bus driver interface can be built.