### PR TITLE
bsp/pca10056: Allow to build with nRF52811 MCU

### DIFF
--- a/hw/bsp/nordic_pca10056/pkg.yml
+++ b/hw/bsp/nordic_pca10056/pkg.yml
@@ -28,8 +28,11 @@ pkg.keywords:
     - nordic
     - pca10056
 
-pkg.cflags:
+pkg.cflags.'MCU_TARGET=="nRF52840"':
     - '-DNRF52840_XXAA'
+
+pkg.cflags.'MCU_TARGET=="nRF52811"':
+    - '-DNRF52811_XXAA'
 
 pkg.cflags.HARDFLOAT:
     - -mfloat-abi=hard -mfpu=fpv4-sp-d16


### PR DESCRIPTION
nRF52811 doesn't come with own BSP and PCA10056 is expected to be used for development.