### PR TITLE
mcu/nrf5x: Update nrfx to version 2.11

### DIFF
--- a/hw/mcu/nordic/nrf5340/src/system_nrf5340.c
+++ b/hw/mcu/nordic/nrf5340/src/system_nrf5340.c
@@ -95,7 +95,7 @@ void SystemInit(void)
         /* Trimming of the device. Copy all the trimming values from FICR into the target addresses. Trim
          until one ADDR is not initialized. */
         uint32_t index = 0;
-        for (index = 0; index < 32ul && NRF_FICR_S->TRIMCNF[index].ADDR != (uint32_t *)0xFFFFFFFFul; index++){
+        for (index = 0; index < 32ul && NRF_FICR_S->TRIMCNF[index].ADDR != 0xFFFFFFFFul; index++){
             #if defined ( __ICCARM__ )
                 /* IAR will complain about the order of volatile pointer accesses. */
                 #pragma diag_suppress=Pa082

--- a/hw/mcu/nordic/nrf5340_net/src/system_nrf5340_net.c
+++ b/hw/mcu/nordic/nrf5340_net/src/system_nrf5340_net.c
@@ -57,7 +57,7 @@ void SystemInit(void)
     /* Trimming of the device. Copy all the trimming values from FICR into the target addresses. Trim
      until one ADDR is not initialized. */
     uint32_t index = 0;
-    for (index = 0; index < 32ul && NRF_FICR_NS->TRIMCNF[index].ADDR != (uint32_t *)0xFFFFFFFFul; index++){
+    for (index = 0; index < 32ul && NRF_FICR_NS->TRIMCNF[index].ADDR != 0xFFFFFFFFul; index++){
         #if defined ( __ICCARM__ )
             /* IAR will complain about the order of volatile pointer accesses. */
             #pragma diag_suppress=Pa082

--- a/hw/mcu/nordic/nrf91xx/include/nrfx9160_config.h
+++ b/hw/mcu/nordic/nrf91xx/include/nrfx9160_config.h
@@ -21,7 +21,7 @@
 #define NRFX9160_CONFIG_H__
 
 #include "syscfg/syscfg.h"
-#include "nrfx_config_nrf9160.h"
+#include "nrfx_config_nrf91.h"
 
 #ifndef NRFX_CLOCK_ENABLED
 #define NRFX_CLOCK_ENABLED 0

--- a/hw/mcu/nordic/nrf91xx/src/nrf91_clock.c
+++ b/hw/mcu/nordic/nrf91xx/src/nrf91_clock.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include "mcu/nrf91_hal.h"
 #include "nrfx.h"
-#include "nrfx_config_nrf9160.h"
+#include "nrfx_config_nrf91.h"
 
 static uint8_t nrf91_clock_hfxo_refcnt;
 

--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -58,7 +58,7 @@ pkg.deps:
 
 repository.nordic-nrfx:
     type: github
-    vers: v2.8.0-commit
+    vers: v2.11.0-commit
     branch: master
     user: NordicSemiconductor
     repo: nrfx


### PR DESCRIPTION
This is latest nrfx 2.X version.