### PR TITLE
FWS-1372 Fix os_eventq_put() to wake up task only if EVQ_WAIT flag is set

### DIFF
--- a/kernel/os/src/os_eventq.c
+++ b/kernel/os/src/os_eventq.c
@@ -69,7 +69,8 @@ os_eventq_put(struct os_eventq *evq, struct os_event *ev)
          * Check if task is sleeping, because another event
          * queue may have woken this task up beforehand.
          */
-        if (evq->evq_task->t_state == OS_TASK_SLEEP) {
+        if (evq->evq_task->t_state == OS_TASK_SLEEP &&
+            evq->evq_task->t_flags & OS_TASK_FLAG_EVQ_WAIT) {
             os_sched_wakeup(evq->evq_task);
             resched = 1;
         }


### PR DESCRIPTION
- This was causing a task waiting on a semaphore to wakeup on scheduling an event