### PR TITLE
ci: Restore bootloader target for nRF51

### DIFF
--- a/.github/targets_linux/nordic_pca10028_boot/README
+++ b/.github/targets_linux/nordic_pca10028_boot/README
@@ -1,0 +1,3 @@
+*** targets/nordic_pca10028_boot
+Note: security is disabled in this boot loader target.  With security,
+the boot loader is just barely too large to fit on the nRF51.

--- a/.github/targets_linux/nordic_pca10028_boot/pkg.yml
+++ b/.github/targets_linux/nordic_pca10028_boot/pkg.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+### Package: "targets/nordic_pca10028_boot
+pkg.name: "targets/nordic_pca10028_boot"
+pkg.type: "target"
+pkg.description: 
+pkg.author: 
+pkg.homepage: 

--- a/.github/targets_linux/nordic_pca10028_boot/syscfg.yml
+++ b/.github/targets_linux/nordic_pca10028_boot/syscfg.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    BOOTUTIL_SIGN_RSA: 0
+    BOOTUTIL_SIGN_ECC: 0
+    UART_0: 0
+    TIMER_0: 0
+    OS_CPUTIME_TIMER_NUM: -1

--- a/.github/targets_linux/nordic_pca10028_boot/target.yml
+++ b/.github/targets_linux/nordic_pca10028_boot/target.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+### Target: targets/nordic_pca10028_boot
+target.app: "@mcuboot/boot/mynewt"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10028"
+target.build_profile: "optimized"


### PR DESCRIPTION
It was accidentally moved to NimBLE CI.