### PR TITLE
hw/usb/tinyusb: usb cdc console and tinyusb library sysinit before console uses it

### DIFF
--- a/hw/usb/tinyusb/cdc_console/pkg.yml
+++ b/hw/usb/tinyusb/cdc_console/pkg.yml
@@ -32,4 +32,4 @@ pkg.deps:
     - "@apache-mynewt-core/hw/usb/tinyusb/cdc"
 
 pkg.init:
-    usb_cdc_console_pkg_init: 'MYNEWT_VAL(CONSOLE_SYSINIT_STAGE)'
+    usb_cdc_console_pkg_init: 'MYNEWT_VAL(CONSOLE_USB_CDC_SYSINIT_STAGE)'

--- a/hw/usb/tinyusb/cdc_console/syscfg.yml
+++ b/hw/usb/tinyusb/cdc_console/syscfg.yml
@@ -25,5 +25,12 @@ syscfg.defs:
 syscfg.vals:
     USBD_CDC_CONSOLE: 1
 
+syscfg.defs:
+    CONSOLE_USB_CDC_SYSINIT_STAGE:
+        description: >
+          Initialize USB CDC Console at the specified sysinit level
+        value: 502
+
 syscfg.restrictions:
     - "USBD_CDC_CONSOLE"
+    - CONSOLE_USB_CDC_SYSINIT_STAGE > USBD_SYSINIT_STAGE


### PR DESCRIPTION
hw/usb/tinyusb: Fix sysinit levels so that tinyusb gets initialized
before console uses it

- Changing cdc_console sysinit to 502 adding a new syscfg
  `CONSOLE_USB_CDC_SYSINIT_STAGE` for CDC USB console
  and use that instead
- Also add restrictions so that usbd is never inited after
  cdc_console