### PR TITLE
stm32/hal: Fix STM32H7 with RTC as system tick

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -324,6 +324,8 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
 
 #ifdef __HAL_RCC_RTCAPB_CLK_ENABLE
     __HAL_RCC_RTCAPB_CLK_ENABLE();
+#elif defined(__HAL_RCC_RTC_CLK_ENABLE)
+    __HAL_RCC_RTC_CLK_ENABLE();
 #endif
 #ifdef __HAL_RCC_RTCAPB_CLKAM_ENABLE
     __HAL_RCC_RTCAPB_CLKAM_ENABLE();


### PR DESCRIPTION
STM32H7 HAL has __HAL_RCC_RTC_CLK_ENABLE macro for turning on RTC clock.
Some other MCUs also have this and for historical reasons have __HAL_RCC_RTCAPB_CLK_ENABLE that is an alias. Other only have __HAL_RCC_RTCAPB_CLK_ENABLE.

This uses __HAL_RCC_RTC_CLK_ENABLE() if defined to enable RTC clock in RCC.