### PR TITLE
sys/log: Zero-initialize log_offset struct

### DIFF
--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -336,7 +336,7 @@ static int
 log_read_last_hdr(struct log *log, struct log_entry_hdr *out_hdr)
 {
     struct log_read_hdr_arg arg;
-    struct log_offset log_offset;
+    struct log_offset log_offset = {};
 
     arg.hdr = out_hdr;
     arg.read_success = 0;

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -804,7 +804,7 @@ static int
 log_fcb_set_watermark(struct log *log, uint32_t index)
 {
     int rc;
-    struct log_offset log_offset;
+    struct log_offset log_offset = {};
     struct fcb_log *fl;
     struct fcb *fcb;
 

--- a/sys/log/full/src/log_fcb2.c
+++ b/sys/log/full/src/log_fcb2.c
@@ -693,7 +693,7 @@ static int
 log_fcb2_set_watermark(struct log *log, uint32_t index)
 {
     int rc;
-    struct log_offset log_offset;
+    struct log_offset log_offset = {};
     struct fcb_log *fl;
     struct fcb2 *fcb;
 


### PR DESCRIPTION
1063e8201 added new field to log_offset struct so functions that define that struct on stack may have random results if struct is not initialized properly.