### PR TITLE
fs/littlefs: Fix open functions

### DIFF
--- a/fs/littlefs/src/mynewt_glue.c
+++ b/fs/littlefs/src/mynewt_glue.c
@@ -303,7 +303,8 @@ littlefs_open(const char *path, uint8_t access_flags, struct fs_file **out_fs_fi
      */
 
     flags = 0;
-    if (access_flags & (FS_ACCESS_READ | FS_ACCESS_WRITE)) {
+    if ((access_flags & (FS_ACCESS_READ | FS_ACCESS_WRITE)) ==
+        (FS_ACCESS_READ | FS_ACCESS_WRITE)) {
         flags |= LFS_O_RDWR;
     } else if (access_flags & FS_ACCESS_READ) {
         flags |= LFS_O_RDONLY;


### PR DESCRIPTION
RDRW was chosen if either read or write was requested.

Now LFS_O_RDRW is selected correctly