### PR TITLE
mcu/pic32mz: Fix build when no UART is enabled

### DIFF
--- a/hw/mcu/microchip/pic32mz/pkg.yml
+++ b/hw/mcu/microchip/pic32mz/pkg.yml
@@ -25,11 +25,9 @@ pkg.keywords:
     - pic32
     - pic32mz
 
-pkg.deps.(UART_0 || UART_1 || UART_2 || UART_3 || UART_4 || UART_5):
-    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
-
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
 pkg.deps.ETH_0:
     - "@apache-mynewt-core/hw/drivers/lwip/pic32_eth"


### PR DESCRIPTION
Dependency to hal_uart was only added when one or more UART_x was enabled. pic32mz_periph.c uses normal if statement to exclude unused UART's so package dependency is needed event though no UART is used.