### PR TITLE
ci: Add native to ignored BSPs in bootloader build test

### DIFF
--- a/.github/test_build_bootloader.sh
+++ b/.github/test_build_bootloader.sh
@@ -20,9 +20,9 @@
 EXIT_CODE=0
 
 BSPS=$(ls repos/apache-mynewt-core/hw/bsp)
-IGNORED_BSPS="ci40 dialog_cmac embarc_emsk hifive1 native-armv7 native-mips\
-              olimex-pic32-emz64 olimex-pic32-hmz144 pic32mx470_6lp_clicker\
-              pic32mz2048_wi-fire usbmkw41z"
+IGNORED_BSPS="ci40 dialog_cmac embarc_emsk hifive1 native native-armv7\
+              native-mips olimex-pic32-emz64 olimex-pic32-hmz144\
+              pic32mx470_6lp_clicker pic32mz2048_wi-fire usbmkw41z"
 
 # native is supported only on Linux (mind the space)
 if [ $RUNNER_OS != "Linux" ]; then


### PR DESCRIPTION
After the merge of https://github.com/apache/mynewt-newt/commit/a798fcc687dd81857de7bb92e77711c9a74f0692
newt passes to the linker the same .a files as before, but in different order and it causes linker error. It means that previously this test was passing just by accident.

It does not make sense to build bootloader for native target anyway, so this test will simply be skipped.