### PR TITLE
spiflash: Add missing include

### DIFF
--- a/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
+++ b/hw/drivers/flash/spiflash/include/spiflash/spiflash.h
@@ -23,6 +23,7 @@
 #if MYNEWT_VAL(OS_SCHEDULING)
 #include <os/os_mutex.h>
 #endif
+#include <stdbool.h>
 #include <hal/hal_flash_int.h>
 #include <hal/hal_spi.h>
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)


### PR DESCRIPTION
spiflash uses bool type without including correct
header relaying on it being included before.

Now there is direct inclusion of stdbool.h