### PR TITLE
kernel/os: Increase mutex test timeout

### DIFF
--- a/kernel/os/selftest/src/testcases/os_mutex_test_basic.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_basic.c
@@ -25,5 +25,5 @@ TEST_CASE_TASK(os_mutex_test_basic)
     os_mutex_init(&g_mutex1);
     taskpool_alloc_assert(mutex_test_basic_handler,
                           MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 2);
-    taskpool_wait_assert(200);
+    taskpool_wait_assert(OS_TICKS_PER_SEC * 4);
 }

--- a/kernel/os/selftest/src/testcases/os_mutex_test_case_1.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_case_1.c
@@ -42,5 +42,5 @@ TEST_CASE_TASK(os_mutex_test_case_1)
     taskpool_alloc_assert(mutex_task3_handler,
                           MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 4);
 
-    taskpool_wait_assert(200);
+    taskpool_wait_assert(OS_TICKS_PER_SEC * 4);
 }

--- a/kernel/os/selftest/src/testcases/os_mutex_test_case_2.c
+++ b/kernel/os/selftest/src/testcases/os_mutex_test_case_2.c
@@ -39,5 +39,5 @@ TEST_CASE_TASK(os_mutex_test_case_2)
     taskpool_alloc_assert(mutex_task4_handler,
                           MYNEWT_VAL(OS_MAIN_TASK_PRIO) + 5);
 
-    taskpool_wait_assert(200);
+    taskpool_wait_assert(OS_TICKS_PER_SEC * 4);
 }


### PR DESCRIPTION
On slower VMs (for example GHA's mac-os) tests were failing, as previous timeout was not enough.