### PR TITLE
boot/startup: Increase interrupt stack in bootloader

### DIFF
--- a/boot/startup/syscfg.yml
+++ b/boot/startup/syscfg.yml
@@ -43,3 +43,4 @@ syscfg.defs:
 
 syscfg.vals.BOOT_LOADER:
     INCLUDE_IMAGE_HEADER: 0
+    MAIN_STACK_SIZE: 1024


### PR DESCRIPTION
Default 768 bytes for stack is not enough for mcuboot with mbedtls.

This change was already present in NRF53 but it applies to more devices