### PR TITLE
boot/startup: Add user_section.ld.h

### DIFF
--- a/boot/startup/mynewt_cortex_m0.ld
+++ b/boot/startup/mynewt_cortex_m0.ld
@@ -43,6 +43,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+#include <user_sections.ld.h>
+
     /*
      * Image header is added by newt tool during execution newt image-create.
      * This section allows to have complete elf with predefined image header that

--- a/boot/startup/mynewt_cortex_m0.ld
+++ b/boot/startup/mynewt_cortex_m0.ld
@@ -19,6 +19,7 @@
 
 #include <syscfg/syscfg.h>
 #include <sysflash/sysflash.h>
+#include <mcu_config.ld.h>
 #include <bsp_config.ld.h>
 #include <target_config.ld.h>
 #include <mynewt_config.ld.h>
@@ -36,7 +37,18 @@ MEMORY
 #ifdef FLASH_AREA_IMAGE_0_OFFSET
     SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
 #endif
+    /*
+     * If STACK_REGION is defined it means that MCU stack is place in other region then RAM
+     * int that case RAM region size is exactly RAM_SIZE
+     * If STACK_REGION is NOT defined STACK_RAM region is place at the end of RAM
+     * and RAM region size is shortened.
+     */
+#ifdef STACK_REGION
     RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#else
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = (RAM_SIZE - STACK_SIZE)
+    STACK_RAM (rw) : ORIGIN = RAM_START + RAM_SIZE - STACK_SIZE, LENGTH = STACK_SIZE
+#endif
 #include <memory_regions.ld.h>
 }
 
@@ -247,7 +259,7 @@ SECTIONS
     __data_image__ = LOADADDR(.data);
     _sidata = LOADADDR(.data);
 
-    .bssnz :
+    .bssnz (NOLOAD) :
     {
         . = ALIGN(4);
         __bssnz_start__ = .;
@@ -269,14 +281,8 @@ SECTIONS
         __ecorebss = .;
     } > COREBSS_RAM
 #endif
-    .bssnz (NOLOAD):
-    {
-        . = ALIGN(4);
-        *(.bss.core.nz)
-        . = ALIGN(4);
-    } > RAM
 
-    .bss :
+    .bss (NOLOAD) :
     {
         . = ALIGN(4);
         _sbss = .;
@@ -291,27 +297,19 @@ SECTIONS
     /* Heap starts after BSS */
     . = ALIGN(8);
     __HeapBase = .;
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
-    /* Dummy section to calculate whether we need to move stack out of MTB
-     * buffer or not. */
-    .mtb (NOLOAD) :
-    {
-        KEEP(*(.mtb));
-    }
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "No space for MCU heap")
 
     _ram_start = ORIGIN(RAM);
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    __StackTop = ORIGIN(STACK_RAM) + LENGTH(STACK_RAM);
+    __StackLimit = ORIGIN(STACK_RAM);
     _estack = __StackTop;
-    __StackLimit = __StackTop - STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Top of head is the bottom of the stack */
-    __HeapLimit = __StackLimit;
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
 }
 

--- a/boot/startup/mynewt_cortex_m3.ld
+++ b/boot/startup/mynewt_cortex_m3.ld
@@ -43,6 +43,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+#include <user_sections.ld.h>
+
     /*
      * Image header is added by newt tool during execution newt image-create.
      * This section allows to have complete elf with predefined image header that

--- a/boot/startup/mynewt_cortex_m3.ld
+++ b/boot/startup/mynewt_cortex_m3.ld
@@ -19,6 +19,7 @@
 
 #include <syscfg/syscfg.h>
 #include <sysflash/sysflash.h>
+#include <mcu_config.ld.h>
 #include <bsp_config.ld.h>
 #include <target_config.ld.h>
 #include <mynewt_config.ld.h>
@@ -36,7 +37,18 @@ MEMORY
 #ifdef FLASH_AREA_IMAGE_0_OFFSET
     SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
 #endif
+    /*
+     * If STACK_REGION is defined it means that MCU stack is place in other region then RAM
+     * int that case RAM region size is exactly RAM_SIZE
+     * If STACK_REGION is NOT defined STACK_RAM region is place at the end of RAM
+     * and RAM region size is shortened.
+     */
+#ifdef STACK_REGION
     RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#else
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = (RAM_SIZE - STACK_SIZE)
+    STACK_RAM (rw) : ORIGIN = RAM_START + RAM_SIZE - STACK_SIZE, LENGTH = STACK_SIZE
+#endif
 #include <memory_regions.ld.h>
 }
 
