### PR TITLE
mcu/stm32u5: Fix flash write

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_flash.c
+++ b/hw/mcu/stm/stm32_common/src/hal_flash.c
@@ -100,6 +100,8 @@ stm32_flash_write_linear(const struct hal_flash *dev, uint32_t address,
     num_words = ((num_bytes - 1) >> 2) + 1;
 #elif MYNEWT_VAL(MCU_FLASH_MIN_WRITE_SIZE) == 8
     num_words = ((num_bytes - 1) >> 3) + 1;
+#elif MYNEWT_VAL(MCU_FLASH_MIN_WRITE_SIZE) == 16
+    num_words = ((num_bytes - 1) >> 4) + 1;
 #else
     #error "Unsupported MCU_FLASH_MIN_WRITE_SIZE"
 #endif

--- a/hw/mcu/stm/stm32u5xx/syscfg.yml
+++ b/hw/mcu/stm/stm32u5xx/syscfg.yml
@@ -21,7 +21,7 @@ syscfg.defs:
         description: >
             Specifies the required alignment for internal flash writes.
             Used internally by the newt tool.
-        value: 8
+        value: 16
 
     MCU_STM32U5:
         description: MCUs are of STM32U5xx family


### PR DESCRIPTION
STM32U5 devices require quad writes (128 bits).
64 bits writes result in error so write size is extended.