### PR TITLE
lvgl: Display driver optimizations

### DIFF
--- a/hw/drivers/display/lcd_itf/include/lcd_itf.h
+++ b/hw/drivers/display/lcd_itf/include/lcd_itf.h
@@ -96,6 +96,6 @@ void lcd_itf_init(void);
 
 /* Function implemented by LCD interface driver */
 void lcd_ift_write_cmd(const uint8_t *cmd, int cmd_length);
-void lcd_itf_write_color_data(const void *data, size_t size);
+void lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels);
 
 #endif /* LCD_ITF_H */

--- a/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
+++ b/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
@@ -91,9 +91,10 @@ lcd_itf_write_bytes(const uint8_t *bytes, size_t size)
 }
 
 void
-lcd_itf_write_color_data(const void *pixels, size_t size)
+lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels)
 {
     const uint16_t *data = (const uint16_t *)pixels;
+    size_t size = (x2 - x1 + 1) * (y2 - y1 + 1) * 2;
 
     LCD_DC_PIN_DATA();
     LCD_CS_PIN_ACTIVE();

--- a/hw/drivers/display/lcd_itf/itf_lcd_da1469x/pkg.yml
+++ b/hw/drivers/display/lcd_itf/itf_lcd_da1469x/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/drivers/display/lcd_itf/itf_lcd_da1469x
+pkg.description: LCD controller
+pkg.keywords:
+    - display
+
+pkg.apis:
+    - lcd_interface
+
+pkg.deps:

--- a/hw/drivers/display/lcd_itf/itf_lcd_da1469x/src/itf_lcd_da1469x.c
+++ b/hw/drivers/display/lcd_itf/itf_lcd_da1469x/src/itf_lcd_da1469x.c
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <bsp/bsp.h>
+#include <hal/hal_gpio.h>
+#include <bus/drivers/spi_common.h>
+
+#include <lv_conf.h>
+#include <misc/lv_color.h>
+#include <lcd_itf.h>
+
+static uint16_t display_resx;
+static uint16_t display_resy;
+
+void
+lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels)
+{
+    uint16_t width = 1 + x2 - x1;
+    uint16_t height = 1 + y2 - y1;
+
+    LCDC->LCDC_LAYER0_BASEADDR_REG = (uint32_t)pixels;
+    LCDC->LCDC_RESXY_REG = (width << 16) | height;
+    LCDC->LCDC_LAYER0_OFFSETX_REG = 0;
+    LCDC->LCDC_LAYER0_SIZEXY_REG = (width << 16) | height;
+    LCDC->LCDC_LAYER0_RESXY_REG = (width << 16) | height;
+    LCDC->LCDC_LAYER0_STRIDE_REG = width * sizeof(lv_color_t);
+    LCDC->LCDC_LAYER0_MODE_REG = LCDC_LCDC_LAYER0_MODE_REG_LCDC_L0_EN_Msk | 5;
+    LCDC->LCDC_MODE_REG |= LCDC_LCDC_MODE_REG_LCDC_SFRAME_UPD_Msk;
+    /* Dummy read, it looks like busy status may not be there on the first read */
+    (void)LCDC->LCDC_STATUS_REG;
+    while ((LCDC->LCDC_STATUS_REG & LCDC_LCDC_STATUS_REG_LCDC_FRAMEGEN_BUSY_Msk));
+}
+
+void
+lcd_ift_write_cmd(const uint8_t *cmd, int cmd_length)
+{
+    int i;
+    uint32_t cmd_bit = LCDC_LCDC_DBIB_CMD_REG_LCDC_DBIB_CMD_SEND_Msk;
+
+    for (i = 0; i < cmd_length; ++i) {
+        if (((LCDC->LCDC_DBIB_CFG_REG & (LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI_HOLD_Msk |
+                                         LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI4_EN_Msk)) !=
+             LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI4_EN_Msk) ||
+            (LCDC->LCDC_DBIB_CMD_REG & LCDC_LCDC_DBIB_CMD_REG_LCDC_DBIB_CMD_SEND_Msk) == cmd_bit) {
+            while (LCDC->LCDC_STATUS_REG & LCDC_LCDC_STATUS_REG_LCDC_DBIB_CMD_FIFO_FULL_Msk);
+        } else {
+            while (LCDC->LCDC_STATUS_REG & LCDC_LCDC_STATUS_REG_LCDC_DBIB_CMD_PENDING_Msk);
+        }
+
+        LCDC->LCDC_DBIB_CMD_REG = cmd_bit | cmd[i];
+        cmd_bit = 0;
+    }
+}
+
+
+void
+lcd_itf_init(void)
+{
+    CRG_SYS->CLK_SYS_REG |= CRG_SYS_CLK_SYS_REG_LCD_ENABLE_Msk |
+                            CRG_SYS_CLK_SYS_REG_LCD_CLK_SEL_Msk;
+
+    /* Device without LCD controller DA14691 does not have magic number at this address */
+    if (LCDC->LCDC_IDREG_REG != 0x87452365) {
+        assert(0);
+        return;
+    }
+
+    display_resx = 240;
+    display_resy = 320;
+
+    if (MYNEWT_VAL(LCD_DC_PIN) >= 0) {
+        mcu_gpio_set_pin_function(MYNEWT_VAL(LCD_DC_PIN), MCU_GPIO_MODE_OUTPUT, MCU_GPIO_FUNC_LCD_SPI_DC);
+    }
+    if (MYNEWT_VAL(LCD_CS_PIN) >= 0) {
+        mcu_gpio_set_pin_function(MYNEWT_VAL(LCD_CS_PIN), MCU_GPIO_MODE_OUTPUT, MCU_GPIO_FUNC_LCD_SPI_EN);
+    }
+    if (MYNEWT_VAL(LCD_MOSI_PIN) >= 0) {
+        mcu_gpio_set_pin_function(MYNEWT_VAL(LCD_MOSI_PIN), MCU_GPIO_MODE_OUTPUT, MCU_GPIO_FUNC_LCD_SPI_DO);
+    }
+    if (MYNEWT_VAL(LCD_SCLK_PIN) >= 0) {
+        mcu_gpio_set_pin_function(MYNEWT_VAL(LCD_SCLK_PIN), MCU_GPIO_MODE_OUTPUT, MCU_GPIO_FUNC_LCD_SPI_CLK);
+    }
+
+    uint32_t clk_sys_reg = CRG_SYS->CLK_SYS_REG &
+                           ~(CRG_SYS_CLK_SYS_REG_LCD_RESET_REQ_Msk | CRG_SYS_CLK_SYS_REG_LCD_CLK_SEL_Msk |
+                             CRG_SYS_CLK_SYS_REG_LCD_ENABLE_Msk);
+    CRG_SYS->CLK_SYS_REG = clk_sys_reg | CRG_SYS_CLK_SYS_REG_LCD_RESET_REQ_Msk;
+    CRG_SYS->CLK_SYS_REG = clk_sys_reg | CRG_SYS_CLK_SYS_REG_LCD_ENABLE_Msk | CRG_SYS_CLK_SYS_REG_LCD_CLK_SEL_Msk;
+
+    LCDC->LCDC_CLKCTRL_REG = (4 << 8) | 2; /* TODO: calculate divider */
+    LCDC->LCDC_CLKCTRL_REG = 0x401;
+    LCDC->LCDC_MODE_REG = 0;
+    while (LCDC->LCDC_STATUS_REG & LCDC_LCDC_STATUS_REG_LCDC_DBIB_CMD_FIFO_FULL_Msk);
+    LCDC->LCDC_DBIB_CFG_REG =
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI4_EN_Msk |
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_DMA_EN_Msk |
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_TE_DIS_Msk |
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_RESX_Msk |
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI_CPHA_Msk |
+        LCDC_LCDC_DBIB_CFG_REG_LCDC_DBIB_SPI_CPOL_Msk |
+        0x12 /* RGB565 */;
+    /* RGB565 */
+    LCDC->LCDC_RESXY_REG = (240 << 16) | 320;
+    LCDC->LCDC_FRONTPORCHXY_REG = (240 << 16) | 320;
+    LCDC->LCDC_BLANKINGXY_REG = (240 << 16) | 321;
+    LCDC->LCDC_BACKPORCHXY_REG = (240 << 16) | 321;
+    LCDC->LCDC_LAYER0_MODE_REG = LCDC_LCDC_LAYER0_MODE_REG_LCDC_L0_EN_Msk | 5;
+}

