### PR TITLE
hw/ipc_nrf5340: Apply Errata 161 workaround

### DIFF
--- a/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
+++ b/hw/drivers/ipc_nrf5340/src/ipc_nrf5340.c
@@ -327,7 +327,14 @@ ipc_nrf5340_init(void)
     }
 
     /* Start Network Core */
+    /* Workaround for Errata 161: "RESET: Core is not fully reset after Force-OFF" */
+    *(volatile uint32_t *) ((uint32_t)NRF_RESET + 0x618ul) = 1ul;
     NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+    os_cputime_delay_usecs(5);
+    NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Hold;
+    os_cputime_delay_usecs(1);
+    NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+    *(volatile uint32_t *) ((uint32_t)NRF_RESET + 0x618ul) = 0;
 
     /*
      * Waits for NET core to start and init it's side of IPC.


### PR DESCRIPTION
Symptoms
Network core peripherals or CPU behave erratically after Force-OFF release.

Conditions
Network core is in System ON IDLE state when it is entering Force-OFF or the device enters System OFF mode.

Consequences
Network core peripherals and CPU are not reset. CPU does not restart from the reset vector, and peripherals can behave erratically.

This adds code suggested by Nordic Errata 161 when network core reset is released.