### PR TITLE
mcu/stm32h7: Fix flash write/erase

### DIFF
--- a/hw/mcu/stm/stm32h7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32h7xx/syscfg.yml
@@ -21,7 +21,7 @@ syscfg.defs:
         description: >
             Specifies the required alignment for internal flash writes.
             Used internally by the newt tool.
-        value: 1
+        value: 32
 
     MCU_STM32H7:
         description: MCUs are of STM32H7xx family


### PR DESCRIPTION
Flash min write size was incorrectly set to 1 while for most H7 MCUs it has to be 32 bytes.

HAL_FLASH_Program uses different arguments then the reset of MCU with non-linear flash sectors.
Write now respects minimum write size.

STM32H7 hal requires eraseInit.Banks field to be set.