### PR TITLE
Add support for alternative libc

### DIFF
--- a/apps/bleuart/pkg.yml
+++ b/apps/bleuart/pkg.yml
@@ -34,7 +34,7 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log"
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/mgmt/mgmt"
     - "@apache-mynewt-core/mgmt/smp/transport/ble"
     - "@apache-mynewt-nimble/nimble/host/services/bleuart"

--- a/compiler/arc/compiler.yml
+++ b/compiler/arc/compiler.yml
@@ -31,6 +31,6 @@ compiler.flags.debug: [compiler.flags.default, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/arm-none-eabi-m0/compiler.yml
+++ b/compiler/arm-none-eabi-m0/compiler.yml
@@ -32,6 +32,6 @@ compiler.flags.debug: [compiler.flags.default, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/arm-none-eabi-m3/compiler.yml
+++ b/compiler/arm-none-eabi-m3/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/arm-none-eabi-m33/compiler.yml
+++ b/compiler/arm-none-eabi-m33/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/arm-none-eabi-m4/compiler.yml
+++ b/compiler/arm-none-eabi-m4/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -O0, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -lgcc -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -lgcc -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/riscv-none-embed/compiler.yml
+++ b/compiler/riscv-none-embed/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/compiler/riscv64/compiler.yml
+++ b/compiler/riscv64/compiler.yml
@@ -33,6 +33,6 @@ compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x assembler-with-cpp]
 
-compiler.ld.flags: -static -specs=nosys.specs -Wl,--gc-sections -nostartfiles
+compiler.ld.flags: -static -Wl,--gc-sections -nostartfiles
 compiler.ld.resolve_circular_deps: true
 compiler.ld.mapfile: true

--- a/hw/bsp/ada_feather_nrf52/pkg.yml
+++ b/hw/bsp/ada_feather_nrf52/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/ada_feather_stm32f405/pkg.yml
+++ b/hw/bsp/ada_feather_stm32f405/pkg.yml
@@ -37,4 +37,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/apollo2_evb/pkg.yml
+++ b/hw/bsp/apollo2_evb/pkg.yml
@@ -32,7 +32,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/ambiq/apollo2"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/apollo3_evb/pkg.yml
+++ b/hw/bsp/apollo3_evb/pkg.yml
@@ -32,5 +32,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/ambiq/apollo3"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - '@apache-mynewt-core/sys/flash_map'

--- a/hw/bsp/arduino_primo_nrf52/pkg.yml
+++ b/hw/bsp/arduino_primo_nrf52/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/b-l072z-lrwan1/pkg.yml
+++ b/hw/bsp/b-l072z-lrwan1/pkg.yml
@@ -32,7 +32,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32l0xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.LORA_NODE:
     - "@apache-mynewt-core/hw/drivers/lora/sx1276"

--- a/hw/bsp/b-l475e-iot01a/pkg.yml
+++ b/hw/bsp/b-l475e-iot01a/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32l4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.LPS22HB_ONB:
     - "@apache-mynewt-core/hw/drivers/sensors/lps33hw"

--- a/hw/bsp/bbc_microbit/pkg.yml
+++ b/hw/bsp/bbc_microbit/pkg.yml
@@ -31,7 +31,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/black_vet6/pkg.yml
+++ b/hw/bsp/black_vet6/pkg.yml
@@ -35,6 +35,6 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/ble400/pkg.yml
+++ b/hw/bsp/ble400/pkg.yml
@@ -32,7 +32,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/bmd200/pkg.yml
+++ b/hw/bsp/bmd200/pkg.yml
@@ -32,7 +32,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/bmd300eval/pkg.yml
+++ b/hw/bsp/bmd300eval/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/calliope_mini/pkg.yml
+++ b/hw/bsp/calliope_mini/pkg.yml
@@ -31,7 +31,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/ci40/pkg.yml
+++ b/hw/bsp/ci40/pkg.yml
@@ -31,7 +31,7 @@ pkg.keywords:
 pkg.cflags:
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/mips/danube"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/mips-hal"
 
 pkg.arch: mips

--- a/hw/bsp/dialog_cmac/pkg.yml
+++ b/hw/bsp/dialog_cmac/pkg.yml
@@ -28,5 +28,5 @@ pkg.keywords:
     - cmac
 
 pkg.deps:
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/mcu/dialog/cmac"

--- a/hw/bsp/dialog_da14695-dk-usb/pkg.yml
+++ b/hw/bsp/dialog_da14695-dk-usb/pkg.yml
@@ -31,5 +31,5 @@ pkg.cflags.HARDFLOAT:
     - '-mfpu=fpv5-sp-d16'
 
 pkg.deps:
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/mcu/dialog/da14695"

--- a/hw/bsp/dialog_da1469x-dk-pro/pkg.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/pkg.yml
@@ -31,5 +31,5 @@ pkg.cflags.HARDFLOAT:
     - '-mfpu=fpv5-sp-d16'
 
 pkg.deps:
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/mcu/dialog/da14699"

--- a/hw/bsp/dwm1001-dev/pkg.yml
+++ b/hw/bsp/dwm1001-dev/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/embarc_emsk/pkg.yml
+++ b/hw/bsp/embarc_emsk/pkg.yml
@@ -28,6 +28,6 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/arc/snps"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.cflags: -mcpu=em4_dmips -mlittle-endian -mcode-density -mdiv-rem -mswap -mbarrel-shifter

--- a/hw/bsp/fanstel-ev-bt840/pkg.yml
+++ b/hw/bsp/fanstel-ev-bt840/pkg.yml
@@ -34,5 +34,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"

--- a/hw/bsp/frdm-k64f/pkg.yml
+++ b/hw/bsp/frdm-k64f/pkg.yml
@@ -43,7 +43,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nxp/kinetis/MK64F12"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/frdm-k82f/pkg.yml
+++ b/hw/bsp/frdm-k82f/pkg.yml
@@ -43,7 +43,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nxp/kinetis/MK8xF/MK82F"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/hifive1/pkg.yml
+++ b/hw/bsp/hifive1/pkg.yml
@@ -28,7 +28,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/sifive/fe310"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nina-b1/pkg.yml
+++ b/hw/bsp/nina-b1/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nordic_pca10028-16k/pkg.yml
+++ b/hw/bsp/nordic_pca10028-16k/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nordic_pca10028/pkg.yml
+++ b/hw/bsp/nordic_pca10028/pkg.yml
@@ -33,7 +33,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nordic_pca10040/pkg.yml
+++ b/hw/bsp/nordic_pca10040/pkg.yml
@@ -36,7 +36,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"
 
 pkg.deps.ENC_FLASH_DEV:

--- a/hw/bsp/nordic_pca10056/pkg.yml
+++ b/hw/bsp/nordic_pca10056/pkg.yml
@@ -36,7 +36,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.SOFT_PWM:

--- a/hw/bsp/nordic_pca10059/pkg.yml
+++ b/hw/bsp/nordic_pca10059/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.SOFT_PWM:

--- a/hw/bsp/nordic_pca10090/pkg.yml
+++ b/hw/bsp/nordic_pca10090/pkg.yml
@@ -38,7 +38,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf91xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UARTBB_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"

--- a/hw/bsp/nordic_pca10095/pkg.yml
+++ b/hw/bsp/nordic_pca10095/pkg.yml
@@ -36,7 +36,7 @@ pkg.cflags.HARDFLOAT:
 pkg.deps:
     - "@apache-mynewt-core/hw/scripts"
     - "@apache-mynewt-core/hw/mcu/nordic/nrf5340"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.BSP_NRF5340_NET_FLASH_ENABLE:

--- a/hw/bsp/nordic_pca10095_net/pkg.yml
+++ b/hw/bsp/nordic_pca10095_net/pkg.yml
@@ -33,6 +33,6 @@ pkg.cflags:
 pkg.deps:
     - "@apache-mynewt-core/hw/scripts"
     - "@apache-mynewt-core/hw/mcu/nordic/nrf5340_net"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
     - "@apache-mynewt-core/hw/drivers/flash/ipc_nrf5340_flash"

--- a/hw/bsp/nordic_pca10121/net/pkg.yml
+++ b/hw/bsp/nordic_pca10121/net/pkg.yml
@@ -32,6 +32,6 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf5340_net"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
     - "@apache-mynewt-core/hw/drivers/flash/ipc_nrf5340_flash"

--- a/hw/bsp/nordic_pca10121/pkg.yml
+++ b/hw/bsp/nordic_pca10121/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf5340"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
 
 pkg.deps.BSP_NRF5340_NET_FLASH_ENABLE:

--- a/hw/bsp/nordic_pca20020/pkg.yml
+++ b/hw/bsp/nordic_pca20020/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/nrf51-arduino_101/pkg.yml
+++ b/hw/bsp/nrf51-arduino_101/pkg.yml
@@ -31,7 +31,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nrf51-blenano/pkg.yml
+++ b/hw/bsp/nrf51-blenano/pkg.yml
@@ -32,7 +32,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/nucleo-f030r8/pkg.yml
+++ b/hw/bsp/nucleo-f030r8/pkg.yml
@@ -35,4 +35,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f0xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f072rb/pkg.yml
+++ b/hw/bsp/nucleo-f072rb/pkg.yml
@@ -35,4 +35,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f0xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f103rb/pkg.yml
+++ b/hw/bsp/nucleo-f103rb/pkg.yml
@@ -30,5 +30,5 @@ pkg.cflags: -DSTM32F103xB
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f1xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-f303k8/pkg.yml
+++ b/hw/bsp/nucleo-f303k8/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f303re/pkg.yml
+++ b/hw/bsp/nucleo-f303re/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f401re/pkg.yml
+++ b/hw/bsp/nucleo-f401re/pkg.yml
@@ -35,4 +35,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f411re/pkg.yml
+++ b/hw/bsp/nucleo-f411re/pkg.yml
@@ -36,5 +36,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-f413zh/pkg.yml
+++ b/hw/bsp/nucleo-f413zh/pkg.yml
@@ -36,4 +36,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f439zi/pkg.yml
+++ b/hw/bsp/nucleo-f439zi/pkg.yml
@@ -36,4 +36,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f746zg/pkg.yml
+++ b/hw/bsp/nucleo-f746zg/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/nucleo-f767zi/pkg.yml
+++ b/hw/bsp/nucleo-f767zi/pkg.yml
@@ -34,5 +34,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-h723zg/pkg.yml
+++ b/hw/bsp/nucleo-h723zg/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32h7xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash"
     - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-l073rz/pkg.yml
+++ b/hw/bsp/nucleo-l073rz/pkg.yml
@@ -31,5 +31,5 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32l0xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-l476rg/pkg.yml
+++ b/hw/bsp/nucleo-l476rg/pkg.yml
@@ -35,5 +35,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32l4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/nucleo-u575zi-q/pkg.yml
+++ b/hw/bsp/nucleo-u575zi-q/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32u5xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash"
     - "@apache-mynewt-core/hw/bus/drivers/spi_hal"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/olimex-p103/pkg.yml
+++ b/hw/bsp/olimex-p103/pkg.yml
@@ -30,4 +30,4 @@ pkg.cflags: -DSTM32F103xB
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f1xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/olimex-pic32-emz64/pkg.yml
+++ b/hw/bsp/olimex-pic32-emz64/pkg.yml
@@ -34,5 +34,5 @@ pkg.lflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/microchip/pic32mz"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash"

--- a/hw/bsp/olimex-pic32-hmz144/pkg.yml
+++ b/hw/bsp/olimex-pic32-hmz144/pkg.yml
@@ -34,5 +34,5 @@ pkg.lflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/microchip/pic32mz"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash"

--- a/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/pkg.yml
@@ -36,4 +36,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/p-nucleo-wb55-usbdongle/pkg.yml
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/pkg.yml
@@ -35,5 +35,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32wbxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/p-nucleo-wb55/pkg.yml
+++ b/hw/bsp/p-nucleo-wb55/pkg.yml
@@ -35,5 +35,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32wbxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/hw/scripts"

--- a/hw/bsp/puckjs/pkg.yml
+++ b/hw/bsp/puckjs/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/rb-blend2/pkg.yml
+++ b/hw/bsp/rb-blend2/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/rb-nano2/pkg.yml
+++ b/hw/bsp/rb-nano2/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/reel_board/pkg.yml
+++ b/hw/bsp/reel_board/pkg.yml
@@ -33,5 +33,5 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"

--- a/hw/bsp/ruuvitag_rev_b/pkg.yml
+++ b/hw/bsp/ruuvitag_rev_b/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UARTBB_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_bitbang"

--- a/hw/bsp/stm32f3discovery/pkg.yml
+++ b/hw/bsp/stm32f3discovery/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f3xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.LSM303DLHC_ONB:
     - "@apache-mynewt-core/hw/drivers/sensors/lsm303dlhc"

--- a/hw/bsp/stm32f411discovery/pkg.yml
+++ b/hw/bsp/stm32f411discovery/pkg.yml
@@ -36,4 +36,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/stm32f429discovery/pkg.yml
+++ b/hw/bsp/stm32f429discovery/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/stm32f4discovery/pkg.yml
+++ b/hw/bsp/stm32f4discovery/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f4xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/stm32f7discovery/pkg.yml
+++ b/hw/bsp/stm32f7discovery/pkg.yml
@@ -34,4 +34,4 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/stm32l152discovery/pkg.yml
+++ b/hw/bsp/stm32l152discovery/pkg.yml
@@ -31,4 +31,4 @@ pkg.cflags: -DSTM32L152xC
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32l1xx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"

--- a/hw/bsp/telee02/pkg.yml
+++ b/hw/bsp/telee02/pkg.yml
@@ -35,7 +35,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/ublox_bmd_345/pkg.yml
+++ b/hw/bsp/ublox_bmd_345/pkg.yml
@@ -36,7 +36,7 @@ pkg.cflags.HARDFLOAT:
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
     - "@apache-mynewt-core/sys/flash_map"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/vbluno51/pkg.yml
+++ b/hw/bsp/vbluno51/pkg.yml
@@ -31,7 +31,7 @@ pkg.cflags:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf51xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"

--- a/hw/bsp/vbluno52/pkg.yml
+++ b/hw/bsp/vbluno52/pkg.yml
@@ -34,7 +34,7 @@ pkg.cflags.HARDFLOAT:
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc/baselibc"
+    - "@apache-mynewt-core/libc"
 
 pkg.deps.SOFT_PWM:
     - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/hal/src/sbrk.c
+++ b/hw/hal/src/sbrk.c
@@ -49,4 +49,10 @@ _sbrk(int incr)
     return prev_brk;
 }
 
