### PR TITLE
hw/mcu/cmac: Add chip variant detection on startup

### DIFF
--- a/hw/mcu/dialog/cmac/include/mcu/mcu.h
+++ b/hw/mcu/dialog/cmac/include/mcu/mcu.h
@@ -31,6 +31,16 @@ extern "C" {
 #define MCU_MEM_SYSRAM_START_ADDRESS    (0x20000000)
 #define MCU_MEM_SYSRAM_END_ADDRESS      (0x20080000)
 
+#define MCU_CHIP_VARIANT_TSMC           1
+#define MCU_CHIP_VARIANT_GF             2
+
+static inline uint8_t
+mcu_chip_variant_get(void)
+{
+    extern uint8_t g_mcu_chip_variant;
+    return g_mcu_chip_variant;
+}
+
 /* Map diagnostic signal to diagnostic port (output) */
 #define MCU_DIAG_MAP(_port, _word, _evt)                                \
     CMAC->CM_DIAG_PORT ## _port ## _REG =                               \


### PR DESCRIPTION
This adds chip variant dedection early during startup. Previously this was done during RF initialization, but since CHIP_ID1 register resides in PD_SYS it could happen that domain was powered down already due to M33 going to sleep.

Reading on boot is safe since M33 starts CMAC and then waits for shm to initialize so PD_SYS is always available at CMAC startup.