### PR TITLE
console log pretty

### DIFF
--- a/hw/usb/tinyusb/dfu/syscfg.yml
+++ b/hw/usb/tinyusb/dfu/syscfg.yml
@@ -111,6 +111,7 @@ syscfg.logs:
     USBD_DFU_LOG:
         module: MYNEWT_VAL(USBD_DFU_LOG_MODULE)
         level: MYNEWT_VAL(USBD_DFU_LOG_LVL)
+        name: '"DFU"'
 
 
 syscfg.vals.BOOT_LOADER:

--- a/hw/usb/tinyusb/msc_fat_view/syscfg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/syscfg.yml
@@ -141,3 +141,4 @@ syscfg.logs:
     MSC_FAT_VIEW_LOG:
         module: MYNEWT_VAL(MSC_FAT_VIEW_LOG_MOD)
         level: MYNEWT_VAL(MSC_FAT_VIEW_LOG_LVL)
+        name: '"FATVIEW"'

--- a/sys/log/common/syscfg.yml
+++ b/sys/log/common/syscfg.yml
@@ -34,4 +34,5 @@ syscfg.logs:
     DFLT_LOG:
         module: MYNEWT_VAL(DFLT_LOG_MOD)
         level: MYNEWT_VAL(DFLT_LOG_LVL)
+        name: '"DEFAULT"'
 

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -230,48 +230,20 @@ const char *
 log_module_get_name(uint8_t module)
 {
     int idx;
+    const char *name;
 
-    switch (module) {
-#ifdef MYNEWT_VAL_DFLT_LOG_MOD
-    case MYNEWT_VAL(DFLT_LOG_MOD):
-        return "DEFAULT";
-#endif
-#ifdef MYNEWT_VAL_OS_LOG_MOD
-    case MYNEWT_VAL(OS_LOG_MOD):
-        return "OS";
-#endif
-#ifdef MYNEWT_VAL_BLE_LL_LOG_MOD
-    case MYNEWT_VAL(BLE_LL_LOG_MOD):
-        return "NIMBLE_CTLR";
-#endif
-#ifdef MYNEWT_VAL_BLE_HS_LOG_MOD
-    case MYNEWT_VAL(BLE_HS_LOG_MOD):
-        return "NIMBLE_HOST";
-#endif
-#ifdef MYNEWT_VAL_NFFS_LOG_MOD
-    case MYNEWT_VAL(NFFS_LOG_MOD):
-        return "NFFS";
-#endif
-#ifdef MYNEWT_VAL_REBOOT_LOG_MOD
-    case MYNEWT_VAL(REBOOT_LOG_MOD):
-        return "REBOOT";
-#endif
-#ifdef MYNEWT_VAL_OC_LOG_MOD
-    case MYNEWT_VAL(OC_LOG_MOD):
-        return "IOTIVITY";
-#endif
-#ifdef MYNEWT_VAL_TEST_LOG_MOD
-    case MYNEWT_VAL(TEST_LOG_MOD):
-        return "TEST";
-#endif
-    default:
+    /* Find module defined in syscfg.logcfg sections */
+    name = logcfg_log_module_name(module);
+
+    if (name == NULL) {
+        /* not in syscfg.logcfg, find module registered with log_module_register() */
         idx = log_module_find_idx(module);
         if (idx != -1) {
-            return g_log_module_list[idx].name;
+            name = g_log_module_list[idx].name;
         }
     }
 
-    return NULL;
+    return name;
 }
 
 /**

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -57,7 +57,7 @@ log_console_print_hdr(const struct log_entry_hdr *hdr)
                    hdr->ue_ts, hdr->ue_module, hdr->ue_level);
 
     if (hdr->ue_flags & LOG_FLAGS_IMG_HASH) {
-        console_printf("ih=0x%x%x%x%x", hdr->ue_imghash[0], hdr->ue_imghash[1],
+        console_printf("ih=0x%02x%02x%02x%02x", hdr->ue_imghash[0], hdr->ue_imghash[1],
                        hdr->ue_imghash[2], hdr->ue_imghash[3]);
     }
     console_printf("]");

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -32,6 +32,22 @@ syscfg.defs:
         description: 'Limits what level log messages are compiled in.'
         value: 0
 
+    LOG_CONSOLE_PRETTY:
+        description: >
+            Use alternative formatting of mod log prints.
+        value: 0
+
+    LOG_CONSOLE_PRETTY_WITH_COLORS:
+        description: >
+            Use color for mod log levels.
+        value: 0
+
+    LOG_CONSOLE_PRETTY_WITH_TIMESTAMP:
+        description: >
+            Print timestamp in us.
+            Turned off by default when CONSOLE_TICKS is on.
+        value: 1
+
     LOG_FLAGS_IMAGE_HASH:
         description: >
             Enable logging of the first 4 bytes of the image hash. 0 - disable;
@@ -154,6 +170,9 @@ syscfg.defs:
             Don't increment the global index for LOG_STREAM_TYPE. This allows
             the global index to be sequentially increasing for persisted logs.
         value: 0
+
+syscfg.vals.CONSOLE_TICKS:
+    LOG_CONSOLE_PRETTY_WITH_TIMESTAMP: 0
 
 syscfg.vals.LOG_NEWTMGR:
     LOG_MGMT: MYNEWT_VAL(LOG_MGMT)


### PR DESCRIPTION
This adds alternative way of printing mod log logs.

This change requires https://github.com/apache/mynewt-newt/pull/551

New syscfg values that can be use to configure console printing
```yml
   # enable alternative mod log prints
    LOG_CONSOLE_PRETTY: 1
   # enable severity level coloring
    LOG_CONSOLE_PRETTY_WITH_COLORS: 1
   # disable time stamp
    LOG_CONSOLE_PRETTY_WITH_TIMESTAMP: 0
```

Old way of showing mod log logs:
![image](https://github.com/apache/mynewt-core/assets/23063648/ae41c998-3ab3-497c-8ac0-68245d6a68f0)
New way:
![image](https://github.com/apache/mynewt-core/assets/23063648/7c012557-6794-446e-bffa-7c661606b8f5)
