### PR TITLE
hw/bsp/nordic: Fix flash sector size for NRF5340 network core

### DIFF
--- a/hw/mcu/nordic/nrf_common/src/hal_flash.c
+++ b/hw/mcu/nordic/nrf_common/src/hal_flash.c
@@ -26,6 +26,8 @@
 
 #ifdef NRF51
 #define NRF_FLASH_SECTOR_SZ 1024
+#elif defined(NRF5340_XXAA_NETWORK)
+#define NRF_FLASH_SECTOR_SZ 2048
 #else
 #define NRF_FLASH_SECTOR_SZ 4096
 #endif


### PR DESCRIPTION
Commit 11d13cc1a4621160e045d612ebba3031b50d9d95 of #3270 that removed duplicated hal_flash.c did not set correct value for network core flash sector size of NRF5340 which should be 2048 not 4096