### PR TITLE
hw/mcu/pic32: Put cache init code in non-cached space

### DIFF
--- a/hw/mcu/microchip/pic32mz/p32mz_app.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_app.ld
@@ -700,7 +700,9 @@ SECTIONS
     _app_reset = .;
     KEEP(*(.reset))
     KEEP(*(.reset.startup))
-  } > kseg0_program_mem
+    KEEP(*(.cache_init.*))
+    KEEP(*(.kseg1.*))
+  } > kseg1_program_mem AT >kseg0_program_mem
   .bev_excpt /*_BEV_EXCPT_ADDR*/ :
   {
     KEEP(*(.bev_handler))


### PR DESCRIPTION
kseg1_program_mem and kseg0_program_mem point to same physical memory.
kseg1 is not cached while kseg0 is cached.
cache init was placed in cached segment which cold lead to crashes during restart.