### PR TITLE
util/scfg: Update for c++

### DIFF
--- a/sys/config/include/config/config.h
+++ b/sys/config/include/config/config.h
@@ -171,7 +171,7 @@ struct conf_handler {
     /**
      * The name of the conifguration item/subtree
      */
-    char *ch_name;
+    const char *ch_name;
 
     /**
      * Whether to use the extended callbacks.

--- a/util/scfg/include/scfg/scfg.h
+++ b/util/scfg/include/scfg/scfg.h
@@ -20,7 +20,13 @@
 #ifndef H_SCFG_
 #define H_SCFG_
 
-#include "config/config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <config/config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct scfg_setting {
     /** The name of the setting. */
@@ -42,7 +48,7 @@ struct scfg_setting {
      * Whether this setting contains private data.  If true, the value is
      * hidden in config dump output.
      */
-    bool private;
+    bool priv;
 };
 
 struct scfg_group {
@@ -96,6 +102,10 @@ int scfg_save_val(const struct scfg_group *group, const void *val);
  *
  * @return                      0 on success; SYS_E[...] code on failure.
  */
-int scfg_register(struct scfg_group *group, char *name);
+int scfg_register(struct scfg_group *group, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/util/scfg/src/scfg.c
+++ b/util/scfg/src/scfg.c
@@ -154,7 +154,7 @@ scfg_handler_export(void (*func)(char *name, char *val),
 
     SCFG_FOREACH_SETTING(group, setting) {
         scfg_setting_id(group->handler.ch_name, setting->name, id_buf);
-        if (setting->private) {
+        if (setting->priv) {
             val = "<set>";
         } else {
             val = conf_str_from_value(setting->type, setting->val,
@@ -218,7 +218,7 @@ scfg_save_val(const struct scfg_group *group, const void *val)
 }
 
 int
-scfg_register(struct scfg_group *group, char *name)
+scfg_register(struct scfg_group *group, const char *name)
 {
     const struct scfg_setting *setting;
     int rc;


### PR DESCRIPTION
This:
- adds standard __cplusplus block
- changes filed name private to priv so file struct can be used in C++ where private is keyword
- adds const to scfg_register name parameter that would block usage in C++ where string literal const-ness is enforced