### PR TITLE
hmcu/stm32: Add link_tables to all ld scripts

### DIFF
--- a/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
+++ b/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f1xx/stm32f103.ld
+++ b/hw/mcu/stm/stm32f1xx/stm32f103.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f3xx/stm32f303.ld
+++ b/hw/mcu/stm/stm32f3xx/stm32f303.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f401.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f401.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f407.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f407.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f411.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f411.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f413.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f413.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f427.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f427.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f429.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f429.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f439.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f439.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32h7xx/stm32h723.ld
+++ b/hw/mcu/stm/stm32h7xx/stm32h723.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l0xx/stm32l072.ld
+++ b/hw/mcu/stm/stm32l0xx/stm32l072.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l0xx/stm32l073.ld
+++ b/hw/mcu/stm/stm32l0xx/stm32l073.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l1xx/stm32l152.ld
+++ b/hw/mcu/stm/stm32l1xx/stm32l152.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l4xx/stm32l476.ld
+++ b/hw/mcu/stm/stm32l4xx/stm32l476.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32u5xx/stm32u5xx.ld
+++ b/hw/mcu/stm/stm32u5xx/stm32u5xx.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32wbxx/stm32wb55.ld
+++ b/hw/mcu/stm/stm32wbxx/stm32wb55.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+        INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))


### PR DESCRIPTION
newt tool can create link_tables.ld.h file from
pkg.link_table section
This modifies all STM32 linker scripts to have this functionality.

G4 and G0 already have common linker script so they are already covered.