@@ -247,7 +259,7 @@ SECTIONS
     __data_image__ = LOADADDR(.data);
     _sidata = LOADADDR(.data);
 
-    .bssnz :
+    .bssnz (NOLOAD) :
     {
         . = ALIGN(4);
         __bssnz_start__ = .;
@@ -269,14 +281,8 @@ SECTIONS
         __ecorebss = .;
     } > COREBSS_RAM
 #endif
-    .bssnz (NOLOAD):
-    {
-        . = ALIGN(4);
-        *(.bss.core.nz)
-        . = ALIGN(4);
-    } > RAM
 
-    .bss :
+    .bss (NOLOAD) :
     {
         . = ALIGN(4);
         _sbss = .;
@@ -291,27 +297,19 @@ SECTIONS
     /* Heap starts after BSS */
     . = ALIGN(8);
     __HeapBase = .;
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
-    /* Dummy section to calculate whether we need to move stack out of MTB
-     * buffer or not. */
-    .mtb (NOLOAD) :
-    {
-        KEEP(*(.mtb));
-    }
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "No space for MCU heap")
 
     _ram_start = ORIGIN(RAM);
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    __StackTop = ORIGIN(STACK_RAM) + LENGTH(STACK_RAM);
+    __StackLimit = ORIGIN(STACK_RAM);
     _estack = __StackTop;
-    __StackLimit = __StackTop - STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Top of head is the bottom of the stack */
-    __HeapLimit = __StackLimit;
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
 }
 

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -43,6 +43,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+#include <user_sections.ld.h>
+
     /*
      * Image header is added by newt tool during execution newt image-create.
      * This section allows to have complete elf with predefined image header that

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -19,6 +19,7 @@
 
 #include <syscfg/syscfg.h>
 #include <sysflash/sysflash.h>
+#include <mcu_config.ld.h>
 #include <bsp_config.ld.h>
 #include <target_config.ld.h>
 #include <mynewt_config.ld.h>
@@ -36,7 +37,18 @@ MEMORY
 #ifdef FLASH_AREA_IMAGE_0_OFFSET
     SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
 #endif
+    /*
+     * If STACK_REGION is defined it means that MCU stack is place in other region then RAM
+     * int that case RAM region size is exactly RAM_SIZE
+     * If STACK_REGION is NOT defined STACK_RAM region is place at the end of RAM
+     * and RAM region size is shortened.
+     */
+#ifdef STACK_REGION
     RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#else
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = (RAM_SIZE - STACK_SIZE)
+    STACK_RAM (rw) : ORIGIN = RAM_START + RAM_SIZE - STACK_SIZE, LENGTH = STACK_SIZE
+#endif
 #include <memory_regions.ld.h>
 }
 
@@ -247,7 +259,7 @@ SECTIONS
     __data_image__ = LOADADDR(.data);
     _sidata = LOADADDR(.data);
 
-    .bssnz :
+    .bssnz (NOLOAD) :
     {
         . = ALIGN(4);
         __bssnz_start__ = .;
@@ -269,14 +281,8 @@ SECTIONS
         __ecorebss = .;
     } > COREBSS_RAM
 #endif
-    .bssnz (NOLOAD):
-    {
-        . = ALIGN(4);
-        *(.bss.core.nz)
-        . = ALIGN(4);
-    } > RAM
 
-    .bss :
+    .bss (NOLOAD) :
     {
         . = ALIGN(4);
         _sbss = .;
@@ -291,27 +297,19 @@ SECTIONS
     /* Heap starts after BSS */
     . = ALIGN(8);
     __HeapBase = .;
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
-    /* Dummy section to calculate whether we need to move stack out of MTB
-     * buffer or not. */
-    .mtb (NOLOAD) :
-    {
-        KEEP(*(.mtb));
-    }
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "No space for MCU heap")
 
     _ram_start = ORIGIN(RAM);
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    __StackTop = ORIGIN(STACK_RAM) + LENGTH(STACK_RAM);
+    __StackLimit = ORIGIN(STACK_RAM);
     _estack = __StackTop;
-    __StackLimit = __StackTop - STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Top of head is the bottom of the stack */
-    __HeapLimit = __StackLimit;
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
 }
 

