### PR TITLE
Update flash_test with access to flash area directly

### DIFF
--- a/hw/hal/include/hal/hal_flash.h
+++ b/hw/hal/include/hal/hal_flash.h
@@ -36,6 +36,21 @@ extern "C" {
 int hal_flash_ioctl(uint8_t flash_id, uint32_t cmd, void *args);
 
 /**
+ * @brief Return information about flash sector
+ *
+ * @param flash_id              The ID of the flash device to read from.
+ * @param sector_index          The sector number to get information about.
+ * @param start_address         A buffer to fill with start address of the sector.
+ * @param size                  A buffer for sector size.
+ *
+ * @return                      0 on success;
+ *                              SYS_EINVAL on bad argument error;
+ *                              SYS_EIO on flash driver error.
+ */
+int hal_flash_sector_info(uint8_t flash_id, int sector_index,
+                          uint32_t *start_address, uint32_t *size);
+
+/**
  * @brief Reads a block of data from flash.
  *
  * @param flash_id              The ID of the flash device to read from.

--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -77,6 +77,21 @@ hal_flash_erased_val(uint8_t flash_id)
     return hf->hf_erased_val;
 }
 
+int
+hal_flash_sector_info(uint8_t flash_id, int sector_index,
+                      uint32_t *start_address, uint32_t *size)
+{
+    const struct hal_flash *hf;
+
+    hf = hal_bsp_flash_dev(flash_id);
+    if (!hf) {
+        return SYS_EINVAL;
+    }
+
+    return hf->hf_itf->hff_sector_info(hf, sector_index, start_address, size);
+}
+
+
 uint32_t
 hal_flash_sector_size(const struct hal_flash *hf, int sec_idx)
 {

--- a/test/flash_test/pkg.yml
+++ b/test/flash_test/pkg.yml
@@ -26,6 +26,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/util/parse"
 pkg.req_apis:
     - console
 


### PR DESCRIPTION
command flash used to work on flash id
```
flash 0 read 0 100
```
Now it can be used with flash area id instead, while rest of the syntax remain unchanged
```
flash area 10 read 0 100
```

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>