### PR TITLE
stm32/hal_uart: Enable FIFO if present

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_uart.c
+++ b/hw/mcu/stm/stm32_common/src/hal_uart.c
@@ -482,6 +482,9 @@ hal_uart_config(int port, int32_t baudrate, uint8_t databits, uint8_t stopbits,
 #if !MYNEWT_VAL(MCU_STM32F1)
     cr1 &= ~(USART_CR1_OVER8);
 #endif
+#ifdef USART_CR1_FIFOEN
+    cr1 |= USART_CR1_FIFOEN;
+#endif
     cr2 &= ~(USART_CR2_STOP);
     cr3 &= ~(USART_CR3_RTSE | USART_CR3_CTSE);
 


### PR DESCRIPTION
More recent STM32 devices have FIFO that
can help to use higher baudrate speeds without
DMA (which is not used in hal_uart).
This enables FIFO if proper bit in CR1 register
exists.