### PR TITLE
Added Blues Wireless note-c library support and example application.

### DIFF
--- a/apps/blues-wireless/pkg.yml
+++ b/apps/blues-wireless/pkg.yml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: apps/blues-wireless
+pkg.type: app
+pkg.description: Basic example application for Blues Wireless notecard.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/stub"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-core/sys/sysinit"
+    - "@apache-mynewt-core/net/cellular/blues"
+    
+

--- a/apps/blues-wireless/src/main.c
+++ b/apps/blues-wireless/src/main.c
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <assert.h>
+#include <string.h>
+
+#include "sysinit/sysinit.h"
+#include "os/os.h"
+#include "bsp/bsp.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_i2c.h"
+#include "hal/hal_uart.h"
+#include <console/console.h>
+
+#include <note.h>
+#include "note_c_hooks.h"
+
+/*Product UUID from notehub*/
+
+#define PRODUCT_UID "UID"
+
+float lat, lon;
+
+/* For LED toggling */
+int g_led_pin;
+
+static void
+init_notecard(void)
+{
+    NoteSetFnDefault(malloc, free, platform_delay, platform_millis);
+    NoteSetFnDebugOutput(note_log_print);
+    NoteSetFnI2C(NOTE_I2C_ADDR_DEFAULT, NOTE_I2C_MAX_DEFAULT, note_i2c_reset, note_i2c_transmit, note_i2c_receive);
+
+    J *req = NoteNewRequest("hub.set");
+    JAddStringToObject(req, "product", PRODUCT_UID);
+    JAddStringToObject(req, "mode", "periodic");
+    JAddBoolToObject(req, "sync", true);
+
+    NoteRequestWithRetry(req, 5);
+
+    J *req2 = NoteNewRequest("card.version");
+
+    NoteRequestWithRetry(req2, 5);
+
+    J *req3 = NoteNewRequest("card.location.mode");
+    JAddStringToObject(req3, "mode","continuous");
+
+    NoteRequestWithRetry(req3, 5);
+}
+
+static void
+update_location(void)
+{
+    J *location = NoteRequestResponse(NoteNewRequest("card.location"));
+
+    if (location != NULL) {
+        lat = JGetNumber(location, "lat");
+        lon = JGetNumber(location, "lon");
+    }
+    J *req = NoteNewRequest("note.add");
+    JAddStringToObject(req, "file", "location.qo");
+    JAddBoolToObject(req, "sync", true);
+
+    J *body = JCreateObject();
+    JAddStringToObject(body, "message", "location");
+
+    if (location == NULL) {
+        J *timereq = NoteRequestResponse(NoteNewRequest("card.time"));
+        if (timereq != NULL) {
+            lat = JGetNumber(timereq, "lat");
+            lon = JGetNumber(timereq, "lat");
+        }
+    }
+    JAddNumberToObject(body, "Latitude", lat);
+    JAddNumberToObject(body, "Longitude", lon);
+    JAddItemToObject(req, "body", body);
+    NoteRequest(req);
+}
+
+/**
+ * main
+ *
+ * The main task for the project. This function initializes packages,
+ * and then blinks the BSP LED in a loop.
+ *
+ * @return int NOTE: this function should never return!
+ */
+int
+mynewt_main(int argc, char **argv)
+{
+    int rc;
+    sysinit();
+
+    g_led_pin = LED_BLINK_PIN;
+    hal_gpio_init_out(g_led_pin, 1);
+    init_notecard();
+
+    while (1) {
+        /* Wait one second */
+        os_time_delay(OS_TICKS_PER_SEC * 10);
+
+        /* Toggle the LED */
+        hal_gpio_toggle(g_led_pin);
+        update_location();
+    }
+    assert(0);
+    return rc;
+}

