### PR TITLE
boot/split: Fix SPLIT_CONFIG_SUPPORT initialization

### DIFF
--- a/boot/split/syscfg.yml
+++ b/boot/split/syscfg.yml
@@ -28,5 +28,5 @@ syscfg.defs:
             Sysinit stage for split image functionality.
         value: 500
 
-syscfg.defs.'(CONFIG_NFFS==1||CONFIG_LITTLEFS==1||CONFIG_FCB==1||CONFIG_FCB2==1)':
+syscfg.vals.'(CONFIG_NFFS==1||CONFIG_LITTLEFS==1||CONFIG_FCB==1||CONFIG_FCB2==1)':
     SPLIT_CONFIG_SUPPORT: 1


### PR DESCRIPTION
For certain configurations SPLIT_CONFIG_SUPPORT was double defined and second definition was constant because syscfg.defs section was used instead of syscfg.vals.

So when CONFIG_xxx was set to 1 for NFFS/LITTLEFS/CFB/FCB2 SPLIT_CONFIG_SUPPORT could not be disabled