### PR TITLE
util/crc: Add option for crc16_ccitt without table

### DIFF
--- a/util/crc/src/crc16.c
+++ b/util/crc/src/crc16.c
@@ -26,10 +26,12 @@
  */
 
 #include <inttypes.h>
+#include <syscfg/syscfg.h>
 #include "crc/crc16.h"
 
-/* CRC16 implementation acording to CCITT standards */
+/* CRC16 implementation according to CCITT standards */
 
+#if MYNEWT_VAL(UTIL_CRC_CRC16_CCITT_USE_TABLE)
 static const uint16_t crc16tab[256]= {
     0x0000,0x1021,0x2042,0x3063,0x4084,0x50a5,0x60c6,0x70e7,
     0x8108,0x9129,0xa14a,0xb16b,0xc18c,0xd1ad,0xe1ce,0xf1ef,
@@ -81,3 +83,23 @@ crc16_ccitt(uint16_t initial_crc, const void *buf, int len)
 
     return crc;
 }
+
+#else
+
+uint16_t
+crc16_ccitt(uint16_t initial_crc, const void *buf, int len)
+{
+    uint8_t x;
+    uint16_t crc = initial_crc;
+    const uint8_t *ptr = buf;
+    int i;
+
+    for (i = 0; i < len; ++i) {
+        x = (crc >> 8) ^ ptr[i];
+        x ^= x >> 4;
+        crc = (crc << 8) ^ ((uint16_t)(x << 12)) ^ ((uint16_t)(x << 5)) ^ ((uint16_t)x);
+    }
+    return crc;
+}
+
+#endif

--- a/util/crc/syscfg.yml
+++ b/util/crc/syscfg.yml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+syscfg.defs:
+    UTIL_CRC_CRC16_CCITT_USE_TABLE:
+        description: >
+            Use table for calculation CRC to make it faster.
+            Set it 0 to reduce code size.
+        value: 1


### PR DESCRIPTION
This adds crc16_ccitt() version without table.
It makes it slower but can reduce flash usage
about 512 bytes.

Default still uses table but can be disabled
with UTIL_CRC_CRC16_CCITT_USE_TABLE: 0