### PR TITLE
tinyusb: Add hardware initialization for stm32f3

### DIFF
--- a/hw/usb/tinyusb/pkg.yml
+++ b/hw/usb/tinyusb/pkg.yml
@@ -56,6 +56,8 @@ pkg.deps.MCU_STM32U5:
     - "@apache-mynewt-core/hw/usb/tinyusb/synopsys"
 pkg.deps.MCU_STM32F1:
     - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev"
+pkg.deps.MCU_STM32F3:
+    - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev/stm32f3"
 pkg.deps.MCU_STM32L0:
     - "@apache-mynewt-core/hw/usb/tinyusb/stm32_fsdev/stm32l0"
 pkg.deps.MCU_STM32WB:

--- a/hw/usb/tinyusb/stm32_fsdev/stm32f3/include/tusb_hw.h
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32f3/include/tusb_hw.h
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TUSB_HW_H__
+#define __TUSB_HW_H__
+
+#define CFG_TUSB_MCU OPT_MCU_STM32F3
+
+#include <syscfg/syscfg.h>
+
+#define CFG_TUSB_RHPORT0_SPEED  OPT_MODE_FULL_SPEED
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP)
+#define USBD_CDC_NOTIFY_EP      MYNEWT_VAL(USBD_CDC_NOTIFY_EP)
+#else
+#define USBD_CDC_NOTIFY_EP      0x81
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_NOTIFY_EP_SIZE)
+#define USBD_CDC_NOTIFY_EP_SIZE MYNEWT_VAL(USBD_CDC_NOTIFY_EP_SIZE)
+#else
+#define USBD_CDC_NOTIFY_EP_SIZE 0x08
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_OUT_EP)
+#define USBD_CDC_DATA_OUT_EP    MYNEWT_VAL(USBD_CDC_DATA_OUT_EP)
+#else
+#define USBD_CDC_DATA_OUT_EP    0x01
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_IN_EP)
+#define USBD_CDC_DATA_IN_EP     MYNEWT_VAL(USBD_CDC_DATA_IN_EP)
+#else
+#define USBD_CDC_DATA_IN_EP     0x82
+#endif
+
+#if defined(MYNEWT_VAL_USBD_CDC_DATA_EP_SIZE)
+#define USBD_CDC_DATA_EP_SIZE   MYNEWT_VAL(USBD_CDC_DATA_EP_SIZE)
+#else
+#define USBD_CDC_DATA_EP_SIZE   0x40
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP)
+#define USBD_HID_REPORT_EP      MYNEWT_VAL(USBD_HID_REPORT_EP)
+#else
+#define USBD_HID_REPORT_EP      0x83
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_SIZE)
+#define USBD_HID_REPORT_EP_SIZE MYNEWT_VAL(USBD_HID_REPORT_EP_SIZE)
+#else
+#define USBD_HID_REPORT_EP_SIZE 0x10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_HID_REPORT_EP_INTERVAL)
+#define USBD_HID_REPORT_EP_INTERVAL MYNEWT_VAL(USBD_HID_REPORT_EP_INTERVAL)
+#else
+#define USBD_HID_REPORT_EP_INTERVAL 10
+#endif
+
+#if defined(MYNEWT_VAL_USBD_MSC_DATA_IN_EP)
+#define USBD_MSC_DATA_IN_EP     MYNEWT_VAL(USBD_MSC_DATA_IN_EP)
+#else
+#define USBD_MSC_DATA_IN_EP     0x86
+#endif
+
+#if defined(MYNEWT_VAL_USBD_MSC_DATA_OUT_EP)
+#define USBD_MSC_DATA_OUT_EP     MYNEWT_VAL(USBD_MSC_DATA_OUT_EP)
+#else
+#define USBD_MSC_DATA_OUT_EP     0x06
+#endif
+
+#endif

--- a/hw/usb/tinyusb/stm32_fsdev/stm32f3/pkg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32f3/pkg.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: hw/usb/tinyusb/stm32_fsdev/stm32f3
+pkg.description: Hardware initialization for TinyUSB
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - usb
+    - tinyusb
+
+pkg.apis:
+    - TINYUSB_HW_INIT
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/usb/tinyusb"

--- a/hw/usb/tinyusb/stm32_fsdev/stm32f3/src/stm32_fsdev.c
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32f3/src/stm32_fsdev.c
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <mcu/mcu.h>
+
+#include <tusb.h>
+
+#include <mcu/stm32f3_bsp.h>
+#include <mcu/stm32f3xx_mynewt_hal.h>
+#include <bsp/stm32f3xx_hal_conf.h>
+#include <stm32f3xx_hal.h>
+
+static void
+USB_IRQHandler(void)
+{
+    tud_int_handler(0);
+}
+
+void
+tinyusb_hardware_init(void)
+{
+    /*
+     * Use remapped interrupt (not shared with CAN).
+     * Enable SYSCFG in RCC to remap
+     */
+    bool syscfg_enabled = __HAL_RCC_GPIOA_IS_CLK_ENABLED();
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    __HAL_REMAPINTERRUPT_USB_ENABLE();
+    if (!syscfg_enabled) {
+        __HAL_RCC_GPIOA_CLK_DISABLE();
+    }
+
+    /* TinyUSB provides interrupt handler, here it is setup the mynewt way */
+    NVIC_SetVector(USB_HP_IRQn, (uint32_t)USB_IRQHandler);
+    NVIC_SetPriority(USB_HP_IRQn, 2);
+    NVIC_SetVector(USB_LP_IRQn, (uint32_t)USB_IRQHandler);
+    NVIC_SetPriority(USB_LP_IRQn, 2);
+    NVIC_SetVector(USBWakeUp_RMP_IRQn, (uint32_t)USB_IRQHandler);
+    NVIC_SetPriority(USBWakeUp_RMP_IRQn, 2);
+
+    /*
+     * USB Pin Init
+     * PA11- DM, PA12- DP
+     */
+    hal_gpio_init_af(MCU_GPIO_PORTA(11), GPIO_AF14_USB, GPIO_NOPULL, GPIO_MODE_AF_PP);
+#if defined(MYNEWT_VAL_USB_DP_PULLUP_CONTROL_PIN) && MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN) >= 0
+    if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_1_disable_0) ||
+        MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_input_disable_0)) {
+        hal_gpio_init_out(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN), 0);
+    } else if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_0_disable_1) ||
+               MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_input_disable_1)) {
+        hal_gpio_init_out(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN), 1);
+    } else if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_0_disable_input) ||
+               MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_1_disable_input)) {
+        hal_gpio_deinit(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN));
+    }
+#else
+    hal_gpio_init_out(MCU_GPIO_PORTA(12), 0);
+#endif
+#if MYNEWT_VAL(OS_SCHEDULING)
+    os_time_delay(2);
+#else
+    os_cputime_delay_usecs(1000);
+#endif
+#if defined(MYNEWT_VAL_USB_DP_PULLUP_CONTROL_PIN) && MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN) >= 0
+    if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_1_disable_0) ||
+        MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_1_disable_input)) {
+        hal_gpio_init_out(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN), 1);
+    } else if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_0_disable_1) ||
+               MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_0_disable_input)) {
+        hal_gpio_init_out(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN), 0);
+    } else if (MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_input_disable_0) ||
+               MYNEWT_VAL_CHOICE(USB_DP_PULLUP_CONTROL_PIN_MODE, enable_input_disable_1)) {
+        hal_gpio_deinit(MYNEWT_VAL(USB_DP_PULLUP_CONTROL_PIN));
+    }
+#else
+    hal_gpio_init_out(MCU_GPIO_PORTA(12), 0);
+#endif
+    hal_gpio_init_af(MCU_GPIO_PORTA(12), GPIO_AF14_USB, GPIO_NOPULL, GPIO_MODE_AF_PP);
+
+    /*
+     * Enable USB clock
+     */
+    __HAL_RCC_USB_CLK_ENABLE();
+}

--- a/hw/usb/tinyusb/stm32_fsdev/stm32f3/syscfg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32f3/syscfg.yml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    USB_DP_PULLUP_CONTROL_PIN:
+        description: >
+            Set pin number (other then PA11) that connects 1.5k resistor to D+
+        value: -1
+
+syscfg.defs.(USB_DP_PULLUP_CONTROL_PIN!=-1):
+    USB_DP_PULLUP_CONTROL_PIN_MODE:
+        description: >
+            1.5 kOhm Resistor can be connected directly to one of the output pins,
+            or it can use additional switch to connect resistor.
+        choices:
+            # Following two cases are used when 1.5k is connected when MCU is down
+            # and needs some control pin value to be shorted to ground
+            - enable_input_disable_0
+            - enable_input_disable_1
+            # This is rare case when both disable and enable requires control pin
+            # to be connected and set to certain value
+            - enable_1_disable_0
+            - enable_0_disable_1
+            # Current can be drawn directly from control PIN it there is not additional
+            # switching hardware element.
+            - enable_1_disable_input
+            # Case when resistor is connected from MCU pin via inverting transistor
+            # current is not drawn from MCU pin.
+            - enable_0_disable_input
+        value:


### PR DESCRIPTION
STM32F3 while similar to STM32F1 has different interrupt settings.

This also allows signal disconnect on D+ line during restart.