### PR TITLE
hw/bus/spi_hal: Fix duplex write/read

### DIFF
--- a/hw/bus/drivers/spi_hal/src/spi_hal.c
+++ b/hw/bus/drivers/spi_hal/src/spi_hal.c
@@ -266,11 +266,13 @@ bus_spi_duplex_write_read(struct bus_dev *bdev, struct bus_node *bnode,
 
     hal_gpio_write(node->pin_cs, 0);
 
-    rc = hal_spi_txrx_noblock(dev->spi_dev.cfg.spi_num, (uint8_t *)wbuf, rbuf, length);
 #if MYNEWT_VAL(SPI_HAL_USE_NOBLOCK)
+    rc = hal_spi_txrx_noblock(dev->spi_dev.cfg.spi_num, (uint8_t *)wbuf, rbuf, length);
     if (rc == 0) {
         os_sem_pend(&dev->sem, OS_TIMEOUT_NEVER);
     }
+#else
+    rc = hal_spi_txrx(dev->spi_dev.cfg.spi_num, (uint8_t *)wbuf, rbuf, length);
 #endif
 
     if (rc || !(flags & BUS_F_NOSTOP)) {


### PR DESCRIPTION
bus_spi_duplex_write_read (unlike all other read/write functions) was always using hal_spi_txrx_noblock().

Now when SPI_HAL_USE_NOBLOCK is not set it calls hal_spi_txrx() as the rest of API functions.