--- a/hw/drivers/display/lcd_itf/itf_lcd_da1469x/syscfg.yml
+++ b/hw/drivers/display/lcd_itf/itf_lcd_da1469x/syscfg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    LCD_MOSI_PIN:
+        description: >
+            LCD MOSI pin.
+        value: -1
+    LCD_SCLK_PIN:
+        description: >
+            LCD CLK pin.
+        value: -1
+
+syscfg.restrictions:
+    - LV_DISP_X_ALIGN == 1

--- a/hw/drivers/display/lcd_itf/itf_spi/src/itf_spi.c
+++ b/hw/drivers/display/lcd_itf/itf_spi/src/itf_spi.c
@@ -38,10 +38,11 @@ static uint8_t *lv_color_16_swap_buffer;
 static size_t lv_color_16_swap_buffer_size;
 
 void
-lcd_itf_write_color_data(const void *pixels, size_t size)
+lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels)
 {
     const void *color_data = pixels;
     size_t i;
+    size_t size = (x2 - x1 + 1) * (y2 - y1 + 1) * 2;
 
     LCD_DC_PIN_DATA();
     LCD_CS_PIN_ACTIVE();

--- a/hw/drivers/display/lvgl/default/lv_conf.h
+++ b/hw/drivers/display/lvgl/default/lv_conf.h
@@ -40,10 +40,10 @@
  *=========================*/
 
 /*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
-#define LV_MEM_CUSTOM 0
+#define LV_MEM_CUSTOM MYNEWT_VAL(LV_MEM_CUSTOM)
 #if LV_MEM_CUSTOM == 0
     /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (MYNEWT_VAL(LV_MEM_SIZE))          /*[bytes]*/
 
     /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
     #define LV_MEM_ADR 0     /*0: unused*/

--- a/hw/drivers/display/lvgl/src/mynewt_lvgl.c
+++ b/hw/drivers/display/lvgl/src/mynewt_lvgl.c
@@ -50,6 +50,7 @@ init_lv_timer(void)
     os_callout_reset(&lv_callout, lv_timer_period);
 }
 
