### PR TITLE
tinyusb/msc_fat_view: Enable update handler by default

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/syscfg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/syscfg.yml
@@ -97,10 +97,12 @@ syscfg.defs:
         description: >
             If set to 1, adds 'Drop image here' file.
         value: 0
+        restrictions:
+            - 'MSC_FAT_VIEW_UPDATE_HANDLER if 1'
     MSC_FAT_VIEW_UPDATE_HANDLER:
         description: >
             If set to 1, image can be dropped to upgrade firmware.
-        value: 0
+        value: 1
     MSC_FAT_VIEW_SYSTEM_VOLUME_INFORMATION:
         description: >
             If set to 1, adds 'System Volume Information' file.


### PR DESCRIPTION
Update functionality was not enabled by default.
This enables this since it's easier to disable it
once functionality works then guessing why it's
not working.

'Drop image here' file now requires update handler to be enabled to avoid confusion when file shows
up in the volume but update is not enabled.