--- a/boot/startup/mynewt_cortex_m4.ld
+++ b/boot/startup/mynewt_cortex_m4.ld
@@ -55,6 +55,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+#include <user_sections.ld.h>
+
     /*
      * Image header is added by newt tool during execution newt image-create.
      * This section allows to have complete elf with predefined image header that

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -44,6 +44,8 @@ MEMORY
 /* Define output sections */
 SECTIONS
 {
+#include <user_sections.ld.h>
+
     /*
      * Image header is added by newt tool during execution newt image-create.
      * This section allows to have complete elf with predefined image header that

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -37,7 +37,18 @@ MEMORY
 #ifdef FLASH_AREA_IMAGE_0_OFFSET
     SLOT0 (rx!w) : ORIGIN = FLASH_AREA_IMAGE_0_OFFSET, LENGTH = FLASH_AREA_IMAGE_0_SIZE
 #endif
+    /*
+     * If STACK_REGION is defined it means that MCU stack is place in other region then RAM
+     * int that case RAM region size is exactly RAM_SIZE
+     * If STACK_REGION is NOT defined STACK_RAM region is place at the end of RAM
+     * and RAM region size is shortened.
+     */
+#ifdef STACK_REGION
     RAM (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
+#else
+    RAM (rwx) : ORIGIN = RAM_START, LENGTH = (RAM_SIZE - STACK_SIZE)
+    STACK_RAM (rw) : ORIGIN = RAM_START + RAM_SIZE - STACK_SIZE, LENGTH = STACK_SIZE
+#endif
 #include <memory_regions.ld.h>
 }
 
@@ -248,7 +259,7 @@ SECTIONS
     __data_image__ = LOADADDR(.data);
     _sidata = LOADADDR(.data);
 
-    .bssnz :
+    .bssnz (NOLOAD) :
     {
         . = ALIGN(4);
         __bssnz_start__ = .;
@@ -271,7 +282,7 @@ SECTIONS
     } > COREBSS_RAM
 #endif
 
-    .bss :
+    .bss (NOLOAD) :
     {
         . = ALIGN(4);
         _sbss = .;
@@ -286,27 +297,19 @@ SECTIONS
     /* Heap starts after BSS */
     . = ALIGN(8);
     __HeapBase = .;
+    /* Top of head is the bottom of the stack */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
-    /* Dummy section to calculate whether we need to move stack out of MTB
-     * buffer or not. */
-    .mtb (NOLOAD) :
-    {
-        KEEP(*(.mtb));
-    }
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__HeapBase <= __HeapLimit, "No space for MCU heap")
 
     _ram_start = ORIGIN(RAM);
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.mtb);
+    __StackTop = ORIGIN(STACK_RAM) + LENGTH(STACK_RAM);
+    __StackLimit = ORIGIN(STACK_RAM);
     _estack = __StackTop;
-    __StackLimit = __StackTop - STACK_SIZE;
     PROVIDE(__stack = __StackTop);
-
-    /* Top of head is the bottom of the stack */
-    __HeapLimit = __StackLimit;
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__HeapBase <= __HeapLimit, "region RAM overflowed with stack")
 }
 

--- a/boot/startup/scripts/generate_linker_script.sh
+++ b/boot/startup/scripts/generate_linker_script.sh
@@ -25,6 +25,7 @@ touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/target_config.ld.h
 touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/memory_regions.ld.h
 touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/bsp_config.ld.h
 touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/mcu_config.ld.h
+touch ${MYNEWT_BUILD_GENERATED_DIR}/link/include/user_sections.ld.h
 
 set >env.txt
 ${MYNEWT_CC_PATH} -xc -DMYNEWT_SYSFLASH_ONLY_CONST -P -E \

--- a/hw/mcu/stm/stm32h7xx/link/include/user_sections.ld.h
+++ b/hw/mcu/stm/stm32h7xx/link/include/user_sections.ld.h
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+    _dtcmram_start = ORIGIN(DTCM);
+    _dtcmram_limit = ORIGIN(DTCM) + LENGTH(DTCM);
+    _itcmram_start = ORIGIN(ITCM);
+    _itcmram_limit = ORIGIN(ITCM) + LENGTH(ITCM);


### PR DESCRIPTION
Some MCU/applications may require special sections
in linker script

So far memory_regions.ld.h could add non standard
memory regions, newt link_tables could add filters
to read only data for easy link time table generations.

This adds way to add whole sections and or symbol
definitions if required

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>