### PR TITLE
util/stream: Add ostream_write_str function

### DIFF
--- a/util/stream/include/stream/stream.h
+++ b/util/stream/include/stream/stream.h
@@ -250,4 +250,14 @@ ostream_write_uint32(struct out_stream *ostream, uint32_t data)
     return ostream_write(ostream, (uint8_t *)&data, 4, false);
 }
 
+/**
+ * Write null terminated string to output stream
+ *
+ * @param ostream - stream to write to
+ * @param str     - string to write to stream
+ *
+ * @return number of bytes written, negative on error
+ */
+int ostream_write_str(struct out_stream *ostream, const char *str);
+
 #endif /* H_STREAM_ */

--- a/util/stream/src/stream.c
+++ b/util/stream/src/stream.c
@@ -136,3 +136,10 @@ stream_pump(struct in_stream *istream, struct out_stream *ostream, uint32_t coun
     }
     return pumped;
 }
+
+int
+ostream_write_str(struct out_stream *ostream, const char *str)
+{
+    int len = strlen(str);
+    return ostream_write(ostream, (const uint8_t *)str, len, false);
+}


### PR DESCRIPTION
This is simple utility function to write null terminated string to stream.

Function is already referenced in msc_fat_view.