### PR TITLE
repo: Add dependency to TinyUSB

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -143,3 +143,11 @@ repo.deps:
             mynewt_1_9_0_tag: 0.2.0
             mynewt_1_10_0_tag: 0.3.0
             mynewt_1_11_0_tag: 0.4.0
+
+    tinyusb:
+        type: github
+        user: hathach
+        repo: tinyusb
+        branch: master
+        vers:
+            master: 0-dev


### PR DESCRIPTION
User had to add dependecy to TinyUSB in project.yml. Now repository dependency is added.