### PR TITLE
hw/stm32: Make flash definition common

### DIFF
--- a/hw/bsp/ada_feather_stm32f405/syscfg.yml
+++ b/hw/bsp/ada_feather_stm32f405/syscfg.yml
@@ -16,16 +16,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 12
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 12
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/b-l072z-lrwan1/syscfg.yml
+++ b/hw/bsp/b-l072z-lrwan1/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 192
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 192
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 20K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/b-l475e-iot01a/syscfg.yml
+++ b/hw/bsp/b-l475e-iot01a/syscfg.yml
@@ -18,9 +18,6 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
     MCU_PATH:
         value: '"repos/apache-mynewt-core/hw/mcu/stm/stm32l4xx"'
 
@@ -29,6 +26,7 @@ syscfg.defs:
         value:  0
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 96K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/black_vet6/syscfg.yml
+++ b/hw/bsp/black_vet6/syscfg.yml
@@ -17,14 +17,6 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
     STM32_ETH_PHY_TYPE:
         description: >
             PHY type that can be found in enum in file stm32_eth_cfg.h.
@@ -39,6 +31,8 @@ syscfg.defs:
         value: -1
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/bluepill/syscfg.yml
+++ b/hw/bsp/bluepill/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 128
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 128
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 20K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f030r8/syscfg.yml
+++ b/hw/bsp/nucleo-f030r8/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 64
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 64
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 0x2000
     INCLUDE_IMAGE_HEADER: 0

--- a/hw/bsp/nucleo-f072rb/syscfg.yml
+++ b/hw/bsp/nucleo-f072rb/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 128
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 128
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 0x4000
     INCLUDE_IMAGE_HEADER: 0

--- a/hw/bsp/nucleo-f103rb/syscfg.yml
+++ b/hw/bsp/nucleo-f103rb/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 128
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 128
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 20K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f303k8/syscfg.yml
+++ b/hw/bsp/nucleo-f303k8/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 64
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 64
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 12K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f303re/syscfg.yml
+++ b/hw/bsp/nucleo-f303re/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 64K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f401re/syscfg.yml
+++ b/hw/bsp/nucleo-f401re/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 96K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f411re/syscfg.yml
+++ b/hw/bsp/nucleo-f411re/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f413zh/syscfg.yml
+++ b/hw/bsp/nucleo-f413zh/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1536
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 16
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1536
+    STM32_FLASH_NUM_AREAS: 16
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 256K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f439zi/syscfg.yml
+++ b/hw/bsp/nucleo-f439zi/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 2048
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 24
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 2048
+    STM32_FLASH_NUM_AREAS: 24
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 192K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f746zg/syscfg.yml
+++ b/hw/bsp/nucleo-f746zg/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20010000
     MCU_RAM_SIZE: 240K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-f767zi/syscfg.yml
+++ b/hw/bsp/nucleo-f767zi/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 2048
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 12
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 2048
+    STM32_FLASH_NUM_AREAS: 12
     MCU_RAM_START: 0x20020000
     MCU_RAM_SIZE: 368K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-g0b1re/syscfg.yml
+++ b/hw/bsp/nucleo-g0b1re/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     NFFS_FLASH_AREA: FLASH_AREA_NFFS

--- a/hw/bsp/nucleo-g491re/syscfg.yml
+++ b/hw/bsp/nucleo-g491re/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     NFFS_FLASH_AREA: FLASH_AREA_NFFS

--- a/hw/bsp/nucleo-h723zg/syscfg.yml
+++ b/hw/bsp/nucleo-h723zg/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x24000000
     MCU_RAM_SIZE: 0x50000
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-h753zi/syscfg.yml
+++ b/hw/bsp/nucleo-h753zi/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 2048
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 16
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 2048
+    STM32_FLASH_NUM_AREAS: 16
     MCU_RAM_START: 0x24000000
     MCU_RAM_SIZE: 0x80000
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-l073rz/syscfg.yml
+++ b/hw/bsp/nucleo-l073rz/syscfg.yml
@@ -17,11 +17,6 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 192
-
 syscfg.defs.BUS_DRIVER_PRESENT:
     BSP_FLASH_SPI_NAME:
         description: 'SPIFLASH device name'
