### PR TITLE
hw/bsp/nucleo-u575-q: Update flash layout

### DIFF
--- a/hw/bsp/nucleo-u575zi-q/boot-nucleo-u575zi-q.ld
+++ b/hw/bsp/nucleo-u575zi-q/boot-nucleo-u575zi-q.ld
@@ -20,7 +20,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) :  ORIGIN = 0x08000000, LENGTH = 128K
+  FLASH (rx) :  ORIGIN = 0x08000000, LENGTH = 48K
   RAM (rwx)  :  ORIGIN = 0x20000000, LENGTH = 32K
 }
 

--- a/hw/bsp/nucleo-u575zi-q/bsp.yml
+++ b/hw/bsp/nucleo-u575zi-q/bsp.yml
@@ -37,31 +37,31 @@ bsp.flash_map:
         FLASH_AREA_BOOTLOADER:
             device: 0
             offset: 0x08000000
-            size: 128kB
+            size: 48kB
         FLASH_AREA_IMAGE_0:
             device: 0
-            offset: 0x08020000
-            size: 256kB
+            offset: 0x08010000
+            size: 512kB
         FLASH_AREA_IMAGE_1:
             device: 0
-            offset: 0x08060000
-            size: 256kB
+            offset: 0x08090000
+            size: 512kB
         FLASH_AREA_IMAGE_SCRATCH:
             device: 0
-            offset: 0x080A0000
-            size: 128kB
+            offset: 0x0800E000
+            size: 8kB
 
         # User areas.
         FLASH_AREA_REBOOT_LOG:
             user_id: 0
             device: 0
-            offset: 0x080C0000
-            size: 128kB
+            offset: 0x08110000
+            size: 16kB
         FLASH_AREA_NFFS:
             user_id: 1
             device: 0
-            offset: 0x080E0000
-            size: 128kB
+            offset: 0x08114000
+            size: 32kB
 
         FLASH_AREA_SPI:
             user_id: 2

--- a/hw/bsp/nucleo-u575zi-q/nucleo-u575zi-q.ld
+++ b/hw/bsp/nucleo-u575zi-q/nucleo-u575zi-q.ld
@@ -22,7 +22,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) :  ORIGIN = 0x08020000, LENGTH = 384K /* Image slot 1 */
+  FLASH (rx) :  ORIGIN = 0x08010000, LENGTH = 384K /* Image slot 0 */
   RAM (rwx)  :  ORIGIN = 0x20000000, LENGTH = 704K /* SRAM1 + SRAM2 + SRAM3 */
 }
 


### PR DESCRIPTION
Flash layout (in bsp.yml) was copied form STM32F7. It has huge space for scratch/reboot log/nffs
because of sector sizes on STM32F7.
STM32U5 has sector size 8kB so flash areas are
updated to better match hardware capabilities.