### PR TITLE
hw/battery: Add missing dependency to adc

### DIFF
--- a/hw/battery/pkg.yml
+++ b/hw/battery/pkg.yml
@@ -23,6 +23,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/drivers/adc"
 
 pkg.req_apis:
     - console


### PR DESCRIPTION
battery_adc.c included adc/adc.h but package
for hw/drivers/adc was missing from dependency list.