### PR TITLE
sys/flash_map: Allow build with 1 flash image area

### DIFF
--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -334,8 +334,10 @@ flash_area_id_from_image_slot(int slot)
     switch (slot) {
     case 0:
         return FLASH_AREA_IMAGE_0;
+#ifdef FLASH_AREA_IMAGE_1
     case 1:
         return FLASH_AREA_IMAGE_1;
+#endif
     default:
         assert(0);
         return FLASH_AREA_IMAGE_0;
@@ -352,8 +354,10 @@ flash_area_id_to_image_slot(int area_id)
     switch (area_id) {
     case FLASH_AREA_IMAGE_0:
         return 0;
+#ifdef FLASH_AREA_IMAGE_1
     case FLASH_AREA_IMAGE_1:
         return 1;
+#endif
     default:
         return -1;
     }


### PR DESCRIPTION
When bootloader alone can write new image to device (no swap needed) there is no need to define fake
flash area anymore.

This allows build when there is no definition for secondary swap image flash area.