### PR TITLE
hw/mcu/dialog: Add 1MHz high-speed mode to hal i2c

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_i2c.c
+++ b/hw/mcu/dialog/da1469x/src/hal_i2c.c
@@ -187,13 +187,18 @@ i2c_config(const struct da1469x_hal_i2c *i2c, uint32_t frequency)
     i2c_con_reg = i2c->data->I2C_CON_REG;
 
     /* Clear speed register */
-    i2c_con_reg &= ~I2C_I2C_CON_REG_I2C_SPEED_Msk;
+    i2c_con_reg &= ~(I2C_I2C_CON_REG_I2C_SPEED_Msk |
+                     I2C_I2C_CON_REG_I2C_RESTART_EN_Msk);
     switch (frequency) {
     case 100:
         i2c_con_reg |= (1 << I2C_I2C_CON_REG_I2C_SPEED_Pos);
         break;
     case 400:
         i2c_con_reg |= (2 << I2C_I2C_CON_REG_I2C_SPEED_Pos);
+        break;
+    case 1000:
+        i2c_con_reg |= ((3 << I2C_I2C_CON_REG_I2C_SPEED_Pos) |
+                        I2C_I2C_CON_REG_I2C_RESTART_EN_Msk);
         break;
     default:
         return HAL_I2C_ERR_INVAL;


### PR DESCRIPTION
Adds 1MHz i2c speed to the i2c hal. The 1MHz speed requires high speed mode on the chip. In order for this to work it appears that the RESTART_EN bit has to be set in the control register or a tx abort condition occurs (bit 8 in tx abort source reg).

I tried to find some decent documentation on enabling high-speed mode for the da1469x. I also looked at some SDK versions that I had and I did not see that this bit was being set. When I tried simply setting the speed to 1MHz I was seeing this abort condition and read the chip doc and it appears that the RESTART_EN bit needs to be set for high-speed mode to work. Tested it with a da1469x equivalent chip and another chip that works with 1MHz i2c and things seem ok.