### PR TITLE
hw/mcu/stm32: Add option to set HSE_VALUE from syscfg

### DIFF
--- a/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/ada_feather_stm32f405/include/bsp/stm32f4xx_hal_conf.h
@@ -114,7 +114,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)12000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/b-l072z-lrwan1/include/bsp/stm32l0xx_hal_conf.h
+++ b/hw/bsp/b-l072z-lrwan1/include/bsp/stm32l0xx_hal_conf.h
@@ -91,7 +91,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).  
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/b-l475e-iot01a/include/bsp/stm32l4xx_hal_conf.h
+++ b/hw/bsp/b-l475e-iot01a/include/bsp/stm32l4xx_hal_conf.h
@@ -105,7 +105,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    8000000U /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/black_vet6/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/black_vet6/include/bsp/stm32f4xx_hal_conf.h
@@ -112,7 +112,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/bluepill/include/bsp/stm32f1xx_hal_conf.h
+++ b/hw/bsp/bluepill/include/bsp/stm32f1xx_hal_conf.h
@@ -108,7 +108,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #if defined(USE_STM3210C_EVAL)
   #define HSE_VALUE    25000000U /*!< Value of the External oscillator in Hz */
 #else

--- a/hw/bsp/nucleo-f030r8/include/bsp/stm32f0xx_hal_conf.h
+++ b/hw/bsp/nucleo-f030r8/include/bsp/stm32f0xx_hal_conf.h
@@ -86,7 +86,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f072rb/include/bsp/stm32f0xx_hal_conf.h
+++ b/hw/bsp/nucleo-f072rb/include/bsp/stm32f0xx_hal_conf.h
@@ -86,7 +86,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f103rb/include/bsp/stm32f1xx_hal_conf.h
+++ b/hw/bsp/nucleo-f103rb/include/bsp/stm32f1xx_hal_conf.h
@@ -108,7 +108,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #if defined(USE_STM3210C_EVAL)
   #define HSE_VALUE    25000000U /*!< Value of the External oscillator in Hz */
 #else

