### PR TITLE
tinyusb/msc_fat_view: Fix update handler

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/syscfg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/syscfg.yml
@@ -97,6 +97,10 @@ syscfg.defs:
         description: >
             If set to 1, adds 'Drop image here' file.
         value: 0
+    MSC_FAT_VIEW_UPDATE_HANDLER:
+        description: >
+            If set to 1, image can be dropped to upgrade firmware.
+        value: 0
     MSC_FAT_VIEW_SYSTEM_VOLUME_INFORMATION:
         description: >
             If set to 1, adds 'System Volume Information' file.


### PR DESCRIPTION
When update handler for writing images to flash
was moved to separate file pkg.yml was changed
to have update_handler.c included conditionally
but syscfg definition was not commited

This fixes the problem and updates can be
used again