### PR TITLE
hw/mcu/stm32f3: Fix flash write

### DIFF
--- a/hw/mcu/stm/stm32f3xx/include/mcu/stm32_hal.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/stm32_hal.h
@@ -83,7 +83,10 @@ struct stm32_hal_spi_cfg {
 #include "stm32f3xx_hal_def.h"
 #include "stm32f3xx_hal_flash.h"
 #include "stm32f3xx_hal_flash_ex.h"
-#define STM32_HAL_FLASH_INIT()
+#define STM32_HAL_FLASH_INIT()        \
+    do {                              \
+        HAL_FLASH_Unlock();           \
+    } while (0)
 #define FLASH_PROGRAM_TYPE FLASH_TYPEPROGRAM_HALFWORD
 #define STM32_HAL_FLASH_CLEAR_ERRORS()            \
     do {                                          \

--- a/hw/mcu/stm/stm32f3xx/src/hal_flash.c
+++ b/hw/mcu/stm/stm32f3xx/src/hal_flash.c
@@ -32,11 +32,9 @@ stm32_mcu_flash_erase_sector(const struct hal_flash *dev, uint32_t sector_addres
     erase.PageAddress = sector_address;
     erase.NbPages = 1;
 
-    HAL_FLASH_Unlock();
     if (HAL_OK == HAL_FLASHEx_Erase(&erase, &errorPage)) {
       rc = 0;
     }
-    HAL_FLASH_Lock();
 
     return rc;
 }


### PR DESCRIPTION
STM32_HAL_FLASH_INIT macro was empty unlike all other implementations leaving embedded flash locked.

stm32_mcu_flash_erase_sector() unlocked flash before erase and locked it afterwards.
Erase flash worked but write did not since write is done in common stm32 code that assumed that flash is unlocked.

Now flash is unlocked at the start and not locked during erase.