+#define DISP_DRAW_BUF_LINES MYNEWT_VAL(LV_DISP_DRAW_BUF_LINES)
 /* A static or global variable to store the buffers */
 static lv_disp_draw_buf_t disp_buf;
 /* A variable to hold the drivers. Must be static or global. */
@@ -57,8 +58,36 @@ static lv_disp_drv_t disp_drv;
 #define DISP_HOR_RES MYNEWT_VAL(LVGL_DISPLAY_HORIZONTAL_RESOLUTION)
 #define DISP_VERT_RES MYNEWT_VAL(LVGL_DISPLAY_VERTICAL_RESOLUTION)
 /* Static or global buffer(s). The second buffer is optional */
-static lv_color_t buf_1[DISP_HOR_RES * 10];
-static lv_color_t buf_2[DISP_HOR_RES * 10];
+static lv_color_t buf_1[DISP_HOR_RES * DISP_DRAW_BUF_LINES];
+#if MYNEWT_VAL(LV_DISP_DOUBLE_BUFFER)
+static lv_color_t buf_2[DISP_HOR_RES * DISP_DRAW_BUF_LINES];
+#else
+#define buf_2 NULL
+#endif
+
+/** Extend the invalidated areas to match with the display drivers requirements
+ * E.g. round `y` to, 8, 16 ..) on a monochrome display*/
+static void
+mynewt_lv_rounder(struct _lv_disp_drv_t *driver, lv_area_t *area)
+{
+    (void)driver;
+    uint32_t mask;
+
+    if (MYNEWT_VAL(LV_DISP_X_ALIGN)) {
+        mask = (1 << MYNEWT_VAL(LV_DISP_X_ALIGN)) - 1;
+        /* Clear left side bits */
+        area->x1 &= ~mask;
+        /* Set right side bits */
+        area->x2 |= mask;
+    }
+    if (MYNEWT_VAL(LV_DISP_Y_ALIGN)) {
+        mask = (1 << MYNEWT_VAL(LV_DISP_Y_ALIGN)) - 1;
+        /* Clear top side bits */
+        area->y1 &= ~mask;
+        /* Set bottom side bits */
+        area->y2 |= mask;
+    }
+}
 
 void
 mynewt_lv_init(void)
