### PR TITLE
hw/bus/spi_stm32: Add DMA configuration for STM32G0

### DIFF
--- a/hw/bus/drivers/spi_stm32/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/pkg.yml
@@ -42,6 +42,9 @@ pkg.deps.MCU_STM32F4:
 pkg.deps.MCU_STM32F7:
     - hw/bus/drivers/spi_stm32/stm32f7xx
 
+pkg.deps.MCU_STM32G0:
+    - hw/bus/drivers/spi_stm32/stm32g0xx
+
 pkg.deps.MCU_STM32G4:
     - hw/bus/drivers/spi_stm32/stm32g4xx
 

--- a/hw/bus/drivers/spi_stm32/stm32g0xx/include/spidmacfg.h
+++ b/hw/bus/drivers/spi_stm32/stm32g0xx/include/spidmacfg.h
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <stm32g0xx_hal_dma.h>
+
+struct stm32_dma_cfg {
+    uint8_t dma_ch;
+    uint8_t irqn;
+    void (*irq_handler)(void);
+    DMA_Channel_TypeDef *regs;
+    DMA_InitTypeDef init;
+};
+
+#define SPI_DMA_RX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx;
+
+#define SPI_DMA_TX_CHANNEL(dma, ch, spi_num) \
+    extern const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx;
+
+SPI_DMA_RX_CHANNEL(1, 1, 1);
+SPI_DMA_RX_CHANNEL(1, 2, 1);
+SPI_DMA_RX_CHANNEL(1, 3, 1);
+SPI_DMA_RX_CHANNEL(1, 4, 1);
+SPI_DMA_RX_CHANNEL(1, 5, 1);
+SPI_DMA_RX_CHANNEL(1, 6, 1);
+SPI_DMA_RX_CHANNEL(1, 7, 1);
+#ifdef DMA2
+SPI_DMA_RX_CHANNEL(2, 1, 1);
+SPI_DMA_RX_CHANNEL(2, 2, 1);
+SPI_DMA_RX_CHANNEL(2, 3, 1);
+SPI_DMA_RX_CHANNEL(2, 4, 1);
+SPI_DMA_RX_CHANNEL(2, 5, 1);
+SPI_DMA_RX_CHANNEL(2, 6, 1);
+SPI_DMA_RX_CHANNEL(2, 7, 1);
+#endif
+
+SPI_DMA_RX_CHANNEL(1, 1, 2);
+SPI_DMA_RX_CHANNEL(1, 2, 2);
+SPI_DMA_RX_CHANNEL(1, 3, 2);
+SPI_DMA_RX_CHANNEL(1, 4, 2);
+SPI_DMA_RX_CHANNEL(1, 5, 2);
+SPI_DMA_RX_CHANNEL(1, 6, 2);
+SPI_DMA_RX_CHANNEL(1, 7, 2);
+#ifdef DMA2
+SPI_DMA_RX_CHANNEL(2, 1, 2);
+SPI_DMA_RX_CHANNEL(2, 2, 2);
+SPI_DMA_RX_CHANNEL(2, 3, 2);
+SPI_DMA_RX_CHANNEL(2, 4, 2);
+SPI_DMA_RX_CHANNEL(2, 5, 2);
+SPI_DMA_RX_CHANNEL(2, 6, 2);
+SPI_DMA_RX_CHANNEL(2, 7, 2);
+#endif
+
+SPI_DMA_RX_CHANNEL(1, 1, 3);
+SPI_DMA_RX_CHANNEL(1, 2, 3);
+SPI_DMA_RX_CHANNEL(1, 3, 3);
+SPI_DMA_RX_CHANNEL(1, 4, 3);
+SPI_DMA_RX_CHANNEL(1, 5, 3);
+SPI_DMA_RX_CHANNEL(1, 6, 3);
+SPI_DMA_RX_CHANNEL(1, 7, 3);
+#ifdef DMA2
+SPI_DMA_RX_CHANNEL(2, 1, 3);
+SPI_DMA_RX_CHANNEL(2, 2, 3);
+SPI_DMA_RX_CHANNEL(2, 3, 3);
+SPI_DMA_RX_CHANNEL(2, 4, 3);
+SPI_DMA_RX_CHANNEL(2, 5, 3);
+SPI_DMA_RX_CHANNEL(2, 6, 3);
+SPI_DMA_RX_CHANNEL(2, 7, 3);
+#endif
+
+SPI_DMA_TX_CHANNEL(1, 1, 1);
+SPI_DMA_TX_CHANNEL(1, 2, 1);
+SPI_DMA_TX_CHANNEL(1, 3, 1);
+SPI_DMA_TX_CHANNEL(1, 4, 1);
+SPI_DMA_TX_CHANNEL(1, 5, 1);
+SPI_DMA_TX_CHANNEL(1, 6, 1);
+SPI_DMA_TX_CHANNEL(1, 7, 1);
+#ifdef DMA2
+SPI_DMA_TX_CHANNEL(2, 1, 1);
+SPI_DMA_TX_CHANNEL(2, 2, 1);
+SPI_DMA_TX_CHANNEL(2, 3, 1);
+SPI_DMA_TX_CHANNEL(2, 4, 1);
+SPI_DMA_TX_CHANNEL(2, 5, 1);
+SPI_DMA_TX_CHANNEL(2, 6, 1);
+SPI_DMA_TX_CHANNEL(2, 7, 1);
+#endif
+
+SPI_DMA_TX_CHANNEL(1, 1, 2);
+SPI_DMA_TX_CHANNEL(1, 2, 2);
+SPI_DMA_TX_CHANNEL(1, 3, 2);
+SPI_DMA_TX_CHANNEL(1, 4, 2);
+SPI_DMA_TX_CHANNEL(1, 5, 2);
+SPI_DMA_TX_CHANNEL(1, 6, 2);
+SPI_DMA_TX_CHANNEL(1, 7, 2);
+#ifdef DMA2
+SPI_DMA_TX_CHANNEL(2, 1, 2);
+SPI_DMA_TX_CHANNEL(2, 2, 2);
+SPI_DMA_TX_CHANNEL(2, 3, 2);
+SPI_DMA_TX_CHANNEL(2, 4, 2);
+SPI_DMA_TX_CHANNEL(2, 5, 2);
+SPI_DMA_TX_CHANNEL(2, 6, 2);
+SPI_DMA_TX_CHANNEL(2, 7, 2);
+#endif
+
+SPI_DMA_TX_CHANNEL(1, 1, 3);
+SPI_DMA_TX_CHANNEL(1, 2, 3);
+SPI_DMA_TX_CHANNEL(1, 3, 3);
+SPI_DMA_TX_CHANNEL(1, 4, 3);
+SPI_DMA_TX_CHANNEL(1, 5, 3);
+SPI_DMA_TX_CHANNEL(1, 6, 3);
+SPI_DMA_TX_CHANNEL(1, 7, 3);
+#ifdef DMA2
+SPI_DMA_TX_CHANNEL(2, 1, 3);
+SPI_DMA_TX_CHANNEL(2, 2, 3);
+SPI_DMA_TX_CHANNEL(2, 3, 3);
+SPI_DMA_TX_CHANNEL(2, 4, 3);
+SPI_DMA_TX_CHANNEL(2, 5, 3);
+SPI_DMA_TX_CHANNEL(2, 6, 3);
+SPI_DMA_TX_CHANNEL(2, 7, 3);
+#endif

