### PR TITLE
tinyusb: Disable unused variable warning

### DIFF
--- a/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
+++ b/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
@@ -29,6 +29,9 @@ pkg.type: sdk
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
 
+pkg.cflags:
+    - -Wno-unused-variable
+
 pkg.include_dirs:
     - "@tinyusb/src"
 


### PR DESCRIPTION
TinyUSB is not a part of mynewt-core and may occasionally has code that produces unsued-varialble warning that is escalated in mynewt to error.

This disable warning that may cause builds to fail.