### PR TITLE
boot/split: Make config support optional

### DIFF
--- a/boot/split/src/split.c
+++ b/boot/split/src/split.c
@@ -48,12 +48,14 @@ static struct scfg_group split_scfg = {
 void
 split_app_init(void)
 {
-    int rc;
+    int rc = 0;
 
     /* Ensure this function only gets called by sysinit. */
     SYSINIT_ASSERT_ACTIVE();
 
-    rc = scfg_register(&split_scfg, "split");
+    if (MYNEWT_VAL(SPLIT_CONFIG_SUPPORT)) {
+        rc = scfg_register(&split_scfg, "split");
+    }
     assert(rc == 0);
 }
 
@@ -124,9 +126,11 @@ split_write_split(split_mode_t split_mode)
         return rc;
     }
 
-    rc = scfg_save_val(&split_scfg, &split_mode_cur);
-    if (rc != 0) {
-        return rc;
+    if (MYNEWT_VAL(SPLIT_CONFIG_SUPPORT)) {
+        rc = scfg_save_val(&split_scfg, &split_mode_cur);
+        if (rc != 0) {
+            return rc;
+        }
     }
 
     return 0;

--- a/boot/split/syscfg.yml
+++ b/boot/split/syscfg.yml
@@ -18,7 +18,15 @@
 #
 
 syscfg.defs:
+    SPLIT_CONFIG_SUPPORT:
+        description: >
+            Enable use of sys/config in split code.
+        value: 0
+
     SPLIT_APP_SYSINIT_STAGE:
         description: >
             Sysinit stage for split image functionality.
         value: 500
+
+syscfg.defs.'(CONFIG_NFFS==1||CONFIG_LITTLEFS==1||CONFIG_FCB==1||CONFIG_FCB2==1)':
+    SPLIT_CONFIG_SUPPORT: 1


### PR DESCRIPTION
When there is no config store defined there is little need to have config support in boot/split.
When config is NOT present even if boot/split is present final code size can be significantly reduced that is important when bootloader has functionality to confirm images:

```
newt size nucleo-g491re-boot
Size of Application Image: app
   BOOT   SLOT0     RAM
     66       0     490 *fill*
     79       0      38 @apache-mynewt-core_boot_split.a
    586       0       0 @apache-mynewt-core_boot_startup.a
   1172       0       4 @apache-mynewt-core_crypto_mbedtls.a
    132       0       0 @apache-mynewt-core_hw_bsp_nucleo-g491re.a
    398       0       0 @apache-mynewt-core_hw_drivers_uart_uart_hal.a
    672       0      13 @apache-mynewt-core_hw_hal.a
   3074       0     160 @apache-mynewt-core_hw_mcu_stm_stm32_common.a
   4090       0      40 @apache-mynewt-core_hw_mcu_stm_stm32g4xx.a
     26       0       0 @apache-mynewt-core_hw_usb_tinyusb.a
   4345       0     404 @apache-mynewt-core_hw_usb_tinyusb_msc_fat_view.a
    248       0      76 @apache-mynewt-core_hw_usb_tinyusb_std_descriptors.a
    190       0       0 @apache-mynewt-core_hw_usb_tinyusb_stm32_fsdev_stm32g4.a
   9868       0    1309 @apache-mynewt-core_hw_usb_tinyusb_tinyusb_sdk.a
   1452       0      46 @apache-mynewt-core_kernel_os.a
   1810       0       0 @apache-mynewt-core_libc_baselibc.a
    359       0      20 @apache-mynewt-core_sys_config.a
    536       0       8 @apache-mynewt-core_sys_flash_map.a
      6       0       4 @apache-mynewt-core_sys_sysinit.a
    182       0       0 @apache-mynewt-core_util_scfg.a
    174       0       4 @apache-mynewt-mcumgr_cmd_img_mgmt.a
     74       0       0 @apache-mynewt-mcumgr_cmd_img_mgmt_port_mynewt.a
   4958       0    6012 @mcuboot_boot_bootutil.a
     80       0       0 @mcuboot_boot_mynewt.a
     16       0       0 @mcuboot_boot_mynewt_flash_map_backend.a
     84       0       0 nucleo-g491re-boot-sysinit-app.a
   1660       0       0 libgcc.a

objsize
   text	   data	    bss	    dec	    hex	filename
  35865	    720	   8424	  45009	   afd1	targets/nucleo-g491re-boot/app/@mcuboot/boot/mynewt/mynewt.elf
```

--------------------------------------------
```
newt size nucleo-g491re-boot
Size of Application Image: app
   BOOT   SLOT0     RAM
     61       0     487 *fill*
     32       0       2 @apache-mynewt-core_boot_split.a
    586       0       0 @apache-mynewt-core_boot_startup.a
   1172       0       4 @apache-mynewt-core_crypto_mbedtls.a
    132       0       0 @apache-mynewt-core_hw_bsp_nucleo-g491re.a
    398       0       0 @apache-mynewt-core_hw_drivers_uart_uart_hal.a
    672       0      13 @apache-mynewt-core_hw_hal.a
   3074       0     160 @apache-mynewt-core_hw_mcu_stm_stm32_common.a
   4090       0      40 @apache-mynewt-core_hw_mcu_stm_stm32g4xx.a
     26       0       0 @apache-mynewt-core_hw_usb_tinyusb.a
   4345       0     404 @apache-mynewt-core_hw_usb_tinyusb_msc_fat_view.a
    248       0      76 @apache-mynewt-core_hw_usb_tinyusb_std_descriptors.a
    190       0       0 @apache-mynewt-core_hw_usb_tinyusb_stm32_fsdev_stm32g4.a
   9868       0    1309 @apache-mynewt-core_hw_usb_tinyusb_tinyusb_sdk.a
    534       0      29 @apache-mynewt-core_kernel_os.a
   1724       0       0 @apache-mynewt-core_libc_baselibc.a
    536       0       8 @apache-mynewt-core_sys_flash_map.a
      6       0       4 @apache-mynewt-core_sys_sysinit.a
    174       0       4 @apache-mynewt-mcumgr_cmd_img_mgmt.a
     74       0       0 @apache-mynewt-mcumgr_cmd_img_mgmt_port_mynewt.a
   4958       0    6012 @mcuboot_boot_bootutil.a
     80       0       0 @mcuboot_boot_mynewt.a
     16       0       0 @mcuboot_boot_mynewt_flash_map_backend.a
     84       0       0 nucleo-g491re-boot-sysinit-app.a
    772       0       0 libgcc.a

objsize
   text	   data	    bss	    dec	    hex	filename
  33380	    676	   8392	  42448	   a5d0	bin/targets/nucleo-g491re-boot/app/@mcuboot/boot/mynewt/mynewt.elf
```