### PR TITLE
tinyusb/msc_fat_view: Fix directory population condition

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
@@ -1630,9 +1630,9 @@ tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], ui
 bool
 tud_msc_test_unit_ready_cb(uint8_t lun)
 {
-    bool ret = medium_state >= MEDIUM_RELOAD;
+    bool ret = medium_state == MEDIUM_PRESENT;
 
-    if (medium_state == MEDIUM_RELOAD && last_scsi_command == SCSI_CMD_TEST_UNIT_READY) {
+    if (medium_state == MEDIUM_RELOAD) {
         /* This path will report medium not present */
         medium_state = REPORT_MEDIUM_CHANGE;
         init_disk_data();


### PR DESCRIPTION
Condition to populate disk presented over USB checked if last SCSI command was TEST_UNIT_READY.
This only worked if TEST_UNIT_READY was send twice one after the other. It seems to work on Linux but for Windows it did not happen very often.

Now disk data is populated (init_disk_data()) on first TEST_UNIT_READY request when medium state is set to MEDIUM_REALOAD.