### PR TITLE
baselibc: Don't use -umain for native build

### DIFF
--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -37,5 +37,5 @@ pkg.cflags:
 pkg.cflags.BASELIBC_DEBUG_MALLOC:
     - -DDEBUG_MALLOC
 
-pkg.lflags:
+pkg.lflags.!MCU_NATIVE:
     - -umain


### PR DESCRIPTION
This is not needed for native but was causing link issues on MacOS (clang).