### PR TITLE
link: Add link_tables to all ld scripts

### DIFF
--- a/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
+++ b/hw/bsp/ada_feather_nrf52/ada_feather_nrf52_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ada_feather_nrf52/split_ada_feather_nrf52.ld
+++ b/hw/bsp/ada_feather_nrf52/split_ada_feather_nrf52.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ada_feather_stm32f405/run_from_sram.ld
+++ b/hw/bsp/ada_feather_stm32f405/run_from_sram.ld
@@ -89,6 +89,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
+++ b/hw/bsp/arduino_primo_nrf52/primo_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/arduino_primo_nrf52/split-primo.ld
+++ b/hw/bsp/arduino_primo_nrf52/split-primo.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/bbc_microbit/split-microbit.ld
+++ b/hw/bsp/bbc_microbit/split-microbit.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/black_vet6/run_from_sram.ld
+++ b/hw/bsp/black_vet6/run_from_sram.ld
@@ -89,6 +89,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/bsp/ble400/ble400_no_boot.ld
+++ b/hw/bsp/ble400/ble400_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ble400/split-ble400.ld
+++ b/hw/bsp/ble400/split-ble400.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/bmd200/nrf51dk_no_boot.ld
+++ b/hw/bsp/bmd200/nrf51dk_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/bmd200/split-nrf51dk.ld
+++ b/hw/bsp/bmd200/split-nrf51dk.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
+++ b/hw/bsp/bmd300eval/bmd300eval_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/bmd300eval/split-bmd300eval.ld
+++ b/hw/bsp/bmd300eval/split-bmd300eval.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/calliope_mini/split-calliope_mini.ld
+++ b/hw/bsp/calliope_mini/split-calliope_mini.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
+++ b/hw/bsp/dwm1001-dev/dwm1001-dev_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/dwm1001-dev/split-dwm1001-dev.ld
+++ b/hw/bsp/dwm1001-dev/split-dwm1001-dev.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/fanstel-ev-bt840/fanstel-ev-bt840_no_boot.ld
+++ b/hw/bsp/fanstel-ev-bt840/fanstel-ev-bt840_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/fanstel-ev-bt840/split-fanstel-ev-bt840.ld
+++ b/hw/bsp/fanstel-ev-bt840/split-fanstel-ev-bt840.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/MK64FN1M0xxx12_flash.ld
@@ -96,6 +96,7 @@ SECTIONS
     . = ALIGN(4);
     *(.text)                 /* .text sections (code) */
     *(.text*)                /* .text* sections (code) */
+INCLUDE "link_tables.ld.h"
     *(.rodata)               /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
     *(.glue_7)               /* glue arm to thumb code */

--- a/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
+++ b/hw/bsp/frdm-k64f/boot-MK64FN1M0xxx12_flash.ld
@@ -89,6 +89,7 @@ SECTIONS
     . = ALIGN(4);
     *(.text)                 /* .text sections (code) */
     *(.text*)                /* .text* sections (code) */
+INCLUDE "link_tables.ld.h"
     *(.rodata)               /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
     *(.glue_7)               /* glue arm to thumb code */

--- a/hw/bsp/frdm-k82f/MK82FN256xxx15_flash.ld
+++ b/hw/bsp/frdm-k82f/MK82FN256xxx15_flash.ld
@@ -65,6 +65,7 @@ SECTIONS
     . = ALIGN(4);
     *(.text)                 /* .text sections (code) */
     *(.text*)                /* .text* sections (code) */
+INCLUDE "link_tables.ld.h"
     *(.rodata)               /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
     *(.glue_7)               /* glue arm to thumb code */

--- a/hw/bsp/frdm-k82f/boot-MK82FN256xxx15_flash.ld
+++ b/hw/bsp/frdm-k82f/boot-MK82FN256xxx15_flash.ld
@@ -76,6 +76,7 @@ SECTIONS
     . = ALIGN(4);
     *(.text)                 /* .text sections (code) */
     *(.text*)                /* .text* sections (code) */
+INCLUDE "link_tables.ld.h"
     *(.rodata)               /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
     *(.glue_7)               /* glue arm to thumb code */

--- a/hw/bsp/hifive1/hifive1.ld
+++ b/hw/bsp/hifive1/hifive1.ld
@@ -57,6 +57,7 @@ SECTIONS
   .rodata         :
   {
     *(.rdata)
+INCLUDE "link_tables.ld.h"
     *(.rodata .rodata.*)
     *(.gnu.linkonce.r.*)
   } >flash

