### PR TITLE
config: Cleanup config file initialization

### DIFF
--- a/sys/config/include/config/config_file.h
+++ b/sys/config/include/config/config_file.h
@@ -39,6 +39,13 @@ struct conf_file {
 int conf_file_src(struct conf_file *);  /* register file to be source of cfg */
 int conf_file_dst(struct conf_file *);  /* cfg saves go to a file */
 
+/**
+ * @brief Initialize config with syscfg values
+ *
+ * Function registers config source and destination stores.
+ */
+void config_file_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/config/src/config_file.c
+++ b/sys/config/src/config_file.c
@@ -19,7 +19,7 @@
 
 #include "os/mynewt.h"
 
-#if MYNEWT_VAL(CONFIG_NFFS) || MYNEWT_VAL(CONFIG_LITTLEFS)
+#if MYNEWT_VAL(CONFIG_FILE)
 
 #include <string.h>
 #include <assert.h>
@@ -35,7 +35,7 @@ static int conf_file_load(struct conf_store *, conf_store_load_cb cb,
 static int conf_file_save(struct conf_store *, const char *name,
   const char *value);
 
-static struct conf_store_itf conf_file_itf = {
+static const struct conf_store_itf conf_file_itf = {
     .csi_load = conf_file_load,
     .csi_save = conf_file_save,
 };
@@ -281,6 +281,22 @@ conf_file_save(struct conf_store *cs, const char *name, const char *value)
     }
     fs_close(file);
     return rc;
+}
+
+static struct conf_file config_init_conf = {
+    .cf_name = MYNEWT_VAL(CONFIG_FILE_FILE_NAME),
+    .cf_maxlines = MYNEWT_VAL(CONFIG_FILE_MAX_LINES)
+};
+
+void
+config_file_init(void)
+{
+    int rc;
+
+    rc = conf_file_src(&config_init_conf);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+    rc = conf_file_dst(&config_init_conf);
+    SYSINIT_PANIC_ASSERT(rc == 0);
 }
 
 #endif

--- a/sys/config/src/config_init.c
+++ b/sys/config/src/config_init.c
@@ -27,46 +27,7 @@
 
 #if MYNEWT_VAL(CONFIG_AUTO_INIT)
 
-#if MYNEWT_VAL(CONFIG_LITTLEFS)
-#include "fs/fs.h"
-
-static struct conf_file config_init_conf_littlefs = {
-    .cf_name = MYNEWT_VAL(CONFIG_LITTLEFS_FILE),
-    .cf_maxlines = MYNEWT_VAL(CONFIG_LITTLEFS_MAX_LINES)
-};
-
-static void
-config_init_littlefs(void)
-{
-    int rc;
-
-    rc = conf_file_src(&config_init_conf_littlefs);
-    SYSINIT_PANIC_ASSERT(rc == 0);
-    rc = conf_file_dst(&config_init_conf_littlefs);
-    SYSINIT_PANIC_ASSERT(rc == 0);
-}
-
-#elif MYNEWT_VAL(CONFIG_NFFS)
-
-#include "fs/fs.h"
-
-static struct conf_file config_init_conf_file = {
-    .cf_name = MYNEWT_VAL(CONFIG_NFFS_FILE),
-    .cf_maxlines = MYNEWT_VAL(CONFIG_NFFS_MAX_LINES)
-};
-
-static void
-config_init_fs(void)
-{
-    int rc;
-
-    rc = conf_file_src(&config_init_conf_file);
-    SYSINIT_PANIC_ASSERT(rc == 0);
-    rc = conf_file_dst(&config_init_conf_file);
-    SYSINIT_PANIC_ASSERT(rc == 0);
-}
-
-#elif MYNEWT_VAL(CONFIG_FCB)
+#if MYNEWT_VAL(CONFIG_FCB)
 
 #include "config/config_fcb.h"
 
@@ -157,10 +118,8 @@ config_pkg_init(void)
     conf_init();
 
 #if MYNEWT_VAL(CONFIG_AUTO_INIT)
-#if MYNEWT_VAL(CONFIG_LITTLEFS)
-    config_init_littlefs();
-#elif MYNEWT_VAL(CONFIG_NFFS)
-    config_init_fs();
+#if MYNEWT_VAL(CONFIG_FILE)
+    config_file_init();
 #elif MYNEWT_VAL(CONFIG_FCB)
     config_init_fcb();
 #elif MYNEWT_VAL(CONFIG_FCB2)

--- a/sys/config/syscfg.yml
+++ b/sys/config/syscfg.yml
@@ -48,6 +48,13 @@ syscfg.defs:
             - '!CONFIG_FCB'
             - '!CONFIG_FCB2'
 
+    CONFIG_FILE:
+        description: 'Config default storage is in file system file'
+        value: 0
+        restrictions:
+            - '!CONFIG_FCB'
+            - '!CONFIG_FCB2'
+
     CONFIG_MGMT:
         description: 'SMP access to config'
         value: 0
@@ -143,8 +150,26 @@ syscfg.defs.CONFIG_LITTLEFS:
         description: 'Limit how many items stored in file before compressing'
         value: 32
 
+syscfg.defs.CONFIG_FILE:
+    CONFIG_FILE_FILE_NAME:
+        description: 'Name for the default config file'
+        value: '"cfg"'
+    CONFIG_FILE_MAX_LINES:
+        description: 'Limit how many items stored in file before compressing'
+        value: 32
+
 syscfg.vals.CONFIG_FCB2:
     CONFIG_FCB_MAGIC: 0xd0b1d0b1
 
 syscfg.vals.CONFIG_NEWTMGR:
     CONFIG_MGMT: MYNEWT_VAL(CONFIG_NEWTMGR)
+
+syscfg.vals.CONFIG_LITTLEFS:
+    CONFIG_FILE: 1
+    CONFIG_FILE_FILE_NAME: MYNEWT_VAL(CONFIG_LITTLEFS_FILE)
+    CONFIG_FILE_MAX_LINES: MYNEWT_VAL(CONFIG_LITTLEFS_MAX_LINES)
+
+syscfg.vals.CONFIG_NFFS:
+    CONFIG_FILE: 1
+    CONFIG_FILE_FILE_NAME: MYNEWT_VAL(CONFIG_NFFS_FILE)
+    CONFIG_FILE_MAX_LINES: MYNEWT_VAL(CONFIG_NFFS_MAX_LINES)


### PR DESCRIPTION
There was duplicated code for config base on file system for littlefs and nffs.

Now there is common initialization function for both file systems. Additionally other file system can be used for config storage without need to modify initialization code since it used mynewt fs api and nothing specific to littlefs of nffs. It is needed if FATFS (sdcard) is to be used for config storage