### PR TITLE
hw/drivers/bme280: Fix writes to I2C

### DIFF
--- a/hw/drivers/sensors/bme280/include/bme280/bme280.h
+++ b/hw/drivers/sensors/bme280/include/bme280/bme280.h
@@ -111,6 +111,7 @@ struct bme280 {
         struct bus_i2c_node i2c_node;
         struct bus_spi_node spi_node;
     };
+    bool node_is_spi;
 #else
     struct os_dev dev;
 #endif


### PR DESCRIPTION
I2C writes when driver was enabled clear MSB of register address.

This prevented any write to control registers.

Now registers MSB is cleared on write only for SPI.