### PR TITLE
Enable FATFS features in syscfg

### DIFF
--- a/fs/fatfs/include/fatfs/ffconf.h
+++ b/fs/fatfs/include/fatfs/ffconf.h
@@ -99,9 +99,8 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-
-#define	_USE_LFN	0
-#define	_MAX_LFN	255
+#define _USE_LFN MYNEWT_VAL(FATFS_LONG_FILE_NAMES)
+#define _MAX_LFN 255
 /* The _USE_LFN switches the support of long file name (LFN).
 /
 /   0: Disable support of LFN. _MAX_LFN has no effect.
@@ -210,8 +209,7 @@
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the file system object (FATFS) is used for the file data transfer. */
 
-
-#define _FS_EXFAT	0
+#define _FS_EXFAT MYNEWT_VAL(FATFS_EXFAT_SUPPORT)
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */

--- a/fs/fatfs/include/fatfs/ffconf.h
+++ b/fs/fatfs/include/fatfs/ffconf.h
@@ -2,6 +2,8 @@
 /  FatFs - FAT file system module configuration file
 /---------------------------------------------------------------------------*/
 
+#include <syscfg/syscfg.h>
+
 #define _FFCONF 68020	/* Revision ID */
 
 /*---------------------------------------------------------------------------/
@@ -240,10 +242,9 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-
-#define _FS_REENTRANT	0
-#define _FS_TIMEOUT		1000
-#define	_SYNC_t			HANDLE
+#define _FS_REENTRANT MYNEWT_VAL_FATFS_REENTRANT
+#define _FS_TIMEOUT   MYNEWT_VAL_FATFS_TIMEOUT
+#define _SYNC_t       void *
 /* The option _FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()

--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -18,6 +18,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -715,6 +716,30 @@ ff_del_syncobj(_SYNC_t sobj)
     os_free(mutex);
 
     return FR_OK;
+}
+
+void *
+ff_memalloc(UINT msize)
+{
+    return os_malloc(msize);
+}
+
+void
+ff_memfree(void *mblock)
+{
+    os_free(mblock);
+}
+
+WCHAR
+ff_convert(WCHAR chr, UINT dir)
+{
+    return chr;
+}
+
+WCHAR
+ff_wtoupper(WCHAR chr)
+{
+    return toupper(chr);
 }
 
 void

--- a/fs/fatfs/src/mynewt_glue.c
+++ b/fs/fatfs/src/mynewt_glue.c
@@ -674,6 +674,49 @@ get_fattime(void)
     return 0;
 }
 
+int
+ff_cre_syncobj(BYTE vol, _SYNC_t *sobj)
+{
+    struct os_mutex *mutex = os_malloc(sizeof(*mutex));
+
+    if (mutex) {
+        os_mutex_init(mutex);
+        *sobj = mutex;
+    }
+
+    return mutex != NULL;
+}
+
+int
+ff_req_grant(_SYNC_t sobj)
+{
+    struct os_mutex *mutex = (struct os_mutex *)sobj;
+    int rc;
+
+    rc = os_mutex_pend(mutex, _FS_TIMEOUT);
+
+    return rc == OS_OK;
+}
+
+void
+ff_rel_grant(_SYNC_t sobj)
+{
+    struct os_mutex *mutex = (struct os_mutex *)sobj;
+
+    os_mutex_release(mutex);
+}
+
+int
+ff_del_syncobj(_SYNC_t sobj)
+{
+    struct os_mutex *mutex = (struct os_mutex *)sobj;
+
+    assert(mutex->mu_owner == NULL);
+    os_free(mutex);
+
+    return FR_OK;
+}
+
 void
 fatfs_pkg_init(void)
 {

--- a/fs/fatfs/syscfg.yml
+++ b/fs/fatfs/syscfg.yml
@@ -23,12 +23,26 @@ syscfg.defs:
             Sysinit stage for FATFS functionality.
         value: 200
 
+    FATFS_REENTRANT:
+        description: >
+            0 - Disable locking on file system
+            1 - Enable locking to multi thread access
+        value: 0
+
+    FATFS_TIMEOUT:
+        description: >
+            Timout for locking file system object.
+        value: 1000
+
     FATFS_LOG_MODULE:
         description: 'Numeric module ID to use for FATFS log messages.'
         value: 253
     FATFS_LOG_LVL:
         description: 'Minimum level for the FATFS log.'
         value: 2
+
+syscfg.vals.OS_SCHEDULING:
+    FATFS_REENTRANT: 1
 
 syscfg.logs:
     FATFS_LOG:

--- a/fs/fatfs/syscfg.yml
+++ b/fs/fatfs/syscfg.yml
@@ -23,6 +23,20 @@ syscfg.defs:
             Sysinit stage for FATFS functionality.
         value: 200
 
+    FATFS_LONG_FILE_NAMES:
+        description: >
+            0 - Disable support of LFN. _MAX_LFN has no effect.
+            1 - Enable LFN with static working buffer on the BSS. Always NOT thread-safe.
+            2 - Enable LFN with dynamic working buffer on the STACK.
+            3 - Enable LFN with dynamic working buffer on the HEAP.
+        value: 2
+
+    FATFS_EXFAT_SUPPORT:
+        description: >
+            0 - Disable ExFAT support
+            1 - Enable ExFAT support
+        value: 1
+
     FATFS_REENTRANT:
         description: >
             0 - Disable locking on file system

--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -856,7 +856,7 @@ mmc_pkg_init(void)
             /* For now only FAT partition are mounted */
             if (mmc_read(0, 0, sector, 512) == 0) {
                 /* Check if first partition is FAT */
-                if (sector[450] == 0x0C) {
+                if (sector[450] == 0x0C || sector[450] == 0x07) {
                     disk_register(MYNEWT_VAL(MMC_DEV_NAME), "fatfs", &mmc_ops);
                 }
             }


### PR DESCRIPTION
This:
- Add option to enable long line support in FAT driver
- Add option to enable ExFAT driver
- Add option to enable thread safe code
- enables ExFAT in mmc driver during disk detection