--- a/apps/blues-wireless/src/note_c_hooks.c
+++ b/apps/blues-wireless/src/note_c_hooks.c
@@ -1,0 +1,140 @@
+/**
+ #
+ # Licensed to the Apache Software Foundation (ASF) under one
+ # or more contributor license agreements.  See the NOTICE file
+ # distributed with this work for additional information
+ # regarding copyright ownership.  The ASF licenses this file
+ # to you under the Apache License, Version 2.0 (the
+ # "License"); you may not use this file except in compliance
+ # with the License.  You may obtain a copy of the License at
+ #
+ #  http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing,
+ # software distributed under the License is distributed on an
+ # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ # KIND, either express or implied.  See the License for the
+ # specific language governing permissions and limitations
+ # under the License.
+ #
+ */
+
+
+#include "note_c_hooks.h"
+#include "bsp/bsp.h"
+#include "hal/hal_i2c.h"
+#include "os/os_time.h"
+#include <console/console.h>
+
+static const size_t REQUEST_HEADER_SIZE = 2;
+
+const uint8_t i2c_num = 0;
+bool i2c_initialized = false;
+
+uint32_t
+platform_millis(void)
+{
+    return (uint32_t)(os_get_uptime_usec()/1000);
+}
+
+void
+platform_delay(uint32_t ms)
+{
+    os_time_t d_time;
+    d_time = os_time_ms_to_ticks32(ms);
+    os_time_delay(d_time);
+}
+
+const char *
+note_i2c_receive(uint16_t device_address, uint8_t *buffer,
+                 uint16_t size, uint32_t *available)
+{
+    uint8_t size_buf[2];
+    size_buf[0] = 0;
+    size_buf[1] = (uint8_t)size;
+
+    struct hal_i2c_master_data data = {
+        .address = device_address,
+        .len = sizeof(size_buf),
+        .buffer = size_buf,
+    };
+
+    uint8_t write_result = hal_i2c_master_write(i2c_num, &data, OS_TICKS_PER_SEC / 10, 0);
+
+    if (write_result != 0) {
+        return "i2c: unable to initiate read from the notecard\n";
+    }
+    /*
+       Read from the Notecard and copy the response bytes into the
+       response buffer
+     */
+    const int request_length = size + REQUEST_HEADER_SIZE;
+    uint8_t read_buf[256];
+
+    data.len = request_length;
+    data.buffer = read_buf;
+    int8_t read_result = hal_i2c_master_read(i2c_num, &data, OS_TICKS_PER_SEC / 10, 1);
+
+    if (read_result != 0) {
+        return "i2c: Unable to receive data from the Notecard.\n";
+    } else {
+        *available = (uint32_t)read_buf[0];
+        uint8_t bytes_to_read = read_buf[1];
+        for (size_t i = 0; i < bytes_to_read; i++) {
+            buffer[i] = read_buf[i + 2];
+        }
+        return NULL;
+    }
+}
+
+bool
+note_i2c_reset(uint16_t device_address)
+{
+    (void)device_address;
+
+    if (i2c_initialized) {
+        return true;
+    }
+    if (hal_i2c_enable(i2c_num) != 0) {
+        console_printf("i2c: Device not ready.\n");
+        return false;
+    }
+    console_printf("i2c: Device is ready.\n");
+    i2c_initialized = true;
+    return true;
+}
+
+const char *
+note_i2c_transmit(uint16_t device_address, uint8_t *buffer,
+                  uint16_t size)
+{
+    uint8_t write_buf[size + 1];
+    write_buf[0] = (uint8_t)size;
+    for (size_t i = 0; i < size; i++) {
+        write_buf[i + 1] = buffer[i];
+    }
+
+    struct hal_i2c_master_data data = {
+        .address = device_address,
+        .len = size + 1,
+        .buffer = write_buf,
+    };
+
+    uint8_t write_result = hal_i2c_master_write(i2c_num, &data, OS_TICKS_PER_SEC / 5, 1);
+
+    if (write_result != 0) {
+        return "i2c: Unable to transmit data to the Notecard\n";
+    } else {
+        return NULL;
+    }
+}
+
+size_t
+note_log_print(const char *message)
+{
+    if (message) {
+        console_printf("%s", message);
+        return 1;
+    }
+    return 0;
+}

--- a/apps/blues-wireless/src/note_c_hooks.h
+++ b/apps/blues-wireless/src/note_c_hooks.h
@@ -1,0 +1,38 @@
+/**
+ # Licensed to the Apache Software Foundation (ASF) under one
+ # or more contributor license agreements.  See the NOTICE file
+ # distributed with this work for additional information
+ # regarding copyright ownership.  The ASF licenses this file
+ # to you under the Apache License, Version 2.0 (the
+ # "License"); you may not use this file except in compliance
+ # with the License.  You may obtain a copy of the License at
+ #
+ #  http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing,
+ # software distributed under the License is distributed on an
+ # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ # KIND, either express or implied.  See the License for the
+ # specific language governing permissions and limitations
+ # under the License.
+ #
+ */
+
+#ifndef NOTE_C_HOOKS_H
+#define NOTE_C_HOOKS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void platform_delay(uint32_t ms);
+uint32_t platform_millis(void);
+
+const char *note_i2c_receive(uint16_t device_address, uint8_t *buffer,
+                             uint16_t size, uint32_t *available);
+bool note_i2c_reset(uint16_t device_address);
+const char *note_i2c_transmit(uint16_t device_address, uint8_t *buffer, uint16_t size);
+
+size_t note_log_print(const char *message);
+
+#endif /* NOTE_C_HOOKS_H */

--- a/net/cellular/blues/pkg.yml
+++ b/net/cellular/blues/pkg.yml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: net/cellular/blues
+pkg.description: Blues Wireless Note-c API port
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.type: sdk
+pkg.keywords:
+
+repository.blues-note-c:
+    type: github
+    vers: v2.2.1-commit
+    branch: master
+    user: blues
+    repo: note-c
+
+
+pkg.include_dirs:
+    - "@blues-note-c/."
+
+pkg.source_dirs:
+    - "@blues-note-c/."
+
+pkg.ign_dirs:
+    - "test"


### PR DESCRIPTION
Hi,
I have added support for Blues Wireless [note-c ](https://github.com/blues/note-c/tree/2b31718ec01a9000f8f62cea848449eacfe50807)library. in` /net/cellular`. Also, I have added an example application inside apps/blues-wireless to get location data based on GPS. 

I took the inspiration from [note-zephyr](https://github.com/blues/note-zephyr/tree/main) repository.