### PR TITLE
mcu/nrf51: Fix low frequency clock selection

### DIFF
--- a/hw/mcu/nordic/nrf51xxx/src/hal_system.c
+++ b/hw/mcu/nordic/nrf51xxx/src/hal_system.c
@@ -69,8 +69,7 @@ hal_debugger_connected(void)
 void
 hal_system_clock_start(void)
 {
-#if MYNEWT_VAL(XTAL_32768) || MYNEWT_VAL(XTAL_RC) || \
-                                                 MYNEWT_VAL(XTAL_32768_SYNTH)
+#if MYNEWT_VAL(MCU_LFCLK_SOURCE)
     uint32_t regmsk;
     uint32_t regval;
     uint32_t clksrc;
@@ -78,23 +77,20 @@ hal_system_clock_start(void)
     regmsk = CLOCK_LFCLKSTAT_STATE_Msk | CLOCK_LFCLKSTAT_SRC_Msk;
     regval = CLOCK_LFCLKSTAT_STATE_Running << CLOCK_LFCLKSTAT_STATE_Pos;
 
-#if MYNEWT_VAL(XTAL_32768)
+#if MYNEWT_VAL_CHOICE(MCU_LFCLK_SOURCE, LFXO)
     regval |= CLOCK_LFCLKSTAT_SRC_Xtal << CLOCK_LFCLKSTAT_SRC_Pos;
     clksrc = CLOCK_LFCLKSRC_SRC_Xtal;
-#endif
-
-#if MYNEWT_VAL(XTAL_32768_SYNTH)
+#elif MYNEWT_VAL_CHOICE(MCU_LFCLK_SOURCE, LFSYNTH)
     regval |= CLOCK_LFCLKSTAT_SRC_Synth << CLOCK_LFCLKSTAT_SRC_Pos;
     clksrc = CLOCK_LFCLKSRC_SRC_Synth;
-#endif
-
- #if MYNEWT_VAL(XTAL_RC)
+#elif MYNEWT_VAL_CHOICE(MCU_LFCLK_SOURCE, LFRC)
     regval |= CLOCK_LFCLKSTAT_SRC_RC << CLOCK_LFCLKSTAT_SRC_Pos;
     clksrc = CLOCK_LFCLKSRC_SRC_RC;
+#else
+    #error Unknown LFCLK source selected
 #endif
 
-
-#if MYNEWT_VAL(XTAL_32768_SYNTH)
+#if MYNEWT_VAL_CHOICE(MCU_LFCLK_SOURCE, LFSYNTH)
     /* Must turn on HFLCK for synthesized 32768 crystal */
     if ((NRF_CLOCK->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) !=
                 (CLOCK_HFCLKSTAT_STATE_Running << CLOCK_HFCLKSTAT_STATE_Pos)) {


### PR DESCRIPTION
When XTAL_32768/XTAL_RC/XTAL_32768_SYNTH were deprecated and MCU_LFCLK_SOURCE was chosen to be used instead, code that actually enabled clocks still depended on syscfg values that were never set.

This only changes preprocessor conditions to use MCU_LFCLK_SEOURCE.