### PR TITLE
lvgl/itf: Swap colors in place

### DIFF
--- a/hw/drivers/display/lcd_itf/include/lcd_itf.h
+++ b/hw/drivers/display/lcd_itf/include/lcd_itf.h
@@ -96,6 +96,6 @@ void lcd_itf_init(void);
 
 /* Function implemented by LCD interface driver */
 void lcd_ift_write_cmd(const uint8_t *cmd, int cmd_length);
-void lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels);
+void lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, void *pixels);
 
 #endif /* LCD_ITF_H */

--- a/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
+++ b/hw/drivers/display/lcd_itf/itf_8080/src/itf_8080.c
@@ -91,7 +91,7 @@ lcd_itf_write_bytes(const uint8_t *bytes, size_t size)
 }
 
 void
-lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels)
+lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, void *pixels)
 {
     const uint16_t *data = (const uint16_t *)pixels;
     size_t size = (x2 - x1 + 1) * (y2 - y1 + 1) * 2;

--- a/hw/drivers/display/lcd_itf/itf_lcd_da1469x/src/itf_lcd_da1469x.c
+++ b/hw/drivers/display/lcd_itf/itf_lcd_da1469x/src/itf_lcd_da1469x.c
@@ -29,7 +29,7 @@ static uint16_t display_resx;
 static uint16_t display_resy;
 
 void
-lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const void *pixels)
+lcd_itf_write_color_data(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, void *pixels)
 {
     uint16_t width = 1 + x2 - x1;
     uint16_t height = 1 + y2 - y1;


### PR DESCRIPTION
Function lcd_itf_write_color_data() had pixel pointer constant and in case of SPI when LV_COLOR_16_SWAP was set to 0 additional buffer in RAM was allocated for swapped bytes.
LVGL however does not touch memory after it passes it to interface so it is safe to swap bytes (if needed) in place.

Setting LV_COLOR_16_SWAP to 1 eliminates need for data swap but then LVGL internally uses some extra bit manipulation.