+void *
+sbrk(int incr)
+{
+    return _sbrk(incr);
+}
+
 #endif

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include "syscfg/syscfg.h"
 #include "mcu/mcu.h"
 #include "mcu/da1469x_clock.h"

--- a/hw/mcu/dialog/da1469x/src/da1469x_vbus.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_vbus.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <os/util.h>
+#include <os/os_arch.h>
 #include <mcu/da1469x_vbus.h>
 
 /*

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -19,6 +19,7 @@
  */
 
 #include <assert.h>
+#include <stddef.h>
 #include "syscfg/syscfg.h"
 #include "mcu/da1469x_hal.h"
 #include "mcu/da1469x_pd.h"

--- a/hw/mcu/dialog/da1469x/src/hal_i2c.c
+++ b/hw/mcu/dialog/da1469x/src/hal_i2c.c
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include "syscfg/syscfg.h"
 #include "os/os_time.h"
 #include "mcu/da1469x_pd.h"

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -26,6 +26,8 @@
 #include "mcu/da1469x_pdc.h"
 #include "mcu/da1469x_prail.h"
 #include "hal/hal_system.h"
+#include "hal/hal_debug.h"
+#include "os/os_arch.h"
 #include "os/os_cputime.h"
 
 #if !MYNEWT_VAL(BOOT_LOADER)

