### PR TITLE
github: Remove stm32u5/h7 repositories from project.yml

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -43,30 +43,3 @@ repository.apache-mynewt-mcumgr:
     user: apache
     repo: mynewt-mcumgr
 
-repository.cmsis_device_u5:
-    type: github
-    branch: main
-    vers: v1.1.0-commit
-    user: STMicroelectronics
-    repo: cmsis_device_u5
-
-repository.stm32u5xx_hal_driver:
-    type: github
-    branch: main
-    vers: v1.1.0-commit
-    user: STMicroelectronics
-    repo: stm32u5xx_hal_driver
-
-repository.cmsis_device_h7:
-    type: github
-    branch: master
-    vers: v1.10.3-commit
-    user: STMicroelectronics
-    repo: cmsis_device_h7
-
-repository.stm32h7xx_hal_driver:
-    type: github
-    branch: master
-    vers: v1.11.1-commit
-    user: STMicroelectronics
-    repo: stm32h7xx_hal_driver


### PR DESCRIPTION
stm32u5 and stm32h7 repositories are not referenced in sdk packages and don't need to be specified in project.yml

Versions form project.yml were no longer used anyway so this should reduce github action burden on downloading 4 repositories that are not being used.