### PR TITLE
Fix fcb and log_fcb for flashes with bigger write alignment

### DIFF
--- a/fs/fcb/src/fcb.c
+++ b/fs/fcb/src/fcb.c
@@ -80,7 +80,7 @@ fcb_init(struct fcb *fcb)
     fcb->f_align = max_align;
     fcb->f_oldest = oldest_fap;
     fcb->f_active.fe_area = newest_fap;
-    fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+    fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
     fcb->f_active_id = newest;
 
     /* Require alignment to be a power of two.  Some code depends on this

--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -61,7 +61,7 @@ fcb_append_to_scratch(struct fcb *fcb)
         return rc;
     }
     fcb->f_active.fe_area = fa;
-    fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+    fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
     fcb->f_active_id++;
     return FCB_OK;
 }
@@ -99,7 +99,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
             goto err;
         }
         fcb->f_active.fe_area = fa;
-        fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+        fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
         fcb->f_active_id++;
     }
 

--- a/fs/fcb/src/fcb_getnext.c
+++ b/fs/fcb/src/fcb_getnext.c
@@ -66,7 +66,7 @@ fcb_getnext_nolock(struct fcb *fcb, struct fcb_entry *loc)
         /*
          * If offset is zero, we serve the first entry from the area.
          */
-        loc->fe_elem_off = sizeof(struct fcb_disk_area);
+        loc->fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
         rc = fcb_elem_info(fcb, loc);
     } else {
         rc = fcb_getnext_in_area(fcb, loc);
@@ -94,7 +94,7 @@ next_sector:
                 return FCB_ERR_NOVAR;
             }
             loc->fe_area = fcb_getnext_area(fcb, loc->fe_area);
-            loc->fe_elem_off = sizeof(struct fcb_disk_area);
+            loc->fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
             rc = fcb_elem_info(fcb, loc);
             switch (rc) {
             case 0:

--- a/fs/fcb/src/fcb_rotate.c
+++ b/fs/fcb/src/fcb_rotate.c
@@ -46,7 +46,7 @@ fcb_rotate(struct fcb *fcb)
             goto out;
         }
         fcb->f_active.fe_area = fap;
-        fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+        fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
         fcb->f_active_id++;
     }
     fcb->f_oldest = fcb_getnext_area(fcb, fcb->f_oldest);

--- a/fs/fcb2/src/fcb_getnext.c
+++ b/fs/fcb2/src/fcb_getnext.c
@@ -36,7 +36,8 @@ fcb2_getnext_in_area(struct fcb2 *fcb, struct fcb2_entry *loc)
                                                  fcb2_len_in_flash(loc->fe_range, 2);
         /* Possible entry offset for next data */
         next_entry_offset = fcb->f_active.fe_range->fsr_sector_size -
-                            (FCB2_ENTRY_SIZE * (loc->fe_entry_num + 1));
+                            (fcb2_len_in_flash(fcb->f_active.fe_range, FCB2_ENTRY_SIZE) *
+                             (loc->fe_entry_num + 1));
         loc->fe_data_len = 0;
         loc->fe_entry_num++;
         /* If there is no space for next entry just finish search */

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -27,8 +27,8 @@
 #include "fcb/fcb.h"
 #include "log/log.h"
 
-/* Assume the flash alignment requirement is no stricter than 8. */
-#define LOG_FCB_MAX_ALIGN   8
+/* Assume the flash alignment requirement is no stricter than 32. */
+#define LOG_FCB_MAX_ALIGN   32
 
 static int log_fcb_rtr_erase(struct log *log);
 

--- a/sys/log/full/src/log_fcb2.c
+++ b/sys/log/full/src/log_fcb2.c
@@ -27,8 +27,8 @@
 #include "log/log.h"
 #include "fcb/fcb2.h"
 
-/* Assume the flash alignment requirement is no stricter than 8. */
-#define LOG_FCB2_MAX_ALIGN   8
+/* Assume the flash alignment requirement is no stricter than 32. */
+#define LOG_FCB2_MAX_ALIGN   32
 
 static int log_fcb2_rtr_erase(struct log *log);
 


### PR DESCRIPTION
Changes to accommodate flash with bigger alignment restrictions (STM32H7, STM32U5)

- Now log_fcb and log_fcb will work with flashes with write alignment restriction up to 32 bytes (it was 8)
- fcb now takes into account write alignment restriction that was previously ignored in few places
- fcb2 one additional place respect write alignment restrictions