### PR TITLE
ci: Fix style check

### DIFF
--- a/.github/check_style.py
+++ b/.github/check_style.py
@@ -59,7 +59,7 @@ def check_file(fname: str, commit: str, upstream: str) -> list[str]:
         lines = subprocess.check_output(f"git show {commit}:{fname}",
                                         shell=True)
         tmpf.write(lines)
-
+        tmpf.seek(0)
         in_chunk = False
 
         for s in run_cmd(f"uncrustify -q -c uncrustify.cfg -f {tmpf.name} | "


### PR DESCRIPTION
Resets temporary file pointer to the beginning of a file after writing the data.
In some cases it caused `uncrustify` to return empty list instead of corrected output, because it had not any input to process.