### PR TITLE
util/crc: Add crc32 and Adler32 algorithms

### DIFF
--- a/util/crc/include/crc/adler32.h
+++ b/util/crc/include/crc/adler32.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef _ADLER32_H_
+#define _ADLER32_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t adler32_init(void);
+uint32_t adler32_calc(uint32_t val, const void *buf, size_t cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ADLER32_H_ */

--- a/util/crc/include/crc/crc32.h
+++ b/util/crc/include/crc/crc32.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef _CRC32_H_
+#define _CRC32_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t crc32_init(void);
+uint32_t crc32_calc(uint32_t val, const void *buf, size_t cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CRC16_H_ */

--- a/util/crc/src/adler32.c
+++ b/util/crc/src/adler32.c
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <stdint.h>
+#include <crc/adler32.h>
+
+uint32_t
+adler32_init(void)
+{
+    return 1;
+}
+
+#define MOD_ADLER 65521
+
+uint32_t
+adler32_calc(uint32_t val, const void *buf, size_t cnt)
+{
+    const uint8_t *data = (const uint8_t *)buf;
+    uint32_t a = val & 0xFFFF;
+    uint32_t b = val >> 16;
+
+    while (cnt) {
+        unsigned tlen = cnt > 5550 ? 5550 : cnt;
+        cnt -= tlen;
+        do {
+            a += *data++;
+            b += a;
+        } while (--tlen);
+        a = (a & 0xffff) + (a >> 16) * (65536 - MOD_ADLER);
+        b = (b & 0xffff) + (b >> 16) * (65536 - MOD_ADLER);
+    }
+    /* It can be shown that a <= 0x1013a here, so a single subtract will do. */
+    if (a >= MOD_ADLER)
+        a -= MOD_ADLER;
+    /* It can be shown that b can reach 0xffef1 here. */
+    b = (b & 0xffff) + (b >> 16) * (65536-MOD_ADLER);
+    if (b >= MOD_ADLER)
+        b -= MOD_ADLER;
+    return (b << 16) | a;
+}

--- a/util/crc/src/crc32.c
+++ b/util/crc/src/crc32.c
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <crc/crc32.h>
+
+uint32_t
+crc32_init(void)
+{
+    return 0;
+}
+
+uint32_t
+crc32_calc(uint32_t val, const void *buf, size_t cnt)
+{
+    int i, j;
+    const uint8_t *b = (const uint8_t *)buf;
+    uint32_t byte, crc, mask;
+
+    crc = ~val;
+    for (i = 0; i < cnt; ++i) {
+        byte = *b++;
+        crc = crc ^ byte;
+        for (j = 0; j < 8; ++j) {
+            mask = -(int32_t)(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB88320 & mask);
+        }
+    }
+    return ~crc;
+}


### PR DESCRIPTION
This adds two simple implementations of standard CRC32 and Adler32 algorithms that can be used on block of data and in streams where result from previous call can be used as inptu to continue computation.

No prepcomputed table are used for now.