### PR TITLE
Improve workflow check to diff against merge-base

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -46,8 +46,9 @@ jobs:
         run: |
           set +e
           INFO_URL="https://github.com/apache/mynewt-core/blob/master/CODING_STANDARDS.md"
-          git diff -U0 origin/master...HEAD > diff.patch
-          clang-format-diff -p1 -style=file < diff.patch > clang-fmt.patch
+          GIT_BASE=$(git merge-base origin/master HEAD)
+          git diff -U0 "$GIT_BASE"...HEAD > diff.patch
+          clang-format-diff.py -p1 -style=file < diff.patch > clang-fmt.patch
           if [ -s clang-fmt.patch ]; then
             echo "Code formatting issues found:"
             cat clang-fmt.patch


### PR DESCRIPTION
Updated the compliance workflow to diff against the merge-base of HEAD and origin/master, ensuring only changes introduced in the PR are checked.

Also replaced clang-format-diff with clang-format-diff.py for more reliable multi-file support.