### PR TITLE
kernel/os: Fix issue that causes WDOG reset reason to be lost

### DIFF
--- a/hw/hal/include/hal/hal_watchdog.h
+++ b/hw/hal/include/hal/hal_watchdog.h
@@ -52,6 +52,11 @@ int hal_watchdog_init(uint32_t expire_msecs);
 void hal_watchdog_enable(void);
 
 /**
+ * Stops the watchdog.
+ */
+void hal_watchdog_disable(void);
+
+/**
  * Tickles the watchdog.   This needs to be done periodically, before
  * the value configured in :c:func:`hal_watchdog_init()` expires.
  */

--- a/hw/mcu/ambiq/apollo2/src/hal_watchdog.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_watchdog.c
@@ -35,6 +35,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    /* XXX: Unimplemented. */
+}
+
+void
 hal_watchdog_tickle(void)
 {
     /* XXX: Unimplemented. */

--- a/hw/mcu/ambiq/apollo3/src/hal_watchdog.c
+++ b/hw/mcu/ambiq/apollo3/src/hal_watchdog.c
@@ -35,6 +35,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    /* XXX: Unimplemented. */
+}
+
+void
 hal_watchdog_tickle(void)
 {
     /* XXX: Unimplemented. */

--- a/hw/mcu/arc/snps/src/hal_watchdog.c
+++ b/hw/mcu/arc/snps/src/hal_watchdog.c
@@ -33,6 +33,11 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+}
+
+void
 hal_watchdog_tickle(void)
 {
 }

--- a/hw/mcu/dialog/cmac/src/hal_watchdog.c
+++ b/hw/mcu/dialog/cmac/src/hal_watchdog.c
@@ -35,6 +35,13 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    GPREG->SET_FREEZE_REG |= GPREG_SET_FREEZE_REG_FRZ_CMAC_WDOG_Msk;
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     uint32_t cnt;

--- a/hw/mcu/dialog/da1469x/src/hal_watchdog.c
+++ b/hw/mcu/dialog/da1469x/src/hal_watchdog.c
@@ -55,6 +55,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    GPREG->SET_FREEZE_REG |= GPREG_SET_FREEZE_REG_FRZ_SYS_WDOG_Msk;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     while (SYS_WDOG->WATCHDOG_CTRL_REG & SYS_WDOG_WATCHDOG_CTRL_REG_WRITE_BUSY_Msk) {

--- a/hw/mcu/microchip/pic32mx470f512h/src/hal_watchdog.c
+++ b/hw/mcu/microchip/pic32mx470f512h/src/hal_watchdog.c
@@ -40,6 +40,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     WDTCONSET = _WDTCON_WDTCLR_MASK;

--- a/hw/mcu/microchip/pic32mz/src/hal_watchdog.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_watchdog.c
@@ -40,6 +40,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     volatile uint16_t *wdtclrkey = (volatile uint16_t *)&WDTCON + 1;

--- a/hw/mcu/mips/danube/src/hal_watchdog.c
+++ b/hw/mcu/mips/danube/src/hal_watchdog.c
@@ -33,6 +33,11 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+}
+
+void
 hal_watchdog_tickle(void)
 {
 }

--- a/hw/mcu/native/src/hal_watchdog.c
+++ b/hw/mcu/native/src/hal_watchdog.c
@@ -31,6 +31,11 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+}
+
+void
 hal_watchdog_tickle(void)
 {
 }

--- a/hw/mcu/nordic/nrf51xxx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_watchdog.c
@@ -67,6 +67,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     NRF_WDT->RR[0] = WDT_RR_RR_Reload;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
@@ -70,6 +70,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     NRF_WDT->RR[0] = WDT_RR_RR_Reload;

--- a/hw/mcu/nordic/nrf5340/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_watchdog.c
@@ -72,6 +72,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     NRF_WDT0->RR[0] = WDT_RR_RR_Reload;

--- a/hw/mcu/nordic/nrf5340_net/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_watchdog.c
@@ -71,6 +71,11 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+}
+
+void
 hal_watchdog_tickle(void)
 {
     NRF_WDT_NS->RR[0] = WDT_RR_RR_Reload;

--- a/hw/mcu/nordic/nrf91xx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf91xx/src/hal_watchdog.c
@@ -71,6 +71,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     NRF_WDT->RR[0] = WDT_RR_RR_Reload;

--- a/hw/mcu/nxp/kinetis/src/hal_watchdog.c
+++ b/hw/mcu/nxp/kinetis/src/hal_watchdog.c
@@ -65,6 +65,11 @@ void hal_watchdog_enable(void)
 #endif
 }
 
+void hal_watchdog_disable(void)
+{
+    return;
+}
+
 void hal_watchdog_tickle(void)
 {
 #ifndef WATCHDOG_STUB

--- a/hw/mcu/nxp/mkw41z/src/hal_watchdog.c
+++ b/hw/mcu/nxp/mkw41z/src/hal_watchdog.c
@@ -34,6 +34,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     return;

--- a/hw/mcu/sifive/fe310/src/hal_watchdog.c
+++ b/hw/mcu/sifive/fe310/src/hal_watchdog.c
@@ -98,6 +98,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
 #if !MYNEWT_VAL(WATCHDOG_STUB)

--- a/hw/mcu/stm/stm32_common/src/hal_watchdog.c
+++ b/hw/mcu/stm/stm32_common/src/hal_watchdog.c
@@ -61,6 +61,12 @@ hal_watchdog_enable(void)
 }
 
 void
+hal_watchdog_disable(void)
+{
+    return;
+}
+
+void
 hal_watchdog_tickle(void)
 {
     HAL_IWDG_Refresh(&g_wdt_cfg);

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -244,7 +244,7 @@ os_default_irq(struct trap_frame *tf)
 #endif
 
 #if MYNEWT_VAL(OS_COREDUMP)
-    hal_watchdog_tickle();
+    hal_watchdog_disable();
 #if MYNEWT_VAL(OS_COREDUMP_CB)
     os_coredump_cb(tf);
 #else


### PR DESCRIPTION
In the default irq handler, hal_watchdog_tickle() was called before doing a core dump but on Dialog da1469x this causes the reset reason to be lost, and reboot log was recording the reset reason as HAL_RESET_SOFT instead of HAL_RESET_WDOG.

The issue is fixed by calling hal_watchdog_disable() instead of hal_watchdog_tickle() before doing a core dump.

This PR also adds hal_watchdog_disable() to the HAL API for all MCUs (for now it is implemented only for Dialog da1469x and CMAC).