--- a/hw/mcu/dialog/da1469x/src/hal_timer.c
+++ b/hw/mcu/dialog/da1469x/src/hal_timer.c
@@ -19,6 +19,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include "syscfg/syscfg.h"
 #include "mcu/da1469x_hal.h"
 #include "hal/hal_timer.h"

--- a/hw/mcu/dialog/da1469x/src/hal_watchdog.c
+++ b/hw/mcu/dialog/da1469x/src/hal_watchdog.c
@@ -18,6 +18,7 @@
  */
 
 #include <assert.h>
+#include <os/mynewt.h>
 #include "hal/hal_watchdog.h"
 #include "mcu/mcu.h"
 

--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -33,3 +33,6 @@ pkg.init.BASELIBC_THREAD_SAFE_HEAP_ALLOCATION:
 
 pkg.cflags:
     - -fno-builtin-malloc
+
+pkg.lflags:
+    - -specs=nosys.specs:

--- a/libc/nano/pkg.yml
+++ b/libc/nano/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: libc/nano
+pkg.description: Newlib nano for embedded mynewt.
+pkg.keywords:
+    - libc
+
+pkg.deps:
+
+pkg.lflags:
+    - -specs=nano.specs
+    - -u_close
+    - -u_sbrk
+

--- a/libc/nano/src/start.c
+++ b/libc/nano/src/start.c
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdlib.h>
+#include "os/mynewt.h"
+
+extern int main(int argc, char **argv);
+void __libc_init_array(void);
+
+/*
+ * Rudimentary startup function.
+ */
+void _start(void)
+{
+    /*
+     * Run global objects constructors.
+     * Call to this function is ofter found in startup files.
+     * mynewt did not use this pattern hence we have single place
+     * for all MCU just here
+     */
+    __libc_init_array();
+
+#if !MYNEWT_VAL(OS_SCHEDULING)
+    int rc;
+
+    rc = main(0, NULL);
+    exit(rc);
+#else
+    os_init(main);
+    os_start();
+#endif
+}
+
+__attribute__((weak)) void
+_init(void)
+{
+}
+
+__attribute__((weak)) void
+_fini(void)
+{
+}
+
+extern void (*__preinit_array_start[])(void);
+extern void (*__preinit_array_end[])(void);
+extern void (*__init_array_start[])(void);
+extern void (*__init_array_end[])(void);
+
+void
+__libc_init_array(void)
+{
+    size_t count;
+    size_t i;
+
+    count = __preinit_array_end - __preinit_array_start;
+    for (i = 0; i < count; i++)
+        __preinit_array_start[i]();
+
+    _init();
+
+    count = __init_array_end - __init_array_start;
+    for (i = 0; i < count; i++)
+        __init_array_start[i]();
+}

