### PR TITLE
pwm/pwm_da1469x: Preserve timer state on frequency change.

### DIFF
--- a/hw/drivers/pwm/pwm_da1469x/src/pwm_da1469x.c
+++ b/hw/drivers/pwm/pwm_da1469x/src/pwm_da1469x.c
@@ -91,7 +91,7 @@ da1469x_pwm_configure_channel(struct pwm_dev *dev, uint8_t channel,
 
     pwm = da1469x_pwm_resolve(dev->pwm_instance_id);
     if (!pwm || !pwm->in_use) {
-       return SYS_EINVAL;
+        return SYS_EINVAL;
     }
 
     mcu_gpio_set_pin_function(cfg->pin, MCU_GPIO_MODE_OUTPUT, pwm->gpio_func);
@@ -220,6 +220,7 @@ da1469x_pwm_set_freq(struct pwm_dev *dev, uint32_t freq)
     int tim_pwm_freq;
     uint32_t sys_clk_en;
     uint32_t actual_freq;
+    uint32_t clk_reg;
 
     pwm = da1469x_pwm_resolve(dev->pwm_instance_id);
     if (!pwm || !pwm->in_use) {
@@ -232,7 +233,8 @@ da1469x_pwm_set_freq(struct pwm_dev *dev, uint32_t freq)
     }
 
     pwm->timer_regs->TIMER_PRESCALER_REG = 0;
-    pwm->timer_regs->TIMER_CTRL_REG = sys_clk_en;
+    clk_reg = pwm->timer_regs->TIMER_CTRL_REG & ~TIMER_TIMER_CTRL_REG_TIM_SYS_CLK_EN_Msk;
+    pwm->timer_regs->TIMER_CTRL_REG = (sys_clk_en | clk_reg);
     pwm->timer_regs->TIMER_PWM_FREQ_REG = tim_pwm_freq;
 
     pwm->freq = actual_freq;

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -29,7 +29,7 @@
 #include "config/config_fcb.h"
 #include "config/config_generic_kv.h"
 #include "config_priv.h"
-
+#include "hal/hal_watchdog.h"
 #define CONF_FCB_VERS		1
 
 struct conf_fcb_load_cb_arg {
@@ -195,6 +195,7 @@ conf_fcb_compress_internal(struct fcb *fcb,
         loc2 = loc1;
         copy = 1;
         while (fcb_getnext(fcb, &loc2) == 0) {
+            hal_watchdog_tickle();
             rc = conf_fcb_var_read(&loc2, buf2, &name2, &val2);
             if (rc) {
                 continue;


### PR DESCRIPTION
Read the current timer state (timer control reg) and preserve its running state when setting frequency. The only bits that should be set in the control register are the bits to enable the timer in the proper mode and enable the clock.

The rational behind this change is that some users may want to be able to change the frequency "on the fly" without having to diable pwm, change frequency and then re-enable pwm. I do realize that with this chip if you change frequency the duty cycle changes so changing frequency on the fly also changes the duty cycle but this was always the case.

Note that this should not change the previous functionality (other than adding some extra code to read the control register and mask out the  SYS_CLK_EN bit. This change could have been done using a syscfg value to preserve the old code and make this new code present only present if the syscfg was set but it seems unnecessary. However, if folks think there should be a syscfg to make this behavior optional that would be fine.

