### PR TITLE
Increase size of some `struct fcb` members

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -53,8 +53,8 @@ struct fcb {
     /* Caller of fcb_init fills this in */
     uint32_t f_magic;		/* As placed on the disk */
     uint8_t f_version;  	/* Current version number of the data */
-    uint8_t f_sector_cnt;	/* Number of elements in sector array */
-    uint8_t f_scratch_cnt;	/* How many sectors should be kept empty */
+    uint16_t f_sector_cnt;	/* Number of elements in sector array */
+    uint16_t f_scratch_cnt;	/* How many sectors should be kept empty */
     struct flash_area *f_sectors; /* Array of sectors, must be contiguous */
 
     /* Flash circular buffer internal state */

--- a/hw/drivers/flash/enc_flash/selftest/src/testcases/enc_flash_fcb.c
+++ b/hw/drivers/flash/enc_flash/selftest/src/testcases/enc_flash_fcb.c
@@ -27,6 +27,7 @@ enc_flash_test_fcb_init(struct fcb *fcb)
     fcb->f_sector_cnt = ENC_TEST_FLASH_AREA_CNT;
     fcb->f_scratch_cnt = 0;
     fcb->f_sectors = enc_test_flash_areas;
+    fcb->f_version = 0xa; /* arbitrary version for the test */
 }
 
 TEST_CASE_SELF(enc_flash_test_fcb)


### PR DESCRIPTION
Component: Flash Circular Buffer

Change the type of sector_cnt and scratch_cnt from a uint8_t to a uint16_t, allowing for counts > 255.