### PR TITLE
tinyusb/cdc: Fix missing include file

### DIFF
--- a/hw/usb/tinyusb/cdc/src/cdc.c
+++ b/hw/usb/tinyusb/cdc/src/cdc.c
@@ -18,6 +18,7 @@
  */
 
 #include <assert.h>
+#include <os/os.h>
 #include <cdc/cdc.h>
 
 static cdc_itf_t *cdc_itfs[CFG_TUD_CDC];


### PR DESCRIPTION
cdc.c missed inclusion of os.h.
In come BSP's when CDC was built following error happened:

error: repos/apache-mynewt-core/hw/usb/tinyusb/cdc/src/cdc.c: In function 'cdc_itf_add':
repos/apache-mynewt-core/hw/usb/tinyusb/cdc/src/cdc.c:99:5: error: implicit declaration of function 'OS_ENTER_CRITICAL' [-Werror=implicit-function-declaration]