### PR TITLE
boot/startup: Fix linker script filter for code in RAM

### DIFF
--- a/boot/startup/mynewt_cortex_m0.ld
+++ b/boot/startup/mynewt_cortex_m0.ld
@@ -89,7 +89,7 @@ SECTIONS
     {
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
-        *(.text*)                /* .text* sections (code) */
+        *(.text.*)               /* .text* sections (code) */
 
         KEEP(*(.init))
         KEEP(*(.fini))

--- a/boot/startup/mynewt_cortex_m3.ld
+++ b/boot/startup/mynewt_cortex_m3.ld
@@ -89,7 +89,7 @@ SECTIONS
     {
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
-        *(.text*)                /* .text* sections (code) */
+        *(.text.*)               /* .text* sections (code) */
 
         KEEP(*(.init))
         KEEP(*(.fini))

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -89,7 +89,7 @@ SECTIONS
     {
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
-        *(.text*)                /* .text* sections (code) */
+        *(.text.*)               /* .text* sections (code) */
 
         KEEP(*(.init))
         KEEP(*(.fini))

--- a/boot/startup/mynewt_cortex_m4.ld
+++ b/boot/startup/mynewt_cortex_m4.ld
@@ -101,7 +101,7 @@ SECTIONS
     {
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
-        *(.text*)                /* .text* sections (code) */
+        *(.text.*)               /* .text* sections (code) */
 
         KEEP(*(.init))
         KEEP(*(.fini))

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -90,7 +90,7 @@ SECTIONS
     {
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
-        *(.text*)                /* .text* sections (code) */
+        *(.text.*)               /* .text* sections (code) */
 
         KEEP(*(.init))
         KEEP(*(.fini))


### PR DESCRIPTION
Filter .text* was before .text_ram* resulting in code intended for ram to be placed in normal flash.
Now .text.* is used for flash destination