--- a/hw/bus/drivers/spi_stm32/stm32g0xx/pkg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32g0xx/pkg.yml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/bus/drivers/spi_stm32/stm32g0xx
+pkg.description: STM32G0 specific part of STM32 SPI driver
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - hw/bus
+    - hw/bus/drivers/spi_stm32

--- a/hw/bus/drivers/spi_stm32/stm32g0xx/src/spidmacfg.c
+++ b/hw/bus/drivers/spi_stm32/stm32g0xx/src/spidmacfg.c
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <spidmacfg.h>
+#include <stm32g0xx_hal_dma.h>
+#include <stm32_common/stm32_dma.h>
+
+#define DMA1_Channel2_IRQn  10
+#define DMA1_Channel3_IRQn  10
+#define DMA1_Channel4_IRQn  11
+#define DMA1_Channel5_IRQn  11
+#define DMA1_Channel6_IRQn  11
+#define DMA1_Channel7_IRQn  11
+
+#define SPI_DMA_RX_CHANNEL_DEFINE(dma, ch, spi_num, irq_handler)            \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _rx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        irq_handler,                                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _RX,                   \
+            .Direction = DMA_PERIPH_TO_MEMORY,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+#define SPI_DMA_TX_CHANNEL_DEFINE(dma, ch, spi_num, irq_handler)            \
+    const struct stm32_dma_cfg DMA ## dma ## _channel ## ch ## _spi ## spi_num ## _tx = { \
+        DMA ## dma ## _CH ## ch,                                            \
+        DMA ## dma ## _Channel ## ch ## _IRQn,                              \
+        irq_handler,                                                        \
+        .regs = DMA ## dma ## _Channel ## ch,                               \
+        .init = {                                                           \
+            .Request = DMA_REQUEST_SPI ## spi_num ## _TX,                   \
+            .Direction = DMA_MEMORY_TO_PERIPH,                              \
+            .PeriphInc = DMA_PINC_DISABLE,                                  \
+            .MemInc = DMA_MINC_ENABLE,                                      \
+            .PeriphDataAlignment = DMA_PDATAALIGN_BYTE,                     \
+            .MemDataAlignment = DMA_MDATAALIGN_BYTE,                        \
+            .Mode = DMA_NORMAL,                                             \
+            .Priority = DMA_PRIORITY_LOW,                                   \
+        }                                                                   \
+    }
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 1, stm32_dma1_1_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 1, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 1, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 1, stm32_dma1_4_5_6_7_irq_handler);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 2, stm32_dma1_1_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 2, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 2, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 2, stm32_dma1_4_5_6_7_irq_handler);
+
+SPI_DMA_RX_CHANNEL_DEFINE(1, 1, 3, stm32_dma1_1_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 2, 3, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 3, 3, stm32_dma1_2_3_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 4, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 5, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 6, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_RX_CHANNEL_DEFINE(1, 7, 3, stm32_dma1_4_5_6_7_irq_handler);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 1, stm32_dma1_1_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 1, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 1, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 1, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 1, stm32_dma1_4_5_6_7_irq_handler);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 2, stm32_dma1_1_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 2, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 2, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 2, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 2, stm32_dma1_4_5_6_7_irq_handler);
+
+SPI_DMA_TX_CHANNEL_DEFINE(1, 1, 3, stm32_dma1_1_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 2, 3, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 3, 3, stm32_dma1_2_3_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 4, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 5, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 6, 3, stm32_dma1_4_5_6_7_irq_handler);
+SPI_DMA_TX_CHANNEL_DEFINE(1, 7, 3, stm32_dma1_4_5_6_7_irq_handler);

