### PR TITLE
Add common startup for cortex mcu's

### DIFF
--- a/boot/startup/include/mynewt_config.ld.h
+++ b/boot/startup/include/mynewt_config.ld.h
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef MYNEWT_CONFIG_LD_H
+#define MYNEWT_CONFIG_LD_H
+
+/* Default destination for RTT section */
+#ifndef RTT_RAM
+#define RTT_RAM RAM
+#endif
+
+/* Default destination section for function that should be execute from RAM */
+#ifndef TEXT_RAM
+#define TEXT_RAM RAM
+#endif
+
+#ifndef VECTOR_RELOCATION_RAM
+#define VECTOR_RELOCATION_RAM RAM
+#endif
+/*#define COREDATA_RAM RAM*/
+/*#define COREBSS_RAM RAM*/
+#ifndef DATA_RAM
+#define DATA_RAM RAM
+#endif
+#ifndef BSS_RAM
+#define BSS_RAM RAM
+#endif
+#ifndef BSSNZ_RAM
+#define BSSNZ_RAM RAM
+#endif
+#ifndef STACK_RAM
+#define STACK_RAM RAM
+#endif
+
+#ifndef MYNEWT_VAL_RESET_HANDLER
+#define RESET_HANDLER Reset_Handler
+#else
+#define RESET_HANDLER MYNEWT_VAL_RESET_HANDLER
+#endif
+
+#ifndef MYNEWT_VAL_MAIN_STACK_SIZE
+#define STACK_SIZE 0x800
+#else
+#define STACK_SIZE MYNEWT_VAL_MAIN_STACK_SIZE
+#endif
+
+#define RAM_START MYNEWT_VAL_MCU_RAM_START
+#define RAM_SIZE MYNEWT_VAL_MCU_RAM_SIZE
+
+#ifndef MYNEWT_CODE
+#if MYNEWT_VAL_RAM_RESIDENT
+#define MYNEWT_CODE RAM
+#elif MYNEWT_VAL_BOOT_LOADER
+#define MYNEWT_CODE BOOT
+#else
+#define MYNEWT_CODE SLOT0
+#endif
+#endif
+
+#endif

