### PR TITLE
mcu/stm32: Fix ADC dependencies

### DIFF
--- a/hw/mcu/stm/stm32_common/pkg.yml
+++ b/hw/mcu/stm/stm32_common/pkg.yml
@@ -55,10 +55,3 @@ pkg.deps.CRYPTO:
 
 pkg.deps.HASH:
     - "@apache-mynewt-core/hw/drivers/hash/hash_stm32"
-
-pkg.deps.ADC_0:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
-pkg.deps.ADC_1:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
-pkg.deps.ADC_2:
-    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"

--- a/hw/mcu/stm/stm32f4xx/pkg.yml
+++ b/hw/mcu/stm/stm32f4xx/pkg.yml
@@ -49,6 +49,13 @@ pkg.deps:
 pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER || SPI_3_MASTER || SPI_4_MASTER || SPI_5_MASTER) && BUS_DRIVER_PRESENT':
     - "@apache-mynewt-core/hw/bus/drivers/spi_stm32"
 
+pkg.deps.ADC_0:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+pkg.deps.ADC_1:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+pkg.deps.ADC_2:
+    - "@apache-mynewt-core/hw/drivers/adc/adc_stm32f4"
+
 repository.stm-cmsis_device_f4:
     type: github
     vers: v2.6.8-commit


### PR DESCRIPTION
Package adc_stm32f4 was included for all STM32 devices when ADC_x was enabled.
adc_stm32f4 will only build for STM32F4 devices so dependency is moved to appropriate package