### PR TITLE
Depend on latest MCUboot stable release on master branch

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -126,7 +126,7 @@ repo.deps:
         repo: mcuboot
         branch: main
         vers:
-            master: 0-dev
+            master: 0-latest
             mynewt_1_7_0_tag: 1.3.1
             mynewt_1_8_0_tag: 1.5.0
             mynewt_1_9_0_tag: 1.7.2


### PR DESCRIPTION
There is no point in using MCUboot from main branch even on core master. Core releases are depending on latest stable at point of release so we move 'backward' anyway. It is better to test on with what will likely be used for release.