### PR TITLE
sys/log, fs/fcb: Add support for trailers per entry in logs for fcb

### DIFF
--- a/hw/mcu/native/src/hal_flash.c
+++ b/hw/mcu/native/src/hal_flash.c
@@ -152,7 +152,7 @@ static int
 flash_native_write_internal(uint32_t address, const void *src, uint32_t length,
                             int allow_overwrite)
 {
-    static uint8_t buf[256];
+    uint8_t buf[256] = { 0 };
     uint32_t cur;
     uint32_t end;
     int chunk_sz;

--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -219,6 +219,13 @@ struct log {
 #if MYNEWT_VAL(LOG_STATS)
     STATS_SECT_DECL(logs) l_stats;
 #endif
+#if MYNEWT_VAL(LOG_INIT_CB)
+    /* Custom log init callback to be called by the last hdr
+     * read function to read custom data from log entries
+     * at init
+     */
+    log_walk_func_t l_init_cb;
+#endif
 };
 
 /* Log system level functions (for all logs.) */
@@ -513,6 +520,22 @@ void log_printf(struct log *log, uint8_t module, uint8_t level,
         const char *msg, ...);
 int log_read(struct log *log, const void *dptr, void *buf, uint16_t off,
         uint16_t len);
+
+#if MYNEWT_VAL(LOG_INIT_CB)
+/**
+ * @brief Register Log init callback to be called by log_read_last_hdr
+ * while reading the last log entry at init
+ *
+ * @param log                   The log to register.
+ * @param cb                    The callback to associate with the log.
+ *
+ */
+static inline void
+log_register_init_cb(struct log *log, log_walk_func_t cb)
+{
+    log->l_init_cb = cb;
+}
+#endif
 
 /**
  * @brief Reads a single log entry header.

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_2logs.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_2logs.c
@@ -44,9 +44,9 @@ TEST_CASE_SELF(log_test_case_2logs)
 {
     int rc;
     struct fcb_log fcb_log1;
-    struct log log1;
+    struct log log1 = {0};
     struct fcb_log fcb_log2;
-    struct log log2;
+    struct log log2 = {0};
 
     ltu_setup_2fcbs(&fcb_log1, &log1, &fcb_log2, &log2);
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_append_cb.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_append_cb.c
@@ -43,7 +43,7 @@ ltcwc_append_cb(struct log *log, uint32_t idx)
 TEST_CASE_SELF(log_test_case_append_cb)
 {
     struct fcb_log fcb_log;
-    struct log log;
+    struct log log = {0};
 
     ltu_setup_fcb(&fcb_log, &log);
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_body.c
@@ -22,7 +22,7 @@
 TEST_CASE_SELF(log_test_case_cbmem_append_body)
 {
     struct cbmem cbmem;
-    struct log log;
+    struct log log = {0};
     char *str;
     int i;
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf.c
@@ -23,8 +23,8 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf)
 {
     struct cbmem cbmem;
     struct os_mbuf *om;
-    struct log log;
     char *str;
+    struct log log = {0};
     int rc;
     int i;
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_append_mbuf_body.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(log_test_case_cbmem_append_mbuf_body)
 {
     struct cbmem cbmem;
     struct os_mbuf *om;
-    struct log log;
+    struct log log = {0};
     char *str;
     int rc;
     int i;

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_cbmem_printf.c
@@ -22,7 +22,7 @@
 TEST_CASE_SELF(log_test_case_cbmem_printf)
 {
     struct cbmem cbmem;
-    struct log log;
+    struct log log = {0};
     char *str;
     int i;
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append.c
@@ -22,7 +22,7 @@
 TEST_CASE_SELF(log_test_case_fcb_append)
 {
     struct fcb_log fcb_log;
-    struct log log;
+    struct log log = {0};
     uint8_t buf[256];
     char *str;
     int body_len;

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_body.c
@@ -22,7 +22,7 @@
 TEST_CASE_SELF(log_test_case_fcb_append_body)
 {
     struct fcb_log fcb_log;
-    struct log log;
+    struct log log = {0};
     char *str;
     int i;
 

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf)
 {
     struct fcb_log fcb_log;
     struct os_mbuf *om;
-    struct log log;
+    struct log log = {0};
     char *str;
     int rc;
     int i;

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_append_mbuf_body.c
@@ -23,7 +23,7 @@ TEST_CASE_SELF(log_test_case_fcb_append_mbuf_body)
 {
     struct fcb_log fcb_log;
     struct os_mbuf *om;
-    struct log log;
+    struct log log = {0};
     char *str;
     int rc;
     int i;

--- a/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_printf.c
+++ b/sys/log/full/selftest/util/src/testcases/log_test_case_fcb_printf.c
@@ -22,7 +22,7 @@
 TEST_CASE_SELF(log_test_case_fcb_printf)
 {
     struct fcb_log fcb_log;
-    struct log log;
+    struct log log = {0};
     char *str;
     int i;
 

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -294,9 +294,81 @@ log_find(const char *name)
     return log;
 }
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+uint16_t
+log_read_trailer(struct log *log, const void *dptr, uint8_t *buf)
+{
+    int rc = 0;
+    uint16_t offset = 0;
+    uint16_t trailer_len = 0;
+
+    if (log->l_th) {
+        /* This reads log entry length without alignment */
+        offset = log_read_entry_len(log, dptr);
+        if (offset) {
+            rc = log_read(log, dptr, &trailer_len,
+                          offset - LOG_TRAILER_LEN_SIZE,
+                          LOG_TRAILER_LEN_SIZE);
+            if (rc == LOG_TRAILER_LEN_SIZE) {
+                offset -= LOG_TRAILER_LEN_SIZE;
+                rc = log_read(log, dptr, buf, offset - trailer_len,
+                              trailer_len);
+                if (rc != trailer_len) {
+                    /* Trailer read failed, return 0 length
+                     * buffer remains untouched
+                     */
+                    return 0;
+                }
+            }
+        } else {
+            /* Entry length is 0, no trailer buffer remains untouched */
+            return 0;
+        }
+    }
+
+    /* No trailer, return 0 length */
+    return trailer_len;
+}
+
+uint16_t
+log_read_trailer_len(struct log *log, const void *dptr)
+{
+    int rc = 0;
+    uint16_t offset = 0;
+    uint16_t trailer_len = 0;
+
+    if (log->l_th) {
+        /* This reads log entry length without alignment */
+        offset = log_read_entry_len(log, dptr);
+        if (offset) {
+            rc = log_read(log, dptr, &trailer_len,
+                          offset - LOG_TRAILER_LEN_SIZE,
+                          LOG_TRAILER_LEN_SIZE);
+            if (rc == LOG_TRAILER_LEN_SIZE) {
+                return trailer_len;
+            } else {
+                /* Trailer read failed, return 0 length */
+                return 0;
+            }
+        } else {
+            /* Entry length is 0, no trailer */
+            return 0;
+        }
+    }
+
+    return 0;
+}
+#endif /* MYNEWT_VAL(LOG_FLAGS_TRAILER) */
+
+/* Argument for header/trailer walks */
 struct log_read_hdr_arg {
     struct log_entry_hdr *hdr;
     int read_success;
+    /* This is needed if the init_cb is called to read the trailer data */
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    bool trailer_exists;
+    void *trailer_arg;
+#endif
 };
 
 static int