--- a/boot/startup/mynewt_cortex_m0.ld
+++ b/boot/startup/mynewt_cortex_m0.ld
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <sysflash/sysflash.h>
+#include <bsp_config.ld.h>
+#include <target_config.ld.h>
+#include <mynewt_config.ld.h>
+
+/* Entry Point */
+ENTRY(RESET_HANDLER)
+EXTERN(g_pfnVectors)
+
+/* Specify the memory areas */
+MEMORY
+{
+    BOOT (rx!w) : ORIGIN = FLASH_AREA_BOOTLOADER_OFFSET, LENGTH = FLASH_AREA_BOOTLOADER_SIZE
+    SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#include <memory_regions.ld.h>
+}
+
+/* Define output sections */
+SECTIONS
+{
+    /*
+     * Image header is added by newt tool during execution newt image-create.
+     * This section allows to have complete elf with predefined image header that
+     * will satisfy mcuboot and yet elf file can be written to device
+     * with debugger or IDE that supports elf writing.
+     * This section is not provided by bootloader (or for small-flash devices that
+     * don't have enough space for boot loader.
+     * newt create-image will remove this section when it creates .bin file.
+     */
+    .image_header :
+    {
+        KEEP(*(.image_header))      /* Image header */
+    } > MYNEWT_CODE
+
+    /* The startup code goes first into internal flash */
+    .interrupts :
+    {
+        . = ALIGN(4);
+        __isr_vector = .;
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))      /* Startup code */
+        __isr_vector_end = .;
+    } > MYNEWT_CODE
+
+    /* Keep first in RAM, no need to clear it */
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > VECTOR_RELOCATION_RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RTT_RAM
+
+    /* The program code and other data goes into internal image location */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)                 /* .text sections (code) */
+        *(.text*)                /* .text* sections (code) */
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* preinit data */
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN(__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        KEEP(*crtbegin.o(.dtors))
+        KEEP(*crtbegin?.o(.dtors))
+        KEEP(*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+
+#include <link_tables.ld.h>
+
+        *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+        *(.glue_7)               /* glue arm to thumb code */
+        *(.glue_7t)              /* glue thumb to arm code */
+        *(.eh_frame)
+
+        /* Just in case some old code still has main instead of mynewt_main */
+        PROVIDE(mynewt_main = main);
+    } > MYNEWT_CODE
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > MYNEWT_CODE
+
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > MYNEWT_CODE
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+
+        LONG (LOADADDR(.interrupts))                        /* From */
+        LONG (SIZEOF(.interrupts))                          /* Size */
+        LONG (__vector_tbl_reloc__)                         /* To   */
+
+#ifdef TEXT_RAM
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.text_ram))                          /* From */
+        LONG (SIZEOF(.text_ram))                            /* Size */
+        LONG (__text_ram_start__)                           /* To   */
+#endif
+
+#ifdef COREDATA_RAM
+        /* Copy coredata section to RAM */
+        LONG (LOADADDR(.coredata))                          /* From */
+        LONG (SIZEOF(.coredata))                            /* Size */
+        LONG (__coredata_start__)                           /* To   */
+#endif
+
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.data))                              /* From */
+        LONG (SIZEOF(.data))                                /* Size */
+        LONG (__data_start__)                               /* To   */
+
+        __copy_table_end__ = .;
+    } > MYNEWT_CODE
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+
+#ifdef COREBSS_RAM
+        /* Zero core bss section */
+        LONG (__corebss_start__)                            /* From */
+        LONG (SIZEOF(.corebss))                             /* Size */
+#endif
+
+        /* Zero bss section */
+        LONG (__bss_start__)                                /* From */
+        LONG (SIZEOF(.bss))                                 /* Size */
+
+        __zero_table_end__ = .;
+    } > MYNEWT_CODE
+
+    __etext = .;    /* define a global symbol at end of code */
+    __text_ram_addr = LOADADDR(.text_ram);
+
+#ifdef TEXT_RAM
+    .text_ram :
+    {
+        . = ALIGN(4);
+        __text_ram_start__ = .;
+        *(.text_ram*)
+        *(.ramfunc*)             /* for functions in ram */
+        . = ALIGN(4);
+        __text_ram_end__ = .;
+    } > TEXT_RAM AT > MYNEWT_CODE
+    __text_ram_image__ = LOADADDR(.text_ram);
+#endif
+
+#ifdef COREDATA_RAM
+    .coredata :
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(4);
+        __coredata_end__ = .;
+    } > COREDATA_RAM AT > MYNEWT_CODE
+    __coredata_image__ = LOADADDR(.coredata);
+    __ecoredata = __etext + SIZEOF(.coredata);
+#endif
+
+    .data :
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > DATA_RAM AT > MYNEWT_CODE
+    __data_image__ = LOADADDR(.data);
+    _sidata = LOADADDR(.data);
+
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > BSSNZ_RAM
+
+#ifdef COREBSS_RAM
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        *(.corebss*)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > COREBSS_RAM
+#endif
+    .bssnz (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.bss.core.nz)
+        . = ALIGN(4);
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = .;
+    } > BSS_RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* Dummy section to calculate whether we need to move stack out of MTB
+     * buffer or not. */
+    .mtb (NOLOAD) :
+    {
+        KEEP(*(.mtb));
+    }
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <sysflash/sysflash.h>
+#include <bsp_config.ld.h>
+#include <target_config.ld.h>
+#include <mynewt_config.ld.h>
+
+/* Entry Point */
+ENTRY(RESET_HANDLER)
+EXTERN(g_pfnVectors)
+
+/* Specify the memory areas */
+MEMORY
+{
+    BOOT (rx!w) : ORIGIN = FLASH_AREA_BOOTLOADER_OFFSET, LENGTH = FLASH_AREA_BOOTLOADER_SIZE
+    SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#include <memory_regions.ld.h>
+}
+
+/* Define output sections */
+SECTIONS
+{
+    /*
+     * Image header is added by newt tool during execution newt image-create.
+     * This section allows to have complete elf with predefined image header that
+     * will satisfy mcuboot and yet elf file can be written to device
+     * with debugger or IDE that supports elf writing.
+     * This section is not provided by bootloader (or for small-flash devices that
+     * don't have enough space for boot loader.
+     * newt create-image will remove this section when it creates .bin file.
+     */
+    .image_header :
+    {
+        KEEP(*(.image_header))      /* Image header */
+    } > MYNEWT_CODE
+
+    /* The startup code goes first into internal flash */
+    .interrupts :
+    {
+        . = ALIGN(4);
+        __isr_vector = .;
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))      /* Startup code */
+        __isr_vector_end = .;
+    } > MYNEWT_CODE
+
+    /* Keep first in RAM, no need to clear it */
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > VECTOR_RELOCATION_RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RTT_RAM
+
+    /* The program code and other data goes into internal image location */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)                 /* .text sections (code) */
+        *(.text*)                /* .text* sections (code) */
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* preinit data */
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN(__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        KEEP(*crtbegin.o(.dtors))
+        KEEP(*crtbegin?.o(.dtors))
+        KEEP(*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+
+#include <link_tables.ld.h>
+
+        *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+        *(.glue_7)               /* glue arm to thumb code */
+        *(.glue_7t)              /* glue thumb to arm code */
+        *(.eh_frame)
+
+        /* Just in case some old code still has main instead of mynewt_main */
+        PROVIDE(mynewt_main = main);
+    } > MYNEWT_CODE
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > MYNEWT_CODE
+
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > MYNEWT_CODE
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+
+        LONG (LOADADDR(.interrupts))                        /* From */
+        LONG (SIZEOF(.interrupts))                          /* Size */
+        LONG (__vector_tbl_reloc__)                         /* To   */
+
+#ifdef TEXT_RAM
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.text_ram))                          /* From */
+        LONG (SIZEOF(.text_ram))                            /* Size */
+        LONG (__text_ram_start__)                           /* To   */
+#endif
+
+#ifdef COREDATA_RAM
+        /* Copy coredata section to RAM */
+        LONG (LOADADDR(.coredata))                          /* From */
+        LONG (SIZEOF(.coredata))                            /* Size */
+        LONG (__coredata_start__)                           /* To   */
+#endif
+
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.data))                              /* From */
+        LONG (SIZEOF(.data))                                /* Size */
+        LONG (__data_start__)                               /* To   */
+
+        __copy_table_end__ = .;
+    } > MYNEWT_CODE
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+
+#ifdef COREBSS_RAM
+        /* Zero core bss section */
+        LONG (__corebss_start__)                            /* From */
+        LONG (SIZEOF(.corebss))                             /* Size */
+#endif
+
+        /* Zero bss section */
+        LONG (__bss_start__)                                /* From */
+        LONG (SIZEOF(.bss))                                 /* Size */
+
+        __zero_table_end__ = .;
+    } > MYNEWT_CODE
+
+    __etext = .;    /* define a global symbol at end of code */
+    __text_ram_addr = LOADADDR(.text_ram);
+
+#ifdef TEXT_RAM
+    .text_ram :
+    {
+        . = ALIGN(4);
+        __text_ram_start__ = .;
+        *(.text_ram*)
+        *(.ramfunc*)             /* for functions in ram */
+        . = ALIGN(4);
+        __text_ram_end__ = .;
+    } > TEXT_RAM AT > MYNEWT_CODE
+    __text_ram_image__ = LOADADDR(.text_ram);
+#endif
+
+#ifdef COREDATA_RAM
+    .coredata :
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(4);
+        __coredata_end__ = .;
+    } > COREDATA_RAM AT > MYNEWT_CODE
+    __coredata_image__ = LOADADDR(.coredata);
+    __ecoredata = __etext + SIZEOF(.coredata);
+#endif
+
+    .data :
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > DATA_RAM AT > MYNEWT_CODE
+    __data_image__ = LOADADDR(.data);
+    _sidata = LOADADDR(.data);
+
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > BSSNZ_RAM
+
+#ifdef COREBSS_RAM
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        *(.corebss*)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > COREBSS_RAM
+#endif
+    .bssnz (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.bss.core.nz)
+        . = ALIGN(4);
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = .;
+    } > BSS_RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* Dummy section to calculate whether we need to move stack out of MTB
+     * buffer or not. */
+    .mtb (NOLOAD) :
+    {
+        KEEP(*(.mtb));
+    }
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/boot/startup/mynewt_cortex_m4.ld
+++ b/boot/startup/mynewt_cortex_m4.ld
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <sysflash/sysflash.h>
+#include <bsp_config.ld.h>
+#include <target_config.ld.h>
+#include <mynewt_config.ld.h>
+
+/* Entry Point */
+ENTRY(RESET_HANDLER)
+EXTERN(g_pfnVectors)
+
+/* Specify the memory areas */
+MEMORY
+{
+    BOOT (rx!w) : ORIGIN = FLASH_AREA_BOOTLOADER_OFFSET, LENGTH = FLASH_AREA_BOOTLOADER_SIZE
+    SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#include <memory_regions.ld.h>
+}
+
+/* Define output sections */
+SECTIONS
+{
+    /*
+     * Image header is added by newt tool during execution newt image-create.
+     * This section allows to have complete elf with predefined image header that
+     * will satisfy mcuboot and yet elf file can be written to device
+     * with debugger or IDE that supports elf writing.
+     * This section is not provided by bootloader (or for small-flash devices that
+     * don't have enough space for boot loader.
+     * newt create-image will remove this section when it creates .bin file.
+     */
+    .image_header :
+    {
+        KEEP(*(.image_header))      /* Image header */
+    } > MYNEWT_CODE
+
+    /* The startup code goes first into internal flash */
+    .interrupts :
+    {
+        . = ALIGN(4);
+        __isr_vector = .;
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))      /* Startup code */
+        __isr_vector_end = .;
+    } > MYNEWT_CODE
+
+    /* Keep first in RAM, no need to clear it */
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > VECTOR_RELOCATION_RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RTT_RAM
+
+    /* The program code and other data goes into internal image location */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)                 /* .text sections (code) */
+        *(.text*)                /* .text* sections (code) */
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* preinit data */
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN(__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        KEEP(*crtbegin.o(.dtors))
+        KEEP(*crtbegin?.o(.dtors))
+        KEEP(*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+
+#include <link_tables.ld.h>
+
+        *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+        *(.glue_7)               /* glue arm to thumb code */
+        *(.glue_7t)              /* glue thumb to arm code */
+        *(.eh_frame)
+
+        /* Just in case some old code still has main instead of mynewt_main */
+        PROVIDE(mynewt_main = main);
+    } > MYNEWT_CODE
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > MYNEWT_CODE
+
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > MYNEWT_CODE
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+
+        LONG (LOADADDR(.interrupts))                        /* From */
+        LONG (SIZEOF(.interrupts))                          /* Size */
+        LONG (__vector_tbl_reloc__)                         /* To   */
+
+#ifdef TEXT_RAM
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.text_ram))                          /* From */
+        LONG (SIZEOF(.text_ram))                            /* Size */
+        LONG (__text_ram_start__)                           /* To   */
+#endif
+
+#ifdef COREDATA_RAM
+        /* Copy coredata section to RAM */
+        LONG (LOADADDR(.coredata))                          /* From */
+        LONG (SIZEOF(.coredata))                            /* Size */
+        LONG (__coredata_start__)                           /* To   */
+#endif
+
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.data))                              /* From */
+        LONG (SIZEOF(.data))                                /* Size */
+        LONG (__data_start__)                               /* To   */
+
+        __copy_table_end__ = .;
+    } > MYNEWT_CODE
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+
+#ifdef COREBSS_RAM
+        /* Zero core bss section */
+        LONG (__corebss_start__)                            /* From */
+        LONG (SIZEOF(.corebss))                             /* Size */
+#endif
+
+        /* Zero bss section */
+        LONG (__bss_start__)                                /* From */
+        LONG (SIZEOF(.bss))                                 /* Size */
+
+        __zero_table_end__ = .;
+    } > MYNEWT_CODE
+
+    __etext = .;    /* define a global symbol at end of code */
+    __text_ram_addr = LOADADDR(.text_ram);
+
+#ifdef TEXT_RAM
+    .text_ram :
+    {
+        . = ALIGN(4);
+        __text_ram_start__ = .;
+        *(.text_ram*)
+        *(.ramfunc*)             /* for functions in ram */
+        . = ALIGN(4);
+        __text_ram_end__ = .;
+    } > TEXT_RAM AT > MYNEWT_CODE
+    __text_ram_image__ = LOADADDR(.text_ram);
+#endif
+
+#ifdef COREDATA_RAM
+    .coredata :
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(4);
+        __coredata_end__ = .;
+    } > COREDATA_RAM AT > MYNEWT_CODE
+    __coredata_image__ = LOADADDR(.coredata);
+    __ecoredata = __etext + SIZEOF(.coredata);
+#endif
+
+    .data :
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > DATA_RAM AT > MYNEWT_CODE
+    __data_image__ = LOADADDR(.data);
+    _sidata = LOADADDR(.data);
+
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > BSSNZ_RAM
+
+#ifdef COREBSS_RAM
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        *(.corebss*)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > COREBSS_RAM
+#endif
+    .bssnz (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.bss.core.nz)
+        . = ALIGN(4);
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = .;
+    } > BSS_RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* Dummy section to calculate whether we need to move stack out of MTB
+     * buffer or not. */
+    .mtb (NOLOAD) :
+    {
+        KEEP(*(.mtb));
+    }
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <sysflash/sysflash.h>
+#include <mcu_config.ld.h>
+#include <bsp_config.ld.h>
+#include <target_config.ld.h>
+#include <mynewt_config.ld.h>
+
+/* Entry Point */
+ENTRY(RESET_HANDLER)
+EXTERN(g_pfnVectors)
+
+/* Specify the memory areas */
+MEMORY
+{
+    BOOT (rx!w) : ORIGIN = FLASH_AREA_BOOTLOADER_OFFSET, LENGTH = FLASH_AREA_BOOTLOADER_SIZE
+    SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#include <memory_regions.ld.h>
+}
+
+/* Define output sections */
+SECTIONS
+{
+    /*
+     * Image header is added by newt tool during execution newt image-create.
+     * This section allows to have complete elf with predefined image header that
+     * will satisfy mcuboot and yet elf file can be written to device
+     * with debugger or IDE that supports elf writing.
+     * This section is not provided by bootloader (or for small-flash devices that
+     * don't have enough space for boot loader.
+     * newt create-image will remove this section when it creates .bin file.
+     */
+    .image_header :
+    {
+        KEEP(*(.image_header))      /* Image header */
+    } > MYNEWT_CODE
+
+    /* The startup code goes first into internal flash */
+    .interrupts :
+    {
+        . = ALIGN(4);
+        __isr_vector = .;
+        __isr_vector_start = .;
+        KEEP(*(.isr_vector))      /* Startup code */
+        __isr_vector_end = .;
+    } > MYNEWT_CODE
+
+    /* Keep first in RAM, no need to clear it */
+    .vector_relocation :
+    {
+        . = ALIGN(4);
+        __vector_tbl_reloc__ = .;
+        . = . + (__isr_vector_end - __isr_vector_start);
+        . = ALIGN(4);
+    } > VECTOR_RELOCATION_RAM
+
+    /* This section will be zeroed by RTT package init */
+    .rtt (NOLOAD):
+    {
+        . = ALIGN(4);
+        *(.rtt)
+        . = ALIGN(4);
+    } > RTT_RAM
+
+    /* The program code and other data goes into internal image location */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)                 /* .text sections (code) */
+        *(.text*)                /* .text* sections (code) */
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* preinit data */
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN(__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        KEEP(*crtbegin.o(.dtors))
+        KEEP(*crtbegin?.o(.dtors))
+        KEEP(*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+
+#include <link_tables.ld.h>
+
+        *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+        *(.glue_7)               /* glue arm to thumb code */
+        *(.glue_7t)              /* glue thumb to arm code */
+        *(.eh_frame)
+
+        /* Just in case some old code still has main instead of mynewt_main */
+        PROVIDE(mynewt_main = main);
+    } > MYNEWT_CODE
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > MYNEWT_CODE
+
+    .ARM :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > MYNEWT_CODE
+
+    .copy.table :
+    {
+        . = ALIGN(4);
+        __copy_table_start__ = .;
+
+        LONG (LOADADDR(.interrupts))                        /* From */
+        LONG (SIZEOF(.interrupts))                          /* Size */
+        LONG (__vector_tbl_reloc__)                         /* To   */
+
+#ifdef TEXT_RAM
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.text_ram))                          /* From */
+        LONG (SIZEOF(.text_ram))                            /* Size */
+        LONG (__text_ram_start__)                           /* To   */
+#endif
+
+#ifdef COREDATA_RAM
+        /* Copy coredata section to RAM */
+        LONG (LOADADDR(.coredata))                          /* From */
+        LONG (SIZEOF(.coredata))                            /* Size */
+        LONG (__coredata_start__)                           /* To   */
+#endif
+
+        /* Copy data section to RAM */
+        LONG (LOADADDR(.data))                              /* From */
+        LONG (SIZEOF(.data))                                /* Size */
+        LONG (__data_start__)                               /* To   */
+
+        __copy_table_end__ = .;
+    } > MYNEWT_CODE
+
+    .zero.table :
+    {
+        . = ALIGN(4);
+        __zero_table_start__ = .;
+
+#ifdef COREBSS_RAM
+        /* Zero core bss section */
+        LONG (__corebss_start__)                            /* From */
+        LONG (SIZEOF(.corebss))                             /* Size */
+#endif
+
+        /* Zero bss section */
+        LONG (__bss_start__)                                /* From */
+        LONG (SIZEOF(.bss))                                 /* Size */
+
+        __zero_table_end__ = .;
+    } > MYNEWT_CODE
+
+    __etext = .;    /* define a global symbol at end of code */
+    __text_ram_addr = LOADADDR(.text_ram);
+
+#ifdef TEXT_RAM
+    .text_ram :
+    {
+        . = ALIGN(4);
+        __text_ram_start__ = .;
+        *(.text_ram*)
+        *(.ramfunc*)             /* for functions in ram */
+        . = ALIGN(4);
+        __text_ram_end__ = .;
+    } > TEXT_RAM AT > MYNEWT_CODE
+    __text_ram_image__ = LOADADDR(.text_ram);
+#endif
+
+#ifdef COREDATA_RAM
+    .coredata :
+    {
+        __coredata_start__ = .;
+        *(.data.core)
+        . = ALIGN(4);
+        __coredata_end__ = .;
+    } > COREDATA_RAM AT > MYNEWT_CODE
+    __coredata_image__ = LOADADDR(.coredata);
+    __ecoredata = __etext + SIZEOF(.coredata);
+#endif
+
+    .data :
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > DATA_RAM AT > MYNEWT_CODE
+    __data_image__ = LOADADDR(.data);
+    _sidata = LOADADDR(.data);
+
+    .bssnz :
+    {
+        . = ALIGN(4);
+        __bssnz_start__ = .;
+        *(.bss.core.nz*)
+        . = ALIGN(4);
+        __bssnz_end__ = .;
+    } > BSSNZ_RAM
+
+#ifdef COREBSS_RAM
+    .corebss (NOLOAD):
+    {
+        . = ALIGN(4);
+        __corebss_start__ = .;
+        *(.bss.core)
+        *(.corebss*)
+        . = ALIGN(4);
+        __corebss_end__ = .;
+        . = ALIGN(4);
+        __ecorebss = .;
+    } > COREBSS_RAM
+#endif
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = .;
+    } > BSS_RAM
+
+    /* Heap starts after BSS */
+    . = ALIGN(8);
+    __HeapBase = .;
+
+    /* Dummy section to calculate whether we need to move stack out of MTB
+     * buffer or not. */
+    .mtb (NOLOAD) :
+    {
+        KEEP(*(.mtb));
+    }
+
+    _ram_start = ORIGIN(RAM);
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = __StackLimit;
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
+}
+

