### PR TITLE
stm32 rtc fixes

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -156,7 +156,8 @@ rtc_update_time(void)
     now = rtc_time_to_sub_seconds(&alarm.AlarmTime);
     delta = now - last_rtc_time;
     if (delta < 0) {
-        delta += 3600 << SUB_SECONDS_BITS;
+        /* Day changed, correct delta */
+        delta += (24 * 3600) << SUB_SECONDS_BITS;
     }
     alarm.AlarmTime.SubSeconds = alarm.AlarmTime.SecondFraction - (now & alarm.AlarmTime.SecondFraction);
     alarm.AlarmTime.SubSeconds -= sub_seconds_per_tick;


### PR DESCRIPTION
This fixes RTC based hal_os_tick.
- Fixed build for STM32U5
- Fixed crash at midnight caused by assert due to negative time increment