### PR TITLE
Use pip to install clang-format

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -36,10 +36,9 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install clang-format
+      - name: Install clang-format via pip
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format
+          python -m pip install clang-format
 
       - name: Check formatting (diff only)
         shell: bash


### PR DESCRIPTION
Switched to installing clang-format via pip for more consistent behavior across environments.