### PR TITLE
 hw/mcu/stm32: Fix WFI in RAM for -O3

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_os_tick.c
+++ b/hw/mcu/stm/stm32_common/src/hal_os_tick.c
@@ -28,11 +28,10 @@
 #endif
 
 #if MYNEWT_VAL(STM32_WFI_FROM_RAM)
-__attribute__((section(".text_ram"))) void
+__attribute__((section(".text_ram"),noinline)) void
 stm32_wfi_from_ram(void)
 {
-    __ASM volatile ("wfi\n"
-                    "bx lr");
+    __ASM volatile ("wfi");
 }
 #endif
 


### PR DESCRIPTION
Even though function stm32_wfi_from_ram() has attribute to be placed in ram in -03 it can be inlined that can effectively run WFI from flash.

Now additional attribute is added to make sure that it is not inlined.

bx lr is also removed allowing compiler to make normal exit from function (which in most cases will be bx lr)