### PR TITLE
sys/config: Make floating point support optional

### DIFF
--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -156,7 +156,9 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
 {
     int64_t val;
     uint64_t uval;
+#if MYNEWT_VAL(CONFIG_FLOAT_SUPPORT)
     float fval;
+#endif
     char *eptr;
 
     if (!val_str) {
@@ -223,6 +225,7 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
             *(uint64_t *)vp = uval;
         }
         break;
+#if MYNEWT_VAL(CONFIG_FLOAT_SUPPORT)
     case CONF_FLOAT:
         fval = strtof(val_str, &eptr);
         if (*eptr != '\0') {
@@ -230,6 +233,7 @@ conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
         }
         *(float *)vp = fval;
         break;
+#endif
     case CONF_STRING:
         val = strlen(val_str);
         if (val + 1 > maxlen) {

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -93,6 +93,15 @@ syscfg.defs:
         description: >
             Max length of a value stored in the config FCB.
         value: 256
+    CONFIG_FLOAT_SUPPORT:
+        description: >
+            Enable float support in config.
+            For MCU without hardware support for enabling this if no other
+            function use floating point may increase image size 20kB or more.
+        value: 0
+
+syscfg.vals.HARDFLOAT:
+    value: 1
 
 syscfg.defs.(CONFIG_FCB || CONFIG_FCB2):
     CONFIG_FCB_FLASH_AREA:


### PR DESCRIPTION
Adding CONF_FLOAT support could increase code size significantly if floating point are not used otherwise.

This makes support optional (enabled by default when HARDFLOAT is present).