### PR TITLE
mcu/stm32f7: Fix linker scripts for coredumps

### DIFF
--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -194,6 +194,7 @@ SECTIONS
 
     _ram_start = ORIGIN(RAM);
     _dtcmram_start = ORIGIN(DTCM);
+    _itcmram_start = ORIGIN(ITCM);
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -194,6 +194,7 @@ SECTIONS
 
     _ram_start = ORIGIN(RAM);
     _dtcmram_start = ORIGIN(DTCM);
+    _itcmram_start = ORIGIN(ITCM);
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign


### PR DESCRIPTION
Linker scripts were missing _itcmram_start symbol definition used in hal_bsp.c when core dumps were enabled.

This adds symbols to allow builds with OS_COREDUMP set to 1.