### PR TITLE
crypto: tinycrypt: Fix spurious uninitialized array error

### DIFF
--- a/crypto/tinycrypt/pkg.yml
+++ b/crypto/tinycrypt/pkg.yml
@@ -24,7 +24,9 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.cflags:
-    - "-std=c99"
+    - -std=c99
+    - -Wno-maybe-uninitialized
+    - -Wno-unknown-warning-option
 
 pkg.deps.TINYCRYPT_UECC_RNG_USE_TRNG:
     - "@apache-mynewt-core/hw/drivers/trng"


### PR DESCRIPTION
This disables maybe-uninitialized compile option in tinycrypt library to fix spurious compilation errors.

Error: In function 'uECC_vli_modMult_fast',
    inlined from 'uECC_vli_modSquare_fast' at repos/apache-mynewt-core/crypto/tinycrypt/src/ecc.c:386:2,
    inlined from 'XYcZ_addC' at repos/apache-mynewt-core/crypto/tinycrypt/src/ecc.c:702:2:
repos/apache-mynewt-core/crypto/tinycrypt/src/ecc.c:377:9: error: 't5' may be used uninitialized [-Werror=maybe-uninitialized]
  377 |         uECC_vli_mult(product, left, right, curve->num_words);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~