### PR TITLE
tinyusb/dfu: Fix build when auto confirm is off

### DIFF
--- a/hw/usb/tinyusb/dfu/src/dfu.c
+++ b/hw/usb/tinyusb/dfu/src/dfu.c
@@ -33,8 +33,6 @@
  */
 #define FIRMWARE_SLOT       MYNEWT_VAL(USBD_DFU_SLOT_ID)
 
-#if MYNEWT_VAL(USBD_DFU_RESET_AFTER_DOWNLOAD)
-
 struct os_callout delayed_reset_callout;
 struct os_callout auto_confirm_callout;
 
@@ -43,8 +41,6 @@ delayed_reset_cb(struct os_event *event)
 {
     hal_system_reset();
 }
-
-#endif
 
 /*
  * DFU callbacks


### PR DESCRIPTION
Part of the code and data was included only if
USBD_DFU_RESET_AFTER_DOWNLOAD was set.

While package init function used those functions and data regardless of syscfg value.

package init function is not called from sysinit when USBD_DFU_RESET_AFTER_DOWNLOAD is not set but code inside is still there.

Now all code is there and if functionality is not used package init function will not be called from sysinit.