### PR TITLE
sys/config: Add option to skip dup check when saving values

### DIFF
--- a/sys/config/src/config_store.c
+++ b/sys/config/src/config_store.c
@@ -186,6 +186,7 @@ conf_get_stored_value(char *name, char *buf, int buf_len)
     return 0;
 }
 
+#if !MYNEWT_VAL(CONFIG_NO_DUP_CHECK)
 static void
 conf_dup_check_cb(char *name, char *val, void *cb_arg)
 {
@@ -208,6 +209,7 @@ conf_dup_check_cb(char *name, char *val, void *cb_arg)
         }
     }
 }
+#endif
 
 /*
  * Append a single value to persisted config. Don't store duplicate value.
@@ -216,7 +218,9 @@ int
 conf_save_one(const char *name, char *value)
 {
     struct conf_store *cs;
+#if !MYNEWT_VAL(CONFIG_NO_DUP_CHECK)
     struct conf_dup_check_arg cdca;
+#endif
     int rc;
 
     conf_lock();
@@ -225,6 +229,7 @@ conf_save_one(const char *name, char *value)
         goto out;
     }
 
+#if !MYNEWT_VAL(CONFIG_NO_DUP_CHECK)
     /*
      * Check if we're writing the same value again.
      */
@@ -238,6 +243,7 @@ conf_save_one(const char *name, char *value)
         rc = 0;
         goto out;
     }
+#endif
     cs = conf_save_dst;
     rc = cs->cs_itf->csi_save(cs, name, value);
 out:
@@ -309,6 +315,7 @@ conf_save(void)
     }
 out:
     conf_unlock();
+
     return rc;
 }
 

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -99,6 +99,13 @@ syscfg.defs:
             For MCU without hardware support for enabling this if no other
             function use floating point may increase image size 20kB or more.
         value: 0
+    CONFIG_NO_DUP_CHECK:
+        description: >
+            This disables check for duplicate values when saving new value.
+            Depending on number of values stored in config this may speed up
+            the config save process considerably at the expense of more writes
+            to config storage.
+        value: 0
 
 syscfg.vals.HARDFLOAT:
     value: 1


### PR DESCRIPTION
By default value is written to config storage only if it changed since last stored value. This however requires that all stored values are read to determine last value and in case of conf_save this is done for each saved value which can take a lot of time.

This adds option to skip that dup check and simply stores new value. This results in much faster writes at the expense of load times as there are more copies of the same value stored. Also conf_save will always write all exported values so this increase number of writes to flash. However, e.g. in case of large FCB used as config storage dup check on write can take much longer than simple read or store without dup checks.