### PR TITLE
bus/spi_stm32: Fix spi initialization sequence

### DIFF
--- a/hw/bus/drivers/spi_stm32/src/spi_stm32.c
+++ b/hw/bus/drivers/spi_stm32/src/spi_stm32.c
@@ -657,9 +657,6 @@ spi_stm32_configure(struct bus_dev *bdev, struct bus_node *bnode)
     if (HAL_OK != HAL_SPI_Init(&dd->hspi)) {
         rc = SYS_EINVAL;
     }
-
-    __HAL_SPI_ENABLE(&dd->hspi);
-
 end:
     return rc;
 }


### PR DESCRIPTION
SPI was enabled too soon. It could result in
clock line glitch for STM32H7/5 where GPIO
lines can be left in wrong state before CR registers are correctly filled.
STM HAL will enable it at correct time during transmission.