### PR TITLE
sys/log: Add option to make the global log index increment sequentially

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -540,7 +540,18 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
 
     OS_ENTER_CRITICAL(sr);
 #if MYNEWT_VAL(LOG_GLOBAL_IDX)
+#if MYNEWT_VAL(LOG_SEQUENTIAL_IDX)
+    /*
+     * Avoid incrementing the global index for streamed logs in
+     * order to keep it sequentially increasing for persisted logs.
+     */
+    if (log->l_log->log_type != LOG_TYPE_STREAM) {
+        g_log_info.li_next_index++;
+    }
+    idx = g_log_info.li_next_index;
+#else
     idx = g_log_info.li_next_index++;
+#endif
 #else
     idx = log->l_idx++;
 #endif

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -70,6 +70,9 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
                        ueh->ue_imghash[2], ueh->ue_imghash[3]);
     }
     console_printf(" [%llu] ", ueh->ue_ts);
+#if MYNEWT_VAL(LOG_SHELL_SHOW_INDEX)
+    console_printf(" [ix=%lu] ", ueh->ue_index);
+#endif
 
     switch (ueh->ue_etype) {
     case LOG_ETYPE_STRING:

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -69,6 +69,10 @@ syscfg.defs:
         restrictions:
             - SHELL_TASK
 
+    LOG_SHELL_SHOW_INDEX:
+        description: '"log" command shows log index when dumping entries'
+        value: 0
+
     LOG_MGMT:
         description: 'Expose "log" command in mgmt.'
         value: 0

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -145,5 +145,11 @@ syscfg.defs:
             Max entry length that can be copied from one fcb log to another.
         value: 256
 
+    LOG_SEQUENTIAL_IDX:
+        description: >
+            Don't increment the global index for LOG_STREAM_TYPE. This allows
+            the global index to be sequentially increasing for persisted logs.
+        value: 0
+
 syscfg.vals.LOG_NEWTMGR:
     LOG_MGMT: MYNEWT_VAL(LOG_MGMT)


### PR DESCRIPTION
Adds a syscfg `LOG_SEQUENTIAL_IDX`. When enabled the global log index won't be incremented when adding logs of `LOG_TYPE_STREAM` which are not persisted (e.g. console logs). 

The global index is only useful for persisted logs, and if it is incremented for non-persisted logs there will be jumps in the log indexes of the persisted logs. This makes detection of missing logs a challenging task. By incrementing the global index only for persisted logs, it becomes sequentially increasing, which makes detection of missing/dropped logs trivial for upstream consumers of the logs.

This PR also adds a syscfg `LOG_SHELL_SHOW_INDEX` to enable displaying the log index in the 'log' shell command output. 
