### PR TITLE
hw/bsp: Enable double precision for STM32F767 and STM32H723

### DIFF
--- a/hw/bsp/nucleo-f767zi/pkg.yml
+++ b/hw/bsp/nucleo-f767zi/pkg.yml
@@ -30,7 +30,7 @@ pkg.keywords:
 pkg.cflags: -DSTM32F767xx
 
 pkg.cflags.HARDFLOAT:
-    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+    - -mfloat-abi=hard -mfpu=fpv5-d16
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32f7xx"

--- a/hw/bsp/nucleo-h723zg/pkg.yml
+++ b/hw/bsp/nucleo-h723zg/pkg.yml
@@ -30,7 +30,7 @@ pkg.keywords:
 pkg.cflags: -DSTM32H723xx -DUSE_FULL_LL_DRIVER
 
 pkg.cflags.HARDFLOAT:
-    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
+    - -mfloat-abi=hard -mfpu=fpv5-d16
 
 pkg.deps:
     - "@apache-mynewt-core/hw/mcu/stm/stm32h7xx"


### PR DESCRIPTION
Two boards have MCU with double precision FPU.
This simply enables double precision instruction generation for those two boards.