### PR TITLE
Shell commands and modules added during link time

### DIFF
--- a/kernel/os/include/os/link_tables.h
+++ b/kernel/os/include/os/link_tables.h
@@ -95,7 +95,7 @@
     __attribute__((section("." #table_name), used))
 /* Macro to create attribute for table with name that may affect order of elements */
 #define LINK_TABLE_ELEMENT_SECTION(table_name, elem)                          \
-    __attribute__((section("." #table_name "." #elem)))
+    __attribute__((section("." #table_name "." #elem), used))
 /* Macro to create element that goes to link table.
  * It could be used like this:
  * LINK_TABLE_ELEMENT(example1_table, foo5) = {
@@ -126,7 +126,7 @@
  */
 #define LINK_TABLE_ELEMENT_REF(table_name, elem, var)                         \
     LINK_TABLE_ELEMENT_TYPE(table_name)                                       \
-    const elem##_ptr LINK_TABLE_ELEMENT_SECTION(table_name, elem) = &var
+    const elem##_ptr LINK_TABLE_ELEMENT_SECTION(table_name, elem) = &var;
 
 #define LINK_TABLE(element_type, table_name)                                  \
     typedef element_type table_name##_element_t;                              \

--- a/sys/shell/include/shell/shell.h
+++ b/sys/shell/include/shell/shell.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include "os/mynewt.h"
+#include "os/link_tables.h"
 #include "streamer/streamer.h"
 
 struct os_eventq;
@@ -84,6 +85,192 @@ struct shell_module {
     const char *name;
     const struct shell_cmd *commands;
 };
+
+typedef const struct shell_mod *shell_mod_t;
+typedef const struct shell_cmd *shell_cmd_t;
+
+/*
+ * Shell module enumeration functions
+ */
+typedef struct shell_mod_ops {
+    /** Returns number of module commands */
+    size_t (*count)(shell_mod_t mod);
+    /** Return module command by it's index */
+    shell_cmd_t (*get)(shell_mod_t mod, size_t ix);
+} shell_mod_ops_t;
+
+/*
+ * Shell module
+ */
+struct shell_mod {
+    /* Shell module functions */
+    const shell_mod_ops_t *ops;
+    /* Shell module name visible to end use */
+    const char *name;
+};
+
+/*
+ * Shell module with static array of commands
+ */
+typedef struct shell_mod_std {
+    /* Inherited shell module */
+    struct shell_mod mod;
+    /* Beginning of command array */
+    const struct shell_cmd *commands;
+    /* Pointer to end of command array */
+    const struct shell_cmd *commands_end;
+} shell_mod_std_t;
+extern const struct shell_mod_ops shell_mod_std_ops;
+
+static inline int
+shell_mod_command_count(shell_mod_t mod)
+{
+    return mod->ops->count(mod);
+}
+
+static inline shell_cmd_t
+shell_mod_command(shell_mod_t mod, size_t ix)
+{
+    return mod->ops->get(mod, ix);
+}
+
+LINK_TABLE(shell_mod_t, shell_modules)
+/* Section name for shell modules */
+#define SHELL_MODULES_SECTION LINK_TABLE_SECTION(shell_modules)
+#define SHELL_MODULE_SECTION(mod)                                             \
+    LINK_TABLE_ELEMENT_SECTION(shell_modules, mod)
+
+/**
+ * Create shell module with commands designated by begin and end pointers
+ *
+ * This will create object of type shell_mod_std and pointer to this object.
+ * Pointer will be placed in .shell_modules section so it will be put
+ * together with all other shell modules on one link time table.
+ *
+ * @param _name - name of the module
+ * @param _command_begin - pointer to start of the table with commands
+ * @param _command_end - pointer to end of the table with commands
+ */
+#define SHELL_MODULE_STD(_name, _command_begin, _command_end)                 \
+    const shell_mod_std_t shell_module_##_name = {                            \
+        { &shell_mod_std_ops, #_name },                                       \
+        _command_begin, _command_end                                          \
+    };                                                                        \
+    LINK_TABLE_ELEMENT_REF(shell_modules, _name, shell_module_##_name.mod)
+
+/**
+ * Create shell module with static command table
+ *
+ * @param _name - name of the module
+ * @parma _table - standard table of const struct shell_cmd with know size
+ */
+#define SHELL_MODULE_WITH_TABLE(name_, table_)                                \
+    SHELL_MODULE_STD(name_, table_, table_ + ARRAY_SIZE(table_))
+
+#define SHELL_MODULE_CMD_SECTION(mod_, cmd_)                                  \
+    LINK_TABLE_ELEMENT_SECTION(mod_##_commands, cmd_)
+/* Section name for shell compat (global) commands */
+#define SHELL_COMPAT_CMDS_SECTION LINK_TABLE_SECTION(compat_commands)
+/* Section name for shell compat command */
+#define SHELL_COMPAT_CMD_SECTION(cmd_) SHELL_MODULE_CMD_SECTION(compat, cmd_)
+
+/**
+ * Create shell module with link time table (name derived from _name)
+ *
+ * Link table will have name derived from shell module.
+ * Link table must be declared in some pkg.yml in pkg.link_tables: section
+ *
+ * i.e.
+ * pkg.yml
+ *
+ * pkg.link_tables:
+ *     - mcu_commands
+ *
+ * mcu_cli.c
+ *
+ * SHELL_MODULE_WITH_LINK_TABLE(mcu)
+ *
+ * @param _name - name of the shell module
+ */
+#define SHELL_MODULE_WITH_LINK_TABLE(_name)                                   \
+    LINK_TABLE(struct shell_cmd, _name##_commands)                            \
+    SHELL_MODULE_STD(_name, LINK_TABLE_START(_name##_commands),               \
+                     LINK_TABLE_END(_name##_commands))
+
+/**
+ * Create command for module
+ *
+ * Macro creates object of struct shell_cmd and puts it in link table
+ * for module
+ *
+ * @param mod_ - module name
+ * @param cmd_ - command name
+ * @param name_ - command name as string
+ * @param ext_ - 1 for extended command with streamer
+ * @param func_ - function to execute
+ * @param help_ - help structure for function
+ */
+#define SHELL_MODULE_CMD_WITH_NAME(mod_, cmd_, name_, ext_, func_, help_)            \
+    const struct shell_cmd shell_cmd_##cmd_ SHELL_MODULE_CMD_SECTION(mod_, cmd_) = { \
+        .sc_ext = ext_,                                                              \
+        .sc_cmd_ext_func = (shell_cmd_ext_func_t)(func_),                            \
+        .sc_cmd = name_,                                                             \
+        .help = SHELL_HELP_(help_),                                                  \
+    };
+
+/**
+ * Create command for module
+ *
+ * Macro creates object of struct shell_cmd and puts it in link table
+ * for module
+ *
+ * @param mod_ - module name
+ * @param cmd_ - command name
+ * @param func_ - function to execute
+ * @param help_ - help structure for function
+ */
+#define SHELL_MODULE_CMD(mod_, cmd_, func_, help_)                            \
+    SHELL_MODULE_CMD_WITH_NAME(mod_, cmd_, #cmd_, 0, func_, help_)
+
+/**
+ * Create command for module
+ *
+ * Macro creates object of struct shell_cmd and puts it in link table
+ * for module
+ *
+ * @param mod_ - module name
+ * @param cmd_ - command name
+ * @param func_ - function to execute
+ * @param help_ - help structure for function
+ */
+#define SHELL_MODULE_EXT_CMD(mod_, cmd_, func_, help_)                        \
+    SHELL_MODULE_CMD_WITH_NAME(mod_, cmd_, #cmd_, 1, func_, help_)
+
+/**
+ * @brief Register global shell command function
+ *
+ * Macro creates shell command that can be used when shell task is enabled
+ * This is equivalent of calling deprecated function shell_cmd_register.
+ *
+ * @name - cmd_name command name (it will be put in "" to make string
+ * @func - command function function of shell_cmd_ext_func_t
+ * @help pointer to shell_cmd_help
+ */
+#define MAKE_SHELL_CMD(cmd_name, func, help)                                  \
+    SHELL_MODULE_CMD(compat, cmd_name, func, help)
+
+/**
+ * @brief Register global extended shell command function
+ *
+ * Macro creates shell command that can be used when shell task is enabled
+ * This is equivalent of calling deprecated function shell_cmd_register.
+ *
+ * @name - cmd_name command name (it will be put in "" to make string
+ * @func - command function function of shell_cmd_ext_func_t
+ * @help pointer to shell_cmd_help
+ */
+#define MAKE_SHELL_EXT_CMD(cmd_name, func, help)                              \
+    SHELL_MODULE_EXT_CMD(compat, cmd_name, func, help)
 
 #if MYNEWT_VAL(SHELL_CMD_HELP)
 #define SHELL_HELP_(help_) (help_)

--- a/sys/shell/pkg.yml
+++ b/sys/shell/pkg.yml
@@ -39,5 +39,11 @@ pkg.deps.SHELL_BRIDGE:
 pkg.req_apis:
     - console
 
+pkg.whole_archive: true
+
+pkg.link_tables:
+    - shell_modules
+    - compat_commands
+
 pkg.init:
     shell_init: 'MYNEWT_VAL(SHELL_SYSINIT_STAGE)'

--- a/sys/shell/src/shell_os.c
+++ b/sys/shell/src/shell_os.c
@@ -273,25 +273,9 @@ static const struct shell_cmd_help ls_dev_help = {
 };
 #endif
 
-static const struct shell_cmd os_commands[] = {
-    SHELL_CMD_EXT("tasks", shell_os_tasks_display_cmd, &tasks_help),
-    SHELL_CMD_EXT("mpool", shell_os_mpool_display_cmd, &mpool_help),
-    SHELL_CMD_EXT("date", shell_os_date_cmd, &date_help),
-    SHELL_CMD_EXT("reset", shell_os_reset_cmd, &reset_help),
-    SHELL_CMD_EXT("reset_cause", shell_os_print_reset_cause, &print_reset_cause_help),
-    SHELL_CMD_EXT("lsdev", shell_os_ls_dev_cmd, &ls_dev_help),
-    { 0 },
-};
-
-void
-shell_os_register(void)
-{
-    const struct shell_cmd *cmd;
-    int rc;
-
-    for (cmd = os_commands; cmd->sc_cmd != NULL; cmd++) {
-        rc = shell_cmd_register(cmd);
-        SYSINIT_PANIC_ASSERT_MSG(
-            rc == 0, "Failed to register OS shell commands");
-    }
-}
+MAKE_SHELL_EXT_CMD(tasks, shell_os_tasks_display_cmd, &tasks_help)
+MAKE_SHELL_EXT_CMD(mpool, shell_os_mpool_display_cmd, &mpool_help)
+MAKE_SHELL_EXT_CMD(date, shell_os_date_cmd, &date_help)
+MAKE_SHELL_EXT_CMD(reset, shell_os_reset_cmd, &reset_help)
+MAKE_SHELL_EXT_CMD(reset_cause, shell_os_print_reset_cause, &print_reset_cause_help)
+MAKE_SHELL_EXT_CMD(lsdev, shell_os_ls_dev_cmd, &ls_dev_help)

--- a/sys/shell/src/shell_priv.h
+++ b/sys/shell/src/shell_priv.h
@@ -49,8 +49,6 @@ void shell_nlip_init(void);
 void shell_nlip_clear_pkt(void);
 #endif
 
-void shell_prompt_register(void);
-
 #if MYNEWT_VAL(SHELL_BRIDGE)
 void shell_bridge_streamer_new(struct shell_bridge_streamer *sbs,
                                struct CborEncoder *str_encoder);

--- a/sys/shell/src/shell_priv.h
+++ b/sys/shell/src/shell_priv.h
@@ -49,7 +49,6 @@ void shell_nlip_init(void);
 void shell_nlip_clear_pkt(void);
 #endif
 
-void shell_os_register(void);
 void shell_prompt_register(void);
 
 #if MYNEWT_VAL(SHELL_BRIDGE)

--- a/sys/shell/src/shell_prompt.c
+++ b/sys/shell/src/shell_prompt.c
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-
 #include "os/mynewt.h"
+
+#if MYNEWT_VAL(SHELL_PROMPT_MODULE)
+
 #include "console/console.h"
 #include "console/ticks.h"
 
@@ -73,12 +73,8 @@ static const struct shell_cmd prompt_commands[] = {
         .help = &ticks_help,
 #endif
     },
-    { 0 },
 };
 
+SHELL_MODULE_WITH_TABLE(prompt, prompt_commands)
 
-void
-shell_prompt_register(void)
-{
-    shell_register(SHELL_PROMPT, prompt_commands);
-}
+#endif


### PR DESCRIPTION
### Shell commands registration
So far shell commands could be added with `shell_cmd_register()` and modules (set of commands) could be added with `shell_register()`

This approach requires function call usually added in package initialization function.
Registering commands requires some RAM two tables:
```c
static struct shell_module shell_modules[MYNEWT_VAL(SHELL_MAX_MODULES)];
static struct shell_cmd compat_commands[MYNEWT_VAL(SHELL_MAX_COMPAT_COMMANDS) + 1];
```
Number of modules that can be registered is defined by two mynewt values `SHELL_MAX_MODULES` and `SHELL_MAX_COMPAT_COMMANDS`.
When code tries to add more commands or modules system will crash with assert(0).

### Link time table for commands registration

Now when link time table can be used shell commands and modules can be added to be available in shell.
Commands can be added with macro `MAKE_SHELL_CMD()` and modules can be added using `SHELL_MODULE_WITH_TABLE()`.
Both register commands and modules does not use RAM and do not need function calls.

For backward compatibility `shell_cmd_register()` and `shell_register()` can still be used.
To minimize memory usage syscfg values `SHELL_MAX_MODULES` and `SHELL_MAX_COMPAT_COMMANDS` can be set to 0.

### Benefits of new shell commands registration
- Memory usage is reduced both RAM and flash
- commands are in alphabetical order (they were displayed in order they were registered)
- Targets don't need to specify maximum number of command and modules so adding some package will not result in unexpected assert(0) that instruct you to increase limits.
### Scope of this PR
- Macros for module and commands creation
- Rework of shell command handling to use link time tables
- Update of many packages (not all yet) to use new way of making shell commands
### Comparison of size for target that with many commands
Code without this changes
```
objsize
   text	   data	    bss	    dec	    hex	filename
 121368	   1744	  30572	 153684	  25854	bin/targets/blackpill411ce-slinky/app/@apache-mynewt-core/apps/slinky/slinky.elf
```
Same application after change are applied:
```
objsize
   text	   data	    bss	    dec	    hex	filename
 120844	   1496	  29988	 152328	  25308	bin/targets/blackpill411ce-slinky/app/@apache-mynewt-core/apps/slinky/slinky.elf
```