### PR TITLE
hw/bsp: add missing metadata for multiple BSPs

### DIFF
--- a/hw/bsp/arduino_primo_nrf52/bsp.yml
+++ b/hw/bsp/arduino_primo_nrf52/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Arduino Primo"
+bsp.url: https://docs.arduino.cc/retired/boards/arduino-primo/
+bsp.maker: "Arduino S.r.l."
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/arduino_zero/bsp.yml
+++ b/hw/bsp/arduino_zero/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Arduino Zero"
+bsp.url: https://store.arduino.cc/products/arduino-zero
+bsp.maker: "Arduino S.r.l."
 bsp.arch: cortex_m0
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m0"
 bsp.linkerscript:

--- a/hw/bsp/ble400/bsp.yml
+++ b/hw/bsp/ble400/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "BLE400"
+bsp.url: https://www.waveshare.com/ble400.htm
+bsp.maker: "Waveshare Electronics CO.,Ltd."
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/bluepill/bsp.yml
+++ b/hw/bsp/bluepill/bsp.yml
@@ -19,6 +19,9 @@
 
 ### Entries containing `XXX` need to be replaced with actual values.
 
+bsp.name: "Blue Pill"
+bsp.url: https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill.html
+bsp.maker: "Unknown"
 bsp.arch: cortex_m3
 bsp.compiler: '@apache-mynewt-core/compiler/arm-none-eabi-m3'
 

--- a/hw/bsp/bmd200/bsp.yml
+++ b/hw/bsp/bmd200/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "BMD-200"
+bsp.url: https://content.u-blox.com/sites/default/files/BMD-200_ProductSummary_%28UBX-19033633%29.pdf
+bsp.maker: "u-blox AG"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/calliope_mini/bsp.yml
+++ b/hw/bsp/calliope_mini/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Calliope mini"
+bsp.url: https://calliope.cc
+bsp.maker: "Calliope gGmbH"
 bsp.arch: cortex_m0
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m0"
 bsp.linkerscript:

--- a/hw/bsp/dialog_cmac/bsp.yml
+++ b/hw/bsp/dialog_cmac/bsp.yml
@@ -17,7 +17,11 @@
 # under the License.
 #
 
+bsp.name: "DA1469x CMAC"
+bsp.url: https://www.renesas.com/us/en/products/wireless-connectivity/bluetooth-low-energy/da14695-multi-core-bluetooth-52-soc-system-power-management-unit
+bsp.maker: "Renesas Electronics Corporation"
 bsp.arch: cortex_m0_cmac
+bsp.exclude_site: 1
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m0"
 bsp.debugscript: "@apache-mynewt-core/hw/bsp/dialog_cmac/dialog_cmac_debug.sh"
 

--- a/hw/bsp/dialog_da14695-dk-usb/bsp.yml
+++ b/hw/bsp/dialog_da14695-dk-usb/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "DA14695 DK USB"
+bsp.url: https://www.renesas.com/us/en/products/wireless-connectivity/bluetooth-low-energy/da14695-multi-core-bluetooth-52-soc-system-power-management-unit
+bsp.maker: "Renesas Electronics Corporation"
 bsp.arch: cortex_m33
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m33"
 bsp.downloadscript:

--- a/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "DA1469x DK Pro"
+bsp.url: https://www.renesas.com/us/en/products/wireless-connectivity/bluetooth-low-energy/da14695-multi-core-bluetooth-52-soc-system-power-management-unit
+bsp.maker: "Renesas Electronics Corporation"
 bsp.arch: cortex_m33
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m33"
 bsp.downloadscript:

--- a/hw/bsp/dwm1001-dev/bsp.yml
+++ b/hw/bsp/dwm1001-dev/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "DWM1001-DEV"
+bsp.url: https://www.qorvo.com/products/p/DWM1001-DEV
+bsp.maker: "Qorvo, Inc"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/embarc_emsk/bsp.yml
+++ b/hw/bsp/embarc_emsk/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "EM Starter Kit (EMSK)"
+bsp.url: https://embarc.org/project/arc-em-starter-kit-emsk/
+bsp.maker: "Synopsys, Inc."
 bsp.arch: arc
 bsp.compiler: compiler/arc
 bsp.linkerscript:

--- a/hw/bsp/fanstel-ev-bt840/bsp.yml
+++ b/hw/bsp/fanstel-ev-bt840/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "EV-BT840"
+bsp.url: https://www.fanstel.com/buy/ev-bt840f-evaluation-board-for-bt840f-3re88
+bsp.maker: "Fanstel Corp."
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/native-armv7/bsp.yml
+++ b/hw/bsp/native-armv7/bsp.yml
@@ -18,6 +18,7 @@
 #
 
 bsp.arch: sim-armv7
