### PR TITLE
DA1469x: Clock time shifts on reboots

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -62,6 +62,21 @@ void da1469x_clock_sys_xtal32m_switch_safe(void);
 void da1469x_clock_sys_rc32m_disable(void);
 
 /**
+ * Enable RC32M
+ */
+void da1469x_clock_sys_rc32m_enable(void);
+
+/**
+ * Switch sys_clk to RC32M
+ */
+void da1469x_clock_sys_rc32m_switch(void);
+
+/**
+ * Disable XTAL32K
+ */
+void da1469x_clock_lp_xtal32k_disable(void);
+
+/**
  * Enable XTAL32K
  */
 void da1469x_clock_lp_xtal32k_enable(void);
@@ -72,6 +87,21 @@ void da1469x_clock_lp_xtal32k_enable(void);
  * Caller shall ensure XTAL32K is already settled.
  */
 void da1469x_clock_lp_xtal32k_switch(void);
+
+/**
+ * Disable RC32K
+ */
+void da1469x_clock_lp_rc32k_disable(void);
+
+/**
+ * Enable RC32K
+ */
+void da1469x_clock_lp_rc32k_enable(void);
+
+/**
+ * Switch lp_clk to RC32K
+ */
+void da1469x_clock_lp_rc32k_switch(void);
 
 /**
  * Enable RCX
@@ -96,6 +126,11 @@ void da1469x_clock_lp_rcx_calibrate(void);
 void da1469x_clock_lp_rc32k_calibrate(void);
 
 /**
+ * Calibrate XTAL32K
+ */
+void da1469x_clock_lp_xtal32k_calibrate(void);
+
+/**
  * Calibrate RC32M
  */
 void da1469x_clock_lp_rc32m_calibrate(void);
@@ -109,6 +144,11 @@ uint32_t da1469x_clock_lp_rcx_freq_get(void);
  * Get calibrated (measured) RC32K frequency
  */
 uint32_t da1469x_clock_lp_rc32k_freq_get(void);
+
+/**
+ * Get calibrated XTAL32K frequency
+ */
+uint32_t da1469x_clock_lp_xtal32k_freq_get(void);
 
 /**
  * Get calibrated (measured) RC32M frequency

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -131,6 +131,11 @@ void da1469x_clock_lp_rc32k_calibrate(void);
 void da1469x_clock_lp_xtal32k_calibrate(void);
 
 /**
+ * Calibrate selected LP clock
+ */
+void da1469x_clock_lp_calibrate(void);
+
+/**
  * Calibrate RC32M
  */
 void da1469x_clock_sys_rc32m_calibrate(void);
@@ -149,6 +154,11 @@ uint32_t da1469x_clock_lp_rc32k_freq_get(void);
  * Get calibrated XTAL32K frequency
  */
 uint32_t da1469x_clock_lp_xtal32k_freq_get(void);
+
+/**
+ * Get seleted LP clock's frequency
+ */
+uint32_t da1469x_clock_lp_freq_get(void);
 
 /**
  * Get calibrated (measured) RC32M frequency

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -133,7 +133,7 @@ void da1469x_clock_lp_xtal32k_calibrate(void);
 /**
  * Calibrate RC32M
  */
-void da1469x_clock_lp_rc32m_calibrate(void);
+void da1469x_clock_sys_rc32m_calibrate(void);
 
 /**
  * Get calibrated (measured) RCX frequency
@@ -153,7 +153,7 @@ uint32_t da1469x_clock_lp_xtal32k_freq_get(void);
 /**
  * Get calibrated (measured) RC32M frequency
  */
-uint32_t da1469x_clock_lp_rc32m_freq_get(void);
+uint32_t da1469x_clock_sys_rc32m_freq_get(void);
 
 /**
  * Disable RCX

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -171,6 +171,11 @@ uint32_t da1469x_clock_sys_rc32m_freq_get(void);
 void da1469x_clock_lp_rcx_disable(void);
 
 /**
+ * Set the RTC dividers
+ */
+void da1469x_clock_lp_set_rtc_divs(void);
+
+/**
  * Enable AMBA clock(s)
  *
  * @param mask

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_clock.h
@@ -173,7 +173,7 @@ void da1469x_clock_lp_rcx_disable(void);
 /**
  * Set the RTC dividers
  */
