### PR TITLE
coremark: User FLOAT_USER instead of HARDFLOAT

### DIFF
--- a/util/coremark/repo/include/core_portme.h
+++ b/util/coremark/repo/include/core_portme.h
@@ -29,7 +29,7 @@ Original Author: Shay Gal-on
    Define to 1 if the platform supports floating point.
 */
 #ifndef HAS_FLOAT
-#define HAS_FLOAT MYNEWT_VAL(HARDFLOAT)
+#define HAS_FLOAT MYNEWT_VAL(FLOAT_USER)
 #endif
 /* Configuration : HAS_TIME_H
    Define to 1 if platform has the time.h header file,


### PR DESCRIPTION
Coremark uses float numbers for printing only.
Now default value HAS_FLOAT used FLOAT_USER that tells tinyprintf to have support for %f instead of checking if MCU has FPU.