### PR TITLE
hw/hal: Use 32 bit for flash alignment

### DIFF
--- a/hw/hal/include/hal/hal_flash.h
+++ b/hw/hal/include/hal/hal_flash.h
@@ -159,7 +159,7 @@ int hal_flash_isempty_no_buf(uint8_t id, uint32_t address, uint32_t num_bytes);
  *
  * @return                      The flash device's minimum write alignment.
  */
-uint8_t hal_flash_align(uint8_t flash_id);
+uint32_t hal_flash_align(uint8_t flash_id);
 
 /**
  * @brief Determines the value of an erased byte for a particular flash device.

--- a/hw/hal/src/hal_flash.c
+++ b/hw/hal/src/hal_flash.c
@@ -53,7 +53,7 @@ hal_flash_init(void)
     return rc;
 }
 
-uint8_t
+uint32_t
 hal_flash_align(uint8_t flash_id)
 {
     const struct hal_flash *hf;

--- a/sys/flash_map/include/flash_map/flash_map.h
+++ b/sys/flash_map/include/flash_map/flash_map.h
@@ -60,7 +60,7 @@ struct flash_sector_range {
     uint16_t fsr_first_sector;
     uint16_t fsr_sector_count;
     uint32_t fsr_sector_size;
-    uint8_t fsr_align;
+    uint32_t fsr_align;
 };
 
 extern const struct flash_area *flash_map;
@@ -106,7 +106,7 @@ int flash_area_read_is_empty(const struct flash_area *, uint32_t off, void *dst,
 /*
  * Alignment restriction for flash writes.
  */
-uint8_t flash_area_align(const struct flash_area *);
+uint32_t flash_area_align(const struct flash_area *fa);
 
 /*
  * Value read from flash when it is erased.

--- a/sys/flash_map/src/flash_map.c
+++ b/sys/flash_map/src/flash_map.c
@@ -275,7 +275,7 @@ flash_area_erase(const struct flash_area *fa, uint32_t off, uint32_t len)
     return hal_flash_erase(fa->fa_device_id, fa->fa_off + off, len);
 }
 
-uint8_t
+uint32_t
 flash_area_align(const struct flash_area *fa)
 {
     return hal_flash_align(fa->fa_device_id);


### PR DESCRIPTION
This changes alignment type from uint8_t to uint32_t in several places.

For flash_area_align() function 32 bits are already used by other platform supported by mcuboot.

struct hal_flash also was using 32 bits before.

This is needed for lpc55sxx chips that have flash alignment 512 bytes.