### PR TITLE
mcu/nrf: Increase watchdog interrupt priority

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_watchdog.c
@@ -51,7 +51,7 @@ hal_watchdog_init(uint32_t expire_msecs)
     NRF_WDT->CRV = (uint32_t)expiration;
 
     NVIC_SetVector(WDT_IRQn, (uint32_t) nrf51_wdt_irq_handler);
-    NVIC_SetPriority(WDT_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetPriority(WDT_IRQn, 0);
     NVIC_ClearPendingIRQ(WDT_IRQn);
     NVIC_EnableIRQ(WDT_IRQn);
     NRF_WDT->RREN |= 0x1;

--- a/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf52xxx/src/hal_watchdog.c
@@ -54,7 +54,7 @@ hal_watchdog_init(uint32_t expire_msecs)
     }
 
     NVIC_SetVector(WDT_IRQn, (uint32_t) nrf52_wdt_irq_handler);
-    NVIC_SetPriority(WDT_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetPriority(WDT_IRQn, 0);
     NVIC_ClearPendingIRQ(WDT_IRQn);
     NVIC_EnableIRQ(WDT_IRQn);
     NRF_WDT->RREN |= 0x1;

--- a/hw/mcu/nordic/nrf5340/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_watchdog.c
@@ -56,7 +56,7 @@ hal_watchdog_init(uint32_t expire_msecs)
     NRF_WDT0->CRV = (expire_msecs * 32) + ((expire_msecs * 96) / 125);
 
     NVIC_SetVector(WDT0_IRQn, (uint32_t)nrf5340_wdt_irq_handler);
-    NVIC_SetPriority(WDT0_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetPriority(WDT0_IRQn, 0);
     NVIC_ClearPendingIRQ(WDT0_IRQn);
     NVIC_EnableIRQ(WDT0_IRQn);
     NRF_WDT0->RREN |= 0x1;

--- a/hw/mcu/nordic/nrf5340_net/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf5340_net/src/hal_watchdog.c
@@ -55,7 +55,7 @@ hal_watchdog_init(uint32_t expire_msecs)
     NRF_WDT_NS->CRV = (expire_msecs * 32) + ((expire_msecs * 96) / 125);
 
     NVIC_SetVector(WDT_IRQn, (uint32_t)nrf5340_net_wdt_irq_handler);
-    NVIC_SetPriority(WDT_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetPriority(WDT_IRQn, 0);
     NVIC_ClearPendingIRQ(WDT_IRQn);
     NVIC_EnableIRQ(WDT_IRQn);
     NRF_WDT_NS->RREN |= 0x1;

--- a/hw/mcu/nordic/nrf91xx/src/hal_watchdog.c
+++ b/hw/mcu/nordic/nrf91xx/src/hal_watchdog.c
@@ -55,7 +55,7 @@ hal_watchdog_init(uint32_t expire_msecs)
     }
 
     NVIC_SetVector(WDT_IRQn, (uint32_t) nrf91_wdt_irq_handler);
-    NVIC_SetPriority(WDT_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+    NVIC_SetPriority(WDT_IRQn, 0);
     NVIC_ClearPendingIRQ(WDT_IRQn);
     NVIC_EnableIRQ(WDT_IRQn);
     NRF_WDT->RREN |= 0x1;


### PR DESCRIPTION
Watchdog interrupt priority was set to minimal value. It seems that when Watchdog interrupt is triggered there is no much that can be done and the system reboot is imminent, so there is not point in doing anything else while watchdog interrupt handler can indicate problem.

If some other interrupt had problem that resulted in busy loop watchdog interrupt would never fire due to lowest priority set.

This increases watchdog interrupt priority to maximum for Nordic MCU's.