### PR TITLE
stm32f1/spi: Add definition missing from HAL

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_spi.c
+++ b/hw/mcu/stm/stm32_common/src/hal_spi.c
@@ -39,6 +39,15 @@
 
 #define STM32_HAL_SPI_MAX (6)
 
+#if defined(STM32F1) && !defined(HAL_SPI_ERROR_FRE)
+/*
+ * For some reason HAL_SPI_ERROR_FRE is not defined for STM32F1.
+ * It seems that it used to be. Definition is taken from STM32F0 since
+ * register bit accessed the same as in very other STM32 MCU.
+ */
+#define HAL_SPI_ERROR_FRE               (0x00000008U)   /*!< FRE error                              */
+#endif
+
 extern HAL_StatusTypeDef HAL_SPI_QueueTransmit(SPI_HandleTypeDef *hspi,
         uint8_t *pData, uint16_t Size);
 


### PR DESCRIPTION
It seems that HAL_SPI_ERROR_FRE was defined is some previous versions of HAL for STMF1.
Now it's gone but register bit is still there and there is not Errata stating that bit should not be touched.

SPI block is shared among all STM products and all of them have this UDR bit that is mapped to HAL_SPI_ERROR_FRE in ST HAL.

Without this change HAL SPI will not build for STM32F1 devices.