### PR TITLE
hw/drivers/mmc: Fix Multiple Block Read CMD18

### DIFF
--- a/hw/drivers/mmc/include/mmc/mmc.h
+++ b/hw/drivers/mmc/include/mmc/mmc.h
@@ -46,6 +46,12 @@ extern "C" {
 
 extern struct disk_ops mmc_ops;
 
+struct mmc_spi_cfg {
+    uint32_t initial_freq_khz;
+    uint32_t freq_khz;
+    uint8_t clock_mode;
+};
+
 /**
  * Initialize the MMC driver
  *
@@ -56,7 +62,7 @@ extern struct disk_ops mmc_ops;
  * @return 0 on success, non-zero on failure
  */
 int
-mmc_init(int spi_num, void *spi_cfg, int ss_pin);
+mmc_init(int spi_num, struct mmc_spi_cfg *spi_cfg, int ss_pin);
 
 /**
  * Read data from MMC

--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -400,27 +400,29 @@ mmc_read(uint8_t mmc_id, uint32_t addr, void *buf, uint32_t len)
         goto out;
     }
 
-    /**
-     * 7.3.3 Control tokens
-     *   Wait up to 200ms for control token.
-     */
-    timeout = os_time_get() + OS_TICKS_PER_SEC / 5;
-    do {
-        res = hal_spi_tx_val(mmc->spi_num, 0xff);
-        if (res != 0xFF) break;
-        os_time_delay(OS_TICKS_PER_SEC / 20);
-    } while (os_time_get() < timeout);
-
-    /**
-     * 7.3.3.2 Start Block Tokens and Stop Tran Token
-     */
-    if (res != START_BLOCK) {
-        rc = MMC_TIMEOUT;
-        goto out;
-    }
-
     index = 0;
     while (block_count--) {
+        /**
+         * 7.3.3 Control tokens
+         *   Wait up to 200ms for control token.
+         */
+        timeout = os_time_get() + OS_TICKS_PER_SEC / 5;
+        do {
+            res = hal_spi_tx_val(mmc->spi_num, 0xff);
+            if (res != 0xFF) {
+                break;
+            }
+            os_time_delay(OS_TICKS_PER_SEC / 20);
+        } while (os_time_get() < timeout);
+
+        /**
+         * 7.3.3.2 Start Block Tokens and Stop Tran Token
+         */
+        if (res != START_BLOCK) {
+            rc = MMC_TIMEOUT;
+            goto out;
+        }
+
         for (n = 0; n < BLOCK_LEN; n++) {
             g_block_buf[n] = hal_spi_tx_val(mmc->spi_num, 0xff);
         }


### PR DESCRIPTION
This PR:
- fixes CMD18 multiple block read where read control token and CRC were handled correctly only if single block was read
- adds code that switches to higher speed after initialization (was marked as TODO:)
