### PR TITLE
tinyusb/msc_fat_view: Use link_tables for root entries

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/include/msc_fat_view/msc_fat_view.h
+++ b/hw/usb/tinyusb/msc_fat_view/include/msc_fat_view/msc_fat_view.h
@@ -71,4 +71,20 @@ void msc_fat_view_media_eject(void);
  */
 void msc_fat_view_media_insert(void);
 
+/* Section name for root entries */
+#define ROOT_DIR_SECTION __attribute__((section(".msc_fat_view_root_entry"), used))
+
+/**
+ * Macro to add static root entries
+ */
+#define ROOT_DIR_ENTRY(entry, file_name, attr, size_fun, read_fun, write_fun, delete_fun) \
+const file_entry_t entry ROOT_DIR_SECTION = {  \
+    .name = file_name,                         \
+    .attributes = attr,                        \
+    .size = size_fun,                          \
+    .read_sector = read_fun,                   \
+    .write_sector = write_fun,                 \
+    .delete_entry = delete_fun,                \
+}
+
 #endif /* __MSC_FAT_VIEW_H__ */

--- a/hw/usb/tinyusb/msc_fat_view/pkg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/pkg.yml
@@ -38,8 +38,28 @@ pkg.deps.MSC_FAT_VIEW_COREDUMP_FILES:
 pkg.source_files:
     - src/msc_fat_view.c
 
+pkg.whole_archive: true
+
 pkg.source_files.MSC_FAT_VIEW_COREDUMP_FILES:
     - src/coredump_files.c
+
+pkg.source_files.MSC_FAT_VIEW_DEFAULT_README:
+    - src/entry_readme.c
+
+pkg.source_files.MSC_FAT_VIEW_HUGE_FILE:
+    - src/entry_huge_file.c
+
+pkg.source_files.MSC_FAT_VIEW_SLOT0_IMAGE:
+    - src/entry_slot0.c
+
+pkg.source_files.MSC_FAT_VIEW_SLOT0_HEX:
+    - src/entry_slot0_hex.c
+
+pkg.source_files.MSC_FAT_VIEW_MYNEWT_SHORTCUT:
+    - src/entry_mynewt_htm.c
+
+pkg.link_tables:
+    - msc_fat_view_root_entry
 
 pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START!=0)':
     msc_fat_view_pkg_init: $before:tinyusb_start

--- a/hw/usb/tinyusb/msc_fat_view/src/entry_huge_file.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_huge_file.c
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <sysflash/sysflash.h>
+#include <msc_fat_view/msc_fat_view.h>
+#include <bootutil/image.h>
+
+#if MYNEWT_VAL(MSC_FAT_VIEW_HUGE_FILE_SIZE) > 0
+#define HUGE_FILE_SIZE          MYNEWT_VAL(MSC_FAT_VIEW_HUGE_FILE_SIZE)
+#if HUGE_FILE_SIZE > (MYNEWT_VAL(MSC_FAT_VIEW_DISK_SIZE) * 1024) + 2000000
+#error HUGE_FILE_SIZE is to big for specified disk size
+#endif
+#elif (MYNEWT_VAL(MSC_FAT_VIEW_DISK_SIZE) * 1024) < 2000000
+#error No space for huge file, increase MSC_FAT_VIEW_DISK_SIZE in syscfg
+#else
+#define HUGE_FILE_SIZE          ((MYNEWT_VAL(MSC_FAT_VIEW_DISK_SIZE) * 1024) - 2000000)
+#endif
+
+static uint32_t
+huge_file_size(const file_entry_t *file)
+{
+    (void)file;
+
+    return HUGE_FILE_SIZE;
+}
+
+static void
+huge_file_read(const struct file_entry *entry, uint32_t file_sector, uint8_t buffer[512])
+{
+    (void)entry;
+
+    memset(buffer, (uint8_t)file_sector, 512);
+}
+
+ROOT_DIR_ENTRY(huge_file, "Huge file", FAT_FILE_ENTRY_ATTRIBUTE_READ_ONLY, huge_file_size, huge_file_read, NULL, NULL);

