### PR TITLE
log_fcb: Init all usage of fcb_entry on stack

### DIFF
--- a/fs/fcb/selftest/src/testcases/fcb_test_append.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_append.c
@@ -22,7 +22,7 @@ TEST_CASE_SELF(fcb_test_append)
 {
     int rc;
     struct fcb *fcb;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int i;
     int j;

--- a/fs/fcb/selftest/src/testcases/fcb_test_append_fill.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_append_fill.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_append_fill)
     struct fcb *fcb;
     int rc;
     int i;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int elem_cnts[2] = {0, 0};
     int aa_together_cnts[2];

--- a/fs/fcb/selftest/src/testcases/fcb_test_append_too_big.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_append_too_big.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_append_too_big)
     struct fcb *fcb;
     int rc;
     int len;
-    struct fcb_entry elem_loc;
+    struct fcb_entry elem_loc = {};
 
     fcb_tc_pretest(2);
 

--- a/fs/fcb/selftest/src/testcases/fcb_test_area_info.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_area_info.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_area_info)
     struct fcb *fcb;
     int rc;
     int i;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int elem_cnts[2] = {0, 0};
     int area_elems[2];

--- a/fs/fcb/selftest/src/testcases/fcb_test_last_of_n.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_last_of_n.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_last_of_n)
     const uint8_t ENTRIES = 5;
     struct fcb *fcb;
     int rc;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     struct fcb_entry areas[ENTRIES];
     uint8_t test_data[128];
     uint8_t i;

--- a/fs/fcb/selftest/src/testcases/fcb_test_multiple_scratch.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_multiple_scratch.c
@@ -22,7 +22,7 @@ TEST_CASE_SELF(fcb_test_multiple_scratch)
 {
     struct fcb *fcb;
     int rc;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int elem_cnts[4];
     int idx;

--- a/fs/fcb/selftest/src/testcases/fcb_test_reset.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_reset.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_reset)
     struct fcb *fcb;
     int rc;
     int i;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int var_cnt;
 

--- a/fs/fcb/selftest/src/testcases/fcb_test_rotate.c
+++ b/fs/fcb/selftest/src/testcases/fcb_test_rotate.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(fcb_test_rotate)
     struct fcb *fcb;
     int rc;
     int old_id;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     uint8_t test_data[128];
     int elem_cnts[2] = {0, 0};
     int cnts[2];

--- a/fs/fcb/src/fcb_area_info.c
+++ b/fs/fcb/src/fcb_area_info.c
@@ -23,13 +23,13 @@
 int
 fcb_area_info(struct fcb *fcb, struct flash_area *fa, int *elemsp, int *bytesp)
 {
-    struct fcb_entry loc;
+    struct fcb_entry loc = {
+        .fe_area = fa,
+        .fe_elem_off = 0,
+    };
     int rc;
     int elems = 0;
     int bytes = 0;
-
-    loc.fe_area = fa;
-    loc.fe_elem_off = 0;
 
     while (1) {
         rc = fcb_getnext(fcb, &loc);

--- a/hw/drivers/flash/enc_flash/selftest/src/testcases/enc_flash_fcb.c
+++ b/hw/drivers/flash/enc_flash/selftest/src/testcases/enc_flash_fcb.c
@@ -34,7 +34,7 @@ TEST_CASE_SELF(enc_flash_test_fcb)
 {
     int rc;
     struct flash_area *fa;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     struct fcb fcb;
     int i;
     char *writedata = "foobartest";

--- a/sys/config/src/config_fcb.c
+++ b/sys/config/src/config_fcb.c
@@ -169,8 +169,8 @@ conf_fcb_compress_internal(struct fcb *fcb,
     int rc;
     char buf1[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
     char buf2[CONF_MAX_NAME_LEN + CONF_MAX_VAL_LEN + 32];
-    struct fcb_entry loc1;
-    struct fcb_entry loc2;
+    struct fcb_entry loc1 = {};
+    struct fcb_entry loc2 = {};
     char *name1, *val1;
     char *name2, *val2;
     int copy;
@@ -248,7 +248,7 @@ conf_fcb_append(struct fcb *fcb, char *buf, int len)
 {
     int rc;
     int i;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
 
     for (i = 0; i < 10; i++) {
         rc = fcb_append(fcb, len, &loc);

--- a/sys/log/full/src/log_fcb.c
+++ b/sys/log/full/src/log_fcb.c
@@ -305,7 +305,7 @@ log_fcb_append_body(struct log *log, const struct log_entry_hdr *hdr,
     uint8_t buf[LOG_BASE_ENTRY_HDR_SIZE + LOG_IMG_HASHLEN +
                 LOG_FCB_MAX_ALIGN - 1];
     struct fcb *fcb;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     struct fcb_log *fcb_log;
     const uint8_t *u8p;
     int hdr_alignment;
@@ -412,7 +412,7 @@ log_fcb_append_mbuf_body(struct log *log, const struct log_entry_hdr *hdr,
                          struct os_mbuf *om)
 {
     struct fcb *fcb;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     struct fcb_log *fcb_log;
     int len;
     int rc;
@@ -578,7 +578,7 @@ log_fcb_walk_impl(struct log *log, log_walk_func_t walk_func,
 {
     struct fcb *fcb;
     struct fcb_log *fcb_log;
-    struct fcb_entry loc;
+    struct fcb_entry loc = {};
     struct flash_area *fap;
     int rc;
     struct fcb_entry_cache cache;
@@ -932,7 +932,7 @@ log_fcb_rtr_erase(struct log *log)
     struct fcb fcb_scratch;
     struct fcb *fcb;
     const struct flash_area *ptr;
-    struct fcb_entry entry;
+    struct fcb_entry entry = {};
     int rc;
     struct flash_area sector;
 


### PR DESCRIPTION
In several cases struct fcb_entry was not initialized before usage.
In some cases it could lead to unpredictable behaviour.