### PR TITLE
lvgl: Add backlight pin active level

### DIFF
--- a/hw/drivers/display/lcd_itf/syscfg.yml
+++ b/hw/drivers/display/lcd_itf/syscfg.yml
@@ -36,6 +36,9 @@ syscfg.defs:
     LCD_BL_PIN:
         description: LCD backlight pin.
         value: -1
+    LCD_BL_PIN_ACTIVE_LEVEL:
+        description: Value for LCD_BL_PIN to turn backlight on.
+        value: 1
     LCD_RESET_PIN:
         description: LCD command/data pin for SPI or parallel port.
         value: -1

--- a/hw/drivers/display/lvgl/tft/gc9a01/src/gc9a01.c
+++ b/hw/drivers/display/lvgl/tft/gc9a01/src/gc9a01.c
@@ -245,7 +245,7 @@ void
 mynewt_lv_drv_init(lv_disp_drv_t *driver)
 {
     if (MYNEWT_VAL(LCD_BL_PIN) >= 0) {
-        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), 1);
+        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), MYNEWT_VAL(LCD_BL_PIN_ACTIVE_LEVEL));
     }
     if (MYNEWT_VAL(LCD_RESET_PIN) >= 0) {
         hal_gpio_init_out(MYNEWT_VAL(LCD_RESET_PIN), 1);

--- a/hw/drivers/display/lvgl/tft/ili9341/src/ili9341.c
+++ b/hw/drivers/display/lvgl/tft/ili9341/src/ili9341.c
@@ -247,7 +247,7 @@ void
 mynewt_lv_drv_init(lv_disp_drv_t *driver)
 {
     if (MYNEWT_VAL(LCD_BL_PIN) >= 0) {
-        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), 1);
+        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), MYNEWT_VAL(LCD_BL_PIN_ACTIVE_LEVEL));
     }
     if (MYNEWT_VAL(LCD_RESET_PIN) >= 0) {
         hal_gpio_init_out(MYNEWT_VAL(LCD_RESET_PIN), 1);

--- a/hw/drivers/display/lvgl/tft/ili9486/src/ili9486.c
+++ b/hw/drivers/display/lvgl/tft/ili9486/src/ili9486.c
@@ -230,7 +230,7 @@ void
 mynewt_lv_drv_init(lv_disp_drv_t *driver)
 {
     if (MYNEWT_VAL(LCD_BL_PIN) >= 0) {
-        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), 1);
+        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), MYNEWT_VAL(LCD_BL_PIN_ACTIVE_LEVEL));
     }
     if (MYNEWT_VAL(LCD_RESET_PIN) >= 0) {
         hal_gpio_init_out(MYNEWT_VAL(LCD_RESET_PIN), 1);

--- a/hw/drivers/display/lvgl/tft/st7735s/src/st7735s.c
+++ b/hw/drivers/display/lvgl/tft/st7735s/src/st7735s.c
@@ -223,7 +223,7 @@ void
 mynewt_lv_drv_init(lv_disp_drv_t *driver)
 {
     if (MYNEWT_VAL(LCD_BL_PIN) >= 0) {
-        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), 1);
+        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), MYNEWT_VAL(LCD_BL_PIN_ACTIVE_LEVEL));
     }
     if (MYNEWT_VAL(LCD_RESET_PIN) >= 0) {
         hal_gpio_init_out(MYNEWT_VAL(LCD_RESET_PIN), 1);

--- a/hw/drivers/display/lvgl/tft/st7789/src/st7789.c
+++ b/hw/drivers/display/lvgl/tft/st7789/src/st7789.c
@@ -276,7 +276,7 @@ void
 mynewt_lv_drv_init(lv_disp_drv_t *driver)
 {
     if (MYNEWT_VAL(LCD_BL_PIN) >= 0) {
-        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), 1);
+        hal_gpio_init_out(MYNEWT_VAL(LCD_BL_PIN), MYNEWT_VAL(LCD_BL_PIN_ACTIVE_LEVEL));
     }
     if (MYNEWT_VAL(LCD_RESET_PIN) >= 0) {
         hal_gpio_init_out(MYNEWT_VAL(LCD_RESET_PIN), 1);


### PR DESCRIPTION
This adds way to define active level of backlight pin that will be used during driver initialization.