--- a/boot/startup/pkg.yml
+++ b/boot/startup/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: boot/startup
+pkg.description: Common startup code
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+pkg.type: sdk
+
+pkg.pre_link_cmds:
+    scripts/generate_linker_script.sh: 100
+
+pkg.deps.INCLUDE_IMAGE_HEADER:
+    - mgmt/image_header

--- a/boot/startup/scripts/generate_linker_script.sh
+++ b/boot/startup/scripts/generate_linker_script.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cd ${MYNEWT_PROJECT_ROOT}
+
+TARGET_NAME=`echo ${MYNEWT_VAL_TARGET_NAME} | sed 's/"//g'`
+ARCH=`echo ${MYNEWT_VAL_ARCH_NAME} | sed  's/"//g'`
+MCU_PATH=`echo ${MYNEWT_VAL_MCU_PATH} | sed  's/"//g'`
+LINK_TEMPLATE=`echo ${MYNEWT_VAL_LINK_TEMPLATE} | sed  's/"//g'`
+if [ -z "$LINK_TEMPLATE" ] ; then
+  LINK_TEMPLATE=repos/apache-mynewt-core/boot/startup/mynewt_${ARCH}.ld
+fi
+LINK_TEMPLATE=`echo $LINK_TEMPLATE`
+# Create line and link/include directories
+# link/mynewt.ld will be final linker script
+# link/include/ will have empty files that could be included during mynewt.ld creation if
+# files with the same name are not present in other places
+mkdir -p ${MYNEWT_BUILD_GENERATED_DIR}/link
+mkdir -p ${MYNEWT_BUILD_GENERATED_DIR}/link/include
+if [ ! -f ${MYNEWT_BUILD_GENERATED_DIR}/link/include/link_tables.ld.h ] ; then
+  touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/link_tables.ld.h
+fi
+touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/target_config.ld.h
+touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/memory_regions.ld.h
+touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/bsp_config.ld.h
+touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/mcu_config.ld.h
+
+set >env.txt
+${MYNEWT_CC_PATH} -xc -DMYNEWT_SYSFLASH_ONLY_CONST -P -E \
+  -I${MYNEWT_TARGET_PATH}/link/include \
+  -I${MYNEWT_APP_PATH}/link/include \
+  -I${BSP_PATH}/link/include \
+  -I${MCU_PATH}/link/include \
+  -I${MYNEWT_BUILD_GENERATED_DIR}/include \
+  -Irepos/apache-mynewt-core/boot/startup/include \
+  -I${MYNEWT_BUILD_GENERATED_DIR}/link/include \
+  $LINK_TEMPLATE \
+  >${MYNEWT_BUILD_GENERATED_DIR}/link/mynewt.ld
+

