### PR TITLE
pic32 no bootloader fixes

### DIFF
--- a/hw/mcu/microchip/pic32mz/p32mz_app.ld
+++ b/hw/mcu/microchip/pic32mz/p32mz_app.ld
@@ -117,6 +117,7 @@ MEMORY
 {
   kseg1_boot_mem              : ORIGIN = 0x9FC00000, LENGTH = 0x480
   kseg1_boot_mem_4B0          : ORIGIN = 0xBFC004B0, LENGTH = 0xA50
+  kseg0_image_header_mem (r)  : ORIGIN = 0x9D000000, LENGTH = 0x20
   INCLUDE p32mz_app_mem.ld
   config_BFC0FF40             : ORIGIN = 0xBFC0FF40, LENGTH = 0x4
   config_BFC0FF44             : ORIGIN = 0xBFC0FF44, LENGTH = 0x4
@@ -695,6 +696,10 @@ SECTIONS
     KEEP(*(.boot_reset))
   } > kseg1_boot_mem
   /* Boot Sections */
+  .image_header :
+  {
+      KEEP(*(.image_header*))      /* Image header */
+  } > kseg0_image_header_mem
   .reset :
   {
     _app_reset = .;

--- a/hw/mcu/microchip/pic32mz/pkg.yml
+++ b/hw/mcu/microchip/pic32mz/pkg.yml
@@ -28,6 +28,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+    - "@apache-mynewt-core/mgmt/image_header"
 
 pkg.deps.ETH_0:
     - "@apache-mynewt-core/hw/drivers/lwip/pic32_eth"

--- a/kernel/os/src/arch/pic32/startup/crt0.S
+++ b/kernel/os/src/arch/pic32/startup/crt0.S
@@ -633,6 +633,25 @@ __crt0_exit:
         .globl __crt0_exit
         .end _main_entry
 
+#if MYNEWT_VAL_MCU_NO_BOOTLOADER_BUILD
+        ##################################################################
+        # This is startup code for no boot loader application.
+        # This jumps from boot flash to program flash.
+        # It is not used for bootload/application build since it would
+        # generate huge image.
+        ##################################################################
+        .section .boot_reset,code
+        .align 2
+        .set reorder
+        .ent _boot_reset
+_boot_reset:
+        la      v0, _app_reset
+        jr      v0
+
+        .align 2
+        .end _boot_reset
+#endif
+
         .section .text.SystemInit,code
         .align 2
         .weak SystemInit


### PR DESCRIPTION
This adds image_header section to elf so it can be flashed with IDE
This also adds minimal boot code that allows to have self sufficient elf.