--- a/hw/usb/tinyusb/msc_fat_view/src/entry_mynewt_htm.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_mynewt_htm.c
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <msc_fat_view/msc_fat_view.h>
+
+static const char mynewt_htm_text[] =
+    "<!-- mynewt Website and Authentication Shortcut -->\n"
+    "<html>\n"
+    "<head>\n"
+    "<meta http-equiv=\"refresh\" content=\"0; url=https://mynewt.apache.org/\"/>\n"
+    "<title>mynewt Website Shortcut</title>\n"
+    "</head>\n"
+    "<body></body>\n"
+    "</html>";
+
+static uint32_t
+mynewt_htm_size(const file_entry_t *file)
+{
+    (void)file;
+
+    return strlen(mynewt_htm_text);
+}
+
+static void
+mynewt_htm_read(const struct file_entry *entry, uint32_t file_sector, uint8_t buffer[512])
+{
+    (void)entry;
+
+    if (file_sector == 0) {
+        strcpy((char *)buffer, mynewt_htm_text);
+        memset(buffer + 512 - sizeof(mynewt_htm_text), 0, sizeof(mynewt_htm_text));
+    } else {
+        memset(buffer, 0, 512);
+    }
+}
+
+ROOT_DIR_ENTRY(mynew_htm, "MYNEWT.HTM", FAT_FILE_ENTRY_ATTRIBUTE_READ_ONLY, mynewt_htm_size, mynewt_htm_read, NULL, NULL);