--- a/hw/bus/drivers/spi_stm32/stm32g0xx/syscfg.yml
+++ b/hw/bus/drivers/spi_stm32/stm32g0xx/syscfg.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SPI1_DMA_PRIORITY:
+        description: 'DMA priority for SPI1 RX and TX'
+        value: DMA_PRIORITY_LOW
+    SPI2_DMA_PRIORITY:
+        description: 'DMA priority for SPI2 RX and TX'
+        value: DMA_PRIORITY_LOW
+
+    SPI1_RX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel1_spi1_rx
+    SPI1_TX_DMA:
+        description: >
+            DMA channel to use for SPI1.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel2_spi1_tx
+    SPI2_RX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel3_spi2_rx
+    SPI2_TX_DMA:
+        description: >
+            DMA channel to use for SPI2.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel4_spi2_tx
+    SPI3_RX_DMA:
+        description: >
+            DMA channel to use for SPI3.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel1_spi3_rx
+    SPI3_TX_DMA:
+        description: >
+            DMA channel to use for SPI3.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel2_spi3_tx
+    SPI4_RX_DMA:
+        description: >
+            DMA channel to use for SPI4.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel3_spi4_rx
+    SPI4_TX_DMA:
+        description: >
+            DMA channel to use for SPI4.  DMA number can be 1 or 2.
+            channel can be 1-7.
+        value: DMA1_channel4_spi4_tx


### PR DESCRIPTION
Bus driver for STM32 requires DMA configuration that went missing when STM32G0 support was added