### PR TITLE
hw/bsp: stm32u5/stm32wb: remove reference to ETH

### DIFF
--- a/hw/bsp/nucleo-u575zi-q/src/hal_bsp.c
+++ b/hw/bsp/nucleo-u575zi-q/src/hal_bsp.c
@@ -30,11 +30,6 @@
 #include <stm32_common/stm32_hal.h>
 #include <bus/drivers/spi_common.h>
 
-#if MYNEWT_VAL(ETH_0)
-#include <stm32_eth/stm32_eth.h>
-#include <stm32_eth/stm32_eth_cfg.h>
-#endif
-
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_stm32/pwm_stm32.h>
 #endif

--- a/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/src/hal_bsp.c
@@ -28,11 +28,6 @@
 #include <stm32wb55xx.h>
 #include <stm32_common/stm32_hal.h>
 
-#if MYNEWT_VAL(ETH_0)
-#include <stm32_eth/stm32_eth.h>
-#include <stm32_eth/stm32_eth_cfg.h>
-#endif
-
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_stm32/pwm_stm32.h>
 #endif

--- a/hw/bsp/p-nucleo-wb55/src/hal_bsp.c
+++ b/hw/bsp/p-nucleo-wb55/src/hal_bsp.c
@@ -28,11 +28,6 @@
 #include <stm32wb55xx.h>
 #include <stm32_common/stm32_hal.h>
 
-#if MYNEWT_VAL(ETH_0)
-#include <stm32_eth/stm32_eth.h>
-#include <stm32_eth/stm32_eth_cfg.h>
-#endif
-
 #if MYNEWT_VAL(PWM_0) || MYNEWT_VAL(PWM_1) || MYNEWT_VAL(PWM_2)
 #include <pwm_stm32/pwm_stm32.h>
 #endif


### PR DESCRIPTION
STM32U5 and STM32WB don't ethernet peripheral in any version so extra includes are removed now.