### PR TITLE
drivers/mmc: Add support for bus driver

### DIFF
--- a/hw/drivers/mmc/include/mmc/mmc.h
+++ b/hw/drivers/mmc/include/mmc/mmc.h
@@ -22,6 +22,9 @@
 
 #include "os/mynewt.h"
 #include <disk/disk.h>
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+#include <bus/drivers/spi_common.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -95,6 +98,17 @@ mmc_write(uint8_t mmc_id, uint32_t addr, const void *buf, uint32_t len);
  */
 int
 mmc_ioctl(uint8_t mmc_id, uint32_t cmd, void *arg);
+
+#if MYNEWT_VAL(BUS_DRIVER_PRESENT)
+struct mmc_config {
+    struct bus_spi_node_cfg spi_cfg;
+};
+struct mmc {
+    struct bus_spi_node node;
+};
+
+int mmc_create_dev(struct mmc *mmc, const char *name, struct mmc_config *mmc_cfg);
+#endif
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/mmc/syscfg.yml
+++ b/hw/drivers/mmc/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,17 +16,25 @@
 # under the License.
 #
 
-pkg.name: hw/drivers/mmc
-pkg.description: MMC interfaces
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
-
-pkg.deps.BUS_DRIVER_PRESENT:
-    - "@apache-mynewt-core/hw/bus/drivers/spi_common"
-
-pkg.init.MMC_AUTO_MOUNT:
-    mmc_pkg_init: MYNEWT_VAL(MMC_PKG_SYSINIT_STAGE)
+syscfg.defs:
+    MMC_SPI_NUM:
+        description: MMC SPI number.
+        value: 0
+    MMC_SPI_BUS_NAME:
+        description: MMC SPI device name for bus driver build.
+        value: '"spi0"'
+    MMC_SPI_FREQ:
+        description: SPI device frequency for MMC.
+        value: 25000
+    MMC_SPI_CS_PIN:
+        description: MMC SPI CS pin.
+        value: -1
+    MMC_DEV_NAME:
+        description: MMC SPI device name for bus driver build.
+        value: '"mmc"'
+    MMC_PKG_SYSINIT_STAGE:
+        description: Sysinit stage for MMC package.
+        value: 5
+    MMC_AUTO_MOUNT:
+        description: Try to mount disk at creation time.
+        value: 1


### PR DESCRIPTION
Bus driver support is needed for nrf53 but it
can be used with any MCU that has SPI driver
support (in contrast to just SPI HAL)