@@ -70,11 +99,14 @@ mynewt_lv_init(void)
     lv_init();
 
     /*Initialize `disp_buf` with the buffer(s). With only one buffer use NULL instead buf_2 */
-    lv_disp_draw_buf_init(&disp_buf, buf_1, buf_2, DISP_HOR_RES * 10);
+    lv_disp_draw_buf_init(&disp_buf, buf_1, buf_2, DISP_HOR_RES * DISP_DRAW_BUF_LINES);
     lv_disp_drv_init(&disp_drv);            /* Basic initialization */
     disp_drv.draw_buf = &disp_buf;          /* Set an initialized buffer */
     disp_drv.hor_res = DISP_HOR_RES;        /* Set the horizontal resolution in pixels */
     disp_drv.ver_res = DISP_VERT_RES;       /* Set the vertical resolution in pixels */
+    if (MYNEWT_VAL(LV_DISP_X_ALIGN) || MYNEWT_VAL(LV_DISP_Y_ALIGN)) {
+        disp_drv.rounder_cb = mynewt_lv_rounder;
+    }
 
     mynewt_lv_drv_init(&disp_drv);
 

--- a/hw/drivers/display/lvgl/syscfg.yml
+++ b/hw/drivers/display/lvgl/syscfg.yml
@@ -164,3 +164,35 @@ syscfg.defs:
     LV_USE_DEMO_WIDGETS:
         description: Enable Widgets demo.
         value: 1
+
+    LV_MEM_CUSTOM:
+        description: >
+            If set to 1 malloc/free/realloc is used by lvgl library instead of
+            lv_mem_free/lv_mem_alloc.
+        value: 0
+    LV_MEM_SIZE:
+        description: >
+            Size of the memory available for `lv_malloc()` in bytes.
+        value: 49152
+    LV_DISP_DRAW_BUF_LINES:
+        description: >
+            Number of line for buffer usd for drawing portion of the screen.
+        value: 10
+    LV_DISP_DOUBLE_BUFFER:
+        description: >
+            Enable double buffer when LCD interface has asynchronous write more.
+            It should be set to 1 one DMA is used for transferring color data to
+            display.
+        value: 0
+    LV_DISP_X_ALIGN:
+        description: >
+            Display driver X alignment requirement in bits.
+            If set to 0 display driver can draw pixels at any point.
+            If set to value grater than 0 X pixel coordinates will be rounded.
+        value: 0
+    LV_DISP_Y_ALIGN:
+        description: >
+            Display driver Y alignment requirement in bits.
+            If set to 0 display driver can draw pixels at any point.
+            If set to value grater than 0 X pixel coordinates will be rounded.
+        value: 0

--- a/hw/drivers/display/lvgl/tft/gc9a01/src/gc9a01.c
+++ b/hw/drivers/display/lvgl/tft/gc9a01/src/gc9a01.c
@@ -204,8 +204,6 @@ gc9a01_drv_update(struct _lv_disp_drv_t *drv)
 void
 gc9a01_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    int32_t y;
