### PR TITLE
ci: Build tests under standard project folder tree

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -17,29 +17,16 @@
 # under the License.
 #
 
-project.name: "apache-mynewt-core"
+project.name: "my_project"
 
 project.repositories:
-    - apache-mynewt-nimble
-    - mcuboot
-    - apache-mynewt-mcumgr
+    - apache-mynewt-core
 
-repository.apache-mynewt-nimble:
+# Use github's distribution mechanism for core ASF libraries.
+# This provides mirroring automatically for us.
+#
+repository.apache-mynewt-core:
     type: github
     vers: 0.0.0
     user: apache
-    repo: mynewt-nimble
-
-repository.mcuboot:
-    type: github
-    vers: 0.0.0
-    user: mcu-tools
-    repo: mcuboot
-    branch: main
-
-repository.apache-mynewt-mcumgr:
-    type: github
-    vers: 0.0.0
-    user: apache
-    repo: mynewt-mcumgr
-
+    repo: mynewt-core

--- a/.github/test_build_blinky.sh
+++ b/.github/test_build_blinky.sh
@@ -19,7 +19,7 @@
 
 EXIT_CODE=0
 
-BSPS=$(ls hw/bsp)
+BSPS=$(ls repos/apache-mynewt-core/hw/bsp)
 IGNORED_BSPS="ci40 dialog_cmac embarc_emsk hifive1 native-armv7 native-mips\
               olimex-pic32-emz64 olimex-pic32-hmz144 pic32mx470_6lp_clicker\
               pic32mz2048_wi-fire"

--- a/.github/workflows/build_blinky.yml
+++ b/.github/workflows/build_blinky.yml
@@ -47,10 +47,17 @@ jobs:
              go version
              go install mynewt.apache.org/newt/newt@latest
       - name: Setup Blinky project
+        shell: bash
         run: |
-             cp .github/project.yml project.yml
+             newt new build
+             cp -f .github/project.yml build/project.yml
+             cd build
              newt upgrade --shallow=1
-             git clone https://github.com/apache/mynewt-blinky.git /tmp/blinky
-             cp -r /tmp/blinky/apps/blinky/ apps/blinky
+             rm -rf repos/apache-mynewt-core
+             git clone .. repos/apache-mynewt-core
+             cd ..
       - name: Build Blinky
-        run: bash .github/test_build_blinky.sh
+        shell: bash
+        run: |
+             cd build
+             bash ../.github/test_build_blinky.sh

--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -44,19 +44,28 @@ jobs:
       - name: Setup project
         shell: bash
         run: |
-             cp .github/project.yml project.yml
+             newt new build
+             cp -f .github/project.yml build/project.yml
+             cd build
              newt upgrade --shallow=1
              rm -rf targets
+             rm -rf repos/apache-mynewt-core
+             git clone .. repos/apache-mynewt-core
+             cd ..
       - name: Build targets
         shell: bash
         run: |
-             cp -r .github/targets targets/
+             cp -r .github/targets build/targets
+             cd build
              ls targets | xargs -n1 sh -c 'echo "Testing $0"; newt build -q $0'
              rm -rf targets
+             cd ..
       - name: Build Linux-only targets
         shell: bash
         if: matrix.os == 'ubuntu-latest'
         run: |
-             cp -r .github/targets_linux targets
+             cp -r .github/targets_linux build/targets
+             cd build
              ls targets | xargs -n1 sh -c 'echo "Testing $0"; newt build -q  $0'
              rm -rf targets
+             cd ..

--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -39,8 +39,16 @@ jobs:
              go version
              go install mynewt.apache.org/newt/newt@latest
       - name: Setup project
+        shell: bash
         run: |
-             cp .github/project.yml project.yml
+             newt new build
+             cp -f .github/project.yml build/project.yml
+             cd build
              newt upgrade --shallow=1
+             rm -rf repos/apache-mynewt-core
+             git clone .. repos/apache-mynewt-core
+             cd ..
       - name: newt test all
-        run: newt test all
+        run: |
+             cd build
+             newt test all


### PR DESCRIPTION
This uses standard folder tree to build tests (where core is in
repos folder, and not as a top project folder).