### PR TITLE
hw/mcu/stm32g4: Include hal config

### DIFF
--- a/hw/mcu/stm/stm32g4xx/src/system_stm32g4xx.c
+++ b/hw/mcu/stm/stm32g4xx/src/system_stm32g4xx.c
@@ -76,7 +76,7 @@
   */
 
 #include "stm32g4xx.h"
-#include <mcu/cmsis_nvic.h>
+#include <stm32g4xx_hal_conf.h>
 
 #if !defined  (HSE_VALUE)
   #define HSE_VALUE     24000000U /*!< Value of the External oscillator in Hz */


### PR DESCRIPTION
system_stm32g4xx.c was including mcu/cmsis_nvic.h
while it should include stm32g4xx_hal_conf.h

This is required if external oscillator frequency
(defined in stm32g4xx_hal_conf.h) is not 24MHz