### PR TITLE
mcu/nrf5x: Relax SPI baudrate restrictions

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -428,43 +428,34 @@ hal_spi_config_master(struct nrf52_hal_spi *spi,
     }
     spim->CONFIG = nrf_config;
 
-    switch (settings->baudrate) {
-        case 125:
-            frequency = SPIM_FREQUENCY_FREQUENCY_K125;
-            break;
-        case 250:
-            frequency = SPIM_FREQUENCY_FREQUENCY_K250;
-            break;
-        case 500:
-            frequency = SPIM_FREQUENCY_FREQUENCY_K500;
-            break;
-        case 1000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M1;
-            break;
-        case 2000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M2;
-            break;
-        case 4000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M4;
-            break;
-        case 8000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M8;
-            break;
-            /* 16 and 32 MHz is only supported on SPI_3_MASTER */
-#if defined(SPIM_FREQUENCY_FREQUENCY_M16) && MYNEWT_VAL(SPI_3_MASTER)
-        case 16000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M16;
-            break;
-#endif
+    /* 16 and 32 MHz is only supported on SPI_3_MASTER */
 #if defined(SPIM_FREQUENCY_FREQUENCY_M32) && MYNEWT_VAL(SPI_3_MASTER)
-        case 32000:
-            frequency = SPIM_FREQUENCY_FREQUENCY_M32;
-            break;
+    if (settings->baudrate >= 32000 && spim == NRF_SPIM3) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M32;
+    } else
 #endif
-        default:
-            frequency = 0;
-            rc = EINVAL;
-            break;
+#if defined(SPIM_FREQUENCY_FREQUENCY_M16) && MYNEWT_VAL(SPI_3_MASTER)
+    if (settings->baudrate >= 16000 && spim == NRF_SPIM3) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M16;
+    } else
+#endif
+    if (settings->baudrate >= 8000) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M8;
+    } else if (settings->baudrate >= 4000) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M4;
+    } else if (settings->baudrate >= 2000) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M2;
+    } else if (settings->baudrate >= 1000) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_M1;
+    } else if (settings->baudrate >= 500) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_K500;
+    } else if (settings->baudrate >= 250) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_K250;
+    } else if (settings->baudrate >= 125) {
+        frequency = SPIM_FREQUENCY_FREQUENCY_K125;
+    } else {
+        frequency = 0;
+        rc = EINVAL;
     }
     spim->FREQUENCY = frequency;
 


### PR DESCRIPTION
SPI clock settings allowed only specific number of values to be set. Requesting value not in predefined set resulted in SPI not being configured.
Other MCUs' HALs, when SPI frequency is specified try to set frequency that does not exceed requested one.
This approach allows to have common frequency value that applies to device that is connected to SPI for wider range of MCUs. For example MMC requires SPI to be in range of 100-400kHz during startup and MMC code have frequency set to 125kHz just because this value is supported by NRF52.

With this change NRF5x SPI frequency is set to value that does not exeed requested one. It should not affect existing code that must have exact value set to work at all.

Now it will be possible to specify 200kHz and HAL will setup value 125kHz it this is what hardware supports.