### PR TITLE
ci: check_style: Fix awk filter for nimble

### DIFF
--- a/.github/check_style.py
+++ b/.github/check_style.py
@@ -26,6 +26,8 @@ import tempfile
 import sys
 
 INFO_URL = "https://github.com/apache/mynewt-core/blob/master/CODING_STANDARDS.md"
+# uncrustify.awk is one directory level above current script
+uncrustify_awk = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "uncrustify.awk")
 
 def get_lines_range(m: re.Match) -> range:
     first = int(m.group(1))
@@ -61,7 +63,7 @@ def check_file(fname: str, commit: str, upstream: str) -> list[str]:
         in_chunk = False
 
         for s in run_cmd(f"uncrustify -q -c uncrustify.cfg -f {tmpf.name} | "
-                         f"awk -f uncrustify.awk | "
+                         f"awk -f {uncrustify_awk} | "
                          f"diff -u0 -p {tmpf.name} - || true"):
             m = re.match(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@", s)
             if not m:


### PR DESCRIPTION
nimble repository uses same check_style.py but calls it from different location resulting in missing
uncrasitfy.awk script

This explicitly sets path to awk script so it is found always regardless of how check_style.py was executd