### PR TITLE
sys/log: Add number of entries support in log

### DIFF
--- a/apps/slinky/pkg.yml
+++ b/apps/slinky/pkg.yml
@@ -44,15 +44,3 @@ pkg.deps:
 pkg.deps.I2C_0: test/i2c_scan
 pkg.deps.I2C_1: test/i2c_scan
 pkg.deps.I2C_2: test/i2c_scan
-
-pkg.deps.CONFIG_NFFS:
-    - "@apache-mynewt-core/fs/nffs"
-
-pkg.deps.CONFIG_LITTLEFS:
-    - "@apache-mynewt-core/fs/littlefs"
-
-pkg.deps.CONFIG_FCB:
-    - "@apache-mynewt-core/fs/fcb"
-
-pkg.deps.REBOOT_LOG_FCB:
-    - "@apache-mynewt-core/fs/fcb"

--- a/fs/fcb2/include/fcb/fcb2.h
+++ b/fs/fcb2/include/fcb/fcb2.h
@@ -304,6 +304,15 @@ int fcb2_clear(struct fcb2 *fcb);
  */
 int fcb2_area_info(struct fcb2 *fcb, int sector, int *elemsp, int *bytesp);
 
+/**
+ * Length of data in flash considering alignment
+ *
+ * @param range Active range
+ * @param len Length to be calculated using alignment
+ *
+ */
+int fcb2_len_in_flash(const struct flash_sector_range *range, uint16_t len);
+
 #ifdef __cplusplus
 }
 

--- a/fs/fcb2/src/fcb.c
+++ b/fs/fcb2/src/fcb.c
@@ -102,6 +102,15 @@ fcb2_init(struct fcb2 *fcb)
 }
 
 int
