### PR TITLE
Enable by default some NRFX API for NRF52

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52810_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52810_config.h
@@ -31,7 +31,11 @@
 #endif
 
 #ifndef NRFX_GPIOTE_ENABLED
-#define NRFX_GPIOTE_ENABLED 0
+#define NRFX_GPIOTE_ENABLED 1
+#endif
+
+#ifndef NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS
+#define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
 #endif
 
 #ifndef NRFX_I2S_ENABLED
@@ -51,7 +55,7 @@
 #endif
 
 #ifndef NRFX_PPI_ENABLED
-#define NRFX_PPI_ENABLED 0
+#define NRFX_PPI_ENABLED 1
 #endif
 
 #ifndef NRFX_PRS_ENABLED
@@ -91,7 +95,15 @@
 #endif
 
 #ifndef NRFX_TIMER_ENABLED
-#define NRFX_TIMER_ENABLED 0
+#define NRFX_TIMER_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 1
 #endif
 
 #ifndef NRFX_TWIM_ENABLED

--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52811_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52811_config.h
@@ -31,7 +31,11 @@
 #endif
 
 #ifndef NRFX_GPIOTE_ENABLED
-#define NRFX_GPIOTE_ENABLED 0
+#define NRFX_GPIOTE_ENABLED 1
+#endif
+
+#ifndef NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS
+#define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
 #endif
 
 #ifndef NRFX_I2S_ENABLED
@@ -51,7 +55,7 @@
 #endif
 
 #ifndef NRFX_PPI_ENABLED
-#define NRFX_PPI_ENABLED 0
+#define NRFX_PPI_ENABLED 1
 #endif
 
 #ifndef NRFX_PRS_ENABLED
@@ -91,7 +95,15 @@
 #endif
 
 #ifndef NRFX_TIMER_ENABLED
-#define NRFX_TIMER_ENABLED 0
+#define NRFX_TIMER_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 1
 #endif
 
 #ifndef NRFX_TWIM_ENABLED

--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52840_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52840_config.h
@@ -31,7 +31,11 @@
 #endif
 
 #ifndef NRFX_GPIOTE_ENABLED
-#define NRFX_GPIOTE_ENABLED 0
+#define NRFX_GPIOTE_ENABLED 1
+#endif
+
+#ifndef NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS
+#define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
 #endif
 
 #ifndef NRFX_I2S_ENABLED
@@ -51,7 +55,7 @@
 #endif
 
 #ifndef NRFX_PPI_ENABLED
-#define NRFX_PPI_ENABLED 0
+#define NRFX_PPI_ENABLED 1
 #endif
 
 #ifndef NRFX_PRS_ENABLDE
@@ -91,7 +95,15 @@
 #endif
 
 #ifndef NRFX_TIMER_ENABLED
-#define NRFX_TIMER_ENABLED 0
+#define NRFX_TIMER_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 1
 #endif
 
 #ifndef NRFX_TWIM_ENABLED

--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52_config.h
@@ -31,7 +31,11 @@
 #endif
 
 #ifndef NRFX_GPIOTE_ENABLED
-#define NRFX_GPIOTE_ENABLED 0
+#define NRFX_GPIOTE_ENABLED 1
+#endif
+
+#ifndef NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS
+#define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
 #endif
 
 #ifndef NRFX_I2S_ENABLED
@@ -51,7 +55,7 @@
 #endif
 
 #ifndef NRFX_PPI_ENABLED
-#define NRFX_PPI_ENABLED 0
+#define NRFX_PPI_ENABLED 1
 #endif
 
 #ifndef NRFX_PRS_ENABLED
@@ -91,7 +95,15 @@
 #endif
 
 #ifndef NRFX_TIMER_ENABLED
-#define NRFX_TIMER_ENABLED 0
+#define NRFX_TIMER_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER2_ENABLED
+#define NRFX_TIMER2_ENABLED 1
+#endif
+
+#ifndef NRFX_TIMER3_ENABLED
+#define NRFX_TIMER3_ENABLED 1
 #endif
 
 #ifndef NRFX_TWIM_ENABLED


### PR DESCRIPTION
- GPIOTE
- PPI
- TIMER 2, 3

Tested if builds:
 - pca10056
 - pca10040

Please review @kasjer, thank you ! ; ) 