### PR TITLE
sys/config: Add watchdog tickle before each conf_fcb_var_read

### DIFF
--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -29,6 +29,7 @@
 #include "config/config_fcb.h"
 #include "config/config_generic_kv.h"
 #include "config_priv.h"
+#include "hal/hal_watchdog.h"
 
 #define CONF_FCB_VERS		1
 
@@ -185,6 +186,7 @@ conf_fcb_compress_internal(struct fcb *fcb,
         if (loc1.fe_area != fcb->f_oldest) {
             break;
         }
+        hal_watchdog_tickle();
         rc = conf_fcb_var_read(&loc1, buf1, &name1, &val1);
         if (rc) {
             continue;
@@ -195,6 +197,7 @@ conf_fcb_compress_internal(struct fcb *fcb,
         loc2 = loc1;
         copy = 1;
         while (fcb_getnext(fcb, &loc2) == 0) {
+            hal_watchdog_tickle();
             rc = conf_fcb_var_read(&loc2, buf2, &name2, &val2);
             if (rc) {
                 continue;


### PR DESCRIPTION
If there are a lot of config variables, a watchdog can be triggered by the multiple `conf_fcb_var_read`s.