--- a/boot/startup/src/arch/cortex_m0/cortex_m0_startup.s
+++ b/boot/startup/src/arch/cortex_m0/cortex_m0_startup.s
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    .syntax unified
+    .arch   armv6-m
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl Reset_Handler
+    .type  Reset_Handler, %function
+Reset_Handler:
+    movs    r0, #0
+    msr     control, r0
+
+    ldr	r4, =__copy_table_start__
+    ldr	r5, =__copy_table_end__
+
+.L_for_each_copy_region:
+    cmp     r4, r5
+    bge     .L_copy_table_done
+    ldmia   r4!, {r1, r2, r3}
+
+.L_copy_loop:
+    subs    r2, #4
+    bmi     .L_for_each_copy_region
+    ldr     r0, [r1, r2]
+    str     r0, [r3, r2]
+    b       .L_copy_loop
+
+.L_copy_table_done:
+
+    ldr	r4, =__zero_table_start__
+    ldr	r5, =__zero_table_end__
+
+.L_for_each_zero_region:
+    cmp     r4, r5
+    bge     .L_zero_table_done
+    ldmia   r4!, {r1, r2}
+    movs    r0, #0
+
+.L_zero_loop:
+    subs    r2, #4
+    bmi     .L_for_each_zero_region
+    str     r0, [r1, r2]
+    b       .L_zero_loop
+
+.L_zero_table_done:
+
+    ldr     r0, =__HeapBase
+    ldr     r1, =__HeapLimit
+    bl      _sbrkInit
+    bl      SystemInit
+    bl      hal_system_init
+    bl      _start
+
+    .size   Reset_Handler, . - Reset_Handler

