### PR TITLE
stm32/hal_reset: Fix reported reset reason

### DIFF
--- a/hw/mcu/stm/stm32l0xx/src/hal_reset_cause.c
+++ b/hw/mcu/stm/stm32l0xx/src/hal_reset_cause.c
@@ -32,7 +32,9 @@ hal_reset_cause(void)
 
     reg = RCC->CSR;
 
-    if (reg & RCC_CSR_WWDGRSTF) {
+    if (reg & RCC_CSR_PORRSTF) {
+        reason = HAL_RESET_POR;
+    } else if (reg & (RCC_CSR_WWDGRSTF | RCC_CSR_IWDGRSTF)) {
         reason = HAL_RESET_WATCHDOG;
     } else if (reg & RCC_CSR_SFTRSTF) {
         reason = HAL_RESET_SOFT;


### PR DESCRIPTION
Often when device is powered up Reset pin is also activated. This cause power on never to be reported in favor of reset pin. Now Power On has highest priority.

Independent watchdog that is actually used in mynewt was not reported at all as reset reason. Only Windowed watchdog would be reported but is not used in mynwet-core.

This adds flag check so Watchdog reset can be detected.