### PR TITLE
tinyusb/msc_fat_view: 

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/pkg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/pkg.yml
@@ -76,7 +76,9 @@ pkg.link_tables:
 pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START!=0)':
     msc_fat_view_pkg_init: $before:tinyusb_start
 
+pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START==0)':
+    msc_fat_view_pkg_init: MYNEWT_VAL(MSC_FAT_VIEW_SYSINIT_STAGE)
+
 pkg.init.'!BOOT_LOADER && MSC_FAT_VIEW_COREDUMP_FILES':
     msc_fat_view_coredump_pkg_init:
         - $before:msc_fat_view_pkg_init
-        - $before:tinyusb_start

--- a/hw/usb/tinyusb/msc_fat_view/pkg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/pkg.yml
@@ -78,5 +78,5 @@ pkg.init.'(!BOOT_LOADER && TINYUSB_AUTO_START!=0)':
 
 pkg.init.'!BOOT_LOADER && MSC_FAT_VIEW_COREDUMP_FILES':
     msc_fat_view_coredump_pkg_init:
-        - $after:msc_fat_view_pkg_init
+        - $before:msc_fat_view_pkg_init
         - $before:tinyusb_start


### PR DESCRIPTION
 Change order of package inits, so that the coredump file(s) are added to MSC-FAT-View successfully.