--- a/boot/startup/src/arch/cortex_m33/cortex_m33_startup.s
+++ b/boot/startup/src/arch/cortex_m33/cortex_m33_startup.s
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    .syntax unified
+    .arch   armv7-m
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl Reset_Handler
+    .type  Reset_Handler, %function
+Reset_Handler:
+    mov     r0, #0
+    msr     control, r0
+
+    ldr     r0, =__StackLimit
+    msr     msplim, r0
+
+    ldr	r4, =__copy_table_start__
+    ldr	r5, =__copy_table_end__
+
+.L_for_each_copy_region:
+    cmp     r4, r5
+    bge     .L_copy_table_done
+    ldmia   r4!, {r1, r2, r3}
+
+.L_copy_loop:
+    subs    r2, #4
+    ittt    gt
+    ldrgt   r0, [r1, r2]
+    strgt   r0, [r3, r2]
+    bgt	.L_copy_loop
+
+    b   .L_for_each_copy_region
+
+.L_copy_table_done:
+
+    ldr	r4, =__zero_table_start__
+    ldr	r5, =__zero_table_end__
+
+.L_for_each_zero_region:
+    cmp     r4, r5
+    bge     .L_zero_table_done
+    ldmia   r4!, {r1, r2}
+    mov     r0, #0
+
+.L_zero_loop:
+    subs    r2, #4
+    itt     gt
+    strgt   r0, [r1, r2]
+    bgt     .L_zero_loop
+
+    b       .L_for_each_zero_region
+.L_zero_table_done:
+
+    ldr     r0, =__HeapBase
+    ldr     r1, =__HeapLimit
+    bl      _sbrkInit
+    bl      SystemInit
+    bl      hal_system_init
+    bl      _start
+
+    .size   Reset_Handler, . - Reset_Handler

