### PR TITLE
uncrustify: Update configuration for 4 spaces indent on macros

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -3482,7 +3482,7 @@ pp_ignore_define_body           = false    # true/false
 #      (ex.  3 ==> the body is indented starting 3 columns at the right of '#')
 #
 # Default: 8
-pp_multiline_define_body_indent = 8        # number
+pp_multiline_define_body_indent = 4        # number
 
 # Whether to indent case statements between #if, #else, and #endif.
 # Only applies to the indent of the preprocessor that the case statements


### PR DESCRIPTION
This puts it in line with coding standards.