### PR TITLE
stm32f1/rtc_tick: Fix tick interrupt generation

### DIFF
--- a/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
+++ b/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
@@ -108,6 +108,8 @@ os_tick_idle(os_time_t ticks)
          */
         stm32_os_tick_update_rtc();
     }
+    /* Disable alarm, enable tick interrupt. */
+    RTC->CRH = RTC_CRH_SECIE_Msk;
 }
 
 void


### PR DESCRIPTION
When RTC (STM32F1 specific only) was used as os tick source. If OS requested longer tickles time RTC alarm was set to some time in the future.
After WFI finished RTC periodic tick interrupt was not enabled. If then some task took more time and periodically checked time, time would never advance due to RTC tick interrupt being disabled.
Time would advance only in idle task.
Now normal tick is working all the time unless there is nothing to do and after WFI finishes tick is enabled again.