-void da1469x_clock_lp_set_rtc_divs(void);
+void da1469x_clock_lp_set_rtc_divs(uint32_t rtc_clock_freq);
 
 /**
  * Enable AMBA clock(s)

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -87,6 +87,13 @@ extern const int qspi_flash_config_array_size;
 
 const struct qspi_flash_config *da1469x_qspi_get_config(void);
 
+/**
+ * Calculate the OS tick parameters.
+ *
+ * @param cycles_per_sec Input frequency of timer generating OS ticks
+ */
+void hal_os_tick_calc_params(uint32_t cycles_per_sec);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_lpclk.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_lpclk.h
@@ -33,6 +33,9 @@ void da1469x_lpclk_register_cmac_cb(da1469x_lpclk_cb *cb);
 void da1469x_lpclk_enabled(void);
 /* Frequency of lp clock changed (e.g. after RCX recalibration) */
 void da1469x_lpclk_updated(void);
+/* Initialize selected LP RC clock */
+void da1469x_lpclk_rc_init();
+
 
 #ifdef __cplusplus
 }

--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -111,7 +111,8 @@ da1469x_clock_sys_xtal32m_init(void)
      */
     xtalrdy_cnt = MYNEWT_VAL(MCU_CLOCK_XTAL32M_SETTLE_TIME_US) * XTALRDY_IRQ_FREQ_MAX / 1000000;
 
-    CRG_XTAL->XTALRDY_CTRL_REG = (xtalrdy_cnt << CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CNT_Pos) |
+    CRG_XTAL->XTALRDY_CTRL_REG = ((xtalrdy_cnt << CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CNT_Pos) &
+                                  CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CNT_Msk) |
                                  (DA1469X_XTALRDY_CLK_SEL << CRG_XTAL_XTALRDY_CTRL_REG_XTALRDY_CLK_SEL_Pos);
 }
 
@@ -294,7 +295,8 @@ da1469x_clock_calibrate(uint8_t clock_sel, uint16_t ref_cnt)
     /* Select reference clock & calibrated clock */
     ANAMISC_BIF->CLK_REF_SEL_REG =
         (DA1469X_REF_SEL << ANAMISC_BIF_CLK_REF_SEL_REG_CAL_CLK_SEL_Pos) |
-        (clock_sel << ANAMISC_BIF_CLK_REF_SEL_REG_REF_CLK_SEL_Pos);
+        ((clock_sel << ANAMISC_BIF_CLK_REF_SEL_REG_REF_CLK_SEL_Pos) &
+         ANAMISC_BIF_CLK_REF_SEL_REG_REF_CLK_SEL_Msk);
 
     /* Start measurement */
     ANAMISC_BIF->CLK_REF_SEL_REG |= ANAMISC_BIF_CLK_REF_SEL_REG_REF_CAL_START_Msk;
@@ -332,7 +334,7 @@ rc32k_trim_set(uint32_t trim)
 {
     CRG_TOP->CLK_RC32K_REG =
         (CRG_TOP->CLK_RC32K_REG & ~CRG_TOP_CLK_RC32K_REG_RC32K_TRIM_Msk) |
-        (trim << CRG_TOP_CLK_RC32K_REG_RC32K_TRIM_Pos);
+        ((trim << CRG_TOP_CLK_RC32K_REG_RC32K_TRIM_Pos) & CRG_TOP_CLK_RC32K_REG_RC32K_TRIM_Msk);
 }
 
 void

--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -398,6 +398,18 @@ da1469x_clock_lp_xtal32k_calibrate(void)
 }
 
 void
+da1469x_clock_lp_calibrate(void)
+{
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
+    da1469x_clock_lp_rcx_calibrate();
+#elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RC32K)
+    da1469x_clock_lp_rc32k_calibrate();
+#elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
+    da1469x_clock_lp_xtal32k_calibrate();
+#endif
+}
+
+void
 da1469x_clock_sys_rc32m_calibrate(void)
 {
     g_mcu_clock_rc32m_freq = da1469x_clock_calibrate(DA1469X_CALIB_RC32M,
@@ -426,6 +438,18 @@ da1469x_clock_lp_xtal32k_freq_get(void)
     assert(g_mcu_clock_xtal32k_freq);
 
     return g_mcu_clock_xtal32k_freq;
+}
+
+uint32_t
+da1469x_clock_lp_freq_get(void)
+{
+#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
+    return da1469x_clock_lp_rcx_freq_get();
+#elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RC32K)
+    return da1469x_clock_lp_rc32k_freq_get();
+#elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
+    return da1469x_clock_lp_xtal32k_freq_get();
+#endif
 }
 
 uint32_t

--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -476,14 +476,14 @@ da1469x_clock_lp_rcx_disable(void)
 }
 
 void
