### PR TITLE
sys/log: Add timing option to log command

### DIFF
--- a/fs/fcb/include/fcb/fcb.h
+++ b/fs/fcb/include/fcb/fcb.h
@@ -55,6 +55,8 @@ struct fcb {
     uint8_t f_version;  	/* Current version number of the data */
     uint16_t f_sector_cnt;	/* Number of elements in sector array */
     uint16_t f_scratch_cnt;	/* How many sectors should be kept empty */
+    uint32_t f_entry_count; /* Number of elements in FCB */
+    uint16_t f_active_sector_entry_count;
     struct flash_area *f_sectors; /* Array of sectors, must be contiguous */
 
     /* Flash circular buffer internal state */
@@ -80,6 +82,18 @@ struct fcb {
 #define FCB_ERR_NEXT_SECT -9
 
 int fcb_init(struct fcb *fcb);
+
+/**
+ * Return number of entries in whole FCB or single sector (fa).
+ *
+ * Number of entries for whole FCB is computed during fcb_init.
+ *
+ * @param fcb - fcb to get number of entries from
+ * @param fa - single sector to count entries (optional can be NULL)
+ *
+ * @return number of entries in FCB or one sector of FCB
+ */
+int fcb_get_entry_count(struct fcb *fcb, struct flash_area *fa);
 
 /**
  * fcb_append() appends an entry to circular buffer. When writing the

--- a/fs/fcb/src/fcb_append.c
+++ b/fs/fcb/src/fcb_append.c
@@ -101,6 +101,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
         fcb->f_active.fe_area = fa;
         fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
         fcb->f_active_id++;
+        fcb->f_active_sector_entry_count = 0;
     }
 
     rc = flash_area_write(active->fe_area, active->fe_elem_off, tmp_str, cnt);
@@ -108,6 +109,9 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
         rc = FCB_ERR_FLASH;
         goto err;
     }
+    fcb->f_active_sector_entry_count++;
+    fcb->f_entry_count++;
+
     append_loc->fe_area = active->fe_area;
     append_loc->fe_elem_off = active->fe_elem_off;
     append_loc->fe_data_off = active->fe_elem_off + cnt;

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -96,6 +96,7 @@ typedef int (*lh_append_mbuf_body_func_t)(struct log *log,
                                           struct os_mbuf *om);
 typedef int (*lh_walk_func_t)(struct log *,
         log_walk_func_t walk_func, struct log_offset *log_offset);
+typedef int (*lh_get_entry_count_func_t)(struct log *log, uint32_t *entry_count);
 typedef int (*lh_flush_func_t)(struct log *);
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 typedef int (*lh_storage_info_func_t)(struct log *, struct log_storage_info *);
@@ -116,6 +117,7 @@ struct log_handler {
     lh_walk_func_t log_walk;
     lh_walk_func_t log_walk_sector;
     lh_flush_func_t log_flush;
+    lh_get_entry_count_func_t log_get_entry_count;
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
     lh_storage_info_func_t log_storage_info;
 #endif
@@ -591,6 +593,16 @@ int log_walk(struct log *log, log_walk_func_t walk_func,
 int log_walk_body(struct log *log, log_walk_body_func_t walk_body_func,
         struct log_offset *log_offset);
 int log_flush(struct log *log);
+
+/**
+ * Returns number of entries in log.
+ *
+ * @param log - The log to return number of entries from
+ * @param entry_count - The pointer to variable to store number of entries.
+ *
+ * @return 0 on success, error code otherwise
+ */
+int log_get_entry_count(struct log *log, uint32_t *entry_count);
 
 /**
  * @brief      Walking a section of FCB.

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -1014,6 +1014,22 @@ err:
     return (rc);
 }
 
+int
+log_get_entry_count(struct log *log, uint32_t *entry_count)
+{
+    int rc;
+
+    if (entry_count == NULL) {
+        rc = SYS_EINVAL;
+    } else if (log->l_log->log_get_entry_count == NULL) {
+        rc = SYS_ENOTSUP;
+    } else {
+        rc = log->l_log->log_get_entry_count(log, entry_count);
+    }
+
+    return rc;
+}
+
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
 int
 log_storage_info(struct log *log, struct log_storage_info *info)

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -656,6 +656,20 @@ log_fcb_flush(struct log *log)
 }
 
 static int
+log_fcb_get_entry_count(struct log *log, uint32_t *entry_count)
+{
+    struct fcb_log *fcb_log;
+    struct fcb *fcb;
+
+    fcb_log = (struct fcb_log *)log->l_arg;
+    fcb = &fcb_log->fl_fcb;
+
+    *entry_count = fcb_get_entry_count(fcb, NULL);
+
+    return 0;
+}
+
+static int
 log_fcb_registered(struct log *log)
 {
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
@@ -972,23 +986,24 @@ err:
 }
 
 const struct log_handler log_fcb_handler = {
-    .log_type             = LOG_TYPE_STORAGE,
-    .log_read             = log_fcb_read,
-    .log_read_mbuf        = log_fcb_read_mbuf,
-    .log_append           = log_fcb_append,
-    .log_append_body      = log_fcb_append_body,
-    .log_append_mbuf      = log_fcb_append_mbuf,
+    .log_type = LOG_TYPE_STORAGE,
+    .log_read = log_fcb_read,
+    .log_read_mbuf = log_fcb_read_mbuf,
+    .log_append = log_fcb_append,
+    .log_append_body = log_fcb_append_body,
+    .log_append_mbuf = log_fcb_append_mbuf,
     .log_append_mbuf_body = log_fcb_append_mbuf_body,
-    .log_walk             = log_fcb_walk,
-    .log_walk_sector      = log_fcb_walk_area,
-    .log_flush            = log_fcb_flush,
+    .log_walk = log_fcb_walk,
+    .log_walk_sector = log_fcb_walk_area,
+    .log_flush = log_fcb_flush,
+    .log_get_entry_count = log_fcb_get_entry_count,
 #if MYNEWT_VAL(LOG_STORAGE_INFO)
-    .log_storage_info     = log_fcb_storage_info,
+    .log_storage_info = log_fcb_storage_info,
 #endif
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
-    .log_set_watermark    = log_fcb_set_watermark,
+    .log_set_watermark = log_fcb_set_watermark,
 #endif
-    .log_registered       = log_fcb_registered,
+    .log_registered = log_fcb_registered,
 };
 
 #endif


### PR DESCRIPTION
This adds entry count to FCB (and log_fcb) so it number of entries in FCB and
log based on FCB gen be easily obtained.

Number of entries stored in the log is counted during call to fcb_init()
and used simplified strategy where only record length is read and
there is not verification of data against CRC but it allows to quickly
asses number of records.

Log API is extended to get number of entries in the given log and currently log_fcb has implementation while other logs will return 0.

Shell command log now has additional parameter -t that allows to measure time for log traversal
```
log -t
```
or
```
log -t reboot_log
```

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>