### PR TITLE
ci: Don't build bootloader on native target

### DIFF
--- a/.github/test_build_bootloader.sh
+++ b/.github/test_build_bootloader.sh
@@ -22,7 +22,7 @@ EXIT_CODE=0
 BSPS=$(ls repos/apache-mynewt-core/hw/bsp)
 IGNORED_BSPS="ci40 dialog_cmac embarc_emsk hifive1 native-armv7 native-mips\
               olimex-pic32-emz64 olimex-pic32-hmz144 pic32mx470_6lp_clicker\
-              pic32mz2048_wi-fire usbmkw41z"
+              pic32mz2048_wi-fire usbmkw41z native"
 
 # native is supported only on Linux (mind the space)
 if [ $RUNNER_OS != "Linux" ]; then


### PR DESCRIPTION
There is no point in doing that.