### PR TITLE
hw/drivers/flash/spiflash: Make SPI mode configurable

### DIFF
--- a/hw/bsp/black_vet6/src/hal_bsp.c
+++ b/hw/bsp/black_vet6/src/hal_bsp.c
@@ -290,7 +290,7 @@ extern const struct hal_flash stm32_flash_dev;
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/hifive1/src/hal_bsp.c
+++ b/hw/bsp/hifive1/src/hal_bsp.c
@@ -47,7 +47,7 @@ static const struct hal_bsp_mem_dump dump_cfg[] = {
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/nucleo-h723zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-h723zg/src/hal_bsp.c
@@ -204,7 +204,7 @@ extern const struct hal_flash stm32_flash_dev;
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_0,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/nucleo-l073rz/src/hal_bsp.c
+++ b/hw/bsp/nucleo-l073rz/src/hal_bsp.c
@@ -116,7 +116,7 @@ extern const struct hal_flash stm32_flash_dev;
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/nucleo-u575zi-q/src/hal_bsp.c
+++ b/hw/bsp/nucleo-u575zi-q/src/hal_bsp.c
@@ -154,7 +154,7 @@ extern const struct hal_flash stm32_flash_dev;
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_0,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/olimex-pic32-emz64/src/hal_bsp.c
+++ b/hw/bsp/olimex-pic32-emz64/src/hal_bsp.c
@@ -97,7 +97,7 @@
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/olimex-pic32-hmz144/src/hal_bsp.c
+++ b/hw/bsp/olimex-pic32-hmz144/src/hal_bsp.c
@@ -96,7 +96,7 @@
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/bsp/pinetime/src/hal_bsp.c
+++ b/hw/bsp/pinetime/src/hal_bsp.c
@@ -61,7 +61,7 @@ hal_bsp_core_dump(int *area_cnt)
 struct bus_spi_node_cfg flash_spi_cfg = {
     .node_cfg.bus_name = MYNEWT_VAL(BSP_FLASH_SPI_BUS),
     .pin_cs = MYNEWT_VAL(SPIFLASH_SPI_CS_PIN),
-    .mode = BUS_SPI_MODE_3,
+    .mode = MYNEWT_VAL(SPIFLASH_SPI_MODE),
     .data_order = HAL_SPI_MSB_FIRST,
     .freq = MYNEWT_VAL(SPIFLASH_BAUDRATE),
 };

--- a/hw/drivers/flash/spiflash/src/spiflash.c
+++ b/hw/drivers/flash/spiflash/src/spiflash.c
@@ -655,7 +655,7 @@ struct spiflash_dev spiflash_dev = {
     /* SPI settings */
     .spi_settings = {
         .data_order = HAL_SPI_MSB_FIRST,
-        .data_mode  = HAL_SPI_MODE3,
+        .data_mode  = MYNEWT_VAL(SPIFLASH_SPI_MODE),
         .baudrate   = MYNEWT_VAL(SPIFLASH_BAUDRATE),
         .word_size  = HAL_SPI_WORD_SIZE_8BIT,
     },

--- a/hw/drivers/flash/spiflash/syscfg.yml
+++ b/hw/drivers/flash/spiflash/syscfg.yml
@@ -28,6 +28,13 @@ syscfg.defs:
         description: 'SPI interface CS pin'
         value:  -1
 
+    SPIFLASH_SPI_MODE:
+        description: >
+            SPI clock mode. Most devices support HAL_SPI_MODE0 (clock low when idle,
+            first edge latches data) and HAL_SPI_MODE3 (clock high when idle,
+            second clock edge latches data).
+        value: HAL_SPI_MODE3
+
     SPIFLASH_SECTOR_COUNT:
         description: 'Number of sectors'
         value:  0


### PR DESCRIPTION
SPI mode for hardcoded to HAL_SPI_MODE3, most SPI flashes also support HAL_SPI_MODE0.
Now user can specify which mode to use.