--- a/hw/usb/tinyusb/msc_fat_view/src/entry_readme.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_readme.c
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <ctype.h>
+#include <os/endian.h>
+#include <bsp/bsp.h>
+#include <sysflash/sysflash.h>
+#include <hal/hal_gpio.h>
+#include <os/util.h>
+#include <tusb.h>
+#include <class/msc/msc.h>
+#include <class/msc/msc_device.h>
+#include <tinyusb/tinyusb.h>
+#include <msc_fat_view/msc_fat_view.h>
+#include <img_mgmt/img_mgmt.h>
+#include <bootutil/image.h>
+#include <modlog/modlog.h>
+#include <hal/hal_flash.h>
+#include <console/console.h>
+#include "coredump_files.h"
+
+#if MYNEWT_VAL(BOOT_LOADER)
+#define BOOT_LOADER     1
+#define FLASH_AREA_IMAGE FLASH_AREA_IMAGE_0
+#else
+#define BOOT_LOADER     0
+#ifdef FLASH_AREA_IMAGE_1
+#define FLASH_AREA_IMAGE FLASH_AREA_IMAGE_1
+#endif
+#endif
+
+static const char readme_text[] = "This device runs "
+                                  MYNEWT_VAL(MSC_FAT_VIEW_DEFAULT_README_APP_NAME)  " on "
+                                  MYNEWT_VAL(BSP_NAME);
+
+#if defined MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_CORE
+#define REPO_VERSION_APACHE_MYNEWT_CORE     MYNEWT_VAL(REPO_VERSION_APACHE_MYNEWT_CORE)
+#else
+#define REPO_VERSION_APACHE_MYNEWT_CORE     "unknown"
+#endif
+
+#if defined MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_CORE
+#define REPO_HASH_APACHE_MYNEWT_CORE        MYNEWT_VAL(REPO_HASH_APACHE_MYNEWT_CORE)
+#else
+#define REPO_HASH_APACHE_MYNEWT_CORE        ""
+#endif
+
+#if defined MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_NIMBLE
+#define REPO_VERSION_APACHE_MYNEWT_NIMBLE   MYNEWT_VAL(REPO_VERSION_APACHE_MYNEWT_NIMBLE)
+#else
+#define REPO_VERSION_APACHE_MYNEWT_NIMBLE   "unknown"
+#endif
+
+#if defined MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_NIMBLE
+#define REPO_HASH_APACHE_MYNEWT_NIMBLE      MYNEWT_VAL(REPO_HASH_APACHE_MYNEWT_NIMBLE)
+#else
+#define REPO_HASH_APACHE_MYNEWT_NIMBLE      ""
+#endif
+
+#if defined MYNEWT_VAL_REPO_VERSION_APACHE_MYNEWT_MCUMGR
+#define REPO_VERSION_APACHE_MYNEWT_MCUMGR   MYNEWT_VAL(REPO_VERSION_APACHE_MYNEWT_MCUMGR)
+#else
+#define REPO_VERSION_APACHE_MYNEWT_MCUMGR   "unknown"
+#endif
+
+#if defined MYNEWT_VAL_REPO_HASH_APACHE_MYNEWT_MCUMGR
+#define REPO_HASH_APACHE_MYNEWT_MCUMGR      MYNEWT_VAL(REPO_HASH_APACHE_MYNEWT_MCUMGR)
+#else
+#define REPO_HASH_APACHE_MYNEWT_MCUMGR      ""
+#endif
+
+#if defined MYNEWT_VAL_REPO_VERSION_TINYUSB
+#define REPO_VERSION_TINYUSB                MYNEWT_VAL(REPO_VERSION_TINYUSB)
+#else
+#define REPO_VERSION_TINYUSB                "unknown"
+#endif
+
+#if defined MYNEWT_VAL_REPO_HASH_TINYUSB
+#define REPO_HASH_TINYUSB                   MYNEWT_VAL(REPO_HASH_TINYUSB)
+#else
+#define REPO_HASH_TINYUSB                   ""
+#endif
+
+static int
+readme_create_content(struct MemFile *file)
+{
+    struct image_header image_header;
+    const struct flash_area *fa;
+
+    fwrite(readme_text, 1, sizeof(readme_text) - 1, &file->file);
+
+    if (MYNEWT_VAL(MSC_FAT_VIEW_DEFAULT_README_VERSION) && 0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+        flash_area_read(fa, 0, &image_header, sizeof(image_header));
+        if (image_header.ih_magic == IMAGE_MAGIC) {
+            fprintf(&file->file, "\n\nApp version: %u.%u.%u.%u\n", image_header.ih_ver.iv_major,
+                    image_header.ih_ver.iv_minor,
+                    image_header.ih_ver.iv_revision,
+                    (unsigned)image_header.ih_ver.iv_build_num);
+        }
+        flash_area_close(fa);
+    }
+
+    if (MYNEWT_VAL(MSC_FAT_VIEW_DEFAULT_README_INCLUDE_HASHES)) {
+        fprintf(&file->file, "\n\nmynewt: " REPO_VERSION_APACHE_MYNEWT_CORE " " REPO_HASH_APACHE_MYNEWT_CORE);
+        fprintf(&file->file, "\nnimble: " REPO_VERSION_APACHE_MYNEWT_NIMBLE " " REPO_HASH_APACHE_MYNEWT_NIMBLE);
+        fprintf(&file->file, "\nmcumgr: " REPO_VERSION_APACHE_MYNEWT_MCUMGR " " REPO_HASH_APACHE_MYNEWT_MCUMGR);
+        fprintf(&file->file, "\ntinyusb: " REPO_VERSION_TINYUSB " " REPO_HASH_TINYUSB);
+    }
+    if (MYNEWT_VAL(MSC_FAT_VIEW_HUGE_FILE)) {
+        fprintf(&file->file, "\n\n'Huge file' can be used to verify USB performance.\n");
+    }
+
+#ifdef FLASH_AREA_IMAGE
+    fprintf(&file->file, "\n\nNew firmware can be copied to this drive (drag-drop .img file to upgrade device).\n");
+#endif
+
+    return file->bytes_written;
+}
+
+static uint32_t
+readme_size(const file_entry_t *file_entry)
+{
+    (void)file_entry;
+    struct MemFile empty_mem_file;
+    uint32_t len;
+
+    fmemopen_w(&empty_mem_file, (char *)NULL, 0);
+    len = readme_create_content(&empty_mem_file);
+
+    return len;
+}
+
+static void
+readme_read(const struct file_entry *entry, uint32_t file_sector, uint8_t buffer[512])
+{
+    struct MemFile sector_file;
+    int written = 0;
+    (void)entry;
+
+    MSC_FAT_VIEW_LOG_DEBUG("Readme read %d\n", file_sector);
+    if (file_sector == 0) {
+        fmemopen_w(&sector_file, (char *)buffer, 512);
+        readme_create_content(&sector_file);
+        written = sector_file.bytes_written;
+    }
+
+    memset(buffer + written, 0, 512 - written);
+}
+
+ROOT_DIR_ENTRY(readme, "README.TXT", FAT_FILE_ENTRY_ATTRIBUTE_READ_ONLY, readme_size, readme_read, NULL, NULL);
+

