### PR TITLE
hw/mcu/dialog: GPIO configuration with single value

### DIFF
--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -99,6 +99,8 @@ void hal_os_tick_calc_params(uint32_t cycles_per_sec);
  *
  * @param pin GPIO ID
  * @param raw_mode Combined mode / I/O properties value
+ *                 Mode: Selected feed in the GPIO matrix (see MCU_GPIO_FUNC_*)
+ *                 I/O propeties: Input [bare/PU/PD] or output [PP/OD] (see MCU_GPIO_MODE_*)
  */
 void mcu_gpio_set_pin_function_raw(int pin, uint32_t raw_mode);
 

--- a/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
+++ b/hw/mcu/dialog/da1469x/include/mcu/da1469x_hal.h
@@ -94,6 +94,23 @@ const struct qspi_flash_config *da1469x_qspi_get_config(void);
  */
 void hal_os_tick_calc_params(uint32_t cycles_per_sec);
 
+/**
+ * Configure GPIO using a single value.
+ *
+ * @param pin GPIO ID
+ * @param raw_mode Combined mode / I/O properties value
+ */
+void mcu_gpio_set_pin_function_raw(int pin, uint32_t raw_mode);
+
+/**
+ * Query GPIO mode as a single value.
+ *
+ * @param pin GPIO ID
+ *
+ * @return Combined mode / I/O properties value
+ */
+uint32_t mcu_gpio_get_pin_function_raw(int pin);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -492,6 +492,24 @@ mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func)
 }
 
 void
+mcu_gpio_set_pin_function_raw(int pin, uint32_t raw_mode)
+{
+    uint32_t primask;
+
+    __HAL_DISABLE_INTERRUPTS(primask);
+    mcu_gpio_unlatch_prepare(pin);
+    GPIO_PIN_MODE_REG(pin) = raw_mode;
+    mcu_gpio_unlatch(pin);
+    __HAL_ENABLE_INTERRUPTS(primask);
+}
+
+uint32_t
+mcu_gpio_get_pin_function_raw(int pin)
+{
+    return GPIO_PIN_MODE_REG(pin);
+}
+
+void
 mcu_gpio_enter_sleep(void)
 {
 #if MYNEWT_VAL(MCU_GPIO_RETAINABLE_NUM) >= 0

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -496,7 +496,8 @@ void
 mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func)
 {
     mcu_gpio_set_pin_function_raw(pin, (func & GPIO_P0_00_MODE_REG_PID_Msk) |
-                      (mode & (GPIO_P0_00_MODE_REG_PUPD_Msk | GPIO_P0_00_MODE_REG_PPOD_Msk)));
+                                        (mode &
+                                         (GPIO_P0_00_MODE_REG_PUPD_Msk | GPIO_P0_00_MODE_REG_PPOD_Msk)));
 }
 
 void

--- a/hw/mcu/dialog/da1469x/src/hal_gpio.c
+++ b/hw/mcu/dialog/da1469x/src/hal_gpio.c
@@ -475,23 +475,6 @@ hal_gpio_irq_disable(int pin)
 }
 
 void
-mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func)
-{
-    uint32_t primask;
-
-    __HAL_DISABLE_INTERRUPTS(primask);
-
-    mcu_gpio_unlatch_prepare(pin);
-
-    GPIO_PIN_MODE_REG(pin) = (func & GPIO_P0_00_MODE_REG_PID_Msk) |
-        (mode & (GPIO_P0_00_MODE_REG_PUPD_Msk | GPIO_P0_00_MODE_REG_PPOD_Msk));
-
-    mcu_gpio_unlatch(pin);
-
-    __HAL_ENABLE_INTERRUPTS(primask);
-}
-
-void
 mcu_gpio_set_pin_function_raw(int pin, uint32_t raw_mode)
 {
     uint32_t primask;
@@ -507,6 +490,13 @@ uint32_t
 mcu_gpio_get_pin_function_raw(int pin)
 {
     return GPIO_PIN_MODE_REG(pin);
+}
+
+void
+mcu_gpio_set_pin_function(int pin, int mode, mcu_gpio_func func)
+{
+    mcu_gpio_set_pin_function_raw(pin, (func & GPIO_P0_00_MODE_REG_PID_Msk) |
+                      (mode & (GPIO_P0_00_MODE_REG_PUPD_Msk | GPIO_P0_00_MODE_REG_PPOD_Msk)));
 }
 
 void


### PR DESCRIPTION
Add API to support GPIO configuration using a combined mode / I/O properties value.