### PR TITLE
stm32: Update style_ignored_dirs

### DIFF
--- a/.style_ignored_dirs
+++ b/.style_ignored_dirs
@@ -13,6 +13,34 @@ net/mqtt/eclipse
 hw/mcu/nxp/kinetis/MK64F12/src
 hw/mcu/nxp/kinetis/MK8xF/MK82F
 hw/bsp/frdm-k82f/src
+hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/b-l072z-lrwan1/include/bsp/stm32l0xx_hal_conf.h
+hw/bsp/b-l475e-iot01a/include/bsp/stm32l4xx_hal_conf.h
+hw/bsp/black_vet6/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/bluepill/include/bsp/stm32f1xx_hal_conf.h
+hw/bsp/nucleo-f030r8/include/bsp/stm32f0xx_hal_conf.h
+hw/bsp/nucleo-f072rb/include/bsp/stm32f0xx_hal_conf.h
+hw/bsp/nucleo-f103rb/include/bsp/stm32f1xx_hal_conf.h
+hw/bsp/nucleo-f303k8/include/bsp/stm32f3xx_hal_conf.h
+hw/bsp/nucleo-f303re/include/bsp/stm32f3xx_hal_conf.h
+hw/bsp/nucleo-f401re/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/nucleo-f411re/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/nucleo-f413zh/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/nucleo-f439zi/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/nucleo-f746zg/include/bsp/stm32f7xx_hal_conf.h
+hw/bsp/nucleo-f767zi/include/bsp/stm32f7xx_hal_conf.h
+hw/bsp/nucleo-l073rz/include/bsp/stm32l0xx_hal_conf.h
+hw/bsp/nucleo-l476rg/include/bsp/stm32l4xx_hal_conf.h
+hw/bsp/olimex-p103/include/bsp/stm32f1xx_hal_conf.h
+hw/bsp/olimex_stm32-e407_devboard/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/p-nucleo-wb55/include/bsp/stm32wbxx_hal_conf.h
+hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
+hw/bsp/stm32f3discovery/include/bsp/stm32f3xx_hal_conf.h
+hw/bsp/stm32f411discovery/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/stm32f429discovery/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/stm32f4discovery/include/bsp/stm32f4xx_hal_conf.h
+hw/bsp/stm32f7discovery/include/bsp/stm32f7xx_hal_conf.h
+hw/bsp/stm32l152discovery/include/bsp/stm32l1xx_hal_conf.h
 
 # Skip upstream LittleFS code but check Mynewt glue
 fs/littlefs/include/littlefs/lfs.h


### PR DESCRIPTION
STM32 based BSP contain hal config header that is
formatted by ST.
This change adds those headers to style checker ignore list