### PR TITLE
mcu/stm32l0: Fix voltage scaling configuration

### DIFF
--- a/hw/mcu/stm/stm32l0xx/src/clock_stm32l0xx.c
+++ b/hw/mcu/stm/stm32l0xx/src/clock_stm32l0xx.c
@@ -59,7 +59,9 @@ SystemClock_Config(void)
      * voltage scaling value regarding system frequency refer to product
      * datasheet.
      */
+    __HAL_RCC_PWR_CLK_ENABLE();
     __HAL_PWR_VOLTAGESCALING_CONFIG(MYNEWT_VAL(STM32_CLOCK_VOLTAGESCALING_CONFIG));
+    __HAL_RCC_PWR_CLK_DISABLE();
 
     osc_init.OscillatorType = RCC_OSCILLATORTYPE_NONE;
 


### PR DESCRIPTION
Voltage scaling setting was done with PWR peripheral clock turned off which does not change anything.