### PR TITLE
libc/nano: Update to CMSIS repo to 5.9.0

### DIFF
--- a/libc/nano/src/start.c
+++ b/libc/nano/src/start.c
@@ -45,6 +45,12 @@ void _start(void)
     os_init(mynewt_main);
     os_start();
 #endif
+
+#if !MYNEWT_VAL(SELFTEST)
+    /* _start is noreturn so make sure it never returns except for unittests */
+    while (1) {
+    }
+#endif
 }
 
 __attribute__((weak)) void


### PR DESCRIPTION
CMSIS declares _start function with attribute noreturn

This adds code to prevent warning that _start can return.

Same functionality is already in baselibc #3341