### PR TITLE
stm32/hal_timer: Improve timer power consumption

### DIFF
--- a/hw/mcu/stm/stm32_common/syscfg.yml
+++ b/hw/mcu/stm/stm32_common/syscfg.yml
@@ -472,5 +472,17 @@ syscfg.defs:
             This may be needed for several MCU's including STM32F40x.
         value:
 
+    STM32_TIMER_AUTO_OFF_COUNT:
+        description: >
+            Turn off hal timer if it is not used for a specific number of overflows.
+            HAL timers are used for high frequency time measurement or delays.
+            Due to high frequency nature of the timer, counter overflows interrupts
+            would interrupt sleep event if timer is not in use.
+            This value when set to value graters then 0 will all to turn off timer
+            after number of overflow events without user code asking for timer value
+            or scheduling event.
+        range: 0..255
+        value: 0
+
 syscfg.vals:
     OS_TICKS_PER_SEC: 1000


### PR DESCRIPTION
Code allows to disable hal timer after it was running for some time (number over overflows) and it was not used for anything.
This can reduce power consumption without sacrificing usability. This can be useful for cputimer that is required but not used extensively.