### PR TITLE
tinyusb: Make automatic start of USB optional

### DIFF
--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -33,9 +33,11 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb/tinyusb_sdk"
 
-pkg.init.OS_SCHEDULING:
+pkg.init.'(OS_SCHEDULING!=0 && TINYUSB_AUTO_START!=0)':
     tinyusb_start: 'MYNEWT_VAL(USBD_SYSINIT_STAGE)'
 
+pkg.deps.TINYUSB_SHELL:
+    - "@apache-mynewt-core/hw/usb/tinyusb/shell"
 pkg.deps.USBD_STD_DESCRIPTORS:
     - "@apache-mynewt-core/hw/usb/tinyusb/std_descriptors"
 pkg.deps.'MCU_TARGET == "nRF52840"':

--- a/hw/usb/tinyusb/shell/pkg.yml
+++ b/hw/usb/tinyusb/shell/pkg.yml
@@ -17,24 +17,17 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb/msc_fat_view
-pkg.description: USB MSC protocol that exposes virtual FAT disk
+pkg.name: hw/usb/tinyusb/shell
+pkg.description: Shell for TinyUSB
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - msc
     - usb
+    - tinyusb
 
 pkg.deps:
-    - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/usb/tinyusb"
-    - "@apache-mynewt-core/mgmt/imgmgr"
-    - "@apache-mynewt-core/sys/coredump"
-    - "@mcuboot/boot/bootutil"
 
-pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START!=0)':
-    msc_fat_view_pkg_init: $before:tinyusb_start
-
-pkg.init.'!BOOT_LOADER && MSC_FAT_VIEW_COREDUMP_FILES':
-    msc_fat_view_coredump_pkg_init: $before:msc_fat_view_pkg_init
+pkg.init:
+    tinyusb_cli_init: 'MYNEWT_VAL(SHELL_SYSINIT_STAGE) + 1'

--- a/hw/usb/tinyusb/shell/src/tinyusb_cli.c
+++ b/hw/usb/tinyusb/shell/src/tinyusb_cli.c
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <shell/shell.h>
+#include <tinyusb/tinyusb.h>
+#include <device/usbd.h>
+#include <tusb.h>
+
+static int
+usb_cli_start_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                  struct streamer *streamer)
+{
+    if (!tusb_inited()) {
+        tinyusb_start();
+    } else if (!tud_connected()) {
+        tud_connect();
+    }
+
+    return 0;
+}
+
+static int
+usb_cli_stop_cmd(const struct shell_cmd *cmd, int argc, char **argv,
+                  struct streamer *streamer)
+{
+    if (tud_connected()) {
+        tud_disconnect();
+    }
+
+    return 0;
+}
+
+static const struct shell_cmd usb_cli_commands[] = {
+    SHELL_CMD_EXT("start", usb_cli_start_cmd, NULL),
+    SHELL_CMD_EXT("stop", usb_cli_stop_cmd, NULL),
+    { },
+};
+
+int
+tinyusb_cli_init(void)
+{
+    shell_register("usb", usb_cli_commands);
+
+    return 0;
+}

--- a/hw/usb/tinyusb/syscfg.yml
+++ b/hw/usb/tinyusb/syscfg.yml
@@ -21,6 +21,16 @@ syscfg.defs:
     TINYUSB:
         description: Constant value
         value: 1
+    TINYUSB_AUTO_START:
+        description: >
+            Start USB stack during sysinit stage USBD_SYSINIT_STAGE.
+            If not set tinyusb_start() can be called manually by application code
+            later.
+        value: 1
+    TINYUSB_SHELL:
+        description: >
+            Enable shell for TinyUSB
+        value: 0
 
     USBD_TASK_PRIORITY:
         description: >


### PR DESCRIPTION
So far TinyUSB stack was starting during system init stage. Now it is possible for the application to start it at later time by manually call `tinyusb_start()` function.

Additionally shell commands are added to test functionality:
```
/usb start
/usb stop
```