### PR TITLE
crypto/mbedtls: Remove not needed .gitignore

### DIFF
--- a/crypto/mbedtls/include/.gitignore
+++ b/crypto/mbedtls/include/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-*.sln
-*.vcxproj
-mbedtls/check_config


### PR DESCRIPTION
mbedtls is now build as external repo so this is no longer needed.