### PR TITLE
stm32/hal_watchdog: Fix timeout calculations

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_watchdog.c
+++ b/hw/mcu/stm/stm32_common/src/hal_watchdog.c
@@ -29,7 +29,8 @@ hal_watchdog_init(uint32_t expire_msecs)
     uint32_t reload;
 
     /* Max prescaler is 256 */
-    reload = 32768 / 256;
+    /* LSI is not very precise, assume 10% inaccuracy when calculating reload value */
+    reload = LSI_VALUE * 11 / 2560;
     reload = (reload * expire_msecs) / 1000;
 
     /* Check to make sure we are not trying a reload value that is too large */


### PR DESCRIPTION
All STM32 devices use LSI for watchdog functionality. LSI frequency varies between MCUs and it's approximation is define by LSI_VALUE in stm32xxx_hal_conf.h.
Code was assuming 32768 which is ok for devices that have LSI rate at 30kHz.
Some device has 37kHz others 40kHz it those cases calculated time could be too much off resulting in reset by watchdog.

Now code uses LSI_VALUE adding 10% to avoid cases when LSI runs faster then nominal.