### PR TITLE
boot/startup: Add optional stack fill in startup

### DIFF
--- a/boot/startup/src/arch/cortex_m0/cortex_m0_startup.s
+++ b/boot/startup/src/arch/cortex_m0/cortex_m0_startup.s
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv6-m
 
@@ -63,6 +65,15 @@ Reset_Handler:
     b       .L_zero_loop
 
 .L_zero_table_done:
+
+#if MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r0, =MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r2, =__StackLimit
+    mov     r1, sp
+0:  stm     r2!, {r0}
+    cmp     r2, r1
+    blt     0b
+#endif
 
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit

--- a/boot/startup/src/arch/cortex_m3/cortex_m3_startup.s
+++ b/boot/startup/src/arch/cortex_m3/cortex_m3_startup.s
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv7-m
 
@@ -66,6 +68,15 @@ Reset_Handler:
 
     b       .L_for_each_zero_region
 .L_zero_table_done:
+
+#if MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r0, =MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r2, =__StackLimit
+    mov     r1, sp
+0:  stm     r2!, {r0}
+    cmp     r2, r1
+    blt     0b
+#endif
 
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit

--- a/boot/startup/src/arch/cortex_m33/cortex_m33_startup.s
+++ b/boot/startup/src/arch/cortex_m33/cortex_m33_startup.s
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv7-m
 
@@ -69,6 +71,15 @@ Reset_Handler:
 
     b       .L_for_each_zero_region
 .L_zero_table_done:
+
+#if MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r0, =MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r2, =__StackLimit
+    mov     r1, sp
+0:  stm     r2!, {r0}
+    cmp     r2, r1
+    blt     0b
+#endif
 
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit

--- a/boot/startup/src/arch/cortex_m4/cortex_m4_startup.s
+++ b/boot/startup/src/arch/cortex_m4/cortex_m4_startup.s
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv7-m
 
@@ -66,6 +68,15 @@ Reset_Handler:
 
     b       .L_for_each_zero_region
 .L_zero_table_done:
+
+#if MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r0, =MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r2, =__StackLimit
+    mov     r1, sp
+0:  stm     r2!, {r0}
+    cmp     r2, r1
+    blt     0b
+#endif
 
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit

--- a/boot/startup/src/arch/cortex_m7/cortex_m7_startup.s
+++ b/boot/startup/src/arch/cortex_m7/cortex_m7_startup.s
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "syscfg/syscfg.h"
+
     .syntax unified
     .arch   armv7-m
 
@@ -66,6 +68,15 @@ Reset_Handler:
 
     b       .L_for_each_zero_region
 .L_zero_table_done:
+
+#if MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r0, =MYNEWT_VAL_MAIN_STACK_FILL
+    ldr     r2, =__StackLimit
+    mov     r1, sp
+0:  stm     r2!, {r0}
+    cmp     r2, r1
+    blt     0b
+#endif
 
     ldr     r0, =__HeapBase
     ldr     r1, =__HeapLimit

--- a/boot/startup/syscfg.yml
+++ b/boot/startup/syscfg.yml
@@ -34,6 +34,11 @@ syscfg.defs:
             For bootloader it's main stack, for application this stack is used by interrupts
             and exceptions.
         value: 768
+    MAIN_STACK_FILL:
+        description: >
+            Fill main stack (interrupt stack) with pattern on startup.
+            If not 0, value will be used as a pattern.
+        value: 0
     INCLUDE_IMAGE_HEADER:
         description: Add image header to generated executable.
         value: 1


### PR DESCRIPTION
Code was already present in default startup code for NRF5340. Now is available for all devices with common startup.

It allows to verify real main stack requirements (interrupt stack) and stack used in bootloader.