### PR TITLE
hw/drivers/da1469x_charger: Fix prototype mismatch

### DIFF
--- a/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
+++ b/hw/drivers/chg_ctrl/da1469x_charger/src/da1469x_charger.c
@@ -253,8 +253,7 @@ da1469x_charger_charge_disable(struct da1469x_charger_dev *dev)
 }
 
 int
-da1469x_charger_set_state_change_irq_mask(struct da1469x_charger_dev *dev,
-                                          da1469x_charger_state_irq_t mask)
+da1469x_charger_set_state_change_irq_mask(struct da1469x_charger_dev *dev, uint16_t mask)
 {
     (void)dev;
 


### PR DESCRIPTION
Function da1469x_charger_set_state_change_irq_mask had different signature in header and implementation.

New compiler detects this while older ones probably ignored this.

Implementation now matches header signature.