### PR TITLE
kernel/os_sanity: Remove double function typedef

### DIFF
--- a/kernel/os/include/os/os_sanity.h
+++ b/kernel/os/include/os/os_sanity.h
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 
 struct os_sanity_check;
-typedef int (*os_sanity_check_func_t)(struct os_sanity_check *osc, void *arg);
 
 /**
  * Sanity check callback function.


### PR DESCRIPTION
This is copy-n-paste error.