### PR TITLE
Use syscfg setting for sysinit stage numbers

### DIFF
--- a/hw/bus/pkg.yml
+++ b/hw/bus/pkg.yml
@@ -25,4 +25,4 @@ pkg.keywords:
 pkg.deps:
 
 pkg.init:
-    bus_pkg_init: 100
+    bus_pkg_init: 'MYNEWT_VAL(BUS_SYSINIT_STAGE)'

--- a/hw/bus/syscfg.yml
+++ b/hw/bus/syscfg.yml
@@ -73,3 +73,8 @@ syscfg.defs:
             magic value which is then checked on each operation to ensure
             proper objects are passed to APIs.
         value: 0
+
+    BUS_SYSINIT_STAGE:
+        description: >
+            System initialization stage for bus package
+        value: 100

--- a/hw/mcu/dialog/da1469x/pkg.yml
+++ b/hw/mcu/dialog/da1469x/pkg.yml
@@ -61,4 +61,4 @@ pkg.deps.SDADC:
     - "@apache-mynewt-core/hw/drivers/adc/sdadc_da1469x"
 
 pkg.init:
-    da1469x_lpclk_init: 1
+    da1469x_lpclk_init: 'MYNEWT_VAL(DA1469X_LPCLK_SYSINIT_STAGE)'

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -459,6 +459,11 @@ syscfg.defs:
           'Disable watchdog on init'
         value: 1
 
+    DA1469X_LPCLK_SYSINIT_STAGE:
+        description: >
+          'Initalization stage for DA1469X'
+        value: 1
+
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
 

--- a/mgmt/smp/smp_os/syscfg.yml
+++ b/mgmt/smp/smp_os/syscfg.yml
@@ -17,26 +17,8 @@
 # under the License.
 #
 
-pkg.name: mgmt/smp/smp_os
-pkg.description: Default SMP command.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-    - "@apache-mynewt-core/time/datetime"
-    - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-mcumgr/cmd/os_mgmt"
-    - "@apache-mynewt-mcumgr/mgmt"
-    - "@apache-mynewt-core/encoding/tinycbor"
-    - "@apache-mynewt-mcumgr/cborattr"
-
-pkg.deps.TIMEPERSIST:
-    - "@apache-mynewt-core/time/timepersist"
-
-pkg.req_apis:
-    - smp
-
-pkg.init:
-    smp_os_pkg_init: 'MYNEWT_VAL(SMP_OS_SYSINIT_STAGE)'
+syscfg.defs:
+    SMP_OS_SYSINIT_STAGE:
+        description: >
+          'System initialization stage for SMP OS package'
+        value: 501


### PR DESCRIPTION
This allows the target to rearrange package initialization order via syscfg override