### PR TITLE
baselibc: Fix fflush duplicate error

### DIFF
--- a/libc/baselibc/include/stdio.h
+++ b/libc/baselibc/include/stdio.h
@@ -97,10 +97,7 @@ __extern_inline int putchar(int c)
 #define getc(f) fgetc(f)
 #define getchar() fgetc(stdin)
 
-__extern_inline int fflush(FILE *stream)
-{
-	return 0;
-}
+__extern int fflush(FILE *stream);
 
 __extern int printf(const char *, ...);
 __extern int vprintf(const char *, va_list);

--- a/libc/baselibc/src/mynewt.c
+++ b/libc/baselibc/src/mynewt.c
@@ -48,6 +48,12 @@ struct File *const stdin = &_stdin;
 struct File *const stdout = &_stdin;
 struct File *const stderr = &_stdin;
 
+int __attribute__((weak))
+fflush(FILE *stream)
+{
+    return 0;
+}
+
 #if MYNEWT_VAL(BASELIBC_THREAD_SAFE_HEAP_ALLOCATION)
 
 static struct os_mutex heap_mutex;


### PR DESCRIPTION
This tries to fix error:
Linking review/bin/targets/nordic_pca10056-auracast_usb/app/@apache-mynewt-nimble/apps/auracast_usb/auracast_usb.elf Error: Arm GNU Toolchain arm-none-eabi/13.2 Rel1/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld.exe: Arm GNU Toolchain arm-none-eabi/13.2 Rel1/bin/../lib/gcc/arm-none- eabi/13.2.1/thumb/v7e-m/nofp\libg.a(libc_a-fflush.o): in function `fflush': fflush.c:(.text.fflush+0x0): multiple definition of `fflush'; review/bin/targets/nordic_pca10056-auracast_usb/app/@apache-mynewt-core/libc/baselibc/@apache-mynewt-core_libc_baselibc.a(mynewt.o):review/repos/apache-mynewt-core/libc/baselibc/src/mynewt.c:54: first defined here

fflush is not used anywhere in the code but for some reason gcc 12 and 13 complains about duplicate. When baselibc version of fflush is removed code compiles and links without problem and final elf does not have fflush from libc_a-fflush.o.