-da1469x_clock_lp_set_rtc_divs(void)
+da1469x_clock_lp_set_rtc_divs(uint32_t rtc_clock_freq)
 {
-    /* Please see the DA1469x desig doc section 2.20.4 for details */
+    /* Please see the DA1469x Datasheet section 34.3 for details */
     uint32_t reg;
 
-    reg = ((da1469x_clock_lp_freq_get() % RTC_IN_FREQ_HZ) * RTC_DIV_FRAC_ADJ) <<
+    reg = ((rtc_clock_freq % RTC_IN_FREQ_HZ) * RTC_DIV_FRAC_ADJ) <<
           CRG_TOP_CLK_RTCDIV_REG_RTC_DIV_FRAC_Pos;
-    reg |= ((da1469x_clock_lp_freq_get() / RTC_IN_FREQ_HZ)) <<
+    reg |= ((rtc_clock_freq / RTC_IN_FREQ_HZ)) <<
            CRG_TOP_CLK_RTCDIV_REG_RTC_DIV_INT_Pos;
     reg |= DA1469X_RTC_DIV_DENOM_SEL << CRG_TOP_CLK_RTCDIV_REG_RTC_DIV_DENOM_Pos;
     reg |= CRG_TOP_CLK_RTCDIV_REG_RTC_DIV_ENABLE_Msk;

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -57,7 +57,8 @@ da1469x_lpclk_notify(void)
             g_da1469x_lpclk_cmac_cb(lp_curr_freq);
         }
 
-        da1469x_clock_lp_set_rtc_divs();
+        da1469x_clock_lp_set_rtc_divs(lp_curr_freq);
+        hal_os_tick_calc_params(lp_curr_freq);
     }
 }
 

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -56,6 +56,8 @@ da1469x_lpclk_notify(void)
         if (g_da1469x_lpclk_cmac_cb && g_mcu_lpclk_available) {
             g_da1469x_lpclk_cmac_cb(lp_curr_freq);
         }
+
+        da1469x_clock_lp_set_rtc_divs();
     }
 }
 

--- a/hw/mcu/dialog/da1469x/src/hal_system.c
+++ b/hw/mcu/dialog/da1469x/src/hal_system.c
@@ -125,23 +125,8 @@ hal_system_clock_start(void)
 #endif
     da1469x_clock_sys_rc32m_disable();
 
-#if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
-    /* Switch to RCX and calibrate it */
-    da1469x_clock_lp_rcx_enable();
-    da1469x_clock_lp_rcx_switch();
-    da1469x_clock_lp_rcx_calibrate();
-    da1469x_lpclk_enabled();
-#else
-    /*
-     * We cannot switch lp_clk to XTAL32K here since it needs some time to
-     * settle, so we just disable RCX (we don't need it) and then we'll handle
-     * switch to XTAL32K from sysinit since we need os_cputime for this.
-     */
-    da1469x_clock_lp_rcx_disable();
-#endif
-
-    /* TODO: we should calibrate this periodically */
-    da1469x_clock_lp_rc32k_calibrate();
+    /* Initialize the selected RC LP clock */
+    da1469x_lpclk_rc_init();
 }
 
 enum hal_reset_reason

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -67,6 +67,11 @@ syscfg.defs:
             Specifies settling time [ms] of 32K crystal oscillator.
         value: 8000
 
+    MCU_CLOCK_XTAL32K_ALLOW_CALIB:
+        description: >
+            Specifies that the 32K crystal oscillator should be calibrated.
+        value: 0
+
     MCU_CLOCK_RCX_CAL_REF_CNT:
         description: >
             Reference count value for calibration of RCX clock. The higher

--- a/hw/mcu/dialog/da1469x/syscfg.yml
+++ b/hw/mcu/dialog/da1469x/syscfg.yml
@@ -88,6 +88,18 @@ syscfg.defs:
         value: 1
         restrictions: '!0'
 
+    MCU_CLOCK_XTAL32K_CAL_REF_CNT:
+        description: >
+            Reference count value for calibration of XTAL32K clock.
+        value: 100
+        restrictions: '!0'
+
+    MCU_CLOCK_RC32M_CAL_REF_CNT:
+        description: >
+            Reference count value for calibration of RC32M clock.
+        value: 100
+        restrictions: '!0'
+
     MCU_SYSCLK_SOURCE:
         description: >
             Specifies system clock source


### PR DESCRIPTION
If the LP clock's frequency is not an integer multiple of the specified OS tick frequency, the period of OS ticks will be incorrect due to integer division truncation errors (to the tune of almost 1% for RCX), resulting in OS Time
gradually creeping away from the actual time. This PR fixes the issue, by maintaining the fractional OS tick value and advance OS Time accordingly.

This PR also improves on the implementation of the DA1469x clock driver and updates the RTC divider registers after the selected LP clock is calibrated.