### PR TITLE
kernel/os: Add default irq callback

### DIFF
--- a/kernel/os/include/os/os_fault.h
+++ b/kernel/os/include/os/os_fault.h
@@ -36,6 +36,10 @@ void __assert_func(const char *file, int line, const char *func, const char *e)
 typedef void (*coredump_cb_t)(void *tf);
 #endif
 
+#if MYNEWT_VAL(OS_DEFAULT_IRQ_CB)
+void os_default_irq_cb(void);
+#endif
+
 #if MYNEWT_VAL(OS_CRASH_FILE_LINE)
 #define OS_CRASH() (HAL_DEBUG_BREAK(), __assert_func(__FILE__, __LINE__, NULL, NULL))
 #else

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -213,6 +213,10 @@ os_default_irq(struct trap_frame *tf)
     uint32_t orig_sp;
 #endif
 
+#if MYNEWT_VAL(OS_DEFAULT_IRQ_CB)
+    os_default_irq_cb();
+#endif
+
     /* Stop MTB if implemented so interrupt handler execution is not recorded */
     mtb_stop();
 

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -37,6 +37,12 @@ syscfg.defs:
         value: 0
         restriction: 
             - 'OS_COREDUMP if 1'
+    OS_DEFAULT_IRQ_CB:
+        description: >
+            Calls a custom default irq callback function inside
+            os_default_irq. If enabled it is the first function
+            executed in os_default_irq.
+        value: 0
     OS_CRASH_STACKTRACE:
         description: 'Attempt to print stack trace when system crashes.'
         value: 0


### PR DESCRIPTION
Added a MYNEWT_VAL named OS_DEFAULT_IRQ_CB which, when enabled, will call a user-defined callback as the first function called in os_default_irq(). This will allow users to define custom functionality when a default irq occurs.