### PR TITLE
hw/cmsis-core: Update CMSIS to 5.4.0 release

### DIFF
--- a/hw/cmsis-core/pkg.yml
+++ b/hw/cmsis-core/pkg.yml
@@ -32,7 +32,7 @@ pkg.include_dirs:
 
 repository.arm-CMSIS_5:
     type: github
-    vers: 5.3.0-commit
+    vers: 5.4.0-commit
     branch: master
     user: ARM-software
     repo: CMSIS_5


### PR DESCRIPTION
5.3.0 has broken MPU support.