### PR TITLE
tinyusb/msc_fat_view: Small fixes

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/msc_fat_view.c
@@ -869,17 +869,17 @@ msc_fat_view_create_short_name(const dir_entry_t *entry, char short_name[11])
     int len = strlen(entry->file->name);
     int last_dot;
     const char *name = entry->file->name;
-    bool add_tilda = false;
+    bool add_tilde = false;
 
     memset(short_name, ' ', 11);
     if (entry->dir_slots > 1) {
         last_dot = len;
         for (i = len - 1; i > 0; --i) {
             if (name[i] == '.') {
+                last_dot = i++;
                 for (j = 8; j < 11 && i < len; ++i, ++j) {
                     short_name[j] = toupper((uint8_t)name[i]);
                 }
-                last_dot = i;
                 break;
             }
         }
@@ -887,10 +887,10 @@ msc_fat_view_create_short_name(const dir_entry_t *entry, char short_name[11])
             if (name[i] != '.' && name[i] != ' ') {
                 short_name[j++] = toupper((uint8_t)name[i]);
             } else {
-                add_tilda = true;
+                add_tilde = true;
             }
         }
-        if (add_tilda) {
+        if (add_tilde) {
             for (i = 0; i < 6 && short_name[i] != ' '; ++i) {
             }
             short_name[i++] = '~';

--- a/hw/usb/tinyusb/msc_fat_view/syscfg.yml
+++ b/hw/usb/tinyusb/msc_fat_view/syscfg.yml
@@ -38,6 +38,10 @@ syscfg.defs:
             Auto-confirm image when directory is read after reboot.
         value: 1
 
+    MSC_FAT_VIEW_ROOT_DIR_SECTORS:
+        description: >
+            Number of sectors for root directory.
+        value: 3
     MSC_FAT_VIEW_COREDUMP_FILES:
         description: >
             Adds coredump files (if present) to root directory.


### PR DESCRIPTION
Short name generation incorrectly build file extension.
For config.txt it would create

'CONFIG  .TX' instead of 'CONFIG  TXT'
(Extra dot that should not be there)

Now short name is displayed correctly
Additionally typo in variable name is corrected.

Root directory sector count is not increased to 3
and configurable in syscfg.
This can prevent case when due to number of entries
in root directory host system can't write file with
updated firmware.