### PR TITLE
ci: Add checks for RAT exclusions and LICENSE file

### DIFF
--- a/.github/check_license.py
+++ b/.github/check_license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +20,7 @@
 #
 
 import os
+import re
 import subprocess
 import sys
 import shutil
@@ -27,6 +28,15 @@ from pathlib import Path
 
 tmp_folder = "/tmp/check_license/"
 licenses_url = "https://www.apache.org/legal/resolved.html"
+LICENSE_FILE = "LICENSE"
+RAT_EXCLUDES_FILE = ".rat-excludes"
+ignored = {
+    ".gdb_history",
+    ".gdb_out",
+    "tags",
+    "bin"
+}
+
 
 def run_cmd(cmd: str) -> list[str]:
     out = subprocess.check_output(cmd, text=True, shell=True)
@@ -36,6 +46,73 @@ def run_cmd(cmd: str) -> list[str]:
 def run_cmd_no_check(cmd: str) -> list[str]:
     out = subprocess.run(cmd, text=True, shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
     return out.splitlines()
+
+
+def get_rat_exclusions(file_path: str) -> set[str]:
+    file_names = set()
+    try:
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+            for line in lines:
+                line = re.sub(r'#.*', '', line)
+                line = line.strip()
+                if line:
+                    file_names.add(line)
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.")
+    except IOError as e:
+        print(f"Error reading file '{file_path}': {e}")
+    return file_names
+
+
+def get_license_files(file_path: str) -> set[str]:
+    file_paths = set()
+    try:
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+            for line in lines:
+                line = line.strip()
+                if line.startswith('*'):
+                    line = line[1:].strip()
+                    if line:
+                        file_paths.add(line)
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.")
+    except IOError as e:
+        print(f"Error reading file '{file_path}': {e}")
+    return file_paths
+
+
+def check_rat_exclusions(rat_entries: set[str], ignored_entries: set[str]) -> list[str]:
+    result = []
+    base_dir = Path.cwd()
+    existing_paths = {path.name for path in base_dir.rglob('*')}
+    for entry in rat_entries:
+        if entry not in existing_paths and entry not in ignored_entries:
+            result.append(entry)
+    return result
+
+
+def check_license_files(license_entries: set[str]) -> list[str]:
+    result = []
+    base_dir = Path.cwd()
+    for entry in license_entries:
+        full_path = base_dir / entry
+        if not full_path.exists():
+            result.append(entry)
+    return result
+
+
+def run_rat_check(files_diff: list[str]) -> list[str]:
+    result = []
+    for cfg_fname in files_diff:
+        os.makedirs(str(Path(tmp_folder + cfg_fname).parent), 0o755, True)
+        shutil.copy(cfg_fname, tmp_folder + cfg_fname)
+    rat_out = run_cmd_no_check(f"java -jar apache-rat.jar -E .rat-excludes -d {tmp_folder} | grep \"^ !\"")
+    if rat_out:
+        for entry in rat_out:
+            result.append(entry.strip(' !').replace(tmp_folder, '\t\t'))
+    return result
 
 
 def main() -> bool:
@@ -52,18 +129,35 @@ def main() -> bool:
     upstream = mb[0]
 
     files = run_cmd(f"git diff --diff-filter=AM --name-only {upstream} {commit}")
-    for cfg_fname in files:
-        os.makedirs(str(Path(tmp_folder + cfg_fname).parent), 0o755, True)
-        shutil.copy(cfg_fname, tmp_folder + cfg_fname)
+    result_rat_check = run_rat_check(files)
 
-    files = run_cmd_no_check(f"java -jar apache-rat.jar -E .rat-excludes -d {tmp_folder} | grep \"^ !\"")
-    if files :
-        print(f"\033[31m! Files with unapproved or unknown licenses detected.\033[0m")
-        print(f"\033[31m! See {licenses_url} for details.\033[0m")
-        print()
-        print(f"\033[90mLicense\t\tFilename\033[0m")
-        for f in files:
-            print(f.strip(' !').replace(tmp_folder,'\t\t'))
+    files = get_license_files(LICENSE_FILE)
+    result_license = check_license_files(files)
+
+    files = get_rat_exclusions(RAT_EXCLUDES_FILE)
+    result_rat_exclusions = check_rat_exclusions(files, ignored)
+
+    if any([result_license, result_rat_exclusions, result_rat_check]):
+        if result_rat_check:
+            print(f"\033[31m! Files with unapproved or unknown licenses detected.\033[0m")
+            print(f"\033[31m! See {licenses_url} for details.\033[0m")
+            print()
+            print(f"\033[90mLicense\t\tFilename\033[0m")
+            for result in result_rat_check:
+                print(result)
+            print()
+        if result_license:
+            print(f"\033[31m! 'LICENSE' file contains paths to files or "
+                  f"directories that do not exist in the repository:\033[0m")
+            for result in result_license:
+                print(result)
+            print()
+        if result_rat_exclusions:
+            print(f"\033[31m! File '.rat-excludes' contains files or directories"
+                  f" names that do not exist in the repository:\033[0m")
+            for result in result_rat_exclusions:
+                print(result)
+            print()
         return False
 
     return True

--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
              .github/check_style.py
 
-  style_license:
+  license_check:
     name: Licensing
     runs-on: ubuntu-latest
     steps:

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -20,7 +20,8 @@ README.md
 bin
 
 # CRC16 - BSD License.
-crc16.*
+crc16.h
+crc16.c
 
 
 # Nordic nRF5 SDK - BSD License.

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -30,7 +30,6 @@ system_nrf52.c
 system_nrf9160.c
 gcc_startup_cm0.s
 gcc_startup_cm0_split.s
-gcc_startup_cm4.s
 gcc_startup_cm4_split.s
 gcc_startup_cm33.s
 gcc_startup_cm33_split.s
@@ -283,7 +282,6 @@ startup_stm32f439xx.s
 startup_stm32f413xx.s
 
 # NUCLEO-L467rg BSP - BSD License
-startup_stm32l476xx.s
 stm32l4xx_hal_conf.h
 
 # NUCLEO-F072RB BSP - BSD License
@@ -295,7 +293,6 @@ nucleo-f030r8
 # NUCLEO-F103RB BSP - BSD License
 stm32f1xx_hal_conf.h
 system_stm32f1xx.c
-startup_stm32f103xb.s
 
 # NUCLEO-F411RE BSP - BSD License
 startup_STM32F411.s
@@ -311,7 +308,6 @@ system_stm32g4xx.c
 clock_stm32g4xx.c
 
 # NUCLEO-WB55 BSP - BSD License
-startup_stm32wb55xx_cm4.s
 stm32wbxx_hal_conf.h
 
 # Microchip PIC32 SDK - BSD License
@@ -386,7 +382,6 @@ system_stm32l4xx.c
 # STM32WBxx SDK - BSD License
 clock_stm32wbxx.c
 system_stm32wbxx.c
-stm32wb55.ld
 
 # B-L072Z-LRWAN1 BSP - BSD License
 b-l072z-lrwan1
@@ -422,7 +417,6 @@ gcc_startup_nrf5340_net.s
 
 # nucleo-l073rz BSP - BSD License
 stm32l0xx_hal_conf.h
-startup_stm32l073xx.s
 
 # MK64F12 SDK - BSD License
 MK64F12

--- a/LICENSE
+++ b/LICENSE
@@ -366,7 +366,7 @@ This product bundles parts of stm32f0xx, which is available under the
     * hw/mcu/stm/stm32f0xx/src/clock_stm32f0xx.c
     * hw/mcu/stm/stm32f0xx/src/system_stm32f0xx.c
     * hw/bsp/nucleo-f030r8/include/bsp/stm32f0xx_hal_conf.h
-  . * hw/bsp/nucleo-f030r8/src/arch/cortex_m0/startup_stm32f030x8.s
+    * hw/bsp/nucleo-f030r8/src/arch/cortex_m0/startup_stm32f030x8.s
     * hw/bsp/nucleo-f072rb/include/bsp/stm32f0xx_hal_conf.h
     * hw/bsp/nucleo-f072rb/src/arch/cortex_m0/startup_stm32f072xb.s
     

--- a/LICENSE
+++ b/LICENSE
@@ -236,7 +236,6 @@ which are available under a BSD style license.  Relevant files are:
     * hw/mcu/nordic/nrf5340_net/include/nrfx_config_nrf5340_network.h
     * hw/mcu/nordic/nrf51xxx/src/arch/cortex_m0/gcc_startup_cm0.s
     * hw/mcu/nordic/nrf51xxx/src/arch/cortex_m0/gcc_startup_cm0_split.s
-    * hw/mcu/nordic/nrf52xxx/src/arch/cortex_m4/gcc_startup_cm4.s
     * hw/mcu/nordic/nrf52xxx/src/arch/cortex_m4/gcc_startup_cm4_split.s
     * hw/mcu/nordic/nrf91xx/src/arch/cortex_m33/gcc_startup_cm33_split.s
     * hw/mcu/nordic/nrf91xx/src/arch/cortex_m33/gcc_startup_cm33.s
@@ -355,11 +354,8 @@ This product bundles parts of stm32f1xx, which is available under the
     * hw/mcu/stm/stm32f1xx/src/clock_stm32f1xx.c
     * hw/mcu/stm/stm32f1xx/src/system_stm32f1xx.c
     * hw/bsp/bluepill/include/bsp/stm32f1xx_hal_conf.h
-    * hw/bsp/bluepill/src/arch/cortex_m3/startup_stm32f103xb.s
     * hw/bsp/nucleo-f103rb/include/bsp/stm32f1xx_hal_conf.h
-    * hw/bsp/nucleo-f103rb/src/arch/cortex_m3/startup_stm32f103xb.s
     * hw/bsp/olimex-p103/include/bsp/stm32f1xx_hal_conf.h
-    * hw/bsp/olimex-p103/src/arch/cortex_m3/startup_stm32f103xb.s
     
 This product bundles parts of stm32f0xx, which is available under the
 "3-clause BSD" license.  Bundled files are:
@@ -375,28 +371,21 @@ This product bundles parts of stm32l0xx, which is available under the
     * hw/mcu/stm/stm32l0xx/src/clock_stm32l0xx.c
     * hw/mcu/stm/stm32l0xx/src/system_stm32l0xx.c
     * hw/bsp/b-l072z-lrwan1/include/bsp/stm32l0xx_hal_conf.h
-    * hw/bsp/b-l072z-lrwan1/src/arch/cortex_m0/startup_stm32l072xx.s
     * hw/bsp/nucleo-l073rz/include/bsp/stm32l0xx_hal_conf.h
-    * hw/bsp/nucleo-l073rz/src/arch/cortex_m0/startup_stm32l073xx.s
-    
+
 This product bundles parts of stm32l4xx, which is available under the
 "3-clause BSD" license.  Bundled files are:
     * hw/mcu/stm/stm32l4xx/src/clock_stm32l4xx.c
     * hw/mcu/stm/stm32l4xx/src/system_stm32l4xx.c
     * hw/bsp/b-l475e-iot01a/include/bsp/stm32l4xx_hal_conf.h
-    * hw/bsp/b-l475e-iot01a/src/arch/cortex_m4/startup_stm32l475xx.s
     * hw/bsp/nucleo-l476rg/include/bsp/stm32l4xx_hal_conf.h
-    * hw/bsp/nucleo-l476rg/src/arch/cortex_m4/startup_stm32l476xx.s
 
 This product bundles parts of stm32wbxx, which is available under the
 "3-clause BSD" license.  Bundled files are:
-    * hw/mcu/stm/stm32wbxx/stm32wb55.ld
     * hw/mcu/stm/stm32wbxx/src/clock_stm32wbxx.c
     * hw/mcu/stm/stm32wbxx/src/system_stm32wbxx.c
     * hw/bsp/p-nucleo-wb55/include/bsp/stm32wbxx_hal_conf.h
-    * hw/bsp/p-nucleo-wb55/src/arch/cortex_m4/startup_stm32wb55xx_cm4.s
     * hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
-    * hw/bsp/p-nucleo-wb55-usbdongle/src/arch/cortex_m4/startup_stm32wb55xx_cm4.s
 
 This product bundles parts of STM32CubeU5, which is available under the
 "3-clause BSD" license.  Bundled files are:


### PR DESCRIPTION
The workflow ensures that each entry in 'rat-excludes' and 'LICENSE' files refers to actual (existing) file in the repository.