### PR TITLE
bus/spi_stm32: Update SPI driver for STM32U5

### DIFF
--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -54,6 +54,14 @@
 #error This MCU does not have SPI6
 #endif
 
+#if MYNEWT_VAL(MCU_STM32U5)
+/* DMA peripheral on STM32U5 is called GPDMA and macro to turn it's clock
+ * matches this name. For simplicity define old name __HAL_RCC_DMA1_CLK_ENABLE
+ * to defintion from U5 hal
+ */
+#define __HAL_RCC_DMA1_CLK_ENABLE __HAL_RCC_GPDMA1_CLK_ENABLE
+#endif
+
 /* Minimum transfer size when DMA should be used, for shorter transfers
  * interrupts are used
  */
@@ -613,7 +621,7 @@ spi_stm32_configure(struct bus_dev *bdev, struct bus_node *bnode)
     if (prescaler > 7) {
         rc = SYS_EINVAL;
     } else {
-#if MYNEWT_VAL(MCU_STM32H7)
+#if MYNEWT_VAL(MCU_STM32H7) || MYNEWT_VAL(MCU_STM32U5)
         dd->hspi.Init.BaudRatePrescaler = prescaler << SPI_CFG1_MBR_Pos;
 #else
         dd->hspi.Init.BaudRatePrescaler = prescaler << SPI_CR1_BR_Pos;

--- a/hw/bus/drivers/spi_stm32/stm32u5xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32u5xx/include/spidmacfg.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32u5xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_RX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx;
+
+#define SPI_DMA_TX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx;
+
+SPI_DMA_RX_CHANNEL(1, 1, 1);
+SPI_DMA_RX_CHANNEL(1, 2, 1);
+SPI_DMA_RX_CHANNEL(1, 3, 1);
+SPI_DMA_RX_CHANNEL(1, 4, 1);
+SPI_DMA_RX_CHANNEL(1, 5, 1);
+SPI_DMA_RX_CHANNEL(1, 6, 1);
+SPI_DMA_RX_CHANNEL(1, 7, 1);
+
+SPI_DMA_RX_CHANNEL(1, 1, 2);
+SPI_DMA_RX_CHANNEL(1, 2, 2);
+SPI_DMA_RX_CHANNEL(1, 3, 2);
+SPI_DMA_RX_CHANNEL(1, 4, 2);
+SPI_DMA_RX_CHANNEL(1, 5, 2);
+SPI_DMA_RX_CHANNEL(1, 6, 2);
+SPI_DMA_RX_CHANNEL(1, 7, 2);
+
+SPI_DMA_TX_CHANNEL(1, 1, 1);
+SPI_DMA_TX_CHANNEL(1, 2, 1);
+SPI_DMA_TX_CHANNEL(1, 3, 1);
+SPI_DMA_TX_CHANNEL(1, 4, 1);
+SPI_DMA_TX_CHANNEL(1, 5, 1);
+SPI_DMA_TX_CHANNEL(1, 6, 1);
+SPI_DMA_TX_CHANNEL(1, 7, 1);
+
+SPI_DMA_TX_CHANNEL(1, 1, 2);
+SPI_DMA_TX_CHANNEL(1, 2, 2);
+SPI_DMA_TX_CHANNEL(1, 3, 2);
+SPI_DMA_TX_CHANNEL(1, 4, 2);
+SPI_DMA_TX_CHANNEL(1, 5, 2);
+SPI_DMA_TX_CHANNEL(1, 6, 2);
+SPI_DMA_TX_CHANNEL(1, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32u5xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32u5xx/pkg.yml
@@ -17,46 +17,12 @@
 # under the License.
 #
 
-pkg.name: hw/bus/drivers/spi_stm32
-pkg.description: SPI bus driver that uses ST HAL with interrupts and DMA
+pkg.name: hw/bus/drivers/spi_stm32/stm32u5xx
+pkg.description: STM32U5 specific part of STM32 SPI driver
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
     - hw/bus
-    - hw/bus/drivers/spi_common
-
-pkg.deps.MCU_STM32F0:
-    - hw/bus/drivers/spi_stm32/stm32f0xx
-
-pkg.deps.MCU_STM32F1:
-    - hw/bus/drivers/spi_stm32/stm32f1xx
-
-pkg.deps.MCU_STM32F3:
-    - hw/bus/drivers/spi_stm32/stm32f3xx
-
-pkg.deps.MCU_STM32F4:
-    - hw/bus/drivers/spi_stm32/stm32f4xx
-
-pkg.deps.MCU_STM32F7:
-    - hw/bus/drivers/spi_stm32/stm32f7xx
-
-pkg.deps.MCU_STM32L0:
-    - hw/bus/drivers/spi_stm32/stm32l0xx
-
-pkg.deps.MCU_STM32L1:
-    - hw/bus/drivers/spi_stm32/stm32l1xx
-
-pkg.deps.MCU_STM32L4:
-    - hw/bus/drivers/spi_stm32/stm32l4xx
-
-pkg.deps.MCU_STM32U5:
-    - hw/bus/drivers/spi_stm32/stm32u5xx
-
-pkg.deps.MCU_STM32WB:
-    - hw/bus/drivers/spi_stm32/stm32wbxx
-
-pkg.deps.MCU_STM32H7:
-    - hw/bus/drivers/spi_stm32/stm32h7xx
-    
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32u5xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32u5xx/src/spidmacfg.c
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32u5xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        GPDMA ## dma ## _Channel ## ch ## _IRQn,                            \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = GPDMA ## dma ## _Channel ## ch,                             \
+        .init = {                                                           \
+            .Request = GPDMA ## dma ## _REQUEST_SPI ## spi_num ## _RX,      \
+            .BlkHWRequest = DMA_BREQ_SINGLE_BURST,                          \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .SrcInc = DMA_SINC_FIXED,                                       \
+            .DestInc = DMA_DINC_INCREMENTED,                                \
+            .SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE,                         \
+            .DestDataWidth = DMA_DEST_DATAWIDTH_BYTE,                       \
+            .SrcBurstLength = 1,                                            \
+            .DestBurstLength = 1,                                           \
+            .TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0,               \
+            .TransferEventMode = DMA_TCEM_BLOCK_TRANSFER,                   \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_LOW_PRIORITY_LOW_WEIGHT,                        \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, spi_num)                         \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        GPDMA ## dma ## _Channel ## ch ## _IRQn,                            \
+        stm32_dma ## dma ## _ ## ch ## _irq_handler,                        \
+        .regs = GPDMA ## dma ## _Channel ## ch,                             \
+        .init = {                                                           \
+            .Request = GPDMA ## dma ## _REQUEST_SPI ## spi_num ## _TX,      \
+            .BlkHWRequest = DMA_BREQ_SINGLE_BURST,                          \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .SrcInc = DMA_SINC_INCREMENTED,                                 \
+            .DestInc = DMA_DINC_FIXED,                                      \
+            .SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE,                         \
+            .DestDataWidth = DMA_DEST_DATAWIDTH_BYTE,                       \
+            .SrcBurstLength = 1,                                            \
+            .DestBurstLength = 1,                                           \
+            .TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0,               \
+            .TransferEventMode = DMA_TCEM_BLOCK_TRANSFER,                   \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_LOW_PRIORITY_LOW_WEIGHT,                        \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 1);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 2);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 1);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 1);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 2);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 2);

