### PR TITLE
ci: Use latest RAT release

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -46,13 +46,9 @@ jobs:
           fetch-depth: 0
       - name: Install Dependencies
         run: |
-             sudo apt-get update
-             sudo apt-get install -y libxml2-utils
-             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/maven-metadata.xml -O snapshot.xml
-             SNAPSHOT=`xmllint --xpath "//latest/text()" snapshot.xml`
-             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/$SNAPSHOT/maven-metadata.xml -O version.xml
-             VERSION=`xmllint --xpath "//snapshotVersion[1]/value/text()" version.xml`
-             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/$SNAPSHOT/apache-rat-$VERSION.jar -O apache-rat.jar
+             wget https://dlcdn.apache.org//creadur/apache-rat-0.16.1/apache-rat-0.16.1-bin.tar.gz
+             tar zxf apache-rat-0.16.1-bin.tar.gz apache-rat-0.16.1/apache-rat-0.16.1.jar
+             mv apache-rat-0.16.1/apache-rat-0.16.1.jar apache-rat.jar
       - name: check licensing
         run: |
              .github/check_license.py


### PR DESCRIPTION
RAT 0.16.1 was released so we no longer need to use snapshots for SPDX support.