### PR TITLE
kernel/os: Fix msys unit tests

### DIFF
--- a/kernel/os/selftest/src/msys_test.c
+++ b/kernel/os/selftest/src/msys_test.c
@@ -51,14 +51,14 @@ os_msys_init_pool(void *data, struct os_mempool *mempool,
     TEST_ASSERT_FATAL(rc == 0, "os_msys_register failed");
 }
 
-extern STAILQ_HEAD(, os_mempool) g_os_mempool_list;
+extern struct os_mempool_list g_os_mempool_list;
 
 void
 os_msys_test_setup(int pool_count, struct msys_context *context)
 {
     /* Preserve default state of pools and msys in case other cases use it */
     context->mbuf_list = *get_msys_pool_list();
-    context->mempool_list = *(struct os_mempool_list *)&g_os_mempool_list;
+    context->mempool_list = g_os_mempool_list;
 
     os_mempool_module_init();
     os_msys_reset();


### PR DESCRIPTION
Depending on optimization and compiler used unit test could produce following error:
repos/apache-mynewt-core/kernel/os/selftest/src/msys_test.c: In function ‘os_msys_test_setup’: repos/apache-mynewt-core/kernel/os/selftest/src/msys_test.c:61:30: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
   61 |     context->mempool_list = *(struct os_mempool_list *)&g_os_mempool_list;
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This is because declaration of extern g_os_mempool_list was taken directly from os_mempool.c where this variable is create without specifying type with macro STAILQ_HEAD(, os_mempool) that produces:

struct {
    struct os_mempool *stqh_first;
    struct os_mempool **stqh_last;
} g_os_mempool_list;

while file mempool_list is same structure but with named type. To make compiler happy g_os_mempool_list is now of type struct os_mempool_list that has same fields and is already declared like this:
STAILQ_HEAD(os_mempool_list, os_mempool);