### PR TITLE
log_shell: Add log related shell functionality

### DIFF
--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -65,3 +65,6 @@ pkg.req_apis.LOG_STATS:
 
 pkg.init:
     log_init: 'MYNEWT_VAL(LOG_SYSINIT_STAGE_MAIN)'
+
+pkg.init.LOG_CLI_FILL_CMD:
+    shell_log_fill_register: $after:shell_init

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -254,4 +254,45 @@ shell_log_storage_cmd(int argc, char **argv)
 }
 #endif
 
+static int
+log_fill_command(int argc, char **argv)
+{
+    const char *log_name;
+    struct log *log;
+    int num = 1;
+
+    if (argc > 2) {
+        log_name = argv[2];
+        log = log_find(log_name);
+    } else {
+        log = log_list_get_next(NULL);
+    }
+    if (log == NULL) {
+        console_printf("No log to fill\n");
+        return -1;
+    }
+    if (argc > 1) {
+        num = atoi(argv[1]);
+        if (num <= 0 || num > 10000) {
+            num = 1;
+        }
+    }
+
+    for (int i = 0; i < num; ++i) {
+        log_printf(log, MODLOG_MODULE_DFLT, LOG_LEVEL_INFO, "Log os_time %d", (int)os_time_get());
+    }
+
+    return 0;
+}
+
+static struct shell_cmd log_fill_cmd = {
+    .sc_cmd = "log-fill",
+    .sc_cmd_func = log_fill_command
+};
+
+void
+shell_log_fill_register(void)
+{
+    shell_cmd_register(&log_fill_cmd);
+}
 #endif

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -85,6 +85,10 @@ syscfg.defs:
         restrictions:
             - SHELL_TASK
 
+    LOG_CLI_FILL_CMD:
+        description: 'Add "log-fill" command for filling up log'
+        value: 0
+
     LOG_SHELL_SHOW_INDEX:
         description: '"log" command shows log index when dumping entries'
         value: 0


### PR DESCRIPTION
Shell command log now has additional parameter `-t` that allows to measure time for log traversal

```
compat> log -t
826231 Log reboot_log 30366 entries walked in 2664 ms
826232 Log log 0 entries walked in 0 ms
```

Option `-n` allows to limit number of displayed logs

```
log -n 10
```

`log-fill` command allows to add some logs to test logging

```
log-fill 1000 reboot_log
```
