### PR TITLE
lvgl: Add support for 16 bit 8080 MIPI DSI

### DIFF
--- a/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
+++ b/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
@@ -44,6 +44,44 @@ lcd_itf_8080_write_byte(uint8_t b)
 }
 #endif
 
+#ifndef LCD_ITF_8080_WRITE_WORD
+
+#if MYNEWT_VAL_CHOICE(LCD_ITF, 8080_II_8_bit)
+
+#define LCD_ITF_8080_WRITE_WORD(w) do {         \
+        LCD_ITF_8080_WRITE_BYTE(w >> 8);        \
+        LCD_ITF_8080_WRITE_BYTE((uint8_t)w);    \
+} while (0)
+
+#else
+
+#define LCD_ITF_8080_WRITE_WORD(n) lcd_itf_8080_write_word(n)
+
+void
+lcd_itf_8080_write_word(uint16_t w)
+{
+    hal_gpio_write(MYNEWT_VAL(LCD_D0_PIN), PIN(w, 0));
+    hal_gpio_write(MYNEWT_VAL(LCD_D1_PIN), PIN(w, 1));
+    hal_gpio_write(MYNEWT_VAL(LCD_D2_PIN), PIN(w, 2));
+    hal_gpio_write(MYNEWT_VAL(LCD_D3_PIN), PIN(w, 3));
+    hal_gpio_write(MYNEWT_VAL(LCD_D4_PIN), PIN(w, 4));
+    hal_gpio_write(MYNEWT_VAL(LCD_D5_PIN), PIN(w, 5));
+    hal_gpio_write(MYNEWT_VAL(LCD_D6_PIN), PIN(w, 6));
+    hal_gpio_write(MYNEWT_VAL(LCD_D7_PIN), PIN(w, 7));
+    hal_gpio_write(MYNEWT_VAL(LCD_D8_PIN), PIN(w, 8));
+    hal_gpio_write(MYNEWT_VAL(LCD_D9_PIN), PIN(w, 9));
+    hal_gpio_write(MYNEWT_VAL(LCD_D10_PIN), PIN(w, 10));
+    hal_gpio_write(MYNEWT_VAL(LCD_D11_PIN), PIN(w, 11));
+    hal_gpio_write(MYNEWT_VAL(LCD_D12_PIN), PIN(w, 12));
+    hal_gpio_write(MYNEWT_VAL(LCD_D13_PIN), PIN(w, 13));
+    hal_gpio_write(MYNEWT_VAL(LCD_D14_PIN), PIN(w, 14));
+    hal_gpio_write(MYNEWT_VAL(LCD_D15_PIN), PIN(w, 15));
+    hal_gpio_write(MYNEWT_VAL(LCD_WR_PIN), 0);
+    hal_gpio_write(MYNEWT_VAL(LCD_WR_PIN), 1);
+}
+#endif
+#endif
+
 void
 lcd_itf_write_bytes(const uint8_t *bytes, size_t size)
 {
@@ -61,8 +99,7 @@ lcd_itf_write_color_data(const void *pixels, size_t size)
     LCD_CS_PIN_ACTIVE();
     if (LV_COLOR_16_SWAP == 0) {
         for (size_t i = 0; i < size; i += 2, data++) {
-            LCD_ITF_8080_WRITE_BYTE(*data >> 8);
-            LCD_ITF_8080_WRITE_BYTE((uint8_t)*data);
+            LCD_ITF_8080_WRITE_WORD(*data);
         }
     } else {
         lcd_itf_write_bytes((const uint8_t *)pixels, size);
@@ -107,4 +144,14 @@ lcd_itf_init(void)
     hal_gpio_init_out(MYNEWT_VAL(LCD_D5_PIN), 0);
     hal_gpio_init_out(MYNEWT_VAL(LCD_D6_PIN), 0);
     hal_gpio_init_out(MYNEWT_VAL(LCD_D7_PIN), 0);
+#if MYNEWT_VAL_CHOICE(LCD_ITF, 8080_II_16_bit)
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D8_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D9_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D10_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D11_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D12_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D13_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D14_PIN), 0);
+    hal_gpio_init_out(MYNEWT_VAL(LCD_D15_PIN), 0);
+#endif
 }

--- a/hw/drivers/display/lcd_itf/itf_8080/syscfg.yml
+++ b/hw/drivers/display/lcd_itf/itf_8080/syscfg.yml
@@ -49,6 +49,30 @@ syscfg.defs:
         description: D7 pin for LCD.
         value:
         restrictions: $notnull
+    LCD_D8_PIN:
+        description: D8 pin for LCD.
+        value:
+    LCD_D9_PIN:
+        description: D9 pin for LCD.
+        value:
+    LCD_D10_PIN:
+        description: D10 pin for LCD.
+        value:
+    LCD_D11_PIN:
+        description: D11 pin for LCD.
+        value:
+    LCD_D12_PIN:
+        description: D12 pin for LCD.
+        value:
+    LCD_D13_PIN:
+        description: D13 pin for LCD.
+        value:
+    LCD_D14_PIN:
+        description: D14 pin for LCD.
+        value:
+    LCD_D15_PIN:
+        description: D15 pin for LCD.
+        value:
     LCD_WR_PIN:
         description: WR pin for LCD.
         value:

--- a/hw/drivers/display/lcd_itf/pkg.yml
+++ b/hw/drivers/display/lcd_itf/pkg.yml
@@ -30,4 +30,6 @@ pkg.deps.'LCD_ITF == "spi"':
     - "@apache-mynewt-core/hw/drivers/display/lcd_itf/itf_spi"
 pkg.deps.'LCD_ITF == "8080_II_8_bit"':
     - "@apache-mynewt-core/hw/drivers/display/lcd_itf/itf_8080"
+pkg.deps.'LCD_ITF == "8080_II_16_bit"':
+    - "@apache-mynewt-core/hw/drivers/display/lcd_itf/itf_8080"
 

--- a/hw/drivers/display/lcd_itf/syscfg.yml
+++ b/hw/drivers/display/lcd_itf/syscfg.yml
@@ -24,6 +24,7 @@ syscfg.defs:
             - custom
             - spi
             - 8080_II_8_bit
+            - 8080_II_16_bit
         value: spi
     LCD_CS_PIN:
         description: LCD chip select pin for SPI.


### PR DESCRIPTION
This adds support for 16 bit data bus for LCD.
Default implementation uses hal_gpio to send data.