### PR TITLE
boot/startup: Update generated linker script for newt size

### DIFF
--- a/boot/startup/include/mynewt_config.ld.h
+++ b/boot/startup/include/mynewt_config.ld.h
@@ -68,9 +68,11 @@
 #if MYNEWT_VAL_RAM_RESIDENT
 #define MYNEWT_CODE RAM
 #elif MYNEWT_VAL_BOOT_LOADER
-#define MYNEWT_CODE BOOT
+#define BOOT FLASH
+#define MYNEWT_CODE FLASH
 #else
-#define MYNEWT_CODE SLOT0
+#define SLOT0 FLASH
+#define MYNEWT_CODE FLASH
 #endif
 #endif
 


### PR DESCRIPTION
Autogenerated linker script have BOOT and SLOT0 regions specified to avoid potential inconsistency between bootloader and application code.
Fragment of generated linker script for application:

```ld
MEMORY
{
    BOOT (rx!w) : ORIGIN = 0x08000000, LENGTH = 131072
    SLOT0 (rx!w) : ORIGIN = 0x08020000, LENGTH = 786432
    RAM (rwx) : ORIGIN = (0x24000000), LENGTH = ((0x80000) - (768))
    STACK_RAM (rw) : ORIGIN = (0x24000000) + (0x80000) - (768), LENGTH = (768)
}
SECTIONS
{
...
    .interrupts :
    {
    ...
        __isr_vector_end = .;
    } > SLOT0
    .text :
    {
    ...
    } > SLOT0
```

**SLOT0** is used as destination instead of customary **FLASH**

For bootloader build regions would be the same but destination would be `> BOOT`

This however confuses newt size that expect **FLASH** as destination when used with `newt size -F`

This modifies generated linker script in a way that regions now have **FLASH** instead of **BOOT** or **SLOT0** depending on build type

```ld
MEMORY
{
    BOOT (rx!w) : ORIGIN = 0x08000000, LENGTH = 131072
    FLASH (rx!w) : ORIGIN = 0x08020000, LENGTH = 786432
    RAM (rwx) : ORIGIN = (0x24000000), LENGTH = ((0x80000) - (768))
    STACK_RAM (rw) : ORIGIN = (0x24000000) + (0x80000) - (768), LENGTH = (768)
}
SECTIONS
{
...
    .interrupts :
    {
    ...
        __isr_vector_end = .;
    } > FLASH
    .text :
    {
    ...
    } > FLASH
```