### PR TITLE
sys/config: fix CONF_FLOAT

### DIFF
--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -228,9 +228,6 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
         if (*eptr != '\0') {
             goto err;
         }
-        if ((fval < FLT_MIN) || (fval > FLT_MAX)) {
-            goto err;
-        }
         *(float *)vp = fval;
         break;
     case CONF_STRING:


### PR DESCRIPTION
The check in conf_value_from_str for CONF_FLOAT is incorrect. FLT_MIN is not the smallest negative float; it is the smallest positive float. Removing the check for min/max value as it is not needed in this case.