### PR TITLE
hw/drivers/i2s: Fix I2S driver for STM32F1 family

### DIFF
--- a/hw/drivers/i2s/i2s_stm32f1/src/i2s_stm32f1.c
+++ b/hw/drivers/i2s/i2s_stm32f1/src/i2s_stm32f1.c
@@ -324,8 +324,6 @@ i2s_driver_start(struct i2s *i2s)
     case HAL_I2S_STATE_BUSY:
     case HAL_I2S_STATE_BUSY_RX:
     case HAL_I2S_STATE_BUSY_TX:
-    case HAL_I2S_STATE_BUSY_TX_RX:
-        break;
     default:
         rc = I2S_ERR_INTERNAL;
     }


### PR DESCRIPTION
case HAL_I2S_STATE_BUSY_TX_RX is not valid for this chip It should be only present for F4, F3 and H7.

Definition was present in mynewt copy of stm32f1xx_hal_i2s.h and probably was part of Stm32Cube package, but it is not present in stm32f1xx_hal_driver