--- a/libc/nano/src/syscalls.c
+++ b/libc/nano/src/syscalls.c
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <sys/stat.h>
+#include <syscfg/syscfg.h>
+
+#include <console/console.h>
+
+int
+_write(int fd, char *ptr, int len)
+{
+    (void)fd, (void)ptr;
+
+    if (fd == 1 || fd == 2) {
+        console_write(ptr, len);
+    }
+    return len;
+}
+
+int
+_close(int fd)
+{
+    (void)fd;
+    return 0;
+}
+
+int
+_fstat(int fd, struct stat *st)
+{
+    (void)fd, (void)st;
+    return 0;
+}
+
+int
+_isatty(int fd)
+{
+    (void)fd;
+    return 0;
+}
+
+int
+_read(int fd, char *ptr, int len)
+{
+    (void)fd, (void)ptr, (void)len;
+    return 0;
+}
+
+int
+_lseek(int fd, int ptr, int dir)
+{
+    (void)fd, (void)ptr, (void)dir;
+    return 0;
+}

--- a/libc/pkg.yml
+++ b/libc/pkg.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: libc
+pkg.description: Standard C library selector.
+pkg.keywords:
+    - libc
+
+pkg.deps.'LIBC=="baselibc"':
+    - libc/baselibc
+
+pkg.deps.'LIBC=="nano"':
+    - libc/nano

--- a/libc/syscfg.yml
+++ b/libc/syscfg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    LIBC:
+        description: "Chooses c library implementation"
+        value: baselibc
+        choices:
+            - baselibc
+            # nano is provided by gcc
+            - nano

--- a/sys/console/full/include/console/console.h
+++ b/sys/console/full/include/console/console.h
@@ -20,6 +20,7 @@
 #ifndef __CONSOLE_H__
 #define __CONSOLE_H__
 
+#include <stdarg.h>
 #include <inttypes.h>
 #include "os/mynewt.h"
 


### PR DESCRIPTION
Every compiler.yml had ld.flags with -specs-nosys.specs which is fine
for baselibc.
Changing to newlib-nano provided by compiler could lead to conflict.
Now -specs=nosys.specs is moved to baselibc settings and can
be different if baselibc is not used.

Package for newlib-nano is now added it:
- defines: -speac=nano.spec
- provides required glue functions for system calls

Most BSP for arm switch to be dependent to libc instead of libc/baselibc

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>