--- a/hw/usb/tinyusb/msc_fat_view/src/entry_slot0.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_slot0.c
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <sysflash/sysflash.h>
+#include <msc_fat_view/msc_fat_view.h>
+#include <bootutil/image.h>
+
+static uint32_t
+slot0_img_size(const file_entry_t *file)
+{
+    struct image_header image_header;
+    struct image_tlv_info tlv_info;
+    uint32_t size = 0;
+    const struct flash_area *fa;
+    (void)file;
+
+    if (0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+        flash_area_read(fa, 0, &image_header, sizeof(image_header));
+        size = image_header.ih_img_size + image_header.ih_hdr_size;
+        flash_area_read(fa, size, &tlv_info, sizeof(tlv_info));
+        if (tlv_info.it_magic == IMAGE_TLV_INFO_MAGIC) {
+            size += tlv_info.it_tlv_tot;
+        }
+        flash_area_close(fa);
+    }
+
+    return size;
+}
+
+static void
+slot0_img_read(const struct file_entry *entry, uint32_t file_sector, uint8_t buffer[512])
+{
+    const struct flash_area *fa;
+    uint32_t addr;
+    (void)entry;
+
+    if (0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+        addr = file_sector * 512;
+        flash_area_read(fa, addr, buffer, 512);
+        flash_area_close(fa);
+    }
+}
+
+ROOT_DIR_ENTRY(slot0, "FIRMWARE.IMG", FAT_FILE_ENTRY_ATTRIBUTE_READ_ONLY, slot0_img_size, slot0_img_read, NULL, NULL);

--- a/hw/usb/tinyusb/msc_fat_view/src/entry_slot0_hex.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_slot0_hex.c
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <sysflash/sysflash.h>
+#include <msc_fat_view/msc_fat_view.h>
+#include <bootutil/image.h>
+
+static uint32_t
+slot0_hex_size(const file_entry_t *file)
+{
+    uint32_t size = 0;
+    const struct flash_area *fa;
+    (void)file;
+
+    if (0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+        size = fa->fa_size * 4;
+        flash_area_close(fa);
+    }
+
+    return size;
+}
+
+static uint8_t
+hex_digit(int v)
+{
+    v &= 0xF;
+
+    return (v < 10) ? (v + '0') : (v + 'A' - 10);
+}
+
+static void
+slot0_hex_read(const struct file_entry *entry, uint32_t file_sector, uint8_t buffer[512])
+{
+    const struct flash_area *fa;
+    int i;
+    int j;
+    int k;
+    uint32_t addr = (file_sector * 512) / 4;
+    uint32_t addr_buf;
+    (void)entry;
+
+    if (0 == flash_area_open(FLASH_AREA_IMAGE_0, &fa)) {
+        flash_area_read(fa, addr, buffer, 512 / 4);
+        flash_area_close(fa);
+        for (i = 512, j = 128; i > 0;) {
+            buffer[--i] = '\n';
+            buffer[--i] = '\r';
+            for (k = 0; k < 16; ++k) {
+                buffer[--i] = hex_digit(buffer[--j]);
+                buffer[--i] = hex_digit(buffer[j] >> 4);
+                buffer[--i] = ' ';
+            }
+            for (k = 0; k < 5; ++k) {
+                buffer[--i] = ' ';
+            }
+            buffer[--i] = ':';
+            addr_buf = addr + j;
+            for (k = 0; k < 8; ++k) {
+                buffer[--i] = hex_digit(addr_buf);
+                addr_buf >>= 4;
+            }
+        }
+    }
+}
+
+ROOT_DIR_ENTRY(slot0_hex, "SLOT0.HEX", FAT_FILE_ENTRY_ATTRIBUTE_READ_ONLY, slot0_hex_size, slot0_hex_read, NULL, NULL);


### PR DESCRIPTION
This change extract several FAT root entries definitions to separate files so it's easier to see how to make custom entries.

This feature utilized newt tool features:
- link time tables (used for root dir entries)
- pkg.whole_archive switch that forces to search whole archive
- pkg.source_files (now package files are selected separately)