### PR TITLE
bsp/pca10056: Support reset button by default

### DIFF
--- a/hw/bsp/nordic_pca10056/syscfg.yml
+++ b/hw/bsp/nordic_pca10056/syscfg.yml
@@ -61,6 +61,7 @@ syscfg.vals:
     QSPI_PIN_DIO1: 21
     QSPI_PIN_DIO2: 22
     QSPI_PIN_DIO3: 23
+    GPIO_AS_PIN_RESET: 1
 
 syscfg.vals.BLE_CONTROLLER:
     TIMER_0: 0


### PR DESCRIPTION
Set GPIO_AS_PIN_RESET to 1 in syscfg.