--- a/hw/bsp/nina-b1/nrf52dk_no_boot.ld
+++ b/hw/bsp/nina-b1/nrf52dk_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nina-b1/split-nrf52dk.ld
+++ b/hw/bsp/nina-b1/split-nrf52dk.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10028-16k/nordic_pca10028-16k_no_boot.ld
+++ b/hw/bsp/nordic_pca10028-16k/nordic_pca10028-16k_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10028-16k/split-nordic_pca10028-16k.ld
+++ b/hw/bsp/nordic_pca10028-16k/split-nordic_pca10028-16k.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10028/nordic_pca10028_no_boot.ld
+++ b/hw/bsp/nordic_pca10028/nordic_pca10028_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10028/split-nordic_pca10028.ld
+++ b/hw/bsp/nordic_pca10028/split-nordic_pca10028.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10040/nordic_pca10040_no_boot.ld
+++ b/hw/bsp/nordic_pca10040/nordic_pca10040_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10040/split-nordic_pca10040.ld
+++ b/hw/bsp/nordic_pca10040/split-nordic_pca10040.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10056/nordic_pca10056_no_boot.ld
+++ b/hw/bsp/nordic_pca10056/nordic_pca10056_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10056/split-nordic_pca10056.ld
+++ b/hw/bsp/nordic_pca10056/split-nordic_pca10056.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10059/nordic_pca10059_no_boot.ld
+++ b/hw/bsp/nordic_pca10059/nordic_pca10059_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10059/split-nordic_pca10059.ld
+++ b/hw/bsp/nordic_pca10059/split-nordic_pca10059.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10090/split-nordic_pca10090.ld
+++ b/hw/bsp/nordic_pca10090/split-nordic_pca10090.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10095/nordic_pca10095_no_boot.ld
+++ b/hw/bsp/nordic_pca10095/nordic_pca10095_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10095_net/nordic_pca10095_net_no_boot.ld
+++ b/hw/bsp/nordic_pca10095_net/nordic_pca10095_net_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10121/net/no_boot.ld
+++ b/hw/bsp/nordic_pca10121/net/no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca10121/no_boot.ld
+++ b/hw/bsp/nordic_pca10121/no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca20020/nordic_pca20020_no_boot.ld
+++ b/hw/bsp/nordic_pca20020/nordic_pca20020_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nordic_pca20020/split-nordic_pca20020.ld
+++ b/hw/bsp/nordic_pca20020/split-nordic_pca20020.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
+++ b/hw/bsp/nrf51-arduino_101/nrf51dk-16kbram_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
+++ b/hw/bsp/nrf51-blenano/nrf51dk_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/nrf51-blenano/split-nrf51dk.ld
+++ b/hw/bsp/nrf51-blenano/split-nrf51dk.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
+++ b/hw/bsp/olimex_stm32-e407_devboard/run_from_sram.ld
@@ -89,6 +89,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/bsp/puckjs/puckjs_no_boot.ld
+++ b/hw/bsp/puckjs/puckjs_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/puckjs/split_puckjs.ld
+++ b/hw/bsp/puckjs/split_puckjs.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
+++ b/hw/bsp/rb-blend2/rb-blend2_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/rb-blend2/split-rb-blend2.ld
+++ b/hw/bsp/rb-blend2/split-rb-blend2.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
+++ b/hw/bsp/rb-nano2/rb-nano2_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/rb-nano2/split-rb-nano2.ld
+++ b/hw/bsp/rb-nano2/split-rb-nano2.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/reel_board/reel_board_no_boot.ld
+++ b/hw/bsp/reel_board/reel_board_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/reel_board/split-reel_board.ld
+++ b/hw/bsp/reel_board/split-reel_board.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ruuvitag_rev_b/ruuvitag_rev_b_no_boot.ld
+++ b/hw/bsp/ruuvitag_rev_b/ruuvitag_rev_b_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ruuvitag_rev_b/split-ruuvitag_rev_b.ld
+++ b/hw/bsp/ruuvitag_rev_b/split-ruuvitag_rev_b.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/telee02/split-telee02.ld
+++ b/hw/bsp/telee02/split-telee02.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/telee02/telee02_no_boot.ld
+++ b/hw/bsp/telee02/telee02_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ublox_bmd_345/split-ublox_bmd_345.ld
+++ b/hw/bsp/ublox_bmd_345/split-ublox_bmd_345.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/ublox_bmd_345/ublox_bmd_345_no_boot.ld
+++ b/hw/bsp/ublox_bmd_345/ublox_bmd_345_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/usbmkw41z/boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/boot-mkw41z512.ld
@@ -97,6 +97,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/usbmkw41z/mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/mkw41z512.ld
@@ -87,6 +87,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
+++ b/hw/bsp/usbmkw41z/no-boot-mkw41z512.ld
@@ -97,6 +97,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/vbluno51/split-vbluno51.ld
+++ b/hw/bsp/vbluno51/split-vbluno51.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/vbluno51/vbluno51_no_boot.ld
+++ b/hw/bsp/vbluno51/vbluno51_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/vbluno52/split-vbluno52.ld
+++ b/hw/bsp/vbluno52/split-vbluno52.ld
@@ -83,6 +83,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/bsp/vbluno52/vbluno52_no_boot.ld
+++ b/hw/bsp/vbluno52/vbluno52_no_boot.ld
@@ -80,6 +80,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/ambiq/apollo2/apollo2.ld
+++ b/hw/mcu/ambiq/apollo2/apollo2.ld
@@ -79,6 +79,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/ambiq/apollo3/apollo3.ld
+++ b/hw/mcu/ambiq/apollo3/apollo3.ld
@@ -43,6 +43,7 @@ SECTIONS
 
     /* .rodata */
     . = ALIGN(4);
