### PR TITLE
mcu/fe310: Update to stock compiler

### DIFF
--- a/hw/bsp/hifive1/pkg.yml
+++ b/hw/bsp/hifive1/pkg.yml
@@ -33,5 +33,6 @@ pkg.deps:
 pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
-pkg.cflags: -march=rv32imac -mabi=ilp32
+pkg.cflags: -march=rv32imaczicsr -mabi=ilp32
+pkg.lflags: -march=rv32imac -mabi=ilp32
 


### PR DESCRIPTION
Previously riscv64-unknown-elf toolchain from SiFive was used. Now there is commonly available version.
Unfortunately it does not have required option icsr enabled.

This adds -march=rv32imaczicsr to compiler while keeps -march=rv32imac for linker to be able to used default libraries.