### PR TITLE
mcu/nordic: Update NRFX to version 3.8.0

### DIFF
--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -58,8 +58,7 @@ pkg.deps:
 
 repository.nordic-nrfx:
     type: github
-    vers: v3.3.0-commit
+    vers: v3.8.0-commit
     branch: master
     user: NordicSemiconductor
     repo: nrfx
-


### PR DESCRIPTION
https://github.com/NordicSemiconductor/nrfx/releases/tag/v3.8.0