### PR TITLE
util/stream: Update OSTREAM_DEF and ISTREAM_DEF

### DIFF
--- a/util/stream/include/stream/stream.h
+++ b/util/stream/include/stream/stream.h
@@ -127,11 +127,10 @@ struct mem_in_stream {
 #define OSTREAM_DEF(type) \
     static int type ## _write(struct out_stream *ostream, const uint8_t *buf, uint32_t count); \
     static int type ## _flush(struct out_stream *ostream); \
-    static int type ## _pump_from(struct out_stream *ostream, struct in_stream *istream, uint32_t count); \
     const struct out_stream_vft type ## _vft = { \
         .write = type ## _write, \
         .flush = type ## _flush, \
-        .pump_from = type ## _pump_from, \
+        .pump_from = NULL, \
     }
 
 #define OSTREAM_VFT(type, _write, _flush, _pump) \
@@ -156,7 +155,7 @@ struct mem_in_stream {
     const struct in_stream_vft type ## _vft = { \
         .available = type ## _available,        \
         .read = type ## _read,                  \
-        .pump_to = type ## _pump_to,            \
+        .pump_to = NULL,                        \
     }
 
 #define ISTREAM(type, name)     \


### PR DESCRIPTION
OSTREAM_DEF macro is utility macro for creating function table for output stream with function names derived from stream type name.

i.e. OSTREAM_DEF(mem) would create function table like this: const struct out_stream_vft mem_vft = {
   .write = mem_write,
   .flush = mem_flush,
   .pump_from = mem_pump_from,
}
along with prototypes:
static int mem_write(struct out_stream *, const uint8_t *, uint32_t); static int mem_flush(struct out_stream *);
static int mem_pump_from(struct out_stream *, struct in_stream *, uint32_t);

last function was late addition and is optional

This change removes requirement to define pump_from function from OSTREAM_DEF User still can create function table with pump_from funtion without using macro if pumping is required.