### PR TITLE
kernel/os/arch: Fix Cortex-M irq priority setting

### DIFF
--- a/hw/mcu/dialog/cmac/src/arch/cortex_m0_cmac/os_arch_arm.c
+++ b/hw/mcu/dialog/cmac/src/arch/cortex_m0_cmac/os_arch_arm.c
@@ -128,7 +128,7 @@ os_arch_os_init(void)
     }
 
     /* Drop priority for all interrupts */
-    for (i = 0; i < sizeof(NVIC->IP) / 4; i++) {
+    for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++) {
         NVIC->IP[i] = -1;
     }
 

--- a/kernel/os/src/arch/cortex_m0/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m0/os_arch_arm.c
@@ -209,7 +209,7 @@ os_arch_os_init(void)
         err = OS_OK;
 
         /* Drop priority for all interrupts */
-        for (i = 0; i < sizeof(NVIC->IP); i++) {
+        for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++) {
             NVIC->IP[i] = -1;
         }
 

--- a/kernel/os/src/arch/cortex_m3/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m3/os_arch_arm.c
@@ -233,7 +233,7 @@ os_arch_os_init(void)
         err = OS_OK;
 
         /* Drop priority for all interrupts */
-        for (i = 0; i < sizeof(NVIC->IP); i++) {
+        for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++) {
             NVIC->IP[i] = -1;
         }
 

--- a/kernel/os/src/arch/cortex_m33/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m33/os_arch_arm.c
@@ -237,7 +237,7 @@ os_arch_os_init(void)
         err = OS_OK;
 
         /* Drop priority for all interrupts */
-        for (i = 0; i < sizeof(NVIC->IPR); i++) {
+        for (i = 0; i < ARRAY_SIZE(NVIC->IPR); i++) {
             NVIC->IPR[i] = -1;
         }
 

--- a/kernel/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m4/os_arch_arm.c
@@ -237,7 +237,7 @@ os_arch_os_init(void)
         err = OS_OK;
 
         /* Drop priority for all interrupts */
-        for (i = 0; i < sizeof(NVIC->IP); i++) {
+        for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++) {
             NVIC->IP[i] = -1;
         }
 

--- a/kernel/os/src/arch/cortex_m7/os_arch_arm.c
+++ b/kernel/os/src/arch/cortex_m7/os_arch_arm.c
@@ -237,7 +237,7 @@ os_arch_os_init(void)
         err = OS_OK;
 
         /* Drop priority for all interrupts */
-        for (i = 0; i < sizeof(NVIC->IP); i++) {
+        for (i = 0; i < ARRAY_SIZE(NVIC->IP); i++) {
             NVIC->IP[i] = -1;
         }
 


### PR DESCRIPTION
os_arch_os_init() initialized interrupt priority level for all interrupts using incorrect array limit taken from sizeof instead of ARRAY_SIZE.
For Cortex-M0 field IP is array of uint32_t unlike all other version where this array consist of uint8_t.

Now array is iterated using ARRAY_SIZE(NVIC->IP) to limit instead of sizeof(NVIC->IP) and for Cortex-M33
ARRAY_SIZE(NVIC->IPR).

For all non Cortex-M0 IP or IPR is uint8_t but this changes it to use ARRAY_SIZE() anyway to make it consistent.