### PR TITLE
boot/startup: Fix unused vector macro

### DIFF
--- a/boot/startup/src/interrupts.c
+++ b/boot/startup/src/interrupts.c
@@ -124,7 +124,7 @@ Default_SysTick_Handler(void) {
 #define INT_VECTOR_PENDSV_HANDLER(handler) handler,
 #define INT_VECTOR_SYSTICK_HANDLER(handler) handler,
 #define INT_VECTOR(isr) isr,
-#define INT_VECTOR_UNUSED(a) 0,
+#define INT_VECTOR_UNUSED(a) (void (*)(void))a,
 void (*g_pfnVectors[])(void) __attribute__((section(".isr_vector"))) = {
 #include "mcu/mcu_vectors.h"
 };


### PR DESCRIPTION
When generating isr vector table INT_VECTOR_UNUSED ignored its argument and used 0 instead.
Now this macro may be used to store some values in vector table (needed for STM32F1 where table ends
with some magic value).