### PR TITLE
hw/scripts: Add fallback to gdb-multiarch

### DIFF
--- a/hw/bsp/hifive1/hifive1_debug.sh
+++ b/hw/bsp/hifive1/hifive1_debug.sh
@@ -31,7 +31,7 @@
 
 FILE_NAME=$BIN_BASENAME.elf
 CFG="-f $CORE_PATH/hw/bsp/hifive1/riscv_openocd.cfg"
-GDB=riscv64-unknown-elf-gdb
+gdb_detect
 # Magic value that is checked inside hal_debugger_connected()
 EXTRA_GDB_CMDS="set *0x100000BC=0x5151A2BC"
 openocd_debug

--- a/hw/scripts/common.sh
+++ b/hw/scripts/common.sh
@@ -125,3 +125,34 @@ detect_programmer() {
 
     echo "Detected programmer: $DETECTED_PROGRAMMER"
 }
+
+gdb_detect() {
+    # GDB setup previously, no need to detect
+    if [ -n "$GDB" ] ; then return ; fi
+
+    GDB=gdb
+
+    case ${MYNEWT_VAL_ARCH_NAME} in
+        \"cortex*\")
+            if which arm-none-eabi-gdb >/dev/null 2>/dev/null ; then
+                GDB=arm-none-eabi-gdb
+            elif which gdb-multiarch >/dev/null 2>/dev/null ; then
+                GDB=gdb-multiarch
+            fi
+            ;;
+        \"rv32*\")
+            if which riscv64-unknown-elf-gdb >/dev/null 2>/dev/null ; then
+                GDB=riscv64-unknown-elf-gdb
+            elif which riscv-none-embed-gdb >/dev/null 2>/dev/null ; then
+                GDB=riscv-none-embed-gdb
+            elif which gdb-multiarch >/dev/null 2>/dev/null ; then
+                GDB=gdb-multiarch
+            fi
+            ;;
+        *)
+            if which gdb-multiarch >/dev/null 2>/dev/null ; then
+                GDB=gdb-multiarch
+            fi
+            ;;
+    esac
+}

--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -50,6 +50,7 @@ jlink_load () {
     GDB_OUT_FILE=.gdb_out
 
     windows_detect
+    gdb_detect
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
     jlink_target_cmd
     jlink_sn
@@ -96,7 +97,7 @@ jlink_load () {
 
     echo "quit" >> $GDB_CMD_FILE
 
-    msgs=`arm-none-eabi-gdb -x $GDB_CMD_FILE 2>&1`
+    msgs=`$GDB -x $GDB_CMD_FILE 2>&1`
     echo "$msgs" > $GDB_OUT_FILE
 
     rm $GDB_CMD_FILE
@@ -139,6 +140,7 @@ jlink_load () {
 #
 jlink_debug() {
     windows_detect
+    gdb_detect
     if [ $WINDOWS -eq 1 ]; then
         JLINK_GDB_SERVER=JLinkGDBServerCL
     fi
@@ -189,7 +191,7 @@ jlink_debug() {
             FILE_NAME=`echo $FILE_NAME | sed 's/\//\\\\/g'`
             $COMSPEC /C "start $COMSPEC /C arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME"
         else
-            arm-none-eabi-gdb -x $GDB_CMD_FILE $FILE_NAME
+            $GDB -x $GDB_CMD_FILE $FILE_NAME
             rm $GDB_CMD_FILE
         fi
     else

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -18,7 +18,6 @@
 . $CORE_PATH/hw/scripts/common.sh
 
 CFG_RESET="reset halt"
-GDB=arm-none-eabi-gdb
 
 #
 # FILE_NAME must contain the name of the file to load
@@ -72,6 +71,7 @@ openocd_debug () {
     OCD_CMD_FILE=.openocd_cmds
 
     windows_detect
+    gdb_detect
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD
 
     echo "gdb_port $PORT" > $OCD_CMD_FILE

--- a/hw/scripts/pyocd.sh
+++ b/hw/scripts/pyocd.sh
@@ -18,7 +18,6 @@
 
 . $CORE_PATH/hw/scripts/common.sh
 
-GDB=arm-none-eabi-gdb
 CONNECTION_MODE_DEFAULT="halt"
 
 #
@@ -69,6 +68,7 @@ pyocd_load () {
 #
 pyocd_debug () {
     windows_detect
+    gdb_detect
     PORT=3333
 
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD

--- a/hw/scripts/stlink.sh
+++ b/hw/scripts/stlink.sh
@@ -17,8 +17,6 @@
 #
 . $CORE_PATH/hw/scripts/common.sh
 
-GDB=arm-none-eabi-gdb
-
 #
 # FILE_NAME must contain the name of the file to load
 # FLASH_OFFSET must contain the offset in flash where to place it
@@ -58,6 +56,8 @@ stlink_load () {
 #
 stlink_debug () {
     windows_detect
+    gdb_detect
+
     PORT=3333
 
     parse_extra_jtag_cmd $EXTRA_JTAG_CMD

--- a/hw/scripts/stm32_programmer.sh
+++ b/hw/scripts/stm32_programmer.sh
@@ -17,8 +17,6 @@
 #
 . $CORE_PATH/hw/scripts/common.sh
 
-GDB=arm-none-eabi-gdb
-
 #
 # FILE_NAME must contain the name of the file to load
 # FLASH_OFFSET must contain the offset in flash where to place it


### PR DESCRIPTION
This adds gdb detection so if gdb-multiarch is installed and arm-none-eabi or some of the riscv versions are not available gdb-multiarch will be used.