### PR TITLE
Be consistent in console write order for '\n' and '\r'

### DIFF
--- a/hw/usb/tinyusb/cdc_console/src/cdc_console.c
+++ b/hw/usb/tinyusb/cdc_console/src/cdc_console.c
@@ -51,11 +51,10 @@ cdc_write(int c)
 int
 console_out_nolock(int c)
 {
-    cdc_write(c);
-
     if ('\n' == c) {
         cdc_write('\r');
     }
+    cdc_write(c);
 
     cdc_schedule_tx_flush();
 


### PR DESCRIPTION
In the current implementation of the UART and CDC consoles, there can be a discrepency in the order of the Linefeed and Carriage Return print order. For consistency, we change this to always be "\r\n" for both variants of the implementation. This is useful in automated echo tests for verifying payloads.