+bsp.exclude_site: 1
 bsp.compiler: compiler/sim-armv7
 bsp.debugscript: "hw/bsp/native-armv7/native_debug.sh"
 

--- a/hw/bsp/native-mips/bsp.yml
+++ b/hw/bsp/native-mips/bsp.yml
@@ -18,6 +18,7 @@
 #
 
 bsp.arch: sim
+bsp.exclude_site: 1
 bsp.compiler: compiler/sim-mips
 bsp.debugscript: "hw/bsp/native-mips/native_debug.sh"
 

--- a/hw/bsp/native/bsp.yml
+++ b/hw/bsp/native/bsp.yml
@@ -18,6 +18,7 @@
 #
 
 bsp.arch: sim
+bsp.exclude_site: 1
 bsp.compiler: compiler/sim
 bsp.debugscript: "hw/bsp/native/native_debug.sh"
 

--- a/hw/bsp/nordic_pca10095/bsp.yml
+++ b/hw/bsp/nordic_pca10095/bsp.yml
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-bsp.name: "nRF5340 PDK"
-bsp.url: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK
+bsp.name: "nRF5340 DK"
+bsp.url: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-DK
 bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m33
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m33"

--- a/hw/bsp/nordic_pca10095_net/bsp.yml
+++ b/hw/bsp/nordic_pca10095_net/bsp.yml
@@ -17,10 +17,11 @@
 # under the License.
 #
 
-bsp.name: "nRF5340 PDK (Net Core)"
-bsp.url: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-PDK
+bsp.name: "nRF5340 DK (Net Core)"
+bsp.url: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-DK
 bsp.maker: "Nordic Semiconductor"
 bsp.arch: cortex_m33
+bsp.exclude_site: 1
 bsp.compiler: "@apache-mynewt-core/compiler/arm-none-eabi-m33"
 bsp.linkerscript:
     - "hw/bsp/nordic_pca10095_net/nrf5340_net.ld"

--- a/hw/bsp/nrf51-arduino_101/bsp.yml
+++ b/hw/bsp/nrf51-arduino_101/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Arduino 101"
+bsp.url: https://docs.arduino.cc/retired/boards/arduino-101-619/
+bsp.maker: "Arduino S.r.l."
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nrf51-blenano/bsp.yml
+++ b/hw/bsp/nrf51-blenano/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "BLENano"
+bsp.url: https://github.com/RedBearLab/BLENano
+bsp.maker: "RedBearLab"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/nucleo-l073rz/bsp.yml
+++ b/hw/bsp/nucleo-l073rz/bsp.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-bsp.name: "nucleo-l073rz"
+bsp.name: "NUCLEO-L073RZ"
 bsp.url: https://www.st.com/en/evaluation-tools/nucleo-l073rz.html
 bsp.maker: "STMicroelectronics"
 bsp.arch: cortex_m0

--- a/hw/bsp/pinetime/bsp.yml
+++ b/hw/bsp/pinetime/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "PineTime"
+bsp.url: https://wiki.pine64.org/wiki/PineTime
+bsp.maker: "PINE64"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/puckjs/bsp.yml
+++ b/hw/bsp/puckjs/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "Puck.js"
+bsp.url: https://www.puck-js.com/
+bsp.maker: "Espruino"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/reel_board/bsp.yml
+++ b/hw/bsp/reel_board/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "reel board"
+bsp.url: https://www.phytec.de/reelboard/
+bsp.maker: "PHYTEC Messtechnik GmbH"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/telee02/bsp.yml
+++ b/hw/bsp/telee02/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "EE02"
+bsp.url: https://github.com/ExploratoryEngineering/ee0x-firmware
+bsp.maker: "Telenor Group"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:

--- a/hw/bsp/usbmkw41z/bsp.yml
+++ b/hw/bsp/usbmkw41z/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "USB-KW41Z"
+bsp.url: https://www.nxp.com/design/design-center/designs/bluetooth-low-energy-ieee-802-15-4-packet-sniffer-usb-dongle:USB-KW41Z
+bsp.maker: "NXP B.V."
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/vbluno51/bsp.yml
+++ b/hw/bsp/vbluno51/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "VBLUno51"
+bsp.url: https://vngiotlab.github.io/vbluno/
+bsp.maker: "VNG Corporation"
 bsp.arch: cortex_m0
 bsp.compiler: compiler/arm-none-eabi-m0
 bsp.linkerscript:

--- a/hw/bsp/vbluno52/bsp.yml
+++ b/hw/bsp/vbluno52/bsp.yml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+bsp.name: "VBLUno52"
+bsp.url: https://vngiotlab.github.io/vbluno/
+bsp.maker: "VNG Corporation"
 bsp.arch: cortex_m4
 bsp.compiler: compiler/arm-none-eabi-m4
 bsp.linkerscript:


### PR DESCRIPTION
Adds BSP information required for building site documentation, e.g. name, maker, url.