### PR TITLE
tinusb: Fix usbd_stack memory alignment

### DIFF
--- a/hw/usb/tinyusb/src/tinyusb.c
+++ b/hw/usb/tinyusb/src/tinyusb.c
@@ -31,7 +31,7 @@
 
 #if MYNEWT_VAL(OS_SCHEDULING)
 static struct os_task usbd_task;
-static os_stack_t usbd_stack[OS_STACK_ALIGN(USBD_STACK_SIZE)];
+OS_TASK_STACK_DEFINE(usbd_stack, USBD_STACK_SIZE);
 #endif
 
 /**


### PR DESCRIPTION
usbd_stack could be placed at memory with wrong alignment. For pic32 with FPU enabled that results in exceptions when code tries to store/restore FPU registers.

Now OS_TASK_STACK_DEFINE is used that forces correct alignment.