### PR TITLE
log_console: Add option to print time stamp as clock time

### DIFF
--- a/sys/log/full/pkg.yml
+++ b/sys/log/full/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/sys/flash_map"
     - "@apache-mynewt-core/sys/log/common"
     - "@apache-mynewt-core/util/cbmem"
+    - "@apache-mynewt-core/time/datetime"
 
 pkg.deps.LOG_FCB:
     - "@apache-mynewt-core/hw/hal"

--- a/sys/log/full/syscfg.yml
+++ b/sys/log/full/syscfg.yml
@@ -52,6 +52,11 @@ syscfg.defs:
             Turned off by default when CONSOLE_TICKS is on.
         value: 1
 
+    LOG_CONSOLE_PRETTY_TIMESTAMP_CLOCK:
+        description: >
+            Print timestamp as time yyyy-mm-ddThh:ss:mm.uuuuuu.
+        value: 0
+
     LOG_FLAGS_IMAGE_HASH:
         description: >
             Enable logging of the first 4 bytes of the image hash. 0 - disable;


### PR DESCRIPTION
When LOG_CONSOLE_PRETTY_WITH_TIMESTAMP is set to 1 timestamp of the logs is print in human readable format instead of really big numbers.