### PR TITLE
Improve clang-format handling for macros and enums

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true
   AfterControlStatement: false
-  AfterEnum: true
+  AfterEnum: false
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: false

--- a/.clang-format
+++ b/.clang-format
@@ -27,9 +27,9 @@ BraceWrapping:
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
 
-MacroBlockBegin: '(STATS_NAME_START | STATS_SECT_DECL)'
-MacroBlockEnd: 'STATS_NAME_END'
-StatementMacros: ['SLIST_HEAD', 'STATS_NAME_START', 'STATS_NAME_END']
+MacroBlockBegin: '(STATS_NAME_START|STATS_SECT_START)'
+MacroBlockEnd: '(STATS_NAME_END|STATS_SECT_END)'
+StatementMacros: ['SLIST_HEAD']
 
 ForEachMacros:
   - 'SLIST_FOREACH'


### PR DESCRIPTION
This PR includes two formatting-related changes to `.clang-format` and supporting tooling:

1. **Fix formatting for STATS macros**  
   Updated `MacroBlockBegin`, `MacroBlockEnd`, and `StatementMacros` settings to properly handle macro blocks like `STATS_NAME_START` / `STATS_NAME_END`.  

2. **Disable line breaking after enums**  
   Changed `BraceWrapping.AfterEnum` to `false` to align with the existing code style and prevent unnecessary newlines after enum declarations.