### PR TITLE
mcu/nordic: Require LF clock source to be specified

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -101,6 +101,8 @@ syscfg.defs:
         description: >
             Selected source for low frequency clock (LFCLK).
         value:
+        restrictions:
+            - $notnull
         choices:
             - LFRC      # 32.768 kHz RC oscillator
             - LFXO      # 32.768 kHz crystal oscillator
@@ -143,3 +145,6 @@ syscfg.vals.XTAL_RC:
     MCU_LFCLK_SOURCE: LFRC
 syscfg.vals.XTAL_32768_SYNTH:
     MCU_LFCLK_SOURCE: LFSYNTH
+
+syscfg.restrictions.BLE_CONTROLLER:
+    - 'MCU_LFCLK_SOURCE != "LFRC"'

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -58,6 +58,8 @@ syscfg.defs:
         description: >
             Selected source for low frequency clock (LFCLK).
         value:
+        restrictions:
+            - $notnull
         choices:
             - LFRC      # 32.768 kHz RC oscillator
             - LFXO      # 32.768 kHz crystal oscillator
@@ -500,3 +502,6 @@ syscfg.restrictions:
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"
     - "!UART_1 || (UART_1_PIN_TX && UART_1_PIN_RX)"
     - "(OS_TICKS_PER_SEC == 128 || OS_TICKS_PER_SEC == 256 || OS_TICKS_PER_SEC == 512 || OS_TICKS_PER_SEC == 1024)"
+
+syscfg.restrictions.BLE_CONTROLLER:
+    - 'MCU_LFCLK_SOURCE != "LFRC"'

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -50,6 +50,8 @@ syscfg.defs:
         description: >
             Selected source for low frequency clock (LFCLK).
         value:
+        restrictions:
+            - $notnull
         choices:
             - LFRC      # 32.768 kHz RC oscillator
             - LFXO      # 32.768 kHz crystal oscillator

--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -42,6 +42,8 @@ syscfg.defs:
         description: >
             Selected source for low frequency clock (LFCLK).
         value:
+        restrictions:
+            - $notnull
         choices:
             - LFRC      # 32.768 kHz RC oscillator
             - LFXO      # 32.768 kHz crystal oscillator
@@ -158,3 +160,6 @@ syscfg.vals:
 
 syscfg.restrictions:
     - "!UART_0 || (UART_0_PIN_TX && UART_0_PIN_RX)"
+
+syscfg.restrictions.BLE_CONTROLLER:
+    - 'MCU_LFCLK_SOURCE != "LFRC"'

--- a/hw/mcu/nordic/nrf91xx/syscfg.yml
+++ b/hw/mcu/nordic/nrf91xx/syscfg.yml
@@ -43,6 +43,8 @@ syscfg.defs:
         description: >
             Selected source for low frequency clock (LFCLK).
         value:
+        restrictions:
+            - $notnull
         choices:
             - LFRC      # 32.768 kHz RC oscillator
             - LFXO      # 32.768 kHz crystal oscillator


### PR DESCRIPTION
This is typically specified by BSP and omitting to do so is an error.