-    lv_coord_t w;
     uint8_t cmd[5];
 
     if (area->x2 < 0 || area->y2 < 0 || area->x1 >= GC9A01_HOR_RES || area->y1 >= GC9A01_VER_RES) {
@@ -218,8 +216,6 @@ gc9a01_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     int32_t act_y1 = area->y1 < 0 ? 0 : area->y1;
     int32_t act_x2 = area->x2 >= GC9A01_HOR_RES ? GC9A01_HOR_RES - 1 : area->x2;
     int32_t act_y2 = area->y2 >= GC9A01_VER_RES ? GC9A01_VER_RES - 1 : area->y2;
-
-    w = lv_area_get_width(area);
 
     /* Column address */
     cmd[0] = GC9A01_CASET;
@@ -240,10 +236,7 @@ gc9a01_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     cmd[0] = GC9A01_RAMWR;
     lcd_ift_write_cmd(cmd, 1);
 
-    for (y = act_y1; y <= act_y2; y++) {
-        lcd_itf_write_color_data(color_p, w * sizeof(*color_p));
-        color_p += w;
-    }
+    lcd_itf_write_color_data(act_x1, act_x2, act_y1, act_y2, color_p);
 
     lv_disp_flush_ready(drv);
 }

--- a/hw/drivers/display/lvgl/tft/ili9341/src/ili9341.c
+++ b/hw/drivers/display/lvgl/tft/ili9341/src/ili9341.c
@@ -206,9 +206,7 @@ ili9341_drv_update(struct _lv_disp_drv_t *drv)
 void
 ili9341_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    int32_t y;
     uint8_t cmd[5];
-    lv_coord_t w;
 
     if (area->x2 < 0 || area->y2 < 0 || area->x1 >= ILI9341_HOR_RES || area->y1 >= ILI9341_VER_RES) {
         lv_disp_flush_ready(drv);
@@ -220,8 +218,6 @@ ili9341_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     int32_t act_y1 = area->y1 < 0 ? 0 : area->y1;
     int32_t act_x2 = area->x2 >= ILI9341_HOR_RES ? ILI9341_HOR_RES - 1 : area->x2;
     int32_t act_y2 = area->y2 >= ILI9341_VER_RES ? ILI9341_VER_RES - 1 : area->y2;
-
-    w = lv_area_get_width(area);
 
     /* Column address */
     cmd[0] = ILI9341_CASET;
@@ -242,10 +238,7 @@ ili9341_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     cmd[0] = ILI9341_RAMWR;
     lcd_ift_write_cmd(cmd, 1);
 
-    for (y = act_y1; y <= act_y2; y++) {
-        lcd_itf_write_color_data(color_p, w * sizeof(*color_p));
-        color_p += w;
-    }
+    lcd_itf_write_color_data(act_x1, act_x2, act_y1, act_y2, color_p);
 
     lv_disp_flush_ready(drv);
 }

--- a/hw/drivers/display/lvgl/tft/ili9486/src/ili9486.c
+++ b/hw/drivers/display/lvgl/tft/ili9486/src/ili9486.c
@@ -189,8 +189,6 @@ ili9486_drv_update(struct _lv_disp_drv_t *drv)
 void
 ili9486_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    int32_t y;
-    lv_coord_t w;
     uint8_t cmd[5];
 
     if (area->x2 < 0 || area->y2 < 0 || area->x1 >= ILI9486_HOR_RES || area->y1 >= ILI9486_VER_RES) {
@@ -203,8 +201,6 @@ ili9486_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     int32_t act_y1 = area->y1 < 0 ? 0 : area->y1;
     int32_t act_x2 = area->x2 >= ILI9486_HOR_RES ? ILI9486_HOR_RES - 1 : area->x2;
     int32_t act_y2 = area->y2 >= ILI9486_VER_RES ? ILI9486_VER_RES - 1 : area->y2;
-
-    w = lv_area_get_width(area);
 
     /* Column address */
     cmd[0] = ILI9486_CASET;
@@ -225,10 +221,7 @@ ili9486_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     cmd[0] = ILI9486_RAMWR;
     lcd_ift_write_cmd(cmd, 1);
 
-    for (y = act_y1; y <= act_y2; y++) {
-        lcd_itf_write_color_data(color_p, w * sizeof(*color_p));
-        color_p += w;
-    }
+    lcd_itf_write_color_data(act_x1, act_x2, act_y1, act_y2, color_p);
 
     lv_disp_flush_ready(drv);
 }

