### PR TITLE
boot/startup: Add missing __text symbol

### DIFF
--- a/boot/startup/mynewt_cortex_m0.ld
+++ b/boot/startup/mynewt_cortex_m0.ld
@@ -101,6 +101,8 @@ SECTIONS
     /* The program code and other data goes into internal image location */
     .text :
     {
+        __text = .;
+
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
         *(.text.*)               /* .text* sections (code) */

--- a/boot/startup/mynewt_cortex_m3.ld
+++ b/boot/startup/mynewt_cortex_m3.ld
@@ -101,6 +101,8 @@ SECTIONS
     /* The program code and other data goes into internal image location */
     .text :
     {
+        __text = .;
+
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
         *(.text.*)               /* .text* sections (code) */

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -101,6 +101,8 @@ SECTIONS
     /* The program code and other data goes into internal image location */
     .text :
     {
+        __text = .;
+
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
         *(.text.*)               /* .text* sections (code) */

--- a/boot/startup/mynewt_cortex_m4.ld
+++ b/boot/startup/mynewt_cortex_m4.ld
@@ -101,6 +101,8 @@ SECTIONS
     /* The program code and other data goes into internal image location */
     .text :
     {
+        __text = .;
+
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
         *(.text.*)               /* .text* sections (code) */

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -101,6 +101,8 @@ SECTIONS
     /* The program code and other data goes into internal image location */
     .text :
     {
+        __text = .;
+
         . = ALIGN(4);
         *(.text)                 /* .text sections (code) */
         *(.text.*)               /* .text* sections (code) */


### PR DESCRIPTION
__text symbol is needed when OS_CRASH_STACKTRACE
is enabled. It was lost accidentally where common
autogenerated linker script were added.