### PR TITLE
Add GitHub Action to validate commit message style

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -109,3 +109,55 @@ jobs:
         shell: bash
         run: |
           .github/check_doxygen.py
+
+  commits-check:
+    name: Check commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Validate commit message style
+        shell: bash
+        run: |
+          set -e
+          has_errors=0
+          for commit in $(git rev-list origin/master..HEAD); do
+            short_sha=$(git rev-parse --short=7 $commit)
+            subject=$(git log -1 --pretty=format:%s $commit)
+            body=$(git log -1 --pretty=format:%b $commit)
+
+            if [ ${#subject} -gt 72 ]; then
+              echo "Commit $short_sha subject too long (${#subject} > 72):"
+              has_errors=1
+            fi
+
+            if [[ "$subject" != *:* ]]; then
+              echo "Commit $short_sha subject missing colon (e.g. 'subsystem: msg')"
+              has_errors=1
+            fi
+
+            if [ -z "$body" ]; then
+              echo "Commit $short_sha body is missing"
+              has_errors=1
+            else
+              line_num=0
+              while IFS= read -r line; do
+                line_num=$((line_num + 1))
+                if [ ${#line} -gt 72 ]; then
+                  echo "Commit $short_sha body line $line_num too long (${#line} > 72):"
+                  echo "$line"
+                  has_errors=1
+                fi
+              done <<< "$body"
+            fi
+
+            echo ""
+          done
+
+          if [ "$has_errors" -eq 1 ]; then
+            echo "Commit message check failed."
+            exit 1
+          else
+            echo "All commit messages pass style rules."
+          fi


### PR DESCRIPTION
This workflow checks all commits between the current branch and upstream/master. It enforces subject length, colon usage in the subject line, and body line length. This helps maintain consistency and readability in the project's history.