### PR TITLE
sys/log: Use colors for module name when dumping log

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -226,11 +226,26 @@ log_module_register(uint8_t id, const char *name)
     return id;
 }
 
+static const char *const default_modules[] = {
+    "DEFAULT",
+    "OS",
+    "NEWTMGR",
+    "NIMBLE_CTLR",
+    "NIMBLE_HOST",
+    "NFFS",
+    "REBOOT",
+    "IOTIVITY",
+};
+
 const char *
 log_module_get_name(uint8_t module)
 {
     int idx;
     const char *name;
+
+    if (module < LOG_MODULE_TEST) {
+        return default_modules[module];
+    }
 
     /* Find module defined in syscfg.logcfg sections */
     name = logcfg_log_module_name(module);

--- a/sys/log/full/src/log_console.c
+++ b/sys/log/full/src/log_console.c
@@ -52,18 +52,65 @@ log_console_get(void)
 
 #if MYNEWT_VAL(LOG_CONSOLE_PRETTY)
 #define CSI                     "\x1b["
-#define COLOR_BLUE              "36m"
-#define COLOR_YELLOW            "33m"
-#define COLOR_RED               "31m"
-#define COLOR_RED_BG            "41m"
+#define COLOR_BLACK             CSI "30m"
+#define COLOR_RED               CSI "31m"
+#define COLOR_GREEN             CSI "32m"
+#define COLOR_YELLOW            CSI "33m"
+#define COLOR_BLUE              CSI "34m"
+#define COLOR_MAGENTA           CSI "35m"
+#define COLOR_CYAN              CSI "36m"
+#define COLOR_WHITE             CSI "37m"
+#define COLOR_BLACK_BG          CSI "40m"
+#define COLOR_RED_BG            CSI "41m"
+#define COLOR_GREEN_BG          CSI "42m"
+#define COLOR_YELLOW_BG         CSI "43m"
+#define COLOR_WHITE_BG          CSI "47m"
 
 #if MYNEWT_VAL(LOG_CONSOLE_PRETTY_WITH_COLORS)
-#define COLOR_DBG               CSI COLOR_BLUE
+#define COLOR_DBG               COLOR_CYAN
 #define COLOR_INF               ""
-#define COLOR_WRN               CSI COLOR_YELLOW
-#define COLOR_ERR               CSI COLOR_RED
-#define COLOR_CRI               CSI COLOR_RED_BG
+#define COLOR_WRN               COLOR_YELLOW
+#define COLOR_ERR               COLOR_RED
+#define COLOR_CRI               COLOR_RED_BG
 #define COLOR_RESET             CSI "0m"
+
+const char *const module_colors[] = {
+    COLOR_GREEN COLOR_BLACK_BG,
+    COLOR_RED COLOR_WHITE_BG,
+    COLOR_BLUE,
+    COLOR_YELLOW COLOR_BLACK_BG,
+    COLOR_MAGENTA COLOR_WHITE_BG,
+    COLOR_CYAN COLOR_BLACK_BG,
+    COLOR_WHITE COLOR_RED_BG,
+    COLOR_BLACK COLOR_GREEN_BG,
+    COLOR_BLACK COLOR_YELLOW_BG,
+};
+
+static uint8_t log_module_color_index[10];
+
+static void
+log_module_color(uint8_t module, char *color_on, char *color_off)
+{
+    int i;
+
+    *color_on = 0;
+    *color_off = 0;
+
+    if (module) {
+        for (i = 0; i < ARRAY_SIZE(log_module_color_index) &&
+             log_module_color_index[i] != 0 &&
+             log_module_color_index[i] != module; ++i) {
+        }
+        if (i < ARRAY_SIZE(log_module_color_index)) {
+            if (log_module_color_index[i] == 0) {
+                log_module_color_index[i] = module;
+            }
+            strcpy(color_on, module_colors[i]);
+            strcpy(color_off, COLOR_RESET);
+        }
+    }
+}
+
 #else
 #define COLOR_DBG               ""
 #define COLOR_INF               ""
@@ -71,6 +118,7 @@ log_console_get(void)
 #define COLOR_ERR               ""
 #define COLOR_CRI               ""
 #define COLOR_RESET             ""
+#define log_module_color(hdr, on, off)
 #endif
 
 static const char * const log_level_color[] = {
@@ -82,26 +130,33 @@ static const char * const log_level_color[] = {
 };
 
 static const char * const log_level_str[] = {
-    "[DBG]",
-    "[INF]",
-    "[WRN]",
-    "[ERR]",
-    "[CRI]",
+    "DBG",
+    "INF",
+    "WRN",
+    "ERR",
+    "CRI",
 };
 
-static void
+void
 log_console_print_hdr(const struct log_entry_hdr *hdr)
 {
     char module_num[10];
     char image_hash_str[17];
-    char level_str_buf[13];
+    char level_str_buf[23];
     const char *level_str = "";
     const char *module_name = NULL;
-    const char *color = "";
-    const char *color_off = "";
+    char color[11];
+    char color_off[6];
 
     /* Find module defined in syscfg.logcfg sections */
     module_name = log_module_get_name(hdr->ue_module);
+
+    if (MYNEWT_VAL(LOG_CONSOLE_PRETTY_WITH_COLORS)) {
+        log_module_color(hdr->ue_module, color, color_off);
+    } else {
+        color[0] = 0;
+        color_off[0] = 0;
+    }
 
     if (module_name == NULL) {
         module_name = module_num;
@@ -115,26 +170,29 @@ log_console_print_hdr(const struct log_entry_hdr *hdr)
     }
     if (hdr->ue_level <= LOG_LEVEL_CRITICAL) {
         if (MYNEWT_VAL(LOG_CONSOLE_PRETTY_WITH_COLORS)) {
-            color = log_level_color[hdr->ue_level];
-            color_off = COLOR_RESET;
+            strcpy(level_str_buf, log_level_color[hdr->ue_level]);
+            strcat(level_str_buf, log_level_str[hdr->ue_level]);
+            strcat(level_str_buf, COLOR_RESET);
+            level_str = level_str_buf;
         } else {
             level_str = log_level_str[hdr->ue_level];
         }
     } else {
-        sprintf(level_str_buf, "[level=%u]", hdr->ue_level);
+        sprintf(level_str_buf, "%-3u", hdr->ue_level);
+        level_str = level_str_buf;
     }
 
     if (MYNEWT_VAL(LOG_CONSOLE_PRETTY_WITH_TIMESTAMP)) {
         unsigned int us = (unsigned int)hdr->ue_ts % 1000000;
         unsigned int s = (unsigned int)(hdr->ue_ts / 1000000);
-        console_printf("[%u.%06u][%s%7s%s]%s%s ", s, us, color, module_name, color_off, level_str, image_hash_str);
+        console_printf("[%u.%06u][%s%7s%s][%s]%s ", s, us, color, module_name, color_off, level_str, image_hash_str);
     } else {
-        console_printf("[%s%7s%s]%s%s ", color, module_name, color_off, level_str, image_hash_str);
+        console_printf("[%s%7s%s][%s]%s ", color, module_name, color_off, level_str, image_hash_str);
     }
 }
 
 #else
-static void
+void
 log_console_print_hdr(const struct log_entry_hdr *hdr)
 {
     console_printf("[ts=" "%" PRIu64 "us, mod=%u level=%u ",

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -41,6 +41,10 @@ syscfg.defs:
         description: >
             Use color for mod log levels.
         value: 0
+    LOG_CONSOLE_PRETTY_COLOR_MODULES:
+        description: >
+            Use color for module names.
+        value: 0
 
     LOG_CONSOLE_PRETTY_WITH_TIMESTAMP:
         description: >


### PR DESCRIPTION
When LOG_CONSOLE_PRETTY is set dumping logs from log_shell
uses same function for printing log header

Module names are not printed in colors.
log level now is printed always even when colors are enabled.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>