+fcb2_len_in_flash(const struct flash_sector_range *range, uint16_t len)
+{
+    if (range->fsr_align <= 1) {
+        return len;
+    }
+    return (len + (range->fsr_align - 1)) & ~(range->fsr_align - 1);
+}
+
+int
 fcb2_free_sector_cnt(struct fcb2 *fcb)
 {
     int i;

--- a/fs/fcb2/src/fcb_priv.h
+++ b/fs/fcb2/src/fcb_priv.h
@@ -40,15 +40,6 @@ struct fcb2_sector_info {
     uint16_t si_sector_in_range;          /* Sector number relative to si_range */
 };
 
-static inline int
-fcb2_len_in_flash(const struct flash_sector_range *range, uint16_t len)
-{
-    if (range->fsr_align <= 1) {
-        return len;
-    }
-    return (len + (range->fsr_align - 1)) & ~(range->fsr_align - 1);
-}
-
 int fcb2_getnext_in_area(struct fcb2 *fcb, struct fcb2_entry *loc);
 
 static inline int

--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -152,7 +152,7 @@ static int
 flash_native_write_internal(uint32_t address, const void *src, uint32_t length,
                             int allow_overwrite)
 {
-    static uint8_t buf[256];
+    uint8_t buf[256] = {0};
     uint32_t cur;
     uint32_t end;
     int chunk_sz;

--- a/sys/log/full/selftest/align1_img_hash_num_entries/pkg.yml
+++ b/sys/log/full/selftest/align1_img_hash_num_entries/pkg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/align1_img_hash_num_entries
+pkg.type: unittest
+pkg.description: "Log unit tests; flash-alignment=1."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/boot/stub"

--- a/sys/log/full/selftest/align1_img_hash_num_entries/src/log_test_align1.c
+++ b/sys/log/full/selftest/align1_img_hash_num_entries/src/log_test_align1.c
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+    log_test_suite_fcb_mbuf();
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/align1_img_hash_num_entries/syscfg.yml
+++ b/sys/log/full/selftest/align1_img_hash_num_entries/syscfg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_FCB: 1
+    MCU_FLASH_MIN_WRITE_SIZE: 1
+
+    # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
+    MSYS_1_BLOCK_COUNT: 1000
+    LOG_FLAGS_IMAGE_HASH: 1
+    LOG_FLAGS_TLV_SUPPORT: 1
+    LOG_TLV_NUM_ENTRIES: 1
+    IMGMGR_DUMMY_HDR: 1
+    LOG_MGMT: 0
+    IMG_MGMT: 0

--- a/sys/log/full/selftest/align1_num_entries/pkg.yml
+++ b/sys/log/full/selftest/align1_num_entries/pkg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/align1_num_entries
+pkg.type: unittest
+pkg.description: "Log unit tests; flash-alignment=1."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/boot/stub"

--- a/sys/log/full/selftest/align1_num_entries/src/log_test_align1.c
+++ b/sys/log/full/selftest/align1_num_entries/src/log_test_align1.c
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+    log_test_suite_fcb_mbuf();
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/align1_num_entries/syscfg.yml
+++ b/sys/log/full/selftest/align1_num_entries/syscfg.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_FCB: 1
+    MCU_FLASH_MIN_WRITE_SIZE: 1
+
+    # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
+    MSYS_1_BLOCK_COUNT: 1000
+    LOG_FLAGS_TLV_SUPPORT: 1
+    LOG_TLV_NUM_ENTRIES: 1
+    IMGMGR_DUMMY_HDR: 1
+    LOG_MGMT: 0
+    IMG_MGMT: 0

--- a/sys/log/full/selftest/align4_num_entries/pkg.yml
+++ b/sys/log/full/selftest/align4_num_entries/pkg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/align4_num_entries
+pkg.type: unittest
+pkg.description: "Log unit tests; flash-alignment=4."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/boot/stub"

--- a/sys/log/full/selftest/align4_num_entries/src/log_test_align1.c
+++ b/sys/log/full/selftest/align4_num_entries/src/log_test_align1.c
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+    log_test_suite_fcb_mbuf();
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/align4_num_entries/src/log_test_align4.c
+++ b/sys/log/full/selftest/align4_num_entries/src/log_test_align4.c
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+
+#if 0
+    /* Current fcb mbuf implementation supports only
+     * 1 byte alignment
+     */
+    log_test_suite_fcb_mbuf();
+#endif
+
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/align4_num_entries/syscfg.yml
+++ b/sys/log/full/selftest/align4_num_entries/syscfg.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_FCB: 1
+    MCU_FLASH_MIN_WRITE_SIZE: 1
+
+    # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
+    MSYS_1_BLOCK_COUNT: 1000
+    LOG_FLAGS_TLV_SUPPORT: 1
+    LOG_TLV_NUM_ENTRIES: 1
+    IMGMGR_DUMMY_HDR: 1
+    LOG_MGMT: 0
+    IMG_MGMT: 0

--- a/sys/log/full/selftest/fcb2_align1_imghash/pkg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash/pkg.yml
@@ -27,3 +27,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"
     - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/boot/stub"

--- a/sys/log/full/selftest/fcb2_align1_imghash/pkg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash/pkg.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/fcb2_align1_imghash
+pkg.type: unittest
+pkg.description: "Log unit tests; FCB2 flash-alignment=1."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"

--- a/sys/log/full/selftest/fcb2_align1_imghash/src/log_test_align1.c
+++ b/sys/log/full/selftest/fcb2_align1_imghash/src/log_test_align1.c
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+    log_test_suite_fcb_mbuf();
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/fcb2_align1_imghash/syscfg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash/syscfg.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_FCB2: 1
+    MCU_FLASH_MIN_WRITE_SIZE: 1
+    LOG_FLAGS_IMAGE_HASH: 1
+
+    # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
+    MSYS_1_BLOCK_COUNT: 1000

--- a/sys/log/full/selftest/fcb2_align1_imghash/syscfg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash/syscfg.yml
@@ -23,3 +23,7 @@ syscfg.vals:
 
     # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
     MSYS_1_BLOCK_COUNT: 1000
+    LOG_FLAGS_IMAGE_HASH: 1
+    IMGMGR_DUMMY_HDR: 1
+    LOG_MGMT: 0
+    IMG_MGMT: 0

--- a/sys/log/full/selftest/fcb2_align1_imghash_num_entries/pkg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash_num_entries/pkg.yml
@@ -27,3 +27,4 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/full/selftest/util"
     - "@apache-mynewt-core/test/testutil"
+    - "@apache-mynewt-core/boot/stub"

--- a/sys/log/full/selftest/fcb2_align1_imghash_num_entries/pkg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash_num_entries/pkg.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: sys/log/full/selftest/fcb2_align1_imghash_num_entries
+pkg.type: unittest
+pkg.description: "Log unit tests; FCB2 flash-alignment=1."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/full/selftest/util"
+    - "@apache-mynewt-core/test/testutil"

--- a/sys/log/full/selftest/fcb2_align1_imghash_num_entries/src/log_test_align1.c
+++ b/sys/log/full/selftest/fcb2_align1_imghash_num_entries/src/log_test_align1.c
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "os/mynewt.h"
+#include "log_test_util/log_test_util.h"
+
+int
+main(int argc, char **argv)
+{
+    log_test_suite_cbmem_flat();
+    log_test_suite_cbmem_mbuf();
+    log_test_suite_fcb_flat();
+    log_test_suite_fcb_mbuf();
+    log_test_suite_misc();
+
+    return tu_any_failed;
+}

--- a/sys/log/full/selftest/fcb2_align1_imghash_num_entries/syscfg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash_num_entries/syscfg.yml
@@ -19,9 +19,12 @@
 syscfg.vals:
     LOG_FCB2: 1
     MCU_FLASH_MIN_WRITE_SIZE: 1
-    LOG_FLAGS_IMAGE_HASH: 1
-    LOG_FLAGS_TLV_SUPPORT: 1
-    LOG_TLV_NUM_ENTRIES: 1
 
     # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
     MSYS_1_BLOCK_COUNT: 1000
+    LOG_FLAGS_IMAGE_HASH: 1
+    LOG_FLAGS_TLV_SUPPORT: 1
+    LOG_TLV_NUM_ENTRIES: 1
+    IMGMGR_DUMMY_HDR: 1
+    LOG_MGMT: 0
+    IMG_MGMT: 0

--- a/sys/log/full/selftest/fcb2_align1_imghash_num_entries/syscfg.yml
+++ b/sys/log/full/selftest/fcb2_align1_imghash_num_entries/syscfg.yml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    LOG_FCB2: 1
+    MCU_FLASH_MIN_WRITE_SIZE: 1
+    LOG_FLAGS_IMAGE_HASH: 1
+    LOG_FLAGS_TLV_SUPPORT: 1
+    LOG_TLV_NUM_ENTRIES: 1
+
+    # The mbuf append tests allocate lots of mbufs; ensure no exhaustion.
+    MSYS_1_BLOCK_COUNT: 1000

--- a/sys/log/full/selftest/util/include/log_test_util/log_test_util.h
+++ b/sys/log/full/selftest/util/include/log_test_util/log_test_util.h
@@ -41,6 +41,7 @@ extern struct fcb2 log_fcb;
 #endif
 extern struct log my_log;
 extern char *ltu_str_logs[];
+extern uint8_t dummy_log_arr[];
 
 struct os_mbuf *ltu_flat_to_fragged_mbuf(const void *flat, int len,
                                          int frag_sz);
@@ -49,6 +50,9 @@ void ltu_setup_2fcbs(struct fcb_log *fcb_log1, struct log *log1,
                      struct fcb_log *fcb_log2, struct log *log2);
 void ltu_setup_cbmem(struct cbmem *cbmem, struct log *log);
 void ltu_verify_contents(struct log *log);
+uint16_t *ltu_get_ltu_off_arr(void);
+uint16_t ltu_init_arr(void);
+int ltu_num_strs(void);
 
 TEST_SUITE_DECL(log_test_suite_cbmem_flat);
 TEST_CASE_DECL(log_test_case_cbmem_append);

--- a/sys/log/full/selftest/util/src/log_test_util.c
+++ b/sys/log/full/selftest/util/src/log_test_util.c
@@ -60,10 +60,10 @@ struct dummy_log dummy_log = {
         .ue_etype = 3,
         .ue_flags = 0
 #if MYNEWT_VAL(LOG_FLAGS_IMAGE_HASH)
-            | LOG_FLAGS_IMG_HASH
+                    | LOG_FLAGS_IMG_HASH
 #endif
 #if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
-            | LOG_FLAGS_TLV_SUPPORT
+                    | LOG_FLAGS_TLV_SUPPORT
 #endif
         ,
         .ue_etype = 0,
@@ -72,8 +72,8 @@ struct dummy_log dummy_log = {
         .ue_num_entries = 5
     },
     .tlv = {
-       .tag = LOG_TLV_NUM_ENTRIES,
-       .len = LOG_NUM_ENTRIES_SIZE
+        .tag = LOG_TLV_NUM_ENTRIES,
+        .len = LOG_NUM_ENTRIES_SIZE
     },
     .num_entries = 0,
 };

--- a/sys/log/full/selftest/util/src/log_test_util.c
+++ b/sys/log/full/selftest/util/src/log_test_util.c
@@ -279,7 +279,7 @@ ltu_walk_verify(struct log *log, struct log_offset *log_offset,
     }
 
     hdr_len = log_hdr_len(&ueh);
-    trailer_len = log_trailer_len(&ueh);
+    trailer_len = log_trailer_len(log, &ueh);
     dlen = len - hdr_len - trailer_len;
     TEST_ASSERT(dlen < sizeof(data));
 
@@ -350,7 +350,7 @@ ltu_walk_body_verify(struct log *log, struct log_offset *log_offset,
 
     TEST_ASSERT(len < sizeof(data));
 
-    len -= log_trailer_len(euh);
+    len -= log_trailer_len(log, euh);
 
     rc = log_read_body(log, dptr, data, 0, len);
     TEST_ASSERT(rc == len);

--- a/sys/log/full/selftest/util/src/log_test_util.c
+++ b/sys/log/full/selftest/util/src/log_test_util.c
@@ -49,8 +49,8 @@ static int ltu_str_max_idx = 0;
 
 struct dummy_log {
     struct log_entry_hdr hdr;
-    struct log_tlv tlv;
     uint32_t num_entries;
+    struct log_tlv tlv;
 };
 
 struct dummy_log dummy_log = {
@@ -71,11 +71,11 @@ struct dummy_log dummy_log = {
         .ue_level = 3,
         .ue_num_entries = 5
     },
+    .num_entries = 0,
     .tlv = {
         .tag = LOG_TLV_NUM_ENTRIES,
         .len = LOG_NUM_ENTRIES_SIZE
     },
-    .num_entries = 0,
 };
 
 char *ltu_str_logs[] = {
@@ -126,11 +126,13 @@ ltu_init_arr(void)
 #endif
         memcpy(dummy_log_arr + offset, ltu_str_logs[i], strlen(ltu_str_logs[i]));
         offset += strlen(ltu_str_logs[i]);
-#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-        memcpy(dummy_log_arr + offset, &dummy_log.tlv, sizeof(struct log_tlv));
-        offset += sizeof(struct log_tlv);
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
+#if MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
         memcpy(dummy_log_arr + offset, &dummy_log.num_entries, LOG_NUM_ENTRIES_SIZE);
         offset += LOG_NUM_ENTRIES_SIZE;
+        memcpy(dummy_log_arr + offset, &dummy_log.tlv, sizeof(struct log_tlv));
+        offset += sizeof(struct log_tlv);
+#endif
 #endif
     }
     ltu_off_arr[i] = offset;
@@ -300,7 +302,7 @@ ltu_walk_verify(struct log *log, struct log_offset *log_offset,
     TEST_ASSERT(rc == dlen);
 
 #if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-    uint32_t num_entries;;
+    uint32_t num_entries;
     rc = log_read_trailer(log, dptr, LOG_TLV_NUM_ENTRIES, &num_entries);
     TEST_ASSERT(rc == 0);
 #endif

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append.c
@@ -39,7 +39,7 @@ TEST_CASE_SELF(log_test_case_cbmem_append)
 
     for (i = 0; i < num_strs; i++) {
 	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
-        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(&log, hdr);
         rc = log_append_typed(&log, 2, 3, LOG_ETYPE_STRING,
                               dummy_log_arr + off_arr[i],
                               len);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append.c
@@ -23,23 +23,26 @@ TEST_CASE_SELF(log_test_case_cbmem_append)
 {
     struct cbmem cbmem;
     struct log log;
-    uint8_t buf[256];
-    char *str;
-    int body_len;
+    uint16_t len = 0;
+    uint16_t *off_arr;
     int i;
     int rc;
+    int num_strs = ltu_num_strs();
+    struct log_entry_hdr *hdr;
 
     ltu_setup_cbmem(&cbmem, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
-        body_len = strlen(str);
-        memcpy(buf + LOG_HDR_SIZE, str, body_len);
-        rc = log_append_typed(&log, 0, 0, LOG_ETYPE_STRING, buf, body_len);
+    for (i = 0; i < num_strs; i++) {
+	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+        rc = log_append_typed(&log, 2, 3, LOG_ETYPE_STRING,
+                              dummy_log_arr + off_arr[i],
+                              len);
         TEST_ASSERT_FATAL(rc == 0);
     }
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
@@ -40,7 +40,7 @@ TEST_CASE_SELF(log_test_case_cbmem_append_body)
     for (i = 0; i < num_strs; i++) {
         hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
         len = off_arr[i + 1] - off_arr[i] -
-              log_hdr_len(hdr) - log_trailer_len(hdr);
+              log_hdr_len(hdr) - log_trailer_len(&log, hdr);
         rc = log_append_body(&log, 2, 3, LOG_ETYPE_STRING,
                              dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
                              len);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
@@ -23,18 +23,28 @@ TEST_CASE_SELF(log_test_case_cbmem_append_body)
 {
     struct cbmem cbmem;
     struct log log;
-    char *str;
+    uint16_t len = 0;
+    uint16_t *off_arr;
     int i;
+    int rc;
+    struct log_entry_hdr *hdr;
+    int num_strs = ltu_num_strs();
 
     ltu_setup_cbmem(&cbmem, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
-        log_append_body(&log, 0, 0, LOG_ETYPE_STRING, str, strlen(str));
+    for (i = 0; i < num_strs; i++) {
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i + 1] - off_arr[i] -
+              log_hdr_len(hdr) - log_trailer_len(hdr);
+        rc = log_append_body(&log, 2, 3, LOG_ETYPE_STRING,
+                             dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
+                             len);
+        TEST_ASSERT_FATAL(rc == 0);
     }
 
     ltu_verify_contents(&log);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
@@ -28,6 +28,7 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf)
     uint16_t *off_arr;
     int i;
     int rc;
+    struct log_entry_hdr *hdr;
     int num_strs = ltu_num_strs();
 
     ltu_setup_cbmem(&cbmem, &log);
@@ -38,7 +39,8 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf)
     TEST_ASSERT_FATAL(off_arr != NULL);
 
     for (i = 0; i < num_strs; i++) {
-        len = off_arr[i+1] - off_arr[i];
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i+1] - off_arr[i] - log_trailer_len(&log, hdr);
         /* Split chain into several mbufs. */
         om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i],
                                       len, 2);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
@@ -22,28 +22,28 @@
 TEST_CASE_SELF(log_test_case_cbmem_append_mbuf)
 {
     struct cbmem cbmem;
-    struct os_mbuf *om;
     struct log log;
-    char *str;
-    int rc;
+    struct os_mbuf *om;
+    uint16_t len = 0;
+    uint16_t *off_arr;
     int i;
+    int rc;
+    int num_strs = ltu_num_strs();
 
     ltu_setup_cbmem(&cbmem, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
+    for (i = 0; i < num_strs; i++) {
+        len = off_arr[i+1] - off_arr[i];
         /* Split chain into several mbufs. */
-        om = ltu_flat_to_fragged_mbuf(str, strlen(str), 2);
+        om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i],
+                                      len, 2);
 
-        /* Prepend space for the entry header. */
-        om = os_mbuf_prepend(om, LOG_HDR_SIZE);
-        TEST_ASSERT(om != NULL);
-
-        rc = log_append_mbuf_typed(&log, 0, 0, LOG_ETYPE_STRING, om);
+        rc = log_append_mbuf_typed(&log, 2, 3, LOG_ETYPE_STRING, om);
         TEST_ASSERT_FATAL(rc == 0);
     }
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
@@ -41,7 +41,7 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf_body)
     for (i = 0; i < num_strs; i++) {
         hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
         len = off_arr[i + 1] - off_arr[i] -
-              log_hdr_len(hdr);
+              log_hdr_len(hdr) - log_trailer_len(&log, hdr);
 
         /* Split chain into several mbufs. */
         om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i] + log_hdr_len(hdr),

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
@@ -24,22 +24,30 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf_body)
     struct cbmem cbmem;
     struct os_mbuf *om;
     struct log log;
-    char *str;
     int rc;
     int i;
+    uint16_t len;
+    int num_strs = ltu_num_strs();
+    struct log_entry_hdr *hdr;
+    uint16_t *off_arr;
 
     ltu_setup_cbmem(&cbmem, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
+
+    for (i = 0; i < num_strs; i++) {
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i + 1] - off_arr[i] -
+              log_hdr_len(hdr);
 
         /* Split chain into several mbufs. */
-        om = ltu_flat_to_fragged_mbuf(str, strlen(str), 2);
+        om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
+                                      len, 2);
 
-        rc = log_append_mbuf_body(&log, 0, 0, LOG_ETYPE_STRING, om);
+        rc = log_append_mbuf_body(&log, 2, 3, LOG_ETYPE_STRING, om);
         TEST_ASSERT_FATAL(rc == 0);
     }
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
@@ -23,18 +23,27 @@ TEST_CASE_SELF(log_test_case_cbmem_printf)
 {
     struct cbmem cbmem;
     struct log log;
-    char *str;
     int i;
+    uint16_t len = 0;
+    int num_strs = ltu_num_strs();
+    uint16_t *off_arr;
+    struct log_entry_hdr *hdr;
+    char data[256];
 
     ltu_setup_cbmem(&cbmem, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
-        log_printf(&log, 0, 0, str, strlen(str));
+    for (i = 0; i < num_strs; i++) {
+	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+	memcpy(data, dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
+	       len);
+	data[len] = '\0';
+        log_printf(&log, 0, 0, data, len);
     }
 
     ltu_verify_contents(&log);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
@@ -39,7 +39,7 @@ TEST_CASE_SELF(log_test_case_cbmem_printf)
 
     for (i = 0; i < num_strs; i++) {
 	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
-        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(&log, hdr);
 	memcpy(data, dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
 	       len);
 	data[len] = '\0';

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
@@ -39,7 +39,7 @@ TEST_CASE_SELF(log_test_case_fcb_append)
 
     for (i = 0;i < num_strs; i++) {
 	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
-        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(&log, hdr);
         rc = log_append_typed(&log, 2, 3, LOG_ETYPE_STRING,
                               dummy_log_arr + off_arr[i],
                               len);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
@@ -23,22 +23,27 @@ TEST_CASE_SELF(log_test_case_fcb_append)
 {
     struct fcb_log fcb_log;
     struct log log;
-    uint8_t buf[256];
-    char *str;
-    int body_len;
+    uint16_t len = 0;
+    uint16_t *off_arr;
     int i;
+    int rc;
+    int num_strs = ltu_num_strs();
+    struct log_entry_hdr *hdr;
 
     ltu_setup_fcb(&fcb_log, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
-        body_len = strlen(str);
-        memcpy(buf + LOG_HDR_SIZE, str, body_len);
-        log_append_typed(&log, 0, 0, LOG_ETYPE_STRING, buf, body_len);
+    for (i = 0;i < num_strs; i++) {
+	hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i+1] - off_arr[i] - log_hdr_len(hdr) - log_trailer_len(hdr);
+        rc = log_append_typed(&log, 2, 3, LOG_ETYPE_STRING,
+                              dummy_log_arr + off_arr[i],
+                              len);
+        TEST_ASSERT_FATAL(rc == 0);
     }
 
     ltu_verify_contents(&log);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
@@ -23,18 +23,30 @@ TEST_CASE_SELF(log_test_case_fcb_append_body)
 {
     struct fcb_log fcb_log;
     struct log log;
-    char *str;
+    uint16_t len = 0;
+    uint16_t *off_arr;
     int i;
+    int rc;
+    struct log_entry_hdr *hdr;
+    int num_strs = ltu_num_strs();
 
     ltu_setup_fcb(&fcb_log, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
-        log_append_body(&log, 0, 0, LOG_ETYPE_STRING, str, strlen(str));
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
+
+    for (i = 0; i < num_strs; i++) {
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i + 1] - off_arr[i] -
+              log_hdr_len(hdr) - log_trailer_len(hdr);
+        rc = log_append_body(&log, 2, 3, LOG_ETYPE_STRING,
+                             dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
+                             len);
+        TEST_ASSERT_FATAL(rc == 0);
     }
 
     ltu_verify_contents(&log);
+
 }

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
@@ -40,7 +40,7 @@ TEST_CASE_SELF(log_test_case_fcb_append_body)
     for (i = 0; i < num_strs; i++) {
         hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
         len = off_arr[i + 1] - off_arr[i] -
-              log_hdr_len(hdr) - log_trailer_len(hdr);
+              log_hdr_len(hdr) - log_trailer_len(&log, hdr);
         rc = log_append_body(&log, 2, 3, LOG_ETYPE_STRING,
                              dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
                              len);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
@@ -24,26 +24,28 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf)
     struct fcb_log fcb_log;
     struct os_mbuf *om;
     struct log log;
-    char *str;
     int rc;
     int i;
+    int num_strs = ltu_num_strs();
+    struct log_entry_hdr *hdr;
+    uint16_t *off_arr;
+    uint16_t len;
 
     ltu_setup_fcb(&fcb_log, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
 
+    for (i = 0; i < num_strs; i++) {
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i+1] - off_arr[i] - log_trailer_len(hdr);
         /* Split chain into several mbufs. */
-        om = ltu_flat_to_fragged_mbuf(str, strlen(str), 2);
+        om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i],
+                                      len, 2);
 
-        /* Prepend space for the entry header. */
-        om = os_mbuf_prepend(om, LOG_HDR_SIZE);
-        TEST_ASSERT(om != NULL);
-
-        rc = log_append_mbuf_typed(&log, 0, 0, LOG_ETYPE_STRING, om);
+        rc = log_append_mbuf_typed(&log, 2, 3, LOG_ETYPE_STRING, om);
         TEST_ASSERT_FATAL(rc == 0);
     }
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
@@ -40,7 +40,7 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf)
 
     for (i = 0; i < num_strs; i++) {
         hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
-        len = off_arr[i+1] - off_arr[i] - log_trailer_len(hdr);
+        len = off_arr[i+1] - off_arr[i] - log_trailer_len(&log, hdr);
         /* Split chain into several mbufs. */
         om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i],
                                       len, 2);

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
@@ -24,22 +24,30 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf_body)
     struct fcb_log fcb_log;
     struct os_mbuf *om;
     struct log log;
-    char *str;
     int rc;
     int i;
+    int num_strs = ltu_num_strs();
+    struct log_entry_hdr *hdr;
+    uint16_t *off_arr;
+    uint16_t len;
 
     ltu_setup_fcb(&fcb_log, &log);
+    len = ltu_init_arr();
+    TEST_ASSERT_FATAL(len != 0);
 
-    for (i = 0; ; i++) {
-        str = ltu_str_logs[i];
-        if (!str) {
-            break;
-        }
+    off_arr = ltu_get_ltu_off_arr();
+    TEST_ASSERT_FATAL(off_arr != NULL);
+
+    for (i = 0; i < num_strs; i++) {
+        hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
+        len = off_arr[i + 1] - off_arr[i] -
+              log_hdr_len(hdr) - log_trailer_len(hdr);
 
         /* Split chain into several mbufs. */
-        om = ltu_flat_to_fragged_mbuf(str, strlen(str), 2);
+        om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i] + log_hdr_len(hdr),
+                                      len, 2);
 
-        rc = log_append_mbuf_body(&log, 0, 0, LOG_ETYPE_STRING, om);
+        rc = log_append_mbuf_body(&log, 2, 3, LOG_ETYPE_STRING, om);
         TEST_ASSERT_FATAL(rc == 0);
     }
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
@@ -41,7 +41,7 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf_body)
     for (i = 0; i < num_strs; i++) {
         hdr = (struct log_entry_hdr *)(dummy_log_arr + off_arr[i]);
         len = off_arr[i + 1] - off_arr[i] -
-              log_hdr_len(hdr) - log_trailer_len(hdr);
+              log_hdr_len(hdr) - log_trailer_len(&log, hdr);
 
         /* Split chain into several mbufs. */
         om = ltu_flat_to_fragged_mbuf(dummy_log_arr + off_arr[i] + log_hdr_len(hdr),

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -604,12 +604,11 @@ log_trailer_len(const struct log_entry_hdr *hdr)
     uint16_t len = 0;
 
     if (hdr->ue_flags & LOG_FLAGS_TLV_SUPPORT) {
-        len += sizeof(struct log_tlv);
-    }
-
 #if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-    len += LOG_NUM_ENTRIES_SIZE;
+        len += sizeof(struct log_tlv);
+        len += LOG_NUM_ENTRIES_SIZE;
 #endif
+    }
 
     return len;
 }

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -772,7 +772,7 @@ int
 log_append_typed(struct log *log, uint8_t module, uint8_t level, uint8_t etype,
                  void *data, uint16_t len)
 {
-    struct log_entry_hdr *hdr;
+    struct log_entry_hdr hdr;
     int rc;
 
     LOG_STATS_INC(log, writes);
@@ -782,20 +782,20 @@ log_append_typed(struct log *log, uint8_t module, uint8_t level, uint8_t etype,
         goto err;
     }
 
-    hdr = (struct log_entry_hdr *)data;
-    rc = log_append_prepare(log, module, level, etype, hdr);
+    hdr = *(struct log_entry_hdr *)data;
+    rc = log_append_prepare(log, module, level, etype, &hdr);
     if (rc != 0) {
         LOG_STATS_INC(log, drops);
         goto err;
     }
 
-    rc = log->l_log->log_append(log, data, len + log_hdr_len(hdr));
+    rc = log->l_log->log_append(log, data, len + log_hdr_len(&hdr));
     if (rc != 0) {
         LOG_STATS_INC(log, errs);
         goto err;
     }
 
-    log_call_append_cb(log, hdr->ue_index);
+    log_call_append_cb(log, hdr.ue_index);
 
     return (0);
 err:

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -27,6 +27,7 @@ log_cbmem_append_body(struct log *log, const struct log_entry_hdr *hdr,
 {
     int rc = 0;
     struct cbmem *cbmem;
+    uint16_t num_tlvs = 0;
     struct cbmem_scat_gath sg = {
         .entries = (struct cbmem_scat_gath_entry[]) {
             {
@@ -42,15 +43,26 @@ log_cbmem_append_body(struct log *log, const struct log_entry_hdr *hdr,
                 .flat_len = body_len,
             },
             {
-                .flat_buf = NULL,
-                .flat_len = 0,
-            },
-            {
                 .flat_buf = &log->l_num_entries,
                 .flat_len = 0
             },
+            {
+                .flat_buf = NULL,
+                .flat_len = 0,
+            },
+            /*
+             * Number of tlvs will always get written at the end
+             */
+            {
+                .flat_buf = &num_tlvs,
+                .flat_len = 0
+            },
+            {
+                .flat_buf = NULL,
+                .flat_len = 0,
+            },
         },
-        .count = 5,
+        .count = 7,
     };
 
     if (hdr->ue_flags & LOG_FLAGS_IMG_HASH) {
@@ -58,10 +70,21 @@ log_cbmem_append_body(struct log *log, const struct log_entry_hdr *hdr,
     }
 
     if (hdr->ue_flags & LOG_FLAGS_TLV_SUPPORT) {
-#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-        sg.entries[3].flat_buf = &(struct log_tlv) {LOG_TLV_NUM_ENTRIES, LOG_NUM_ENTRIES_SIZE};
-        sg.entries[3].flat_len = sizeof(struct log_tlv);
-        sg.entries[4].flat_len = LOG_NUM_ENTRIES_SIZE;
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
+#if MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
+        sg.entries[4].flat_buf = &(struct log_tlv) {LOG_NUM_ENTRIES_SIZE, LOG_TLV_NUM_ENTRIES};
+        sg.entries[4].flat_len = sizeof(struct log_tlv);
+        sg.entries[3].flat_len = LOG_NUM_ENTRIES_SIZE;
+        num_tlvs++;
+#endif
+#if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
+        /* Number of TLVs is only written if there are more than one TLVs */
+        if (num_tlvs > 0) {
+            sg.entries[6].flat_buf = &(struct log_tlv) {LOG_NUM_TLVS_SIZE, LOG_TLV_NUM_TLVS};
+            sg.entries[6].flat_len = sizeof(struct log_tlv);
+            sg.entries[5].flat_len = LOG_NUM_TLVS_SIZE;
+        }
+#endif
 #endif
     }
 
@@ -92,6 +115,7 @@ log_cbmem_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
 {
     int rc = 0;
     struct cbmem *cbmem;
+    uint16_t num_tlvs = 0;
     struct cbmem_scat_gath sg = {
         .entries = (struct cbmem_scat_gath_entry[]) {
             {
@@ -106,15 +130,26 @@ log_cbmem_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
                 .om = om,
             },
             {
-                .flat_buf = NULL,
-                .flat_len = 0,
-            },
-            {
                 .flat_buf = &log->l_num_entries,
                 .flat_len = 0
             },
+            {
+                .flat_buf = NULL,
+                .flat_len = 0,
+            },
+            /*
+             * Number of tlvs will always get written at the end
+             */
+            {
+                .flat_buf = &num_tlvs,
+                .flat_len = 0
+            },
+            {
+                .flat_buf = NULL,
+                .flat_len = 0,
+            },
         },
-        .count = 5,
+        .count = 7,
     };
 
     if (hdr->ue_flags & LOG_FLAGS_IMG_HASH) {
@@ -122,11 +157,21 @@ log_cbmem_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
     }
 
     if (hdr->ue_flags & LOG_FLAGS_TLV_SUPPORT) {
-#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_FLAGS_NUM_ENTRIES)
-        sg.entries[3].flat_buf = &{LOG_TLV_NUM_ENTRIES, LOG_NUM_ENTRIES_SIZE};
-        sg.entries[3].flat_len = sizeof(struct log_tlv);
-        sg.entries[4].flat_len = LOG_NUM_ENTRIES_SIZE;
-        log->l_num_entries++;
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
+#if MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
+        sg.entries[4].flat_buf = &(struct log_tlv) {LOG_NUM_ENTRIES_SIZE, LOG_TLV_NUM_ENTRIES};
+        sg.entries[4].flat_len = sizeof(struct log_tlv);
+        sg.entries[3].flat_len = LOG_NUM_ENTRIES_SIZE;
+        num_tlvs++;
+#endif
+#if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
+        /* Number of TLVs is only written if there are more than one TLVs */
+        if (num_tlvs > 0) {
+            sg.entries[6].flat_buf = &(struct log_tlv) {LOG_NUM_TLVS_SIZE, LOG_TLV_NUM_TLVS};
+            sg.entries[6].flat_len = sizeof(struct log_tlv);
+            sg.entries[5].flat_len = LOG_NUM_TLVS_SIZE;
+        }
+#endif
 #endif
     }
 

--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -27,7 +27,7 @@ log_cbmem_append_body(struct log *log, const struct log_entry_hdr *hdr,
 {
     int rc = 0;
     struct cbmem *cbmem;
-    uint16_t num_tlvs = 0;
+    uint8_t num_tlvs = 0;
     struct cbmem_scat_gath sg = {
         .entries = (struct cbmem_scat_gath_entry[]) {
             {
@@ -79,7 +79,7 @@ log_cbmem_append_body(struct log *log, const struct log_entry_hdr *hdr,
 #endif
 #if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
         /* Number of TLVs is only written if there are more than one TLVs */
-        if (num_tlvs > 0) {
+        if (num_tlvs > 1) {
             sg.entries[6].flat_buf = &(struct log_tlv) {LOG_NUM_TLVS_SIZE, LOG_TLV_NUM_TLVS};
             sg.entries[6].flat_len = sizeof(struct log_tlv);
             sg.entries[5].flat_len = LOG_NUM_TLVS_SIZE;
@@ -115,7 +115,7 @@ log_cbmem_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
 {
     int rc = 0;
     struct cbmem *cbmem;
-    uint16_t num_tlvs = 0;
+    uint8_t num_tlvs = 0;
     struct cbmem_scat_gath sg = {
         .entries = (struct cbmem_scat_gath_entry[]) {
             {
@@ -166,7 +166,7 @@ log_cbmem_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
 #endif
 #if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
         /* Number of TLVs is only written if there are more than one TLVs */
-        if (num_tlvs > 0) {
+        if (num_tlvs > 1) {
             sg.entries[6].flat_buf = &(struct log_tlv) {LOG_NUM_TLVS_SIZE, LOG_TLV_NUM_TLVS};
             sg.entries[6].flat_len = sizeof(struct log_tlv);
             sg.entries[5].flat_len = LOG_NUM_TLVS_SIZE;
@@ -204,7 +204,7 @@ log_cbmem_append_mbuf(struct log *log, struct os_mbuf *om)
      * time is so that we account for the image hash as well.
      */
 
-    os_mbuf_pullup(om, LOG_BASE_ENTRY_HDR_SIZE);
+    om = os_mbuf_pullup(om, LOG_BASE_ENTRY_HDR_SIZE);
 
     /*
      * We can just pass the om->om_data ptr as the log_entry_hdr
@@ -213,10 +213,9 @@ log_cbmem_append_mbuf(struct log *log, struct os_mbuf *om)
      */
     hdr_len = log_hdr_len((struct log_entry_hdr *)om->om_data);
 
-    os_mbuf_pullup(om, hdr_len);
+    om = os_mbuf_pullup(om, hdr_len);
 
     memcpy(&hdr, om->om_data, hdr_len);
-
     os_mbuf_adj(om, hdr_len);
 
     rc = log_cbmem_append_mbuf_body(log, &hdr, om);

--- a/sys/log/full/src/log_fcb2.c
+++ b/sys/log/full/src/log_fcb2.c
@@ -439,7 +439,6 @@ log_fcb2_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
             return rc;
         }
         len += LOG_NUM_ENTRIES_SIZE;
-        loc.fe_data_off += len;
         log->l_num_entries++;
 #endif
     }

--- a/sys/log/full/src/log_fcb2.c
+++ b/sys/log/full/src/log_fcb2.c
@@ -218,22 +218,231 @@ log_fcb2_hdr_body_bytes(uint16_t align, uint16_t len)
 }
 
 static int
+log_fcb2_write_mbuf(struct fcb2_entry *loc, struct os_mbuf *om, int off)
+{
+    int rc;
+
+    while (om) {
+        rc = fcb2_write(loc, off, om->om_data, om->om_len);
+        if (rc != 0) {
+            return SYS_EIO;
+        }
+
+        off += om->om_len;
+        om = SLIST_NEXT(om, om_next);
+    }
+
+    return SYS_EOK;
+}
+
+
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
+static int
+log_fcb2_mbuf_single_tlv_write(struct os_mbuf *om, struct log_tlv *tlv,
+                               void *val, uint8_t f_align,
+                               struct fcb2_entry *loc, int len)
+{
+    uint16_t offset = 0;
+    int alignment = 0;
+    int rc = 0;
+    uint8_t buf[LOG_FCB2_MAX_ALIGN] = {0};
+
+    /* Writes the following reverse TLVs, value first then length and
+     * then tag:
+     *
+     * Reverse TLV:
+     * ---------------------------------------------------------
+     * | Value  |  Value alignment | <len:tag> | TLV alignment |
+     * ---------------------------------------------------------
+     * TLV alignment is necessary here to aid in writing the next TLV
+     * from updated loc->fe_data_off.
+     *
+     * - Value is at alignment boundary
+     * - struct tlv is at alignment boundary <len:tag>
+     *
+     * Both can be read independently.
+     */
+    rc = os_mbuf_append(om, val, tlv->len);
+    if (rc) {
+        return rc;
+    }
+    offset += tlv->len;
+
+    /* Calculate value alignment */
+    alignment = log_fcb2_hdr_body_bytes(f_align, tlv->len);
+    rc = os_mbuf_append(om, buf, alignment);
+    if (rc) {
+        return rc;
+    }
+    offset += alignment;
+
+    rc = os_mbuf_append(om, tlv, sizeof(*tlv));
+    if (rc) {
+        return rc;
+    }
+    offset += sizeof(*tlv);
+
+    /* Calculate tlv alignment */
+    alignment = log_fcb2_hdr_body_bytes(f_align, offset);
+    offset += alignment;
+
+    rc = os_mbuf_append(om, buf, alignment);
+    if (rc) {
+        return rc;
+    }
+
+    rc = log_fcb2_write_mbuf(loc, om, len);
+    if (rc) {
+        return rc;
+    }
+
+    return rc;
+}
+
+static int
+log_fcb2_single_tlv_write(uint8_t *buf, uint16_t buflen, struct log_tlv *tlv,
+                          void *val, uint8_t f_align, struct fcb2_entry *loc,
+                          uint16_t *f_offset)
+{
+    uint16_t offset = 0;
+    int alignment = 0;
+    int rc = 0;
+
+    memset(buf, 0, buflen);
+
+    /* Writes the following reverse TLVs, value first then length and
+     * then tag:
+     *
+     * Reverse TLV:
+     * ---------------------------------------------------------
+     * | Value  |  Value alignment | <len:tag> | TLV alignment |
+     * ---------------------------------------------------------
+     * TLV alignment is necessary here to aid in writing the next TLV
+     * from updated loc.fe_data_off.
+     *
+     * - Value is at alignment boundary
+     * - struct tlv is at alignment boundary <len:tag>
+     *
+     * Both can be read independently.
+     */
+    memcpy(buf, val, tlv->len);
+    offset += tlv->len;
+
+    /* Calculate value alignment */
+    alignment = log_fcb2_hdr_body_bytes(f_align, offset);
+    offset += alignment;
+
+    memcpy(buf + offset, tlv, sizeof(*tlv));
+    offset += sizeof(*tlv);
+
+    /* Calculate tlv alignment */
+    alignment = log_fcb2_hdr_body_bytes(f_align, offset);
+    offset += alignment;
+
+    rc = fcb2_write(loc, *f_offset, buf, offset);
+    if (rc != 0) {
+        return rc;
+    }
+
+    *f_offset += offset;
+
+    return rc;
+}
+
+static int
+log_fcb2_tlvs_write(struct log *log, uint8_t *buf, uint16_t buflen,
+                    struct fcb2_entry *loc, uint16_t *f_offset)
+{
+    int rc = 0;
+    struct log_tlv tlv;
+    uint8_t num_tlvs = 0;
+
+    (void)tlv;
+#if MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
+    tlv.tag = LOG_TLV_NUM_ENTRIES;
+    tlv.len = LOG_NUM_ENTRIES_SIZE;
+    rc = log_fcb2_single_tlv_write(buf, buflen, &tlv, &log->l_num_entries,
+                                   loc->fe_range->fsr_align, loc, f_offset);
+    log->l_num_entries++;
+    num_tlvs++;
+#endif
+
+    /* Always write the number of TLVS TLV at the end
+     * if num_tlvs > 1
+     */
+#if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
+    if (num_tlvs > 1) {
+        tlv.tag = LOG_TLV_NUM_TLVS;
+        tlv.len = LOG_NUM_TLVS_SIZE;
+        rc = log_fcb2_single_tlv_write(buf, buflen, &tlv, &num_tlvs,
+                                       loc->fe_range->fsr_align, loc, f_offset);
+    }
+#endif
+
+    return rc;
+}
+
+static int
+log_fcb2_mbuf_tlvs_write(struct log *log, struct os_mbuf *om,
+                         struct fcb2_entry *loc, int len)
+{
+    int rc = 0;
+    struct fcb2 *fcb;
+    struct fcb_log *fcb_log;
+    struct log_tlv tlv;
+    uint8_t num_tlvs = 0;
+
+    fcb_log = (struct fcb_log *)log->l_arg;
+    fcb = &fcb_log->fl_fcb;
+
+    (void)fcb;
+    (void)fcb_log;
+    (void)tlv;
+    (void)num_tlvs;
+
+#if MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
+    tlv.tag = LOG_TLV_NUM_ENTRIES;
+    tlv.len = LOG_NUM_ENTRIES_SIZE;
+    rc = log_fcb2_mbuf_single_tlv_write(om, &tlv, &log->l_num_entries,
+                                        loc->fe_range->fsr_align, loc, len);
+    log->l_num_entries++;
+#endif
+
+    /* Always write the number of TLVS TLV at the end
+     * if num_tlvs > 1
+     */
+#if MYNEWT_VAL(LOG_TLV_NUM_TLVS)
+    if (num_tlvs > 1) {
+        tlv.tag = LOG_TLV_NUM_TLVS;
+        tlv.len = LOG_NUM_TLVS_SIZE;
+        rc = log_fcb2_mbuf_single_tlv_write(om, &tlv, &num_tlvs,
+                                            loc->fe_range->fsr_align,
+                                            loc, len);
+    }
+#endif
+
+    return rc;
+}
+#endif
+
+static int
 log_fcb2_append_body(struct log *log, const struct log_entry_hdr *hdr,
                      const void *body, int body_len)
 {
-    uint8_t buf[LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN + sizeof(struct log_tlv)
-                + LOG_NUM_ENTRIES_SIZE + LOG_FCB2_MAX_ALIGN * 2 - 1];
+    uint8_t buf[LOG_FCB_FLAT_BUF_SIZE] = {0};
     struct fcb2_entry loc;
     const uint8_t *u8p;
     int hdr_alignment;
     int trailer_alignment = 0;
-    int chunk_sz = 0;
+    uint16_t chunk_sz = 0;
     int rc;
     uint16_t hdr_len;
     uint16_t trailer_len;
 
     hdr_len = log_hdr_len(hdr);
-    trailer_len = log_trailer_len(hdr);
+    trailer_len = log_trailer_len(log, hdr);
+
+    (void)trailer_alignment;
 
     rc = log_fcb2_start_append(log, hdr_len + body_len + trailer_len, &loc);
     if (rc != 0) {
@@ -278,14 +487,8 @@ log_fcb2_append_body(struct log *log, const struct log_entry_hdr *hdr,
         memset(buf, 0, sizeof(buf));
         /* Calculate trailer alignment */
         trailer_alignment = log_fcb2_hdr_body_bytes(loc.fe_range->fsr_align, chunk_sz + body_len);
-        if (trailer_alignment > trailer_len) {
-            chunk_sz += trailer_len;
-        } else {
-            chunk_sz += trailer_alignment;
-        }
 
-#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-        struct log_tlv tlv;
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
         uint16_t offset = 0;
         uint16_t padding = 0;
 
@@ -301,23 +504,25 @@ log_fcb2_append_body(struct log *log, const struct log_entry_hdr *hdr,
             u8p = u8p + body_len - padding;
             memcpy(buf, u8p, padding);
             offset = padding;
-            u8p = (void *)&tlv;
-            tlv.tag = LOG_TLV_NUM_ENTRIES;
-            tlv.len = LOG_NUM_ENTRIES_SIZE;
-            memcpy(buf + offset, u8p, sizeof(struct log_tlv));
-            offset += sizeof(struct log_tlv);
-
-            memcpy(buf + offset, &log->l_num_entries, LOG_NUM_ENTRIES_SIZE);
-            offset += LOG_NUM_ENTRIES_SIZE;
-
+            offset += trailer_alignment;
+            /* Writes the following:
+             * -----------------------------------------------------------------
+             * | body: body_len - padding from end of body | trailer_alignment |
+             * -----------------------------------------------------------------
+             */
             rc = fcb2_write(&loc, chunk_sz, buf, offset);
             if (rc != 0) {
                 return rc;
             }
 
-            log->l_num_entries++;
-
             chunk_sz += offset;
+            /* The first TLV gets appended after the padding + trailer_alignment
+             * Trailers start from updated chunk_sz offset.
+             */
+            rc = log_fcb2_tlvs_write(log, buf, sizeof(buf), &loc, &chunk_sz);
+            if (rc) {
+                return rc;
+            }
         }
 #else
         if (body_len > 0) {
@@ -358,24 +563,6 @@ log_fcb2_append(struct log *log, void *buf, int len)
 }
 
 static int
-log_fcb2_write_mbuf(struct fcb2_entry *loc, struct os_mbuf *om, int off)
-{
-    int rc;
-
-    while (om) {
-        rc = fcb2_write(loc, off, om->om_data, om->om_len);
-        if (rc != 0) {
-            return SYS_EIO;
-        }
-
-        off += om->om_len;
-        om = SLIST_NEXT(om, om_next);
-    }
-
-    return off;
-}
-
-static int
 log_fcb2_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
                           struct os_mbuf *om)
 {
@@ -395,7 +582,7 @@ log_fcb2_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
     }
 #endif
 
-    len = log_hdr_len(hdr) + os_mbuf_len(om) + log_trailer_len(hdr);
+    len = log_hdr_len(hdr) + os_mbuf_len(om) + log_trailer_len(log, hdr);
     rc = log_fcb2_start_append(log, len, &loc);
     if (rc != 0) {
         return rc;
@@ -416,31 +603,22 @@ log_fcb2_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
         len += LOG_IMG_HASHLEN;
     }
 
-    len = log_fcb2_write_mbuf(&loc, om, len);
-    if (len < 0) {
-        return len;
-    }
-
     if (hdr->ue_flags & LOG_FLAGS_TLV_SUPPORT) {
-#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT) && MYNEWT_VAL(LOG_TLV_NUM_ENTRIES)
-        struct log_tlv tlv;
-        tlv.tag = LOG_TLV_NUM_ENTRIES;
-        tlv.len = LOG_NUM_ENTRIES_SIZE;
-        /* Write TLV */
-        rc = fcb2_write(&loc, len, &tlv, sizeof(struct log_tlv));
+#if MYNEWT_VAL(LOG_FLAGS_TLV_SUPPORT)
+        /* The first TLV gets appended after the padding + trailer_alignment
+         * Trailers start from updated loc.fe_data_off. Write everything
+         * together
+         */
+        rc = log_fcb2_mbuf_tlvs_write(log, om, &loc, len);
         if (rc != 0) {
             return rc;
         }
-        len += sizeof(struct log_tlv);
-        /* Write LOG_NUM_ENTRIES_SIZE bytes */
-        rc = fcb2_write(&loc, len,
-                        &hdr->ue_num_entries, LOG_NUM_ENTRIES_SIZE);
-        if (rc != 0) {
-            return rc;
-        }
-        len += LOG_NUM_ENTRIES_SIZE;
-        log->l_num_entries++;
 #endif
+    } else {
+        rc = log_fcb2_write_mbuf(&loc, om, len);
+        if (rc != 0) {
+            return rc;
+        }
     }
 
     rc = fcb2_append_finish(&loc);
@@ -449,6 +627,18 @@ log_fcb2_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
     }
 
     return 0;
+}
+
+static int
+log_fcb2_len_in_medium(struct log *log, uint16_t len)
+{
+    struct fcb_log *fl;
+    struct fcb2 *fcb;
+
+    fl = (struct fcb_log *)log->l_arg;
+    fcb = &fl->fl_fcb;
+
+    return fcb2_len_in_flash(fcb->f_active.fe_range, len);
 }
 
 static int
@@ -992,6 +1182,7 @@ const struct log_handler log_fcb_handler = {
     .log_walk = log_fcb2_walk,
     .log_flush = log_fcb2_flush,
     .log_read_entry_len = log_fcb2_read_entry_len,
+    .log_len_in_medium = log_fcb2_len_in_medium,
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
     .log_storage_info = log_fcb2_storage_info,
 #endif

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -38,6 +38,18 @@ syscfg.defs:
             1 - enable.
         value: 0
 
+    LOG_FLAGS_TLV_SUPPORT:
+        description: >
+            Enable logging TLV with custom data types in every log entry
+            0 - disable; 1 - enable.
+        value: 0
+
+    LOG_TLV_NUM_ENTRIES:
+        description: >
+            Enable logging number entries using TLV in every log entry, max number is 2^32
+            0 - disable; 1 - enable.
+        value: 0
+
     LOG_FCB:
         description: 'Support logging to FCB.'
         value: 0


### PR DESCRIPTION
Please check email on the dev list for more information:
- This adds support for logging number of entries since a given index of the log, it is optional, so only used when enabled
- The MYNEWT_VAL for the same is `LOG_FLAGS_TLV_NUM_ENTRIES` and the TLV support syscfg is `LOG_FLAGS_TLV_SUPPORT`
- No `LOG_VERSION`: 4 needed
- Backwards and forwards compatible with earlier log header since the TLV is added at the end of the log entry
- CLI command support is also added to help read the number of entries since a particular index on the CLI
- Added selftests for num_entries
CLI command:
```
compat> log -ne reboot_log -i 50

043837 entries: 5
```
Example log entries:
```
7143966 [ih=0x92ea3333][ne=0] [1577940571820322]  [ix=16] {_ "rsn": "OTHER: 0x0", "cnt": 238, "img": "24.3.19.131805", "hash": "92ea3333ffe0c6eaa01b842e2a0f8692f6b4a748de10378423b7abc8887993d2", "flags": "active bootable confirmed"}
7143973 [ih=0x92ea3333][ne=1] [1577949942585905]  [ix=33] {_ "rsn": "SOFT", "cnt": 239, "img": "24.3.19.131805", "hash": "92ea3333ffe0c6eaa01b842e2a0f8692f6b4a748de10378423b7abc8887993d2", "flags": "active bootable confirmed"}
7143978 [ih=0x92ea3333][ne=2] [1577951411585993]  [ix=50] {_ "rsn": "SOFT", "cnt": 240, "img": "24.3.19.131805", "hash": "92ea3333ffe0c6eaa01b842e2a0f8692f6b4a748de10378423b7abc8887993d2", "flags": "active bootable confirmed"}
7143984 [ih=0x92ea3333][ne=3] [1577953577609410]  [ix=67] {_ "rsn": "SOFT", "cnt": 241, "img": "24.3.19.131805", "hash": "92ea3333ffe0c6eaa01b842e2a0f8692f6b4a748de10378423b7abc8887993d2", "flags": "active bootable confirmed"}
7143989 [ih=0x92ea3333][ne=4] [1577956085609419]  [ix=84] {_ "rsn": "WDOG", "cnt": 242, "img": "24.3.19.131805", "hash": "92ea3333ffe0c6eaa01b842e2a0f8692f6b4a748de10378423b7abc8887993d2", "flags": "active bootable confirmed"}
```
- mcumgr PR: https://github.com/apache/mynewt-mcumgr/pull/172
- newtmgr PR: https://github.com/apache/mynewt-newtmgr/pull/205

*Tests performed*
- [x] NRF52840 slinky logs fine as it is
- [x] NRF52840 slinky logs fine with `LOG_FLAGS_TLV_SUPPORT` and `LOG_TLV_NUM_ENTRIES` support
- [x] NRF52840 slinky logs fine with downgrading firmware with no `LOG_FLAGS_TLV_SUPPORT` and `LOG_TLV_NUM_ENTRIES` support