### PR TITLE
tinyusb/msc_fat_view: Handle multi file write

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/update_handler.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/update_handler.c
@@ -208,6 +208,7 @@ image_file_written(struct msc_fat_view_write_handler *handler, uint32_t size,
             MSC_FAT_VIEW_LOG_ERROR(
                 "New file not ready to flash new sectors (%d-%d), (sector %d)\n",
                 unallocated_write.first_sector, unallocated_write.last_sector, sector);
+            return 0;
         }
     } else {
         if ((int)unallocated_write.write_status < 0) {


### PR DESCRIPTION
When new file that showed up in root directory was not referring to image file that was written to flash update handler was unregistered and further writes to root directory containing correct information
about new image was not handled.

Now writes to root that were not recognized don't
remove image handler.

This fixes case when user drops two files at once
and only one is actual image.

This was detected on Mac OS that probably
wanted to created additional file when image file was dropped for upgrade.