--- a/hw/bus/drivers/spi_stm32/stm32u5xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32u5xx/syscfg.yml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_RX_DMA:
+        description: >
+            DMA channel to use for SPI1.
+            channel can be 1-8.
+        value: DMA1_channel1_spi1_rx
+    SPI1_TX_DMA:
+        description: >
+            DMA channel to use for SPI1.
+            channel can be 1-8.
+        value: DMA1_channel2_spi1_tx
+    SPI2_RX_DMA:
+        description: >
+            DMA channel to use for SPI2.
+            channel can be 1-8.
+        value: DMA1_channel3_spi2_rx
+    SPI2_TX_DMA:
+        description: >
+            DMA channel to use for SPI2.
+            channel can be 1-8.
+        value: DMA1_channel4_spi2_tx
+    SPI3_RX_DMA:
+        description: >
+            DMA channel to use for SPI3.
+            channel can be 1-8.
+        value: DMA1_channel5_spi3_rx
+    SPI3_TX_DMA:
+        description: >
+            DMA channel to use for SPI3.
+            channel can be 1-8.
+        value: DMA1_channel6_spi3_tx


### PR DESCRIPTION
This adds DMA configuration for STM32U5.
Minor change was needed to spi_stm32.c to accommodate for register and changes in U5 devices.