### PR TITLE
mcu/pic32: Fix memset_func placement

### DIFF
--- a/hw/mcu/microchip/pic32mz/p32mz_boot.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_boot.ld
@@ -1613,9 +1613,8 @@ SECTIONS
   .sdata2 ALIGN(4) :
   {
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
-    *(.data.memset_func.memset_func)
     . = ALIGN(4) ;
-  } >kseg0_program_mem
+  }
   /*
    * Uninitialized constant global and static data (i.e., variables which will
    * always be zero).  Again, this is different from .sbss, which contains


### PR DESCRIPTION
By mistake sdata2 section was put in kseg0_program_mem. It should be left alone with no redirection to region xc32 linker will put it in correct place.

memset_func put in this place resulted in crash during boot since mbedtls was was updated.