### PR TITLE
bsp/pinetime: Add missing include file

### DIFF
--- a/hw/bsp/pinetime/include/bsp/bsp.h
+++ b/hw/bsp/pinetime/include/bsp/bsp.h
@@ -20,6 +20,8 @@
 #ifndef H_BSP_
 #define H_BSP_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
uint8_t was used without stdint.h being included.