### PR TITLE
console: Fix console history placement

### DIFF
--- a/sys/console/full/history_ram/src/history_ram.c
+++ b/sys/console/full/history_ram/src/history_ram.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <os/mynewt.h>
 #include <console/history.h>
+#include <bsp/bsp.h>
 
 #ifndef bssnz_t
 /* Just in case bsp.h does not define it, in this case console history will


### PR DESCRIPTION
Console history was meant to be stored in section pointed by bssnz_t This section is usually defined in bsp.h that was not included. Section was put in normal ram and console history was not able to persist across reboots as was the intentions.

Now bsp.h is included and console history can be accessed after reboot if bsp defines section that is not cleared during startup.