### PR TITLE
stm32: Fix flash write

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_flash.c
+++ b/hw/mcu/stm/stm32_common/src/hal_flash.c
@@ -120,7 +120,7 @@ stm32_flash_write_linear(const struct hal_flash *dev, uint32_t address,
     for (i = 0; i < num_words; i++) {
         if (num_bytes < align) {
             memcpy(&val, &((uint8_t *)src)[i * align], num_bytes);
-            memset((uint32_t *)&val + num_bytes, dev->hf_erased_val, align - num_bytes);
+            memset((uint8_t *)&val + num_bytes, dev->hf_erased_val, align - num_bytes);
         } else {
             memcpy(&val, &((uint8_t *)src)[i * align], align);
         }


### PR DESCRIPTION
Code could corrupt stack when writing to flash that requires write of size greater then 1.

memset function used for filling buffer so writes have correct number of bytes incorrectly cast buffer to (uint32_t *) and then added number of bytes resulting in possible write to unintended stack memory.