+INCLUDE "link_tables.ld.h"
     *(.rodata)
     *(.rodata*)
 

--- a/hw/mcu/atmel/samd21xx/samd21xx.ld
+++ b/hw/mcu/atmel/samd21xx/samd21xx.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/dialog/cmac/cmac.ld
+++ b/hw/mcu/dialog/cmac/cmac.ld
@@ -67,6 +67,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/dialog/da1469x/da1469x.ld
+++ b/hw/mcu/dialog/da1469x/da1469x.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/dialog/da1469x/da1469x_ram_resident.ld
+++ b/hw/mcu/dialog/da1469x/da1469x_ram_resident.ld
@@ -69,6 +69,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf51xxx/nrf51.ld
+++ b/hw/mcu/nordic/nrf51xxx/nrf51.ld
@@ -99,6 +99,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf52xxx/nrf52.ld
+++ b/hw/mcu/nordic/nrf52xxx/nrf52.ld
@@ -99,6 +99,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf52xxx/nrf52_ram_resident.ld
+++ b/hw/mcu/nordic/nrf52xxx/nrf52_ram_resident.ld
@@ -95,6 +95,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf5340/nrf5340.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340.ld
@@ -99,6 +99,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf5340/nrf5340_ram_resident.ld
+++ b/hw/mcu/nordic/nrf5340/nrf5340_ram_resident.ld
@@ -95,6 +95,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf5340_net/nrf5340_net.ld
+++ b/hw/mcu/nordic/nrf5340_net/nrf5340_net.ld
@@ -99,6 +99,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf5340_net/nrf5340_net_ram_resident.ld
+++ b/hw/mcu/nordic/nrf5340_net/nrf5340_net_ram_resident.ld
@@ -95,6 +95,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf91xx/nrf91.ld
+++ b/hw/mcu/nordic/nrf91xx/nrf91.ld
@@ -99,6 +99,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/nordic/nrf91xx/nrf91_ram_resident.ld
+++ b/hw/mcu/nordic/nrf91xx/nrf91_ram_resident.ld
@@ -95,6 +95,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         *(.eh_frame*)

--- a/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
+++ b/hw/mcu/stm/stm32f0xx/stm32f0xx.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f1xx/stm32f103.ld
+++ b/hw/mcu/stm/stm32f1xx/stm32f103.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f3xx/stm32f303.ld
+++ b/hw/mcu/stm/stm32f3xx/stm32f303.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f401.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f401.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f407.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f407.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f411.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f411.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f413.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f413.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f427.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f427.ld
@@ -105,6 +105,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f429.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f429.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f4xx/stm32f439.ld
+++ b/hw/mcu/stm/stm32f4xx/stm32f439.ld
@@ -108,6 +108,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f7xx/stm32f746.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f746.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32f7xx/stm32f767.ld
+++ b/hw/mcu/stm/stm32f7xx/stm32f767.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32h7xx/stm32h723.ld
+++ b/hw/mcu/stm/stm32h7xx/stm32h723.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l0xx/stm32l072.ld
+++ b/hw/mcu/stm/stm32l0xx/stm32l072.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l0xx/stm32l073.ld
+++ b/hw/mcu/stm/stm32l0xx/stm32l073.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l1xx/stm32l152.ld
+++ b/hw/mcu/stm/stm32l1xx/stm32l152.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32l4xx/stm32l476.ld
+++ b/hw/mcu/stm/stm32l4xx/stm32l476.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32u5xx/stm32u5xx.ld
+++ b/hw/mcu/stm/stm32u5xx/stm32u5xx.ld
@@ -106,6 +106,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/hw/mcu/stm/stm32wbxx/stm32wb55.ld
+++ b/hw/mcu/stm/stm32wbxx/stm32wb55.ld
@@ -107,6 +107,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
+INCLUDE "link_tables.ld.h"
         *(.rodata*)
 
         KEEP(*(.eh_frame*))


### PR DESCRIPTION
newt tool can create link_tables.ld.h file from
pkg.link_table section
This modifies all linker scripts to have this
functionality.

supersedes #3171 