### PR TITLE
mcu/stm32h7xx: Fix STM32_HAL_FLASH_CLEAR_ERRORS macro

### DIFF
--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32_hal.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32_hal.h
@@ -100,7 +100,6 @@ struct stm32_hal_spi_cfg {
                 FLASH_CCR_CLR_PGSERR   |             \
                 FLASH_CCR_CLR_STRBERR  |             \
                 FLASH_CCR_CLR_INCERR   |             \
-                FLASH_CCR_CLR_OPERR    |             \
                 FLASH_CCR_CLR_RDPERR   |             \
                 FLASH_CCR_CLR_RDSERR   |             \
                 FLASH_CCR_CLR_SNECCERR |             \


### PR DESCRIPTION
STM32_HAL_FLASH_CLEAR_ERRORS was copied from from F7 stm32h7 does not have OPERR field in CCR register so it is now removed.