### PR TITLE
hw/mcu/stm32f1: Disable SysTick when RTC is selected as tick source

### DIFF
--- a/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
+++ b/hw/mcu/stm/stm32f1xx/src/rtc_tick_stm32f1xx.c
@@ -120,6 +120,7 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
         .PeriphClockSelection = RCC_PERIPHCLK_RTC,
         .RTCClockSelection = RCC_RTCCLKSOURCE_LSE,
     };
+    SysTick->CTRL = 0;
 
     HAL_RCCEx_PeriphCLKConfig(&clock_init);
     __HAL_RCC_RTC_ENABLE();


### PR DESCRIPTION
When tick was provided by RTC instead of SysTick (default) and MCUboot used SysTick during boot, SysTick was never turned off and was running in application code.
This resulted in two interrupts advancing mynewt OS tick so clock was running too fast.

Now os_tick_init() from RTC code disables SysTick that could be started in bootloader