### PR TITLE
mcu/nrf5340/tfm: Add OTP write function

### DIFF
--- a/hw/mcu/nordic/nrf5340/tfm/include/tfm/tfm.h
+++ b/hw/mcu/nordic/nrf5340/tfm/include/tfm/tfm.h
@@ -45,6 +45,17 @@
 int SECURE_CALL tfm_uicr_otp_read(uint8_t n, uint32_t *ret);
 
 /**
+ * Write UICR OTP word
+ *
+ * @param n   - word to read
+ * @param val - 32 bit word to write
+ * @return 0 on success
+ *         TFM_ERR_INVALID_PARAM - when n is out of range <0-191>
+ *         TFM_ERR_ACCESS_DENIED - when n is denied by secure code
+ */
+int SECURE_CALL tfm_uicr_otp_write(uint8_t n, uint32_t val);
+
+/**
  *
  * @param pin_number
  * @param mcu_sel

--- a/hw/mcu/nordic/nrf5340/tfm/pkg.yml
+++ b/hw/mcu/nordic/nrf5340/tfm/pkg.yml
@@ -34,5 +34,6 @@ pkg.cflags.(!BOOT_LOADER && !MCU_APP_SECURE):
 
 pkg.lflags.(MCU_APP_SECURE && TFM_EXPORT_NSC):
     - -utfm_uicr_otp_read
+    - -utfm_uicr_otp_write
     - -utfm_gpio_pin_mcu_select
     - -utfm_uicr_protect_device

--- a/hw/mcu/nordic/nrf5340/tfm/src/tfm.c
+++ b/hw/mcu/nordic/nrf5340/tfm/src/tfm.c
@@ -38,6 +38,26 @@ tfm_uicr_otp_read(uint8_t n, uint32_t *ret)
 }
 
 int SECURE_CALL
+tfm_uicr_otp_write(uint8_t n, uint32_t val)
+{
+    int err = 0;
+
+    if (n >= 192) {
+        err = TFM_ERR_INVALID_PARAM;
+    } else if ((n < MYNEWT_VAL(TFM_UICR_OTP_MIN_ADDR)) ||
+               (n > MYNEWT_VAL(TFM_UICR_OTP_MAX_ADDR)) ||
+               (NRF_UICR_S->OTP[n] != 0xFFFFFFFF)) {
+        err = TFM_ERR_ACCESS_DENIED;
+    } else {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+        NRF_UICR_S->OTP[n] = val;
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+    }
+
+    return err;
+}
+
+int SECURE_CALL
 tfm_uicr_protect_device(uint8_t *approtect, uint8_t *secure_approtect, uint8_t *erase_protect)
 {
     NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;

--- a/hw/mcu/nordic/nrf5340/tfm/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/tfm/syscfg.yml
@@ -34,9 +34,9 @@ syscfg.defs:
         value: 0xFFFFFFFF
     TFM_UICR_OTP_MIN_ADDR:
         description: >
-            Minimum address of UICR OTP that can be read by non-secure core.
+            Minimum address of UICR OTP that can be accessed by non-secure core.
         value: 0
     TFM_UICR_OTP_MAX_ADDR:
         description: >
-            Maximum address of UICR OTP that can be read by non-secure core.
+            Maximum address of UICR OTP that can be accessed by non-secure core.
         value: 191


### PR DESCRIPTION
New NSC function tfm_uicr_otp_write() stores data in OTP