### PR TITLE
sys/log: Log registration fix

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -191,6 +191,7 @@ struct log_entry_hdr {
 STATS_SECT_START(logs)
     STATS_SECT_ENTRY(writes)
     STATS_SECT_ENTRY(drops)
+    STATS_SECT_ENTRY(regerr)
     STATS_SECT_ENTRY(errs)
     STATS_SECT_ENTRY(lost)
     STATS_SECT_ENTRY(too_long)

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -76,12 +76,12 @@ struct shell_cmd g_shell_storage_cmd = {
 
 #if MYNEWT_VAL(LOG_STATS)
 STATS_NAME_START(logs)
-  STATS_NAME(logs, writes)
-  STATS_NAME(logs, drops)
-  STATS_NAME(logs, regerr)
-  STATS_NAME(logs, errs)
-  STATS_NAME(logs, lost)
-  STATS_NAME(logs, too_long)
+    STATS_NAME(logs, writes)
+    STATS_NAME(logs, drops)
+    STATS_NAME(logs, regerr)
+    STATS_NAME(logs, errs)
+    STATS_NAME(logs, lost)
+    STATS_NAME(logs, too_long)
 STATS_NAME_END(logs)
 #endif
 


### PR DESCRIPTION
- Log should only be added to the list after global index and local indexes are set
   The reason is log entries can start appending once the log gets added to the list.
   We want to restrict adding a log unless the global index/log index gets updated
   appropriately.
- Also adding registration error stat to detect any registration failures since error
   condition goes undetected, especially the index update case.
Note: The case where `log_registered()` callback fails, log gets removed from the list,
so a stat increment is of no use