### PR TITLE
bus/spi_stm32: Fix SCK glitch for STM32H7

### DIFF
--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -897,6 +897,9 @@ bus_spi_stm32_dev_init_func(struct os_dev *odev, void *arg)
     dd->hspi.Init.NSS = SPI_NSS_SOFT;
     dd->hspi.Init.TIMode = SPI_TIMODE_DISABLE;
     dd->hspi.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+#ifdef SPI_MASTER_KEEP_IO_STATE_ENABLE
+    dd->hspi.Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_ENABLE;
+#endif
 
     if (MIN_DMA_RX_SIZE >= 0 || MIN_DMA_TX_SIZE >= 0) {
         dd->dmarx.Instance = spi_hw->dmarx_cfg->regs;


### PR DESCRIPTION
When SPI_MASTER_KEEP_IO_STATE_ENABLE flag is not set for STM32H7, SPI SCK line can change state when SPI is re-configured. This change in SCK line can lead to broken SPI transmission.