--- a/hw/drivers/display/lvgl/tft/st7735s/src/st7735s.c
+++ b/hw/drivers/display/lvgl/tft/st7735s/src/st7735s.c
@@ -182,8 +182,6 @@ st7735s_drv_update(struct _lv_disp_drv_t *drv)
 void
 st7735s_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    int32_t y;
-    lv_coord_t w;
     uint8_t cmd[5];
 
     if (area->x2 < 0 || area->y2 < 0 || area->x1 >= ST7735S_HOR_RES || area->y1 >= ST7735S_VER_RES) {
@@ -196,8 +194,6 @@ st7735s_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     int32_t act_y1 = area->y1 < 0 ? 0 : area->y1;
     int32_t act_x2 = area->x2 >= ST7735S_HOR_RES ? ST7735S_HOR_RES - 1 : area->x2;
     int32_t act_y2 = area->y2 >= ST7735S_VER_RES ? ST7735S_VER_RES - 1 : area->y2;
-
-    w = lv_area_get_width(area);
 
     /* Column address */
     cmd[0] = ST7735S_CASET;
@@ -218,10 +214,7 @@ st7735s_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     cmd[0] = ST7735S_RAMWR;
     lcd_ift_write_cmd(cmd, 1);
 
-    for (y = act_y1; y <= act_y2; y++) {
-        lcd_itf_write_color_data(color_p, w * sizeof(*color_p));
-        color_p += w;
-    }
+    lcd_itf_write_color_data(act_x1, act_x2, act_y1, act_y2, color_p);
 
     lv_disp_flush_ready(drv);
 }

--- a/hw/drivers/display/lvgl/tft/st7789/src/st7789.c
+++ b/hw/drivers/display/lvgl/tft/st7789/src/st7789.c
@@ -208,8 +208,6 @@ st7789_drv_update(struct _lv_disp_drv_t *drv)
 void
 st7789_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    int32_t y;
-    lv_coord_t w;
     uint8_t cmd[5];
 
     /* Truncate the area to the screen */
@@ -250,8 +248,6 @@ st7789_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 #endif
 #endif
 
-    w = lv_area_get_width(area);
-
     /* Column addresses */
     cmd[0] = ST7789_CASET;
     cmd[1] = (uint8_t)(offsetx1 >> 8);
@@ -271,10 +267,7 @@ st7789_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
     cmd[0] = ST7789_RAMWR;
     lcd_ift_write_cmd(cmd, 1);
 
-    for (y = offsety1; y <= offsety2; y++) {
-        lcd_itf_write_color_data(color_p, w * sizeof(*color_p));
-        color_p += w;
-    }
+    lcd_itf_write_color_data(offsetx1, offsetx2, offsety1, offsety2, color_p);
 
     lv_disp_flush_ready(drv);
 }


### PR DESCRIPTION
This adds several syscfg values that tweak LVGL build.
LV_DISP_DRAW_BUF_LINES (default 10) specifies buffer size in lines.
Increasing this number can reduce drawing time but uses more memory.
LV_DISP_DOUBLE_BUFFER - when set, allows display driver to draw
pixel asynchronously (with DMA). Currently no driver utilizes this.
LV_DISP_X_ALIGN/LV_DISP_Y_ALIGN - can specify minimum pixel alignment
required by display driver. Currently only DA1469X LCD driver requires
LV_DISP_X_ALIGN to be 1. Increasing this number forces LVGL to draw more
pixels that library needs.

LV_MEM_SIZE allows to reduce (or increase) memory used internally by LVGL.
Default value is 48kB but can now be change in syscfg.

LV_MEM_CUSTOM allows to use libc malloc/free/realloc instead of version
provided by LVGL.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>