### PR TITLE
tinyusb/msc_fat_view: Fix missing include file

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/entry_config.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_config.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
 #include <ctype.h>
 #include <stream/stream.h>
 #include <msc_fat_view/msc_fat_view.h>


### PR DESCRIPTION
entry_config.c uses **size_t** that requires one of the standard headers. **stddef.h** is included to provide
definition as specified by standard