### PR TITLE
lvgl: Add logging settings to syscfg

### DIFF
--- a/hw/drivers/display/lvgl/default/lv_conf.h
+++ b/hw/drivers/display/lvgl/default/lv_conf.h
@@ -213,7 +213,7 @@
  *-----------*/
 
 /*Enable the log module*/
-#define LV_USE_LOG 0
+#define LV_USE_LOG MYNEWT_VAL(LV_USE_LOG)
 #if LV_USE_LOG
 
     /*How important log should be added:
@@ -223,11 +223,11 @@
     *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
     *LV_LOG_LEVEL_USER        Only logs added by the user
     *LV_LOG_LEVEL_NONE        Do not log anything*/
-    #define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+    #define LV_LOG_LEVEL MYNEWT_VAL(LV_LOG_LEVEL)
 
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
-    #define LV_LOG_PRINTF 0
+    #define LV_LOG_PRINTF MYNEWT_VAL(LV_LOG_PRINTF)
 
     /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
     #define LV_LOG_TRACE_MEM        1

--- a/hw/drivers/display/lvgl/syscfg.yml
+++ b/hw/drivers/display/lvgl/syscfg.yml
@@ -72,6 +72,25 @@ syscfg.defs:
         description: Add LVGL demos to build.
         value: 1
 
+    LV_USE_LOG:
+        description: >
+            Enable LVGL logging
+        value: 0
+    LV_LOG_LEVEL:
+        description: >
+            LVGL log level on of:
+            - LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+            - LV_LOG_LEVEL_INFO        Log important events
+            - LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+            - LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+            - LV_LOG_LEVEL_USER        Only logs added by the user
+            - LV_LOG_LEVEL_NONE        Do not log anything
+        value: LV_LOG_LEVEL_WARN
+    LV_LOG_PRINTF:
+        description: >
+            Use printf for writing logs.
+        value: 1
+
     LV_FONT_DEFAULT:
         description: Set default LVGL font.
         value: 'lv_font_montserrat_14'


### PR DESCRIPTION
LVGL has support for logs.
This change allows to enable logs from mynewt syscfg.

- LV_USE_LOG - enables logs
- LV_LOG_LEVEL - allows to choose logging level
- LV_LOG_PRINTF - redirects logs to use printf (default for now,
  can be change latter to use mynewt logging)