### PR TITLE
mcu/nordic: Set flags before running SPI callback

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_spi.c
@@ -129,11 +129,11 @@ nrf51_irqm_handler(struct nrf51_hal_spi *spi)
         }
         ++spi->nhs_rxd_bytes;
         if (spi->nhs_rxd_bytes == spi->nhs_buflen) {
+            spi->spi_xfr_flag = 0;
+            spim->INTENCLR = SPI_INTENCLR_READY_Msk;
             if (spi->txrx_cb_func) {
                 spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
             }
-            spi->spi_xfr_flag = 0;
-            spim->INTENCLR = SPI_INTENCLR_READY_Msk;
         }
         if (spi->nhs_txd_bytes != spi->nhs_buflen) {
             spim->TXD = spi->nhs_txbuf[spi->nhs_txd_bytes];

--- a/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_spi.c
@@ -212,12 +212,11 @@ nrf52_irqm_handler(struct nrf52_hal_spi *spi)
             }
             spim->TASKS_START = 1;
         } else {
-            if (spi->txrx_cb_func) {
-                spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
-
-            }
             spi->spi_xfr_flag = 0;
             spim->INTENCLR = SPIM_INTENSET_END_Msk;
+            if (spi->txrx_cb_func) {
+                spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
+            }
         }
     }
 }

--- a/hw/mcu/nordic/nrf5340/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_spi.c
@@ -170,12 +170,11 @@ nrf5340_irqm_handler(struct nrf5340_hal_spi *spi)
             }
             spim->TASKS_START = 1;
         } else {
-            if (spi->txrx_cb_func) {
-                spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
-
-            }
             spi->spi_xfr_flag = 0;
             spim->INTENCLR = SPIM_INTENSET_END_Msk;
+            if (spi->txrx_cb_func) {
+                spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
+            }
         }
     }
 }

--- a/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_spi.c
@@ -121,12 +121,11 @@ nrf5340_net_spi0_irq_handler(void)
                 }
                 NRF_SPIM0_NS->TASKS_START = 1;
             } else {
-                if (spi->txrx_cb_func) {
-                    spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
-
-                }
                 spi->spi_xfr_flag = 0;
                 NRF_SPIM0_NS->INTENCLR = SPIM_INTENSET_END_Msk;
+                if (spi->txrx_cb_func) {
+                    spi->txrx_cb_func(spi->txrx_cb_arg, spi->nhs_buflen);
+                }
             }
         }
     }

--- a/hw/mcu/nordic/nrf91xx/src/hal_spi.c
+++ b/hw/mcu/nordic/nrf91xx/src/hal_spi.c
@@ -170,12 +170,11 @@ nrf91_irqm_handler(struct nrf91_hal_spi *spi)
             }
             spim->TASKS_START = 1;
         } else {
-            if (spi->txrx_cb_func) {
-                spi->txrx_cb_func(spi->txrx_cb_arg, spi->buflen);
-
-            }
             spi->spi_xfr_flag = 0;
             spim->INTENCLR = SPIM_INTENSET_END_Msk;
+            if (spi->txrx_cb_func) {
+                spi->txrx_cb_func(spi->txrx_cb_arg, spi->buflen);
+            }
         }
     }
 }


### PR DESCRIPTION
When a non-blocking SPI transfer has finished, our `spi->spi_xfr_flag` and the hardware interrupt flag are now reset before the `spi->txrx_cb_func` is run.  This allows the callback to start a new SPI transfer.

I've tested the nRF52 changes and they're fine.  I'm making the bold assumption that the other nRFs work the same.