### PR TITLE
hw/mcu/stm32h7: Remove STM32F4/7 specific code

### DIFF
--- a/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
+++ b/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
@@ -174,16 +174,6 @@ SystemClock_Config(void)
         assert(0);
     }
 
-#if MYNEWT_VAL(STM32_CLOCK_ENABLE_OVERDRIVE)
-    /*
-     * Activate the Over-Drive mode
-     */
-    status = HAL_PWREx_EnableOverDrive();
-    if (status != HAL_OK) {
-        assert(0);
-    }
-#endif
-
     /*
      * Select PLL as system clock source and configure the HCLK, PCLK1 and
      * PCLK2 clocks dividers. HSI and HSE are also valid system clock sources,


### PR DESCRIPTION
This remove function call to HAL_PWREx_EnableOverDrive() that is only available in F4 and F7 and not H7.