### PR TITLE
Disable string breaking in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,6 +79,7 @@ SpacesInParentheses: false
 SpaceAfterCStyleCast: false
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SpaceInEmptyParentheses: false
+BreakStringLiterals: false
 
 AlignArrayOfStructures: Left
 SortIncludes: false


### PR DESCRIPTION
Previous configuration produced weirdly formatted
results while dealing with long strings.