### PR TITLE
drivers/i2s: Fix missing dependency

### DIFF
--- a/hw/drivers/i2s/pkg.yml
+++ b/hw/drivers/i2s/pkg.yml
@@ -22,6 +22,9 @@ pkg.description: I2S device insterace
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-pkg.deps:
+
 pkg.req_apis:
     - I2S_HW_IMPL
+
+pkg.deps:
+    - "@apache-mynewt-core/util/stream"


### PR DESCRIPTION
Package i2s has now i2s_stream that requires
util/stream that is missing in pkg.yml