--- a/boot/startup/src/arch/cortex_m4/cortex_m4_startup.s
+++ b/boot/startup/src/arch/cortex_m4/cortex_m4_startup.s
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    .syntax unified
+    .arch   armv7-m
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl Reset_Handler
+    .type  Reset_Handler, %function
+Reset_Handler:
+    mov     r0, #0
+    msr     control, r0
+
+    ldr	r4, =__copy_table_start__
+    ldr	r5, =__copy_table_end__
+
+.L_for_each_copy_region:
+    cmp     r4, r5
+    bge     .L_copy_table_done
+    ldmia   r4!, {r1, r2, r3}
+
+.L_copy_loop:
+    subs    r2, #4
+    ittt    gt
+    ldrgt   r0, [r1, r2]
+    strgt   r0, [r3, r2]
+    bgt	.L_copy_loop
+
+    b   .L_for_each_copy_region
+
+.L_copy_table_done:
+
+    ldr	r4, =__zero_table_start__
+    ldr	r5, =__zero_table_end__
+
+.L_for_each_zero_region:
+    cmp     r4, r5
+    bge     .L_zero_table_done
+    ldmia   r4!, {r1, r2}
+    mov     r0, #0
+
+.L_zero_loop:
+    subs    r2, #4
+    itt     gt
+    strgt   r0, [r1, r2]
+    bgt     .L_zero_loop
+
+    b       .L_for_each_zero_region
+.L_zero_table_done:
+
+    ldr     r0, =__HeapBase
+    ldr     r1, =__HeapLimit
+    bl      _sbrkInit
+    bl      SystemInit
+    bl      hal_system_init
+    bl      _start
+
+    .size   Reset_Handler, . - Reset_Handler

