### PR TITLE
tinyusb/msc_fat_view: Fix custom entries support

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/pkg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/pkg.yml
@@ -37,4 +37,6 @@ pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START!=0)':
     msc_fat_view_pkg_init: $before:tinyusb_start
 
 pkg.init.'!BOOT_LOADER && MSC_FAT_VIEW_COREDUMP_FILES':
-    msc_fat_view_coredump_pkg_init: $before:msc_fat_view_pkg_init
+    msc_fat_view_coredump_pkg_init:
+        - $after:msc_fat_view_pkg_init
+        - $before:tinyusb_start


### PR DESCRIPTION
For now msc_fat_view provided several FAT root entries that could be enabled in syscfg.

There is function to add new root dir entries msc_fat_view_add_dir_entry(), however even if user added custom entry it would not show up since all entries were refreshed when during test_unit_ready by call to init_disk_data that silently dropped non standard entries and created root from scratch.

Now root population is divided in to two functions. init_disk_data() that provides standard enties is called when packaged is initiated and update_disk_data() is called when actual sectors for host are generated and this function includes user provided entries.

With this change core dump entries have to be initiated after msc_fat_view_pkg_init and any time before tinyusb_start