### PR TITLE
kernel/os: Update os_assert_cb to match assert_func

### DIFF
--- a/kernel/os/include/os/arch/common.h
+++ b/kernel/os/include/os/arch/common.h
@@ -70,7 +70,7 @@ os_error_t os_arch_os_start(void);
 void os_set_env(os_stack_t *);
 void os_arch_init_task_stack(os_stack_t *sf);
 void os_default_irq_asm(void);
-void os_assert_cb(void);
+void os_assert_cb(const char *file, int line, const char *func, const char *e);
 void os_coredump_cb(void *tf);
 
 #ifdef __cplusplus

--- a/kernel/os/src/arch/arc/os_fault.c
+++ b/kernel/os/src/arch/arc/os_fault.c
@@ -135,7 +135,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     OS_PRINT_ASSERT(file, line, func, e);
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     if (hal_debugger_connected()) {
        /*

--- a/kernel/os/src/arch/cortex_m0/os_fault.c
+++ b/kernel/os/src/arch/cortex_m0/os_fault.c
@@ -118,7 +118,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;

--- a/kernel/os/src/arch/cortex_m3/os_fault.c
+++ b/kernel/os/src/arch/cortex_m3/os_fault.c
@@ -131,7 +131,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;

--- a/kernel/os/src/arch/cortex_m33/os_fault.c
+++ b/kernel/os/src/arch/cortex_m33/os_fault.c
@@ -192,7 +192,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     SCB->ICSR = SCB_ICSR_PENDNMISET_Msk;

--- a/kernel/os/src/arch/cortex_m4/os_fault.c
+++ b/kernel/os/src/arch/cortex_m4/os_fault.c
@@ -147,7 +147,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 #endif
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;

--- a/kernel/os/src/arch/cortex_m7/os_fault.c
+++ b/kernel/os/src/arch/cortex_m7/os_fault.c
@@ -130,7 +130,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     OS_PRINT_ASSERT(file, line, func, e);
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     SCB->ICSR = SCB_ICSR_NMIPENDSET_Msk;

--- a/kernel/os/src/arch/mips/os_fault.c
+++ b/kernel/os/src/arch/mips/os_fault.c
@@ -32,7 +32,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     OS_PRINT_ASSERT(file, line, func, e);
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
 
     hal_system_reset();

--- a/kernel/os/src/arch/pic32/os_fault.c
+++ b/kernel/os/src/arch/pic32/os_fault.c
@@ -33,7 +33,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
     OS_PRINT_ASSERT(file, line, func, e);
 
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     hal_system_reset();
 }

--- a/kernel/os/src/arch/rv32imac/os_fault.c
+++ b/kernel/os/src/arch/rv32imac/os_fault.c
@@ -30,7 +30,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
     OS_PRINT_ASSERT(file, line, func, e);
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     _exit(1);
 }

--- a/kernel/os/src/arch/sim-armv7/os_arch.c
+++ b/kernel/os/src/arch/sim-armv7/os_arch.c
@@ -93,7 +93,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
     OS_PRINT_ASSERT_SIM(file, line, func, e);
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     _Exit(1);
 }

--- a/kernel/os/src/arch/sim-mips/os_arch.c
+++ b/kernel/os/src/arch/sim-mips/os_arch.c
@@ -93,7 +93,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
     OS_PRINT_ASSERT_SIM(file, line, func, e);
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     _Exit(1);
 }

--- a/kernel/os/src/arch/sim/os_arch.c
+++ b/kernel/os/src/arch/sim/os_arch.c
@@ -93,7 +93,7 @@ __assert_func(const char *file, int line, const char *func, const char *e)
 
     OS_PRINT_ASSERT_SIM(file, line, func, e);
 #if MYNEWT_VAL(OS_ASSERT_CB)
-    os_assert_cb();
+    os_assert_cb(file, line, func, e);
 #endif
     _Exit(1);
 }


### PR DESCRIPTION
This updates os_assert_cb prototype to match assert_func. This allows to get proper assert information in callback e.g. for logging.

Note that this breaks API, but since updates in other projects are trivial I'd like to get this merged. A good example why this is useful is a blehci app which can use os_assert_cb to log asserts system-wide via HCI vs event: https://github.com/apache/mynewt-nimble/pull/1930