### PR TITLE
Add targets useful for static code analysis

### DIFF
--- a/targets/coverity/btshell_nrf52840_coverity/nrf52.ld
+++ b/targets/coverity/btshell_nrf52840_coverity/nrf52.ld
@@ -1,0 +1,104 @@
+/* Linker script for Nordic Semiconductor nRF5 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+SECTIONS
+{
+    .imghdr (NOLOAD):
+    {
+        . = . + _imghdr_size;
+    } > FLASH
+
+    __text = .;
+
+    .text :
+    {
+
+    } > FLASH
+
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        . = ALIGN(4);
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .vector_relocation :
+    {
+    } > RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RAM
+
+    .data :
+    {
+
+    } > RAM AT > FLASH
+
+    .bssnz :
+    {
+
+    } > RAM
+
+    .bss :
+    {
+
+    } > RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/targets/coverity/btshell_nrf52840_coverity/nrf52840aa.ld
+++ b/targets/coverity/btshell_nrf52840_coverity/nrf52840aa.ld
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0000c000, LENGTH = 0xa6000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x40000
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/targets/coverity/btshell_nrf52840_coverity/pkg.yml
+++ b/targets/coverity/btshell_nrf52840_coverity/pkg.yml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: targets/coverity/btshell_nrf52840_coverity
+pkg.type: target
+pkg.description: Target for static analysis
+pkg.author: 
+pkg.homepage: 
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/sensor"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/hw/sensor/creator"
+    - "@apache-mynewt-core/sys/reboot"
+    - "@apache-mynewt-core/mgmt/smp/transport/ble"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/test/flash_test"
+    - "@apache-mynewt-core/test/i2c_scan"
+    - "@apache-mynewt-nimble/nimble/host/services/ans"
+    - "@apache-mynewt-nimble/nimble/host/services/bas"
+    - "@apache-mynewt-nimble/nimble/host/services/bleuart"
+    - "@apache-mynewt-nimble/nimble/host/services/dis"
+    - "@apache-mynewt-nimble/nimble/host/services/ias"
+    - "@apache-mynewt-nimble/nimble/host/services/ipss"
+    - "@apache-mynewt-nimble/nimble/host/services/lls"
+    - "@apache-mynewt-nimble/nimble/host/services/tps"
+    - "@apache-mynewt-nimble/nimble/host"
+    - "@apache-mynewt-nimble/nimble/host/services/gap"
+    - "@apache-mynewt-nimble/nimble/host/services/gatt"
+    - "@apache-mynewt-nimble/nimble/transport"
+    - "@apache-mynewt-core/fs/fcb"

--- a/targets/coverity/btshell_nrf52840_coverity/syscfg.yml
+++ b/targets/coverity/btshell_nrf52840_coverity/syscfg.yml
@@ -1,0 +1,172 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_LEVEL: 255
+
+    BLE_ROLE_CENTRAL: 1
+    BLE_ROLE_PERIPHERAL: 1
+    BLE_ROLE_BROADCASTER: 1
+    BLE_ROLE_OBSERVER: 1
+
+    BLE_EDDYSTONE: 1
+    BLE_TRANSPORT_EVT_DISCARDABLE_COUNT: 70
+    BLE_EXT_ADV: 1
+    BLE_EXT_ADV_MAX_SIZE: 1650
+
+    BLE_TRANSPORT_EVT_DISCARDABLE_COUNT: 257
+    BLE_HS_DEBUG: 1
+    BLE_L2CAP_COC_MAX_NUM: 2
+    BLE_LL_CFG_FEAT_LE_2M_PHY: 1
+    BLE_LL_CFG_FEAT_LE_CODED_PHY: 1
+    BLE_LL_CFG_FEAT_LL_PRIVACY: 1
+    BLE_LL_CONN_INIT_MAX_TX_BYTES: 251
+    BLE_LL_DTM: 1
+    BLE_LL_DTM_EXTENSIONS: 1
+    BLE_LL_NUM_SCAN_DUP_ADVS: 1
+    BLE_LL_ISO: 1
+    BLE_LL_ISO_BROADCASTER: 1
+    BLE_PERIODIC_ADV_SYNC_BIGINFO_REPORTS: 1
+    BLE_MAX_CONNECTIONS: 5
+    BLE_MAX_PERIODIC_SYNCS: 5
+    BLE_MONITOR_RTT: 1
+    BLE_MONITOR_RTT_BUFFER_SIZE: 2048
+    BLE_MULTI_ADV_INSTANCES: 5
+    BLE_PERIODIC_ADV: 1
+    BLE_PERIODIC_ADV_SYNC_TRANSFER: 1
+    BLE_SM_BONDING: 1
+    BLE_SM_LEGACY: 1
+    BLE_SM_SC: 1
+    BLE_STORE_MAX_BONDS: 5
+    BLE_VERSION: 54
+
+    CONSOLE_HISTORY: ram
+    CONSOLE_HISTORY_RAM_HISTORY_SIZE: 10
+    CONSOLE_INPUT: 1
+    CONSOLE_RTT: 0
+    CONSOLE_UART: 1
+    CONSOLE_USB: 0
+    MSYS_1_BLOCK_COUNT: 70
+    CONSOLE_STICKY_PROMPT: 1
+    CONSOLE_PROMPT_SOFT_CURSOR: 1
+    CONSOLE_PROMPT_SOFT_CURSOR_ATTR: '"30;42m"'
+    CONSOLE_UART_BAUD: 1000000
+    CONSOLE_UART_RX_BUF_SIZE: 256
+
+    I2C_0: 1
+    SPI_1_MASTER: 1
+    SPI_1_MASTER_PIN_MISO: 1
+    SPI_1_MASTER_PIN_MOSI: 1
+    SPI_1_MASTER_PIN_SCK: 1
+    SPI_0_MASTER: 1
+    DRV2605_OFB: 1
+    LSM303DLHC_OFB: 1
+    LSM6DSO_OFB: 1
+    MPU6050_OFB: 1
+    BNO055_OFB: 1
+    TSL2561_OFB: 1
+    TSL2591_OFB: 1
+    TCS34725_OFB: 1
+    BME280_OFB: 1
+    MS5837_OFB: 1
+    MS5840_OFB: 1
+    BMP280_OFB: 1
+    BMP280_OFB_I2C_NUM: 0
+    BMA253_OFB: 1
+    BMA2XX_OFB: 1
+    BMP388_OFB: 1
+    BMP388_OFB_I2C_NUM: 0
+    ADXL345_OFB: 1
+    ADXL345_OFB_I2C_NUM: 0
+    LPS33HW_OFB: 1
+    LPS33THW_OFB: 1
+    LIS2DW12_OFB: 1
+    LIS2DH12_OFB: 1
+    LIS2DH12_OFB_I2C_NUM: 0
+    LIS2DS12_OFB: 1
+    BME680_OFB: 1
+    KXTJ3_OFB: 1
+    DPS368_OFB: 1
+    ICP101XX_OFB: 1
+
+    SHELL_TASK: 1
+    STATS_NAMES: 1
+    REBOOT_LOG_FCB: 1
+    LOG_FCB: 1
+    CONFIG_FCB: 1
+    CONFIG_CLI: 1
+    STATS_CLI: 1
+    LOG_CLI: 1
+    STATS_MGMT: 1
+    LOG_MGMT: 1
+    CONFIG_MGMT: 1
+    TSL2561_CLI: 1
+    BNO055_CLI: 1
+    TCS34725_CLI: 1
+    BME280_CLI: 1
+    BMA2XX_CLI: 1
+    SENSOR_OIC: 1
+    OC_SERVER: 1
+    OC_TRANSPORT_GATT: 1
+    OC_APP_RESOURCES : 20
+    FLOAT_USER: 1
+    SENSOR_OIC_PERIODIC: 1
+
+    BLE_MESH: 1
+    BLE_MESH_PB_GATT: 1
+    BLE_MESH_SETTINGS: 1
+    BLE_MESH_PROXY: 1
+    BLE_MESH_SHELL: 1
+    BLE_MESH_GATT_PROXY: 1
+    BLE_MESH_RELAY: 1
+    BLE_MESH_LOW_POWER: 1
+    BLE_MESH_FRIEND: 1
+    BLE_MESH_CFG_CLI: 1
+    BLE_MESH_HEALTH_CLI: 1
+    BLE_MESH_SHELL: 1
+    BLE_MESH_TESTING: 1
+    BLE_MESH_SHELL_MODELS: 1
+    BLE_MESH_CDB: 1
+
+
+    PWM_0: 1
+    PWM_1: 1
+    PWM_2: 1
+    PWM_3: 1
+
+    ADC_0: 1
+    ADC_1: 1
+    ADC_2: 1
+    ADC_3: 1
+
+    USB: 1
+    USBD_PID: 0x0001
+    USBD_VID: 0x0002
+    USBD_STD_DESCRIPTORS: 1
+
+    LVGL_ILI9341: 1
+    LVGL_STMPE610: 1
+    LVGL_ILI9486: 1
+    LVGL_XPT2046: 1
+    LVGL_DISPLAY_HORIZONTAL_RESOLUTION: 300
+    LVGL_DISPLAY_VERTICAL_RESOLUTION: 300
+    STMPE610_SPI_CS_PIN: 1
+    XPT2046_INT_PIN: 1
+    XPT2046_SPI_CS_PIN: 1
+    LCD_DC_PIN: 1

--- a/targets/coverity/btshell_nrf52840_coverity/target.yml
+++ b/targets/coverity/btshell_nrf52840_coverity/target.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
+target.build_profile: optimized
+
+bsp.linkerscript:
+    - "targets/coverity/btshell_nrf52840_coverity/nrf52840aa.ld"
+    - "targets/coverity/btshell_nrf52840_coverity/nrf52.ld"

--- a/targets/coverity/btshell_nrf52840_coverity2/pkg.yml
+++ b/targets/coverity/btshell_nrf52840_coverity2/pkg.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: targets/coverity/btshell_nrf52840_coverity2
+pkg.type: target
+pkg.description: Target for static analysis
+pkg.author: 
+pkg.homepage: 
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/sensor"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/hw/sensor/creator"
+    - "@apache-mynewt-core/sys/reboot"
+    - "@apache-mynewt-core/mgmt/smp/transport/ble"
+    - "@apache-mynewt-core/sys/id"
+    - "@apache-mynewt-core/mgmt/imgmgr"
+    - "@apache-mynewt-core/test/flash_test"
+    - "@apache-mynewt-core/test/i2c_scan"
+    - "@apache-mynewt-nimble/nimble/host/services/ans"
+    - "@apache-mynewt-nimble/nimble/host/services/bas"
+    - "@apache-mynewt-nimble/nimble/host/services/bleuart"
+    - "@apache-mynewt-nimble/nimble/host/services/dis"
+    - "@apache-mynewt-nimble/nimble/host/services/ias"
+    - "@apache-mynewt-nimble/nimble/host/services/ipss"
+    - "@apache-mynewt-nimble/nimble/host/services/lls"
+    - "@apache-mynewt-nimble/nimble/host/services/tps"
+    - "@apache-mynewt-nimble/nimble/host"
+    - "@apache-mynewt-nimble/nimble/host/services/gap"
+    - "@apache-mynewt-nimble/nimble/host/services/gatt"
+    - "@apache-mynewt-nimble/nimble/transport"
+    - "@apache-mynewt-core/fs/fcb"
+    - "@apache-mynewt-core/hw/drivers/display/lvgl"

--- a/targets/coverity/btshell_nrf52840_coverity2/syscfg.yml
+++ b/targets/coverity/btshell_nrf52840_coverity2/syscfg.yml
@@ -1,0 +1,172 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_LEVEL: 255
+
+    BLE_ROLE_CENTRAL: 1
+    BLE_ROLE_PERIPHERAL: 1
+    BLE_ROLE_BROADCASTER: 1
+    BLE_ROLE_OBSERVER: 1
+
+    BLE_EDDYSTONE: 1
+    BLE_TRANSPORT_EVT_DISCARDABLE_COUNT: 70
+    BLE_EXT_ADV: 1
+    BLE_EXT_ADV_MAX_SIZE: 1650
+
+    BLE_TRANSPORT_EVT_DISCARDABLE_COUNT: 257
+    BLE_HS_DEBUG: 1
+    BLE_L2CAP_COC_MAX_NUM: 2
+    BLE_LL_CFG_FEAT_LE_2M_PHY: 1
+    BLE_LL_CFG_FEAT_LE_CODED_PHY: 1
+    BLE_LL_CFG_FEAT_LL_PRIVACY: 1
+    BLE_LL_CONN_INIT_MAX_TX_BYTES: 251
+    BLE_LL_DTM: 1
+    BLE_LL_DTM_EXTENSIONS: 1
+    BLE_LL_NUM_SCAN_DUP_ADVS: 1
+    BLE_LL_ISO: 1
+    BLE_LL_ISO_BROADCASTER: 1
+    BLE_PERIODIC_ADV_SYNC_BIGINFO_REPORTS: 1
+    BLE_MAX_CONNECTIONS: 5
+    BLE_MAX_PERIODIC_SYNCS: 5
+    BLE_MONITOR_RTT: 1
+    BLE_MONITOR_RTT_BUFFER_SIZE: 2048
+    BLE_MULTI_ADV_INSTANCES: 5
+    BLE_PERIODIC_ADV: 1
+    BLE_PERIODIC_ADV_SYNC_TRANSFER: 1
+    BLE_SM_BONDING: 1
+    BLE_SM_LEGACY: 1
+    BLE_SM_SC: 1
+    BLE_STORE_MAX_BONDS: 5
+    BLE_VERSION: 54
+
+    CONSOLE_HISTORY: ram
+    CONSOLE_HISTORY_RAM_HISTORY_SIZE: 10
+    CONSOLE_INPUT: 1
+    CONSOLE_RTT: 0
+    CONSOLE_UART: 0
+    CONSOLE_USB: 1
+    MSYS_1_BLOCK_COUNT: 70
+    CONSOLE_STICKY_PROMPT: 1
+    CONSOLE_PROMPT_SOFT_CURSOR: 1
+    CONSOLE_PROMPT_SOFT_CURSOR_ATTR: '"30;42m"'
+    CONSOLE_UART_BAUD: 1000000
+    CONSOLE_UART_RX_BUF_SIZE: 256
+
+    I2C_0: 1
+    SPI_1_MASTER: 1
+    SPI_1_MASTER_PIN_MISO: 1
+    SPI_1_MASTER_PIN_MOSI: 1
+    SPI_1_MASTER_PIN_SCK: 1
+    SPI_0_MASTER: 1
+    DRV2605_OFB: 0
+    LSM303DLHC_OFB: 0
+    LSM6DSO_OFB: 0
+    MPU6050_OFB: 0
+    BNO055_OFB: 0
+    TSL2561_OFB: 0
+    TSL2591_OFB: 0
+    TCS34725_OFB: 0
+    BME280_OFB: 0
+    MS5837_OFB: 0
+    MS5840_OFB: 0
+    BMP280_OFB: 0
+    BMP280_OFB_I2C_NUM: 0
+    BMA253_OFB: 0
+    BMA2XX_OFB: 0
+    BMP388_OFB: 0
+    BMP388_OFB_I2C_NUM: 0
+    ADXL345_OFB: 0
+    ADXL345_OFB_I2C_NUM: 0
+    LPS33HW_OFB: 0
+    LPS33THW_OFB: 0
+    LIS2DW12_OFB: 0
+    LIS2DH12_OFB: 0
+    LIS2DH12_OFB_I2C_NUM: 0
+    LIS2DS12_OFB: 0
+    BME680_OFB: 0
+    KXTJ3_OFB: 0
+    DPS368_OFB: 0
+    ICP101XX_OFB: 0
+
+    SHELL_TASK: 1
+    STATS_NAMES: 1
+    REBOOT_LOG_FCB: 1
+    LOG_FCB: 1
+    CONFIG_FCB: 1
+    CONFIG_CLI: 1
+    STATS_CLI: 1
+    LOG_CLI: 1
+    STATS_MGMT: 1
+    LOG_MGMT: 1
+    CONFIG_MGMT: 1
+    TSL2561_CLI: 1
+    BNO055_CLI: 1
+    TCS34725_CLI: 1
+    BME280_CLI: 1
+    BMA2XX_CLI: 1
+    SENSOR_OIC: 1
+    OC_SERVER: 1
+    OC_TRANSPORT_GATT: 1
+    OC_APP_RESOURCES : 20
+    FLOAT_USER: 1
+    SENSOR_OIC_PERIODIC: 1
+
+    BLE_MESH: 1
+    BLE_MESH_PB_GATT: 1
+    BLE_MESH_SETTINGS: 1
+    BLE_MESH_PROXY: 1
+    BLE_MESH_SHELL: 1
+    BLE_MESH_GATT_PROXY: 1
+    BLE_MESH_RELAY: 1
+    BLE_MESH_LOW_POWER: 1
+    BLE_MESH_FRIEND: 1
+    BLE_MESH_CFG_CLI: 1
+    BLE_MESH_HEALTH_CLI: 1
+    BLE_MESH_SHELL: 1
+    BLE_MESH_TESTING: 1
+    BLE_MESH_SHELL_MODELS: 1
+    BLE_MESH_CDB: 1
+
+
+    PWM_0: 1
+    PWM_1: 1
+    PWM_2: 1
+    PWM_3: 1
+
+    ADC_0: 1
+    ADC_1: 1
+    ADC_2: 1
+    ADC_3: 1
+
+    USB: 1
+    USBD_PID: 0x0001
+    USBD_VID: 0x0002
+    USBD_STD_DESCRIPTORS: 1
+
+    LVGL_ILI9341: 1
+    LVGL_STMPE610: 1
+    LVGL_ILI9486: 1
+    LVGL_XPT2046: 1
+    LVGL_DISPLAY_HORIZONTAL_RESOLUTION: 300
+    LVGL_DISPLAY_VERTICAL_RESOLUTION: 300
+    STMPE610_SPI_CS_PIN: 1
+    XPT2046_INT_PIN: 1
+    XPT2046_SPI_CS_PIN: 1
+    LCD_DC_PIN: 1

--- a/targets/coverity/btshell_nrf52840_coverity2/target.yml
+++ b/targets/coverity/btshell_nrf52840_coverity2/target.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
+target.build_profile: optimized
+
+bsp.linkerscript:
+    - "targets/coverity/btshell_nrf52840_coverity/nrf52840aa.ld"
+    - "targets/coverity/btshell_nrf52840_coverity/nrf52.ld"


### PR DESCRIPTION
Those targets are not meant for normal use but only to build as much code as possible. They use custom linker script to workaround flash overflow on images.