### PR TITLE
sys/config: Add conf_export function

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -247,6 +247,14 @@ int conf_load_one(char *name);
 int conf_ensure_loaded(void);
 
 /**
+ * Export configuration via user defined function.
+ *
+ * @param export_func function to receive configuration entry
+ * @param tgt - export target declaration
+ */
+void conf_export(conf_export_func_t export_func, enum conf_export_tgt tgt);
+
+/**
  * Config setting comes as a result of conf_load().
  *
  * @return 1 if yes, 0 if not.

--- a/sys/config/src/config.c
+++ b/sys/config/src/config.c
@@ -406,6 +406,18 @@ conf_export_cb(struct conf_handler *ch, conf_export_func_t export_func,
     return 0;
 }
 
+void
+conf_export(conf_export_func_t export_func, enum conf_export_tgt tgt)
+{
+    struct conf_handler *ch;
+
+    conf_lock();
+    SLIST_FOREACH(ch, &conf_handlers, ch_list) {
+        conf_export_cb(ch, export_func, tgt);
+    }
+    conf_unlock();
+}
+
 int
 conf_set_value(char *name, char *val_str)
 {

--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -47,13 +47,7 @@ conf_running_one(char *name, char *val)
 static void
 conf_dump_running(void)
 {
-    struct conf_handler *ch;
-
-    conf_lock();
-    SLIST_FOREACH(ch, &conf_handlers, ch_list) {
-        conf_export_cb(ch, conf_running_one, CONF_EXPORT_SHOW);
-    }
-    conf_unlock();
+    conf_export(conf_running_one, CONF_EXPORT_SHOW);
 }
 #endif
 


### PR DESCRIPTION
While every config entry could specify export function there was no easy way to call those functions.
Then only way to export config was to use shell command config dump

Now new function conf_export takes allows to export configuration and conf_dump_running just uses it so functionality is preserved.