### PR TITLE
kernel: Fix builds for C++

### DIFF
--- a/kernel/os/include/os/arch/mips/os/os_arch.h
+++ b/kernel/os/include/os/arch/mips/os/os_arch.h
@@ -25,6 +25,10 @@
 #include <mips/m32c0.h>
 #include "mcu/mips.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* CPU status register */
 typedef uint32_t os_sr_t;
 
@@ -52,6 +56,10 @@ os_arch_in_isr(void)
     /* check the EXL bit */
     return (mips_getsr() & (1 << 1)) ? 1 : 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/arch/pic32/os/os_arch.h
+++ b/kernel/os/include/os/arch/pic32/os/os_arch.h
@@ -24,6 +24,10 @@
 #include <xc.h>
 #include "mcu/pic32.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* CPU status register */
 typedef uint32_t os_sr_t;
 
@@ -49,6 +53,10 @@ os_arch_in_isr(void)
     /* CPU handles interrupt when EXL is set or IPL > 0 */
     return (_CP0_GET_STATUS() & (_CP0_STATUS_EXL_MASK | _CP0_STATUS_IPL_MASK)) ? 1 : 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /* Include common arch definitions and APIs */
 #include "os/arch/common.h"

--- a/kernel/os/include/os/os_callout.h
+++ b/kernel/os/include/os/os_callout.h
@@ -27,12 +27,12 @@
  */
 
 
+#include "os/os_eventq.h"
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "os/os_eventq.h"
-#include <stddef.h>
 
 /**
  * Structure containing the definition of a callout, initialized

--- a/kernel/os/include/os/os_cputime.h
+++ b/kernel/os/include/os/os_cputime.h
@@ -27,13 +27,13 @@
 #ifndef H_OS_CPUTIME_
 #define H_OS_CPUTIME_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "syscfg/syscfg.h"
 #include "os/queue.h"
 #include "hal/hal_timer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * NOTE: these definitions allow one to override the cputime frequency used.

--- a/kernel/os/include/os/os_trace_api.h
+++ b/kernel/os/include/os/os_trace_api.h
@@ -36,6 +36,10 @@
 #endif
 #include "os/os.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define OS_TRACE_ID_EVENTQ_PUT                  (40)
 #define OS_TRACE_ID_EVENTQ_GET_NO_WAIT          (41)
 #define OS_TRACE_ID_EVENTQ_GET                  (42)
@@ -317,6 +321,10 @@ os_trace_api_ret_u32(unsigned id, uint32_t return_value)
 }
 
 #endif /* !MYNEWT_VAL(OS_SYSVIEW) || defined(OS_TRACE_DISABLE_FILE_API) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ASSEMBLER__ */
 

--- a/sys/console/full/include/console/history.h
+++ b/sys/console/full/include/console/history.h
@@ -19,6 +19,12 @@
 #ifndef __SYS_CONSOLE_FULL_HISTORY_H__
 #define __SYS_CONSOLE_FULL_HISTORY_H__
 
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * History search types for console_history_find()
  */
@@ -84,5 +90,9 @@ history_handle_t console_history_find(history_handle_t start,
  */
 int console_history_get(history_handle_t handle, size_t offset, char *buf,
                         size_t buf_size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SYS_CONSOLE_FULL_HISTORY_H__ */

--- a/sys/coredump/include/coredump/coredump.h
+++ b/sys/coredump/include/coredump/coredump.h
@@ -20,11 +20,11 @@
 #ifndef __COREDUMP_H__
 #define __COREDUMP_H__
 
+#include <inttypes.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <inttypes.h>
 
 #define COREDUMP_MAGIC              0x690c47c3
 

--- a/sys/fault/include/fault/fault.h
+++ b/sys/fault/include/fault/fault.h
@@ -65,7 +65,13 @@
  *     fatal failure always triggers a transition to the error state.
  */
 
+#include <stdbool.h>
+#include <stdint.h>
 #include "debounce/debounce.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define FAULT_STATE_GOOD        0
 #define FAULT_STATE_WARN        1
@@ -284,5 +290,9 @@ fault_register_domain(int domain_id, uint8_t success_delta,
     return fault_register_domain_priv(domain_id, success_delta, failure_delta,
                                       name);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -20,10 +20,6 @@
 #ifndef H_UTIL_FLASH_MAP_
 #define H_UTIL_FLASH_MAP_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  *
  * Provides abstraction of flash regions for type of use.
@@ -45,6 +41,10 @@ extern "C" {
 #include <inttypes.h>
 
 #include "syscfg/syscfg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct flash_area {
     uint8_t fa_id;

--- a/sys/log/modlog/include/modlog/modlog.h
+++ b/sys/log/modlog/include/modlog/modlog.h
@@ -50,6 +50,10 @@
 #include "os/mynewt.h"
 #include "log/log.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MODLOG_MODULE_DFLT      255
 
 /**
@@ -545,6 +549,10 @@ modlog_hexdump(uint8_t module, uint8_t level,
 #undef LOG_CRITICAL
 #define LOG_CRITICAL    MODLOG_CRITICAL
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/sys/mfg/include/mfg/mfg.h
+++ b/sys/mfg/include/mfg/mfg.h
@@ -20,6 +20,12 @@
 #ifndef H_MFG_
 #define H_MFG_
 
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MFG_HASH_SZ                     32
 
 #define MFG_META_TLV_TYPE_HASH          0x01
@@ -145,5 +151,9 @@ int mfg_read_tlv_mmr_ref(const struct mfg_reader *reader,
  * Initializes the mfg package.
  */
 void mfg_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Few headers did not have usual extern "C" blocks to be safely included by C++ code.

In few cases extern "C" was place before includes that is not correct way.