--- a/hw/bsp/nucleo-f303k8/include/bsp/stm32f3xx_hal_conf.h
+++ b/hw/bsp/nucleo-f303k8/include/bsp/stm32f3xx_hal_conf.h
@@ -91,7 +91,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    (8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f303re/include/bsp/stm32f3xx_hal_conf.h
+++ b/hw/bsp/nucleo-f303re/include/bsp/stm32f3xx_hal_conf.h
@@ -91,7 +91,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    (8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f401re/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f401re/include/bsp/stm32f4xx_hal_conf.h
@@ -111,7 +111,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f411re/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f411re/include/bsp/stm32f4xx_hal_conf.h
@@ -109,7 +109,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f413zh/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f413zh/include/bsp/stm32f4xx_hal_conf.h
@@ -109,7 +109,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f439zi/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/nucleo-f439zi/include/bsp/stm32f4xx_hal_conf.h
@@ -110,7 +110,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f746zg/include/bsp/stm32f7xx_hal_conf.h
+++ b/hw/bsp/nucleo-f746zg/include/bsp/stm32f7xx_hal_conf.h
@@ -106,7 +106,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-f767zi/include/bsp/stm32f7xx_hal_conf.h
+++ b/hw/bsp/nucleo-f767zi/include/bsp/stm32f7xx_hal_conf.h
@@ -104,7 +104,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-g0b1re/include/bsp/stm32g0xx_hal_conf.h
+++ b/hw/bsp/nucleo-g0b1re/include/bsp/stm32g0xx_hal_conf.h
@@ -99,7 +99,9 @@ extern "C" {
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE    (8000000UL)            /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-g491re/include/bsp/stm32g4xx_hal_conf.h
+++ b/hw/bsp/nucleo-g491re/include/bsp/stm32g4xx_hal_conf.h
@@ -115,7 +115,9 @@ extern "C" {
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE              24000000UL /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-h723zg/include/bsp/stm32h7xx_hal_conf.h
+++ b/hw/bsp/nucleo-h723zg/include/bsp/stm32h7xx_hal_conf.h
@@ -94,7 +94,9 @@ extern "C" {
  *        This value is used by the RCC HAL module to compute the system frequency
  *        (when HSE is used as system clock source, directly or through the PLL).
  */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-l073rz/include/bsp/stm32l0xx_hal_conf.h
+++ b/hw/bsp/nucleo-l073rz/include/bsp/stm32l0xx_hal_conf.h
@@ -91,7 +91,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).  
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-l476rg/include/bsp/stm32l4xx_hal_conf.h
+++ b/hw/bsp/nucleo-l476rg/include/bsp/stm32l4xx_hal_conf.h
@@ -105,7 +105,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    8000000U /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/nucleo-u575zi-q/include/bsp/stm32u5xx_hal_conf.h
+++ b/hw/bsp/nucleo-u575zi-q/include/bsp/stm32u5xx_hal_conf.h
@@ -98,7 +98,9 @@ extern "C" {
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE              16000000UL /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/olimex-p103/include/bsp/stm32f1xx_hal_conf.h
+++ b/hw/bsp/olimex-p103/include/bsp/stm32f1xx_hal_conf.h
@@ -108,7 +108,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #if defined(USE_STM3210C_EVAL)
   #define HSE_VALUE    25000000U /*!< Value of the External oscillator in Hz */
 #else

--- a/hw/bsp/olimex_stm32-e407_devboard/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/olimex_stm32-e407_devboard/include/bsp/stm32f4xx_hal_conf.h
@@ -113,7 +113,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)12000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/include/bsp/stm32wbxx_hal_conf.h
@@ -94,7 +94,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE    32000000U             /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/p-nucleo-wb55/include/bsp/stm32wbxx_hal_conf.h
+++ b/hw/bsp/p-nucleo-wb55/include/bsp/stm32wbxx_hal_conf.h
@@ -94,7 +94,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE    32000000U             /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32f3discovery/include/bsp/stm32f3xx_hal_conf.h
+++ b/hw/bsp/stm32f3discovery/include/bsp/stm32f3xx_hal_conf.h
@@ -91,7 +91,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    (8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32f411discovery/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/stm32f411discovery/include/bsp/stm32f4xx_hal_conf.h
@@ -110,7 +110,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32f429discovery/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/stm32f429discovery/include/bsp/stm32f4xx_hal_conf.h
@@ -111,7 +111,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32f4discovery/include/bsp/stm32f4xx_hal_conf.h
+++ b/hw/bsp/stm32f4discovery/include/bsp/stm32f4xx_hal_conf.h
@@ -110,7 +110,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).  
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32f7discovery/include/bsp/stm32f7xx_hal_conf.h
+++ b/hw/bsp/stm32f7discovery/include/bsp/stm32f7xx_hal_conf.h
@@ -105,7 +105,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/stm32l152discovery/include/bsp/stm32l1xx_hal_conf.h
+++ b/hw/bsp/stm32l152discovery/include/bsp/stm32l1xx_hal_conf.h
@@ -86,7 +86,9 @@
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
   #define HSE_VALUE    (8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/bsp/weact_g431cb/include/bsp/stm32g4xx_hal_conf.h
+++ b/hw/bsp/weact_g431cb/include/bsp/stm32g4xx_hal_conf.h
@@ -115,7 +115,9 @@ extern "C" {
   *        This value is used by the RCC HAL module to compute the system frequency
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
-#if !defined  (HSE_VALUE)
+#if defined (MYNEWT_VAL_STM32_CLOCK_HSE_VALUE)
+#define HSE_VALUE    MYNEWT_VAL(STM32_CLOCK_HSE_VALUE)
+#elif !defined  (HSE_VALUE)
 #define HSE_VALUE              8000000UL /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 

--- a/hw/mcu/stm/stm32f0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f0xx/syscfg.yml
@@ -49,6 +49,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32f1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f1xx/syscfg.yml
@@ -47,6 +47,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32f3xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f3xx/syscfg.yml
@@ -47,6 +47,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32f4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f4xx/syscfg.yml
@@ -51,6 +51,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32f7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32f7xx/syscfg.yml
@@ -59,6 +59,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32g0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32g0xx/syscfg.yml
@@ -55,6 +55,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32g4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32g4xx/syscfg.yml
@@ -55,6 +55,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32h7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32h7xx/syscfg.yml
@@ -58,6 +58,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32l0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l0xx/syscfg.yml
@@ -63,6 +63,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source (16MHz)
         value: 1

--- a/hw/mcu/stm/stm32l1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l1xx/syscfg.yml
@@ -63,6 +63,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32l4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l4xx/syscfg.yml
@@ -63,6 +63,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32u5xx/syscfg.yml
+++ b/hw/mcu/stm/stm32u5xx/syscfg.yml
@@ -63,6 +63,10 @@ syscfg.defs:
         description: 0 for xtal; 1 for input clock
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1

--- a/hw/mcu/stm/stm32wbxx/syscfg.yml
+++ b/hw/mcu/stm/stm32wbxx/syscfg.yml
@@ -75,6 +75,10 @@ syscfg.defs:
         description: Enable HSE prescaler divider
         value: 0
 
+    STM32_CLOCK_HSE_VALUE:
+        description: High-speed external clock speed in Hz
+        value:
+
     STM32_CLOCK_HSI:
         description: Enable high-speed internal clock source
         value: 1


### PR DESCRIPTION
This adds STM32_CLOCK_HSE_VALUE that can be used to
specify HSE frequency in mynewt style.
It could be always set w macro HSE_VALUE but this makes
it easier to manipulate this value in similar way
as most other parameters.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>