### PR TITLE
fs/fatfs: Fix open for write

### DIFF
--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -281,7 +281,7 @@ fatfs_open(const char *path, uint8_t access_flags, struct fs_file **out_fs_file)
         mode |= FA_READ;
     }
     if (access_flags & FS_ACCESS_WRITE) {
-        mode |= FA_WRITE;
+        mode |= FA_WRITE | FA_OPEN_ALWAYS;
     }
     if (access_flags & FS_ACCESS_APPEND) {
         mode |= FA_OPEN_APPEND;


### PR DESCRIPTION
When fatfs_open() was called to open file
for writing it set FA_WRITE flag to fat driver.
It is enough if file already exists but if
it first call to open file to write it always
failed.

Now additional flag FA_OPEN_ALWAYS is added
to make sure file will be created if it's not
present yet.

For FS_ACCESS_READ only flag file still must
exists before.