### PR TITLE
Few small pic32 fixes

### DIFF
--- a/hw/mcu/microchip/pic32mz/p32mz_app.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_app.ld
@@ -1600,6 +1600,7 @@ SECTIONS
   .rodata   :
   {
     *( .gnu.linkonce.r.*)
+     INCLUDE "link_tables.ld.h"
     *(.rodata1)
     . = ALIGN(4) ;
   } >kseg0_program_mem

--- a/hw/mcu/microchip/pic32mz/p32mz_app.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_app.ld
@@ -1613,7 +1613,7 @@ SECTIONS
   {
     *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
     . = ALIGN(4) ;
-  } >kseg0_program_mem
+  }
   /*
    * Uninitialized constant global and static data (i.e., variables which will
    * always be zero).  Again, this is different from .sbss, which contains

--- a/hw/mcu/microchip/pic32mz/p32mz_boot.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_boot.ld
@@ -1602,6 +1602,7 @@ SECTIONS
   .rodata   :
   {
     *( .gnu.linkonce.r.*)
+     INCLUDE "link_tables.ld.h"
     *(.rodata1)
     . = ALIGN(4) ;
   } >kseg0_program_mem

--- a/hw/mcu/microchip/pic32mz/src/hal_gpio.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_gpio.c
@@ -347,6 +347,21 @@ hal_gpio_init_out(int pin, int val)
     return 0;
 }
 
+int
+hal_gpio_deinit(int pin)
+{
+    uint32_t port = GPIO_PORT(pin);
+    uint32_t mask = GPIO_MASK(pin);
+
+    /* Disable pull-up, pull-down and open drain */
+    CNPUxCLR(port) = mask;
+    CNPDxCLR(port) = mask;
+    ODCxCLR(port) = mask;
+
+    /* Configure pin direction as input */
+    TRISxSET(port) = mask;
+}
+
 void
 hal_gpio_write(int pin, int val)
 {

--- a/hw/mcu/microchip/pic32mz/src/pic32mz_periph.c
+++ b/hw/mcu/microchip/pic32mz/src/pic32mz_periph.c
@@ -471,7 +471,7 @@ pic32mz_periph_i2c_devs(void)
     }
 
     if (MYNEWT_VAL(I2C_4)) {
-        rc = hal_i2c_init(4, (void *)&i2c_3_cfg);
+        rc = hal_i2c_init(4, (void *)&i2c_4_cfg);
         assert(rc == 0);
     }
 }


### PR DESCRIPTION
- I2C_4 was incorrectly initialized
- added missing hal_gpio_deinit() function
- added support for link_tables.ld.h
- fix of .sdata2 section placement