### PR TITLE
tinyusb/msc_fat_view: Make application version optional in readme

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
@@ -356,7 +356,7 @@ readme_create_content(struct MemFile *file)
 
     fwrite(readme_text, 1, sizeof(readme_text) - 1, &file->file);
 
-    if (0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+    if (MYNEWT_VAL(MSC_FAT_VIEW_DEFAULT_README_VERSION) && 0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
         flash_area_read(fa, 0, &image_header, sizeof(image_header));
         if (image_header.ih_magic == IMAGE_MAGIC) {
             fprintf(&file->file, "\n\nApp version: %u.%u.%u.%u\n", image_header.ih_ver.iv_major,

--- a/hw/usb/tinyusb/msc_fat_view/syscfg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/syscfg.yml
@@ -81,10 +81,14 @@ syscfg.defs:
         description: >
             If set to 1, adds default 'README.TXT' file with some basic information about firmware.
         value: 1
+    MSC_FAT_VIEW_DEFAULT_README_VERSION:
+        description: >
+            If set to 1, README.TXT will have application version number.
+        value: 1
     MSC_FAT_VIEW_DEFAULT_README_APP_NAME:
         description: >
             Application name that will be put in default README.TXT.
-        value: '"Mynewt+TinyUSB"'
+        value: MYNEWT_VAL(APP_NAME)
     MSC_FAT_VIEW_DEFAULT_README_INCLUDE_HASHES:
         description: >
             Add git hashes into README.TXT.


### PR DESCRIPTION
Generated README.TXT file contains line

App version: 1.2.1.2

This line is generated from image version from SLOT0. This line uses fprintf and can increase code size if printf-like functions were not otherwise used.
Now syscfg value MSC_FAT_VIEW_DEFAULT_README_VERSION can disable line with version possibly reducing code size.

Additionally default application name used in README.TXT is taken from APP_NAME syscfg value generated by newt tool.