@@ -343,7 +415,7 @@ log_read_hdr_walk(struct log *log, struct log_offset *log_offset, const void *dp
 static int
 log_read_last_hdr(struct log *log, struct log_entry_hdr *out_hdr)
 {
-    struct log_read_hdr_arg arg;
+    struct log_read_hdr_arg arg = {0};
     struct log_offset log_offset = {};
 
     arg.hdr = out_hdr;
@@ -355,6 +427,7 @@ log_read_last_hdr(struct log *log, struct log_entry_hdr *out_hdr)
     log_offset.lo_data_len = 0;
 
     log_walk(log, log_read_hdr_walk, &log_offset);
+
     if (!arg.read_success) {
         return -1;
     }
@@ -387,6 +460,12 @@ log_register(const char *name, struct log *log, const struct log_handler *lh,
     log->l_max_entry_len = 0;
 #if !MYNEWT_VAL(LOG_GLOBAL_IDX)
     log->l_idx = 0;
+#endif
+
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log->l_tr_om = NULL;
+    log->l_tr_arg = NULL;
+    log->l_th = NULL;
 #endif
 
     if (!log_registered(log)) {
@@ -503,6 +582,9 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     int sr;
     struct os_timeval tv;
     uint32_t idx;
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    struct os_mbuf *om = NULL;
+#endif
 
     rc = 0;
 
@@ -578,6 +660,19 @@ log_append_prepare(struct log *log, uint8_t module, uint8_t level,
     }
 #endif
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    if (log->l_th) {
+        rc = log_trailer_get_data(log, &om, log->l_tr_arg);
+        if (!rc && om) {
+            ue->ue_flags |= LOG_FLAGS_TRAILER;
+            log->l_tr_om = om;
+            rc = 0;
+        } else {
+            rc = SYS_ENOMEM;
+        }
+    }
+#endif
+
 err:
     return (rc);
 }
@@ -632,8 +727,15 @@ log_append_typed(struct log *log, uint8_t module, uint8_t level, uint8_t etype,
 
     log_call_append_cb(log, hdr->ue_index);
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
+
     return (0);
 err:
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
     return (rc);
 }
 
@@ -648,24 +750,32 @@ log_append_body(struct log *log, uint8_t module, uint8_t level, uint8_t etype,
 
     rc = log_chk_max_entry_len(log, body_len);
     if (rc != OS_OK) {
-        return rc;
+        goto err;
     }
 
     rc = log_append_prepare(log, module, level, etype, &hdr);
     if (rc != 0) {
         LOG_STATS_INC(log, drops);
-        return rc;
+        goto err;
     }
 
     rc = log->l_log->log_append_body(log, &hdr, body, body_len);
     if (rc != 0) {
         LOG_STATS_INC(log, errs);
-        return rc;
+        goto err;
     }
 
     log_call_append_cb(log, hdr.ue_index);
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
     return 0;
+err:
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
+    return rc;
 }
 
 int
@@ -678,7 +788,7 @@ log_append_mbuf_typed_no_free(struct log *log, uint8_t module, uint8_t level,
     uint16_t hdr_len;
     int rc;
 
-    /* Remove a loyer of indirection for convenience. */
+    /* Remove a layer of indirection for convenience. */
     om = *om_ptr;
 
     LOG_STATS_INC(log, writes);
@@ -736,6 +846,9 @@ log_append_mbuf_typed_no_free(struct log *log, uint8_t module, uint8_t level,
 
     log_call_append_cb(log, hdr->ue_index);
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
     *om_ptr = om;
 
     return 0;
@@ -743,6 +856,9 @@ log_append_mbuf_typed_no_free(struct log *log, uint8_t module, uint8_t level,
 err:
     LOG_STATS_INC(log, errs);
 drop:
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
     if (om) {
         os_mbuf_free_chain(om);
         *om_ptr = NULL;
@@ -799,10 +915,17 @@ log_append_mbuf_body_no_free(struct log *log, uint8_t module, uint8_t level,
 
     log_call_append_cb(log, hdr.ue_index);
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
+
     return 0;
 err:
     LOG_STATS_INC(log, errs);
 drop:
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    log_trailer_free(log, log->l_tr_om, log->l_tr_arg);
+#endif
     return rc;
 }
 
@@ -946,6 +1069,20 @@ err:
 }
 
 /**
+ * Reads entry length from the specified log.
+ *
+ * @return                      The number of bytes of entry length; 0 on failure.
+ */
+uint16_t
+log_read_entry_len(struct log *log, const void *dptr)
+{
+    if (log->l_log->log_read_entry_len) {
+        return log->l_log->log_read_entry_len(log, dptr);
+    }
+    return 0;
+}
+
+/**
  * Reads from the specified log.
  *
  * @return                      The number of bytes read; 0 on failure.
@@ -964,7 +1101,7 @@ log_read(struct log *log, const void *dptr, void *buf, uint16_t off,
 int
 log_read_hdr(struct log *log, const void *dptr, struct log_entry_hdr *hdr)
 {
-    int bytes_read;
+    int bytes_read = 0;
 
     bytes_read = log_read(log, dptr, hdr, 0, LOG_BASE_ENTRY_HDR_SIZE);
     if (bytes_read != LOG_BASE_ENTRY_HDR_SIZE) {
@@ -1031,6 +1168,14 @@ int
 log_flush(struct log *log)
 {
     int rc;
+
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    /* Reset trailer data if it exists, if it does not exist
+     * this function will return SYS_ENOTSUP. Currently,
+     * we do not use the return value.
+     */
+    log_trailer_reset_data(log, log->l_tr_arg);
+#endif
 
     rc = log->l_log->log_flush(log);
     if (rc != 0) {

--- a/sys/log/full/src/log.c
+++ b/sys/log/full/src/log.c
@@ -320,6 +320,13 @@ log_read_hdr_walk(struct log *log, struct log_offset *log_offset, const void *dp
         }
     }
 
+#if MYNEWT_VAL(LOG_INIT_CB)
+    if (log->l_init_cb) {
+        /* If the log has an init callback, call it with the header. */
+        log->l_init_cb(log, log_offset, dptr, len);
+    }
+#endif
+
     /* Abort the walk; only one header needed. */
     return 1;
 }

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -197,6 +197,12 @@ syscfg.defs:
             - LOG_FCB_BOOKMARKS
             - LOG_FCB
 
+    LOG_INIT_CB:
+        description: >
+            Enable log init callback. This callback is called after the log
+            module is initialized and most recent entry is read.
+        value: 0
+
 syscfg.vals.CONSOLE_TICKS:
     LOG_CONSOLE_PRETTY_WITH_TIMESTAMP: 0
 

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -63,6 +63,12 @@ syscfg.defs:
             1 - enable.
         value: 0
 
+    LOG_FLAGS_TRAILER:
+        description: >
+            Enable logging trailer with custom data types in every log entry
+            0 - disable; 1 - enable.
+        value: 0
+
     LOG_FCB:
         description: 'Support logging to FCB.'
         value: 0


### PR DESCRIPTION
- Trailer callbacks can be enabled using
  LOG_FLAGS_TRAILER_SUPPORT.
- This is needed since we cannot update the log header
  without breaking backwards compatibility
- Adding a trailer keeps the log header in place and the entry
  intact. On an upgrade or downgrade, log entries are still
  readable.
- Trailer callbacks can be registered using log_trailer_cbs_register().
- Trailer data is managed by the callbacks
- Add trailer buffer append/free callback
- Add reset_data callback for trailer data
- Allocate trailer buffer in log_append_prepare() and
  free the trailer buffer with log_trailer_free() in
  log.c. Both of them being callbacks to be implemented
  by the user.
- Add 2 byte trailer length field after trailer at
  the end of the log entry.
Note: This is a replacement for the number of entries PR, https://github.com/apache/mynewt-core/pull/3168 and most of the comments should be pre-handled in this code. the trailer can be implemented by the user of this feature as they want privately only keeping the trailer handling code upstream.