### PR TITLE
mcu/stm32: Calculate I2C timing register

### DIFF
--- a/hw/mcu/stm/stm32f0xx/include/mcu/stm32f0xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32f0xx/include/mcu/stm32f0xx_mynewt_hal.h
@@ -56,6 +56,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32f3xx/include/mcu/stm32f3xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/stm32f3xx_mynewt_hal.h
@@ -56,6 +56,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32f7xx/include/mcu/stm32f7xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32f7xx/include/mcu/stm32f7xx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7xx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32l0xx/include/mcu/stm32l0xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32l0xx/include/mcu/stm32l0xx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32l4xx/include/mcu/stm32l4xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32l4xx/include/mcu/stm32l4xx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32u5xx/include/mcu/stm32u5xx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32u5xx/include/mcu/stm32u5xx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus

--- a/hw/mcu/stm/stm32wbxx/include/mcu/stm32wbxx_mynewt_hal.h
+++ b/hw/mcu/stm/stm32wbxx/include/mcu/stm32wbxx_mynewt_hal.h
@@ -57,6 +57,7 @@ struct stm32_hal_i2c_cfg {
     uint8_t hic_pin_af;
     uint8_t hic_10bit;
     uint32_t hic_timingr;               /* TIMINGR register */
+    uint32_t hic_speed;                 /* Requested speed (used when hic_timingr is 0) */
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
STM32 F1,F4,L1 do have ClockSpeed filed in I2C initialization API, so it easy to specify requested clock speed for I2C. For all other devices ST HAL does not provide such field and expect that TIMINGR register value is precomputed. This value is specified in each BSP and is likely incorrect for some of them.

This change introduces hic_speed to MCUs that has timing register and function that computes timing register base on requested speed and system clock.

If timing register is specified in settings it is still being used to to configure I2C. If timing register setting is 0 hic_speed is used.
