### PR TITLE
ci: Enable newt test on Mac

### DIFF
--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -24,18 +24,23 @@ on: [push, pull_request]
 jobs:
   newt_test:
     name: Run newt test all
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
       - name: Install Dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
              sudo apt-get update
              sudo apt-get install -y gcc-multilib
       - name: Install GNU sed
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
              brew install gnu-sed
              echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH

--- a/encoding/json/include/json/json.h
+++ b/encoding/json/include/json/json.h
@@ -83,7 +83,7 @@ typedef int (*json_write_func_t)(void *buf, char *data,
 struct json_encoder {
     json_write_func_t je_write;
     void *je_arg;
-    int je_wr_commas:1;
+    unsigned int je_wr_commas : 1;
     char je_encode_buf[64];
 };
 

--- a/util/cbmem/selftest/src/testcases/cbmem_test_case_3.c
+++ b/util/cbmem/selftest/src/testcases/cbmem_test_case_3.c
@@ -26,10 +26,8 @@ TEST_CASE_SELF(cbmem_test_case_3)
     uint16_t off;
     uint16_t len;
     uint8_t buf[128];
-    int i;
     int rc;
 
-    i = 0;
     cbmem_iter_start(&cbmem1, &iter);
     while (1) {
         hdr = cbmem_iter_next(&cbmem1, &iter);
@@ -54,7 +52,6 @@ TEST_CASE_SELF(cbmem_test_case_3)
         TEST_ASSERT_FATAL(len == CBMEM1_ENTRY_SIZE,
                 "Couldn't read full entry, expected %d got %d",
                 CBMEM1_ENTRY_SIZE, len);
-        i++;
 
         /* go apesh*t, and read data out of bounds, see what we get. */
         rc = cbmem_read(&cbmem1, hdr, buf, CBMEM1_ENTRY_SIZE * 2, sizeof(buf));


### PR DESCRIPTION
We properly support 64bit in native target now so those can be re-enabled.