### PR TITLE
mcu/nordic: Disable features not on nRF52810 & 11

### DIFF
--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52810_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52810_config.h
@@ -103,7 +103,7 @@
 #endif
 
 #ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 1
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
 #ifndef NRFX_TWIM_ENABLED

--- a/hw/mcu/nordic/nrf52xxx/include/nrfx52811_config.h
+++ b/hw/mcu/nordic/nrf52xxx/include/nrfx52811_config.h
@@ -103,7 +103,7 @@
 #endif
 
 #ifndef NRFX_TIMER3_ENABLED
-#define NRFX_TIMER3_ENABLED 1
+#define NRFX_TIMER3_ENABLED 0
 #endif
 
 #ifndef NRFX_TWIM_ENABLED

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -97,7 +97,9 @@ syscfg.defs:
     MCU_ICACHE_ENABLED:
        description: >
             Enabled Instruction code cache
-       value: 1
+       value: 0
+       restrictions:
+            - '!(MCU_TARGET == "nRF52810" || MCU_TARGET == "nRF52811")'
 
     MCU_COMMON_STARTUP:
         description: >
@@ -481,6 +483,9 @@ syscfg.vals.MCU_NRF52832:
     MCU_TARGET: nRF52832
 syscfg.vals.MCU_NRF52840:
     MCU_TARGET: nRF52840
+
+syscfg.vals.'(MCU_TARGET == "nRF52832" || MCU_TARGET == "nRF52840")':
+    MCU_ICACHE_ENABLED: 1
 
 syscfg.vals.XTAL_32768:
     MCU_LFCLK_SOURCE: LFXO


### PR DESCRIPTION
They don't have timer 3 or instruction cache

Tested on a Seeed Xiao nRF52840 board (which worked fine) and a custom nRF52811 board (which is getting there.  It's no longer having timer or instruction cache issues at least!)