--- a/boot/startup/src/arch/cortex_m7/cortex_m7_startup.s
+++ b/boot/startup/src/arch/cortex_m7/cortex_m7_startup.s
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    .syntax unified
+    .arch   armv7-m
+
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl Reset_Handler
+    .type  Reset_Handler, %function
+Reset_Handler:
+    mov     r0, #0
+    msr     control, r0
+
+    ldr	r4, =__copy_table_start__
+    ldr	r5, =__copy_table_end__
+
+.L_for_each_copy_region:
+    cmp     r4, r5
+    bge     .L_copy_table_done
+    ldmia   r4!, {r1, r2, r3}
+
+.L_copy_loop:
+    subs    r2, #4
+    ittt    gt
+    ldrgt   r0, [r1, r2]
+    strgt   r0, [r3, r2]
+    bgt	.L_copy_loop
+
+    b   .L_for_each_copy_region
+
+.L_copy_table_done:
+
+    ldr	r4, =__zero_table_start__
+    ldr	r5, =__zero_table_end__
+
+.L_for_each_zero_region:
+    cmp     r4, r5
+    bge     .L_zero_table_done
+    ldmia   r4!, {r1, r2}
+    mov     r0, #0
+
+.L_zero_loop:
+    subs    r2, #4
+    itt     gt
+    strgt   r0, [r1, r2]
+    bgt     .L_zero_loop
+
+    b       .L_for_each_zero_region
+.L_zero_table_done:
+
+    ldr     r0, =__HeapBase
+    ldr     r1, =__HeapLimit
+    bl      _sbrkInit
+    bl      SystemInit
+    bl      hal_system_init
+    bl      _start
+
+    .size   Reset_Handler, . - Reset_Handler

--- a/boot/startup/src/interrupts.c
+++ b/boot/startup/src/interrupts.c
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef weak_alias
+#define weak_alias(name, aliasname) \
+   extern __typeof (name) aliasname __attribute__ ((weak, alias (#name)));
+#endif
+
+extern void Reset_Handler(void);
+
+void
+Default_Handler(void) {
+    while(1);
+}
+
+void
+Default_NMI_Handler(void) {
+    while(1);
+}
+
+void
+Default_HardFault_Handler(void) {
+    while(1);
+}
+
+void
+Default_MemManage_Handler(void) {
+    while(1);
+}
+
+void
+Default_BusFault_Handler(void) {
+    while(1);
+}
+
+void
+Default_UsageFault_Handler(void) {
+    while(1);
+}
+
+void
+Default_SecureFault_Handler(void) {
+    while(1);
+}
+
+void
+Default_SVC_Handler(void) {
+    while(1);
+}
+
+void
+Default_DebugMon_Handler(void) {
+    while(1);
+}
+
+void
+Default_PendSV_Handler(void) {
+    while(1);
+}
+
+void
+Default_SysTick_Handler(void) {
+    while(1);
+}
+
+#define INT_VECTOR_STACK_TOP(stack_top) extern void stack_top(void);
+#define INT_VECTOR_RESET_HANDLER(reset_handler)
+#define INT_VECTOR_NMI_HANDLER(handler) weak_alias(Default_NMI_Handler, handler)
+#define INT_VECTOR_HARDFAULT_HANDLER(handler) weak_alias(Default_HardFault_Handler, handler)
+#define INT_VECTOR_MEMMANAGE_HANDLER(handler) weak_alias(Default_MemManage_Handler, handler)
+#define INT_VECTOR_BUSFAULT_HANDLER(handler) weak_alias(Default_BusFault_Handler, handler)
+#define INT_VECTOR_USAGEFAULT_HANDLER(handler) weak_alias(Default_UsageFault_Handler, handler)
+#define INT_VECTOR_SECUREFAULT_HANDLER(handler) weak_alias(Default_SecureFault_Handler, handler)
+#define INT_VECTOR_SVC_HANDLER(handler) weak_alias(Default_SVC_Handler, handler)
+#define INT_VECTOR_DEBUGMON_HANDLER(handler) weak_alias(Default_DebugMon_Handler, handler)
+#define INT_VECTOR_PENDSV_HANDLER(handler) weak_alias(Default_PendSV_Handler, handler)
+#define INT_VECTOR_SYSTICK_HANDLER(handler) weak_alias(Default_SysTick_Handler, handler)
+#define INT_VECTOR(isr) weak_alias(Default_Handler, isr)
+#define INT_VECTOR_UNUSED(a)
+
+#include "mcu/mcu_vectors.h"
+
+#undef INT_VECTOR_STACK_TOP
+#undef INT_VECTOR_RESET_HANDLER
+#undef INT_VECTOR_NMI_HANDLER
+#undef INT_VECTOR_HARDFAULT_HANDLER
+#undef INT_VECTOR_MEMMANAGE_HANDLER
+#undef INT_VECTOR_BUSFAULT_HANDLER
+#undef INT_VECTOR_USAGEFAULT_HANDLER
+#undef INT_VECTOR_SECUREFAULT_HANDLER
+#undef INT_VECTOR_SVC_HANDLER
+#undef INT_VECTOR_DEBUGMON_HANDLER
+#undef INT_VECTOR_PENDSV_HANDLER
+#undef INT_VECTOR_SYSTICK_HANDLER
+#undef INT_VECTOR
+#undef INT_VECTOR_UNUSED
+
+#define INT_VECTOR_STACK_TOP(stack_top) stack_top,
+#define INT_VECTOR_RESET_HANDLER(handler) handler,
+#define INT_VECTOR_NMI_HANDLER(handler) handler,
+#define INT_VECTOR_HARDFAULT_HANDLER(handler) handler,
+#define INT_VECTOR_MEMMANAGE_HANDLER(handler) handler,
+#define INT_VECTOR_BUSFAULT_HANDLER(handler) handler,
+#define INT_VECTOR_USAGEFAULT_HANDLER(handler) handler,
+#define INT_VECTOR_SECUREFAULT_HANDLER(handler) handler,
+#define INT_VECTOR_SVC_HANDLER(handler) handler,
+#define INT_VECTOR_DEBUGMON_HANDLER(handler) handler,
+#define INT_VECTOR_PENDSV_HANDLER(handler) handler,
+#define INT_VECTOR_SYSTICK_HANDLER(handler) handler,
+#define INT_VECTOR(isr) isr,
+#define INT_VECTOR_UNUSED(a) 0,
+void (*g_pfnVectors[])(void) __attribute__((section(".isr_vector"))) = {
+#include "mcu/mcu_vectors.h"
+};
+

--- a/boot/startup/syscfg.yml
+++ b/boot/startup/syscfg.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    MCU_RAM_START:
+        description: Begin for RAM
+        value:
+        restrictions:
+            - $notnull
+    MCU_RAM_SIZE:
+        description: Size of RAM
+        value:
+        restrictions:
+            - $notnull
+    MAIN_STACK_SIZE:
+        description: >
+            Stack size (in bytes) to use in startup code.
+            For bootloader it's main stack, for application this stack is used by interrupts
+            and exceptions.
+        value: 768
+    INCLUDE_IMAGE_HEADER:
+        description: Add image header to generated executable.
+        value: 1
+    LINK_TEMPLATE:
+        description: Linker template file
+        value:
+
+syscfg.vals.BOOT_LOADER:
+    INCLUDE_IMAGE_HEADER: 0


### PR DESCRIPTION
This is step to make common linker script for mynewt.
So far linker scripts were split in two parts one that usually was in MCU with all the rules for sections.
Second linker script defined memory regions (RAM/FLASH). There were separate memory region scripts
for bootloader.

This change:
- get rids of mcu/bsp linker scripts that differ from MCU to MCU
- makes flash area size consistent with flash size in linker script
- elf files contain stub image header (if needed) that makes it possible to write to flash by IDE without creating actual image
- Vector table is by startup code and does not need to be done by NVIC_Relocate that depends on NVIC_NUM_VECTORS