### PR TITLE
sys/config: Add littlefs configuration

### DIFF
--- a/sys/config/pkg.yml
+++ b/sys/config/pkg.yml
@@ -36,6 +36,8 @@ pkg.deps.CONFIG_FCB2:
     - "@apache-mynewt-core/fs/fcb2"
 pkg.deps.CONFIG_NFFS:
     - "@apache-mynewt-core/fs/nffs"
+pkg.deps.CONFIG_LITTLEFS:
+    - "@apache-mynewt-core/fs/littlefs"
 
 pkg.init:
     config_pkg_init: 'MYNEWT_VAL(CONFIG_SYSINIT_STAGE_1)'

--- a/sys/config/src/config_file.c
+++ b/sys/config/src/config_file.c
@@ -19,7 +19,7 @@
 
 #include "os/mynewt.h"
 
-#if MYNEWT_VAL(CONFIG_NFFS)
+#if MYNEWT_VAL(CONFIG_NFFS) || MYNEWT_VAL(CONFIG_LITTLEFS)
 
 #include <string.h>
 #include <assert.h>

--- a/sys/config/src/config_init.c
+++ b/sys/config/src/config_init.c
@@ -27,7 +27,27 @@
 
 #if MYNEWT_VAL(CONFIG_AUTO_INIT)
 
-#if MYNEWT_VAL(CONFIG_NFFS)
+#if MYNEWT_VAL(CONFIG_LITTLEFS)
+#include "fs/fs.h"
+
+static struct conf_file config_init_conf_littlefs = {
+    .cf_name = MYNEWT_VAL(CONFIG_LITTLEFS_FILE),
+    .cf_maxlines = MYNEWT_VAL(CONFIG_LITTLEFS_MAX_LINES)
+};
+
+static void
+config_init_littlefs(void)
+{
+    int rc;
+
+    rc = conf_file_src(&config_init_conf_littlefs);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+    rc = conf_file_dst(&config_init_conf_littlefs);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+}
+
+#elif MYNEWT_VAL(CONFIG_NFFS)
+
 #include "fs/fs.h"
 
 static struct conf_file config_init_conf_file = {
@@ -137,7 +157,9 @@ config_pkg_init(void)
     conf_init();
 
 #if MYNEWT_VAL(CONFIG_AUTO_INIT)
-#if MYNEWT_VAL(CONFIG_NFFS)
+#if MYNEWT_VAL(CONFIG_LITTLEFS)
+    config_init_littlefs();
+#elif MYNEWT_VAL(CONFIG_NFFS)
     config_init_fs();
 #elif MYNEWT_VAL(CONFIG_FCB)
     config_init_fcb();

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -128,6 +128,14 @@ syscfg.defs.CONFIG_NFFS:
         description: 'Limit how many items stored in file before compressing'
         value: 32
 
+syscfg.defs.CONFIG_LITTLEFS:
+    CONFIG_LITTLEFS_FILE:
+        description: 'Name for the default config file'
+        value: '"cfg"'
+    CONFIG_LITTLEFS_MAX_LINES:
+        description: 'Limit how many items stored in file before compressing'
+        value: 32
+
 syscfg.vals.CONFIG_FCB2:
     CONFIG_FCB_MAGIC: 0xd0b1d0b1
 


### PR DESCRIPTION
Until now CONFIG_LITTLEFS was only defined,
but wasn't doing anything. Now littlefs
is configured and used as backend storage.

Tested with slinky app config.