### PR TITLE
Fix build error with arm gcc 12.3.1

### DIFF
--- a/hw/mcu/nordic/include/nrfx_glue.h
+++ b/hw/mcu/nordic/include/nrfx_glue.h
@@ -67,7 +67,7 @@ extern "C" {
  *
  * @param expression  Expression to evaluate.
  */
-#define NRFX_STATIC_ASSERT(expression) static_assert(expression, "")
+#define NRFX_STATIC_ASSERT(expression) _Static_assert(expression, "")
 
 //------------------------------------------------------------------------------
 

--- a/libc/baselibc/include/assert.h
+++ b/libc/baselibc/include/assert.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #if !defined __cplusplus
 #define static_assert _Static_assert
+#elif !defined _Static_assert
+#define _Static_assert static_assert
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
While trying to build with arm-none-eabi-gcc version 12.3.1 and setting LIBC: nano, the compiler did not recognise static_assert.