### PR TITLE
sys/log: Fix build with LOG_STORAGE_INFO enabled

### DIFF
--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -307,10 +307,8 @@ shell_log_storage_cmd(int argc, char **argv)
         if (log_storage_info(log, &info)) {
             console_printf("Storage info not supported for %s\n", log->l_name);
         } else {
-            uint32_t entry_count = 0;
-            log_get_entry_count(log, &entry_count);
-            console_printf("%s: %d of %d used; %d entries\n", log->l_name,
-                           (unsigned)info.used, (unsigned)info.size, (int)entry_count);
+            console_printf("%s: %d of %d used\n", log->l_name,
+                           (unsigned)info.used, (unsigned)info.size);
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
             console_printf("%s: %d of %d used by unread entries\n", log->l_name,
                            (unsigned)info.used_unread, (unsigned)info.size);


### PR DESCRIPTION
During some log_shell improvements printed storage info was extended to show actual number of entries in the log. Durin review function that counts number of entries was dropped but call remained in log_shell resulting in build error when LOG_STORAGE_INFO is 1

This restores original print for of storage info.