@@ -31,6 +26,7 @@ syscfg.defs.BUS_DRIVER_PRESENT:
         value: '"spi0"'
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 192
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 20K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-l476rg/syscfg.yml
+++ b/hw/bsp/nucleo-l476rg/syscfg.yml
@@ -18,13 +18,11 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
     MCU_PATH:
         value: '"repos/apache-mynewt-core/hw/mcu/stm/stm32l4xx"'
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 96K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/nucleo-u575zi-q/syscfg.yml
+++ b/hw/bsp/nucleo-u575zi-q/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 2048
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 2048
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     NFFS_FLASH_AREA: FLASH_AREA_NFFS

--- a/hw/bsp/olimex-p103/syscfg.yml
+++ b/hw/bsp/olimex-p103/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 128
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 128
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 20K
     BOOTUTIL_SINGLE_APPLICATION_SLOT: 1

--- a/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
+++ b/hw/bsp/olimex_stm32-e407_devboard/syscfg.yml
@@ -16,16 +16,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 12
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 12
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/p-nucleo-wb55-usbdongle/syscfg.yml
+++ b/hw/bsp/p-nucleo-wb55-usbdongle/syscfg.yml
@@ -18,9 +18,6 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
     BUTTON_1_AS_RESET:
         description: >
             This USB dongle does not have physical Reset button.
@@ -36,6 +33,7 @@ syscfg.vals.BUTTON_1_AS_STM32_DFU:
     BOOT_PREBOOT: 1
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 192K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/p-nucleo-wb55/syscfg.yml
+++ b/hw/bsp/p-nucleo-wb55/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 192K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32f3discovery/syscfg.yml
+++ b/hw/bsp/stm32f3discovery/syscfg.yml
@@ -18,10 +18,6 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB'
-        value: 256
-
     LSM303DLHC_ONB:
         description: 'Onboard lsm303dlhc sensor'
         value:  0
@@ -32,6 +28,7 @@ syscfg.defs:
         value: 400
 
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 256
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 48K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32f411discovery/syscfg.yml
+++ b/hw/bsp/stm32f411discovery/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 512
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 512
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32f429discovery/syscfg.yml
+++ b/hw/bsp/stm32f429discovery/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 2048
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 24
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 2048
+    STM32_FLASH_NUM_AREAS: 24
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 256K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32f4discovery/syscfg.yml
+++ b/hw/bsp/stm32f4discovery/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 12
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 12
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 128K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32f7discovery/syscfg.yml
+++ b/hw/bsp/stm32f7discovery/syscfg.yml
@@ -17,16 +17,9 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 1024
-
-    STM32_FLASH_NUM_AREAS:
-        description: 'Number of flash sectors for a non-linear STM32 MCU.'
-        value: 8
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 1024
+    STM32_FLASH_NUM_AREAS: 8
     MCU_RAM_START: 0x20010000
     MCU_RAM_SIZE: 240K
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG

--- a/hw/bsp/stm32l152discovery/syscfg.yml
+++ b/hw/bsp/stm32l152discovery/syscfg.yml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 256
-
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 256
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     NFFS_FLASH_AREA: FLASH_AREA_NFFS

--- a/hw/bsp/weact_g431cb/syscfg.yml
+++ b/hw/bsp/weact_g431cb/syscfg.yml
@@ -18,14 +18,11 @@
 #
 
 syscfg.defs:
-    STM32_FLASH_SIZE_KB:
-        description: 'Total flash size in KB.'
-        value: 128
-
     BOOT_LOADER:
         description: 'Build everything as bootloader'
         value: 1
 syscfg.vals:
+    STM32_FLASH_SIZE_KB: 128
     MCU_RAM_START: 0x20000000
     MCU_RAM_SIZE: 0x8000
     STM32_CLOCK_VOLTAGESCALING_CONFIG: 'PWR_REGULATOR_VOLTAGE_SCALE1'

--- a/hw/mcu/stm/stm32_common/syscfg.yml
+++ b/hw/mcu/stm/stm32_common/syscfg.yml
@@ -492,5 +492,12 @@ syscfg.defs:
         range: 0..255
         value: 0
 
+    STM32_FLASH_SIZE_KB:
+        description: 'Total flash size in KB. Defined in BSP'
+        value:
+    STM32_FLASH_NUM_AREAS:
+        description: 'Number of flash sectors for a non-linear STM32 MCU.'
+        value:
+
 syscfg.vals:
     OS_TICKS_PER_SEC: 1000


### PR DESCRIPTION
STM32_FLASH_SIZE_KB and STM32_FLASH_NUM_AREAS were defined in bsp

Now common definition is provided in stm32_common

bsps provide values