### PR TITLE
ci: Use RAT 0.15 for compliance check

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -46,8 +46,9 @@ jobs:
           fetch-depth: 0
       - name: Install Dependencies
         run: |
-             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/0.16-SNAPSHOT/apache-rat-0.16-20230807.065048-315.jar
-             mv apache-rat-0.16-20230807.065048-315.jar apache-rat.jar
+             wget https://dlcdn.apache.org//creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz
+             tar zxf apache-rat-0.15-bin.tar.gz apache-rat-0.15/apache-rat-0.15.jar
+             mv apache-rat-0.15/apache-rat-0.15.jar apache-rat.jar
       - name: check licensing
         run: |
              .github/check_license.py


### PR DESCRIPTION
RAT 0.16 will have support for SPDX but snapshots links are not permanent so for time being use 0.15.