### PR TITLE
hw/bsp/nucleo-l073: Fix flash map scratch area

### DIFF
--- a/hw/bsp/nucleo-l073rz/bsp.yml
+++ b/hw/bsp/nucleo-l073rz/bsp.yml
@@ -43,15 +43,15 @@ bsp.flash_map:
             size: 72kB
         FLASH_AREA_IMAGE_SCRATCH:
             device: 0
-            offset: 0x08005C00
-            size: 1kB
+            offset: 0x0802f000
+            size: 4kB
 
         # User areas.
         FLASH_AREA_REBOOT_LOG:
             user_id: 0
             device: 0
-            offset: 0x0802c000
-            size: 8kB
+            offset: 0x0802E800
+            size: 2kB
         FLASH_AREA_NFFS:
             user_id: 1
             device: 0


### PR DESCRIPTION
STM32L0 has 128 byte page, this would allow for 16kB of slot0/1 size to be supported by mcuboot.
For this reason flash page is artificially reported to mcuboot to be 2kB.
Scratch area was put in flash with size 1kB making in unusable for mcuboot.

This could be fixed by:
- removing this limit from mcuboot (most reasonable solution)
- setting page size to be 1kB instead of 2
- changing flash area layout to have at least 2kB scratch sector

Third option is chosen because flash area layout
was already left with some holes.
Now scratch has 4kB
Reboot log is reduced to 2kB since current implementation of reboot_log uses only one sector so 75% was unusable anyway