### PR TITLE
crypto/mbedtls: Use config defining flag globally

### DIFF
--- a/apps/crypto_test/pkg.yml
+++ b/apps/crypto_test/pkg.yml
@@ -28,5 +28,3 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log"
     - "@apache-mynewt-core/crypto/mbedtls"
     - "@apache-mynewt-core/crypto/tinycrypt"
-
-pkg.cflags: '-DMBEDTLS_USER_CONFIG_FILE="mbedtls/config_mynewt.h"'

--- a/apps/hash_test/pkg.yml
+++ b/apps/hash_test/pkg.yml
@@ -28,5 +28,3 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log"
     - "@apache-mynewt-core/crypto/mbedtls"
     - "@apache-mynewt-core/crypto/tinycrypt"
-
-pkg.cflags: '-DMBEDTLS_USER_CONFIG_FILE="mbedtls/config_mynewt.h"'

--- a/crypto/mbedtls/pkg.yml
+++ b/crypto/mbedtls/pkg.yml
@@ -26,11 +26,14 @@ pkg.keywords:
     - tls
 pkg.type: sdk
 
-pkg.cflags:
+app.cflags:
     - '-DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h>'
+app.cflags.TEST:
+    - '-DTEST'
+
+pkg.cflags:
     - -Wno-maybe-uninitialized
     - -Wno-unknown-warning-option
-pkg.cflags.TEST: -DTEST
 
 pkg.include_dirs:
     - "include"


### PR DESCRIPTION
Now -DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h> flag is used globally for each build that depends on mbedtls package. This way we won't have to add this flag in each package that uses mbedtls.