### PR TITLE
tinyusb: Add TinyUSB sdk package with repository

### DIFF
--- a/hw/usb/tinyusb/cdc/pkg.yml
+++ b/hw/usb/tinyusb/cdc/pkg.yml
@@ -28,4 +28,3 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb"
-    - "@tinyusb/tinyusb"

--- a/hw/usb/tinyusb/cdc_console/pkg.yml
+++ b/hw/usb/tinyusb/cdc_console/pkg.yml
@@ -30,7 +30,6 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb"
     - "@apache-mynewt-core/hw/usb/tinyusb/cdc"
-    - "@tinyusb/tinyusb"
 
 pkg.init:
     usb_cdc_console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'

--- a/hw/usb/tinyusb/da146xx/pkg.yml
+++ b/hw/usb/tinyusb/da146xx/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/dfu/pkg.yml
+++ b/hw/usb/tinyusb/dfu/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb"
-    - "@tinyusb/tinyusb"
     - "@apache-mynewt-core/mgmt/imgmgr"
     - "@mcuboot/boot/bootutil"
 

--- a/hw/usb/tinyusb/nrf53/pkg.yml
+++ b/hw/usb/tinyusb/nrf53/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/nrf5x/pkg.yml
+++ b/hw/usb/tinyusb/nrf5x/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/pic32mz/pkg.yml
+++ b/hw/usb/tinyusb/pic32mz/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -31,7 +31,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb/tinyusb_sdk"
 
 pkg.init.OS_SCHEDULING:
     tinyusb_start: 'MYNEWT_VAL(USBD_SYSINIT_STAGE)'
@@ -64,3 +64,4 @@ pkg.deps.USBD_DFU_STD:
     - "@apache-mynewt-core/hw/usb/tinyusb/dfu"
 pkg.req_apis:
     - TINYUSB_HW_INIT
+

--- a/hw/usb/tinyusb/stm32_fsdev/pkg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/stm32_fsdev/stm32l0/pkg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32l0/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/stm32_fsdev/stm32wb55/pkg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32wb55/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/synopsys/pkg.yml
+++ b/hw/usb/tinyusb/synopsys/pkg.yml
@@ -30,4 +30,4 @@ pkg.apis:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@tinyusb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
+++ b/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
@@ -17,24 +17,27 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb/msc_fat_view
-pkg.description: USB MSC protocol that exposes virtual FAT disk
+pkg.name: hw/usb/tinyusb/tinyusb_sdk
+pkg.description: Package including TinyUSB sdk
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
+pkg.homepage: "https://mynewt.apache.org/"
 pkg.keywords:
-    - msc
     - usb
 
+pkg.type: sdk
+
 pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/hw/usb/tinyusb"
-    - "@apache-mynewt-core/mgmt/imgmgr"
-    - "@apache-mynewt-core/sys/coredump"
-    - "@mcuboot/boot/bootutil"
 
-pkg.init.!BOOT_LOADER:
-    msc_fat_view_pkg_init: $before:tinyusb_start
+pkg.include_dirs:
+    - "@tinyusb/src"
 
-pkg.init.MSC_FAT_VIEW_COREDUMP_FILES:
-    msc_fat_view_coredump_pkg_init: $before:msc_fat_view_pkg_init
+pkg.source_dirs:
+    - "@tinyusb/src"
+
+repository.tinyusb:
+    type: github
+    branch: master
+    vers: 0.15.0-commit
+    user: hathach
+    repo: tinyusb


### PR DESCRIPTION
With this change there is no need to add TinyUSB to project.yml

alternative to #3056 