### PR TITLE
hw/mcu/stm32: Disable SysTick when RTC is selected as tick source

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -307,6 +307,12 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
         .PeriphClockSelection = RCC_PERIPHCLK_RTC,
         .RTCClockSelection = RCC_RTCCLKSOURCE_LSE,
     };
+    /*
+     * Disable SysTick so only one interrupt advances time.
+     * this is needed when bootloader enabled SysTick
+     */
+    SysTick->CTRL = 0;
+
     HAL_RCCEx_PeriphCLKConfig(&clock_init);
 
     /* Set the system tick priority. */


### PR DESCRIPTION
When tick was provided by RTC instead of SysTick (default) and MCUboot used SysTick during boot, SysTick was never turned off and was running in application code.
This resulted in two interrupts advancing mynewt OS tick so clock was running too fast.

Now os_tick_init() from RTC code disables SysTick that could be started in bootloader.
Same code was already applied to STM32F1 that has different RTC block.