### PR TITLE
hw/bus/drivers/spi_da1469x: Allow for 16-bit SPI transfers

### DIFF
--- a/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
+++ b/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
@@ -53,7 +53,7 @@ STATS_NAME_END(spi_da1469x_stats_section)
 #define MIN_DMA_SIZE 8
 
 /* A value of 1 for the word size means 16-bit words */
-#define SPI_CTRL_REG_16BIT_WORD (1 << SPI_SPI_CTRL_REG_SPI_WORD_Pos) 
+#define SPI_CTRL_REG_16BIT_WORD (1 << SPI_SPI_CTRL_REG_SPI_WORD_Pos)
 
 static const struct da1469x_dma_config spi_write_rx_dma_cfg = {
     .priority = 0,

--- a/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
+++ b/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
@@ -179,7 +179,7 @@ struct da1469x_transfer {
     /* Transfer started */
     uint8_t started : 1;
     /* Transfer is 16 bits */
-    uint8_t xfr_16: 1;
+    uint8_t xfr_16 : 1;
 };
 
 struct spi_da1469x_driver_data {

--- a/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
+++ b/hw/bus/drivers/spi_da1469x/src/spi_da1469x.c
@@ -52,6 +52,9 @@ STATS_NAME_END(spi_da1469x_stats_section)
  */
 #define MIN_DMA_SIZE 8
 
+/* A value of 1 for the word size means 16-bit words */
+#define SPI_CTRL_REG_16BIT_WORD (1 << SPI_SPI_CTRL_REG_SPI_WORD_Pos) 
+
 static const struct da1469x_dma_config spi_write_rx_dma_cfg = {
     .priority = 0,
     .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
@@ -68,6 +71,22 @@ static const struct da1469x_dma_config spi_write_tx_dma_cfg = {
     .src_inc = true,
 };
 
+static const struct da1469x_dma_config spi_write_rx_dma_cfg16 = {
+    .priority = 0,
+    .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
+    .bus_width = MCU_DMA_BUS_WIDTH_2B,
+    .dst_inc = false,
+    .src_inc = false,
+};
+
+static const struct da1469x_dma_config spi_write_tx_dma_cfg16 = {
+    .priority = 0,
+    .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
+    .bus_width = MCU_DMA_BUS_WIDTH_2B,
+    .dst_inc = false,
+    .src_inc = true,
+};
+
 static const struct da1469x_dma_config spi_read_rx_dma_cfg = {
     .priority = 0,
     .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
@@ -80,6 +99,22 @@ static const struct da1469x_dma_config spi_read_tx_dma_cfg = {
     .priority = 0,
     .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
     .bus_width = MCU_DMA_BUS_WIDTH_1B,
+    .dst_inc = false,
+    .src_inc = false,
+};
+
+static const struct da1469x_dma_config spi_read_rx_dma_cfg16 = {
+    .priority = 0,
+    .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
+    .bus_width = MCU_DMA_BUS_WIDTH_2B,
+    .dst_inc = true,
+    .src_inc = false,
+};
+
+static const struct da1469x_dma_config spi_read_tx_dma_cfg16 = {
+    .priority = 0,
+    .burst_mode = MCU_DMA_BURST_MODE_DISABLED,
+    .bus_width = MCU_DMA_BUS_WIDTH_2B,
     .dst_inc = false,
     .src_inc = false,
 };
@@ -488,8 +523,14 @@ spi_da1469x_read(struct bus_dev *bdev, struct bus_node *bnode,
     dd->transfer.started = 1;
     if (length >= MIN_DMA_SIZE && dd->dma_chans[0] != NULL) {
         dd->transfer.dma = 1;
-        da1469x_dma_configure(dd->dma_chans[0], &spi_read_rx_dma_cfg, spi_da1469x_dma_done_cb, dd);
-        da1469x_dma_configure(dd->dma_chans[1], &spi_read_tx_dma_cfg, NULL, NULL);
+        /* NOTE: assumes if 16-bit not used; dma transfers are 8-bits */
+        if ((regs->SPI_CTRL_REG & SPI_SPI_CTRL_REG_SPI_WORD_Msk) == SPI_CTRL_REG_16BIT_WORD) {
+            da1469x_dma_configure(dd->dma_chans[0], &spi_read_rx_dma_cfg16, spi_da1469x_dma_done_cb, dd);
+            da1469x_dma_configure(dd->dma_chans[1], &spi_read_tx_dma_cfg16, NULL, NULL);
+        } else {
+            da1469x_dma_configure(dd->dma_chans[0], &spi_read_rx_dma_cfg, spi_da1469x_dma_done_cb, dd);
+            da1469x_dma_configure(dd->dma_chans[1], &spi_read_tx_dma_cfg, NULL, NULL);
+        }
         da1469x_dma_read_peripheral(dd->dma_chans[0], buf, length);
         da1469x_dma_write_peripheral(dd->dma_chans[1], &dma_dummy_src, length);
         regs->SPI_CTRL_REG |= SPI_SPI_CTRL_REG_SPI_ON_Msk;
@@ -565,8 +606,16 @@ spi_da1469x_write(struct bus_dev *bdev, struct bus_node *bnode,
         dd->transfer.dma = 1;
         regs->SPI_CTRL_REG &= ~SPI_SPI_CTRL_REG_SPI_INT_BIT_Msk;
         spi_da1469x_int_disable(regs);
-        da1469x_dma_configure(dd->dma_chans[0], &spi_write_rx_dma_cfg, spi_da1469x_dma_done_cb, dd);
-        da1469x_dma_configure(dd->dma_chans[1], &spi_write_tx_dma_cfg, NULL, NULL);
+
+        /* NOTE: assumes if 16-bit not used; dma transfers are 8-bits */
+        if ((regs->SPI_CTRL_REG & SPI_SPI_CTRL_REG_SPI_WORD_Msk) == SPI_CTRL_REG_16BIT_WORD) {
+            da1469x_dma_configure(dd->dma_chans[0], &spi_write_rx_dma_cfg16, spi_da1469x_dma_done_cb, dd);
+            da1469x_dma_configure(dd->dma_chans[1], &spi_write_tx_dma_cfg16, NULL, NULL);
+        } else {
+            da1469x_dma_configure(dd->dma_chans[0], &spi_write_rx_dma_cfg, spi_da1469x_dma_done_cb, dd);
+            da1469x_dma_configure(dd->dma_chans[1], &spi_write_tx_dma_cfg, NULL, NULL);
+        }
+
         da1469x_dma_read_peripheral(dd->dma_chans[0], &dma_dummy_dst, length);
         da1469x_dma_write_peripheral(dd->dma_chans[1], buf, length);
         regs->SPI_CTRL_REG |= SPI_SPI_CTRL_REG_SPI_ON_Msk;


### PR DESCRIPTION
Changes allow for 16-bit DMA transfers for spi. Note that the current hal and other configuration code do not allow the spi to be configured for 16 bits. However, if this is configured outside the provided API this code will allow for the proper size transfer.

I do think that we should add 16-bit spi transfers to the HAL (for all hal spi) but this is a larger undertaking and I think this change would be independent (and the same) without doing that which is why I am putting in this PR without adding 16-bit spi for HAL