### PR TITLE
Fix for lis2dh12 shell initialization

### DIFF
--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12.c
@@ -3194,7 +3194,9 @@ lis2dh12_config(struct lis2dh12 *lis2dh12, struct lis2dh12_cfg *cfg)
     if (rc) {
         goto err;
     }
-//    lis2dh12_shell_init();
+#if MYNEWT_VAL(LIS2DH12_CLI)
+    lis2dh12_shell_init();
+#endif
     lis2dh12->cfg.read_mode.int_cfg = cfg->read_mode.int_cfg;
     lis2dh12->cfg.read_mode.int_num = cfg->read_mode.int_num;
     lis2dh12->cfg.read_mode.mode = cfg->read_mode.mode;

--- a/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
+++ b/hw/drivers/sensors/lis2dh12/src/lis2dh12_shell.c
@@ -25,7 +25,7 @@
 #include "lis2dh12/lis2dh12.h"
 #include "lis2dh12_priv.h"
 
-#if MYNEWT_VAL(LIS2DH12_CLI) && MYNEWT_VAL(SENSOR_CLI)
+#if MYNEWT_VAL(LIS2DH12_CLI)
 
 #include "shell/shell.h"
 #include "parse/parse.h"
@@ -166,9 +166,16 @@ lis2dh12_shell_cmd_read(int argc, char **argv)
         lis2dh12_calc_acc_ms2(y, &fy);
         lis2dh12_calc_acc_ms2(z, &fz);
                 
+#if MYNEWT_VAL(SENSOR_CLI)
         console_printf("x:%s ", sensor_ftostr(fx, tmpstr, 13));
         console_printf("y:%s ", sensor_ftostr(fy, tmpstr, 13));
         console_printf("z:%s\n", sensor_ftostr(fz, tmpstr, 13));
+#else
+        (void) tmpstr;
+        console_printf("x:%ld ", (int32_t) (fx * 1000.0f));
+        console_printf("y:%ld ", (int32_t) (fy * 1000.0f));
+        console_printf("z:%ld\n", (int32_t) (fz * 1000.0f));
+#endif
     }
 
     return 0;


### PR DESCRIPTION
Replace commented out `lis2dh12_shell_init()` with `LIS2DH12_CLI` syscfg conditional. 

In `lis2dh12_shell.c`, remove `SENSOR_CLI` conditional so only `LIS2DH12_CLI` is required to enable the shell. `SENSOR_CLI` is now optional to enable output in float format for `lis2dh12 r <num_readings>`, since a helper function in the sensor package is used for float conversion. When `SENSOR_CLI` is 0 the output will be integers with 3 implied decimal places.