### PR TITLE
hw/mcu: Add watchdog support for apollo2 with configurable clock

### DIFF
--- a/hw/bsp/apollo2_evb/syscfg.yml
+++ b/hw/bsp/apollo2_evb/syscfg.yml
@@ -96,6 +96,10 @@ syscfg.defs:
     SPI_5_MASTER_PIN_MISO:
         description: 'MISO pin for SPI_5_MASTER'
         value:  49
+    AM_WATCHDOG_CLOCK:
+        description: "Watchdog clock frequency in Hz"
+        value: 1
+        range: 1, 16, 128
 
 syscfg.vals:
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS

--- a/hw/mcu/ambiq/apollo2/src/ext/AmbiqSuite/mcu/apollo2/hal/am_hal_wdt.h
+++ b/hw/mcu/ambiq/apollo2/src/ext/AmbiqSuite/mcu/apollo2/hal/am_hal_wdt.h
@@ -50,6 +50,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "am_reg_wdt.h"
+#include "am_reg_macros.h"
 
 //*****************************************************************************
 //

--- a/hw/mcu/ambiq/apollo2/src/ext/AmbiqSuite/mcu/apollo2/regs/am_reg_wdt.h
+++ b/hw/mcu/ambiq/apollo2/src/ext/AmbiqSuite/mcu/apollo2/regs/am_reg_wdt.h
@@ -44,6 +44,8 @@
 #ifndef AM_REG_WDT_H
 #define AM_REG_WDT_H
 
+#include "am_reg_base_addresses.h"
+
 //*****************************************************************************
 //
 // Instance finder. (1 instance(s) available)

--- a/hw/mcu/ambiq/apollo2/src/hal_watchdog.c
+++ b/hw/mcu/ambiq/apollo2/src/hal_watchdog.c
@@ -18,24 +18,58 @@
  */
 
 #include "hal/hal_watchdog.h"
+#include "hal/am_hal_wdt.h"
 
 #include <assert.h>
+
+#if MYNEWT_VAL(WATCHDOG_INTERVAL) > 0
+_Static_assert(255 * 1000 / MYNEWT_VAL(AM_WATCHDOG_CLOCK) >=
+                   MYNEWT_VAL(WATCHDOG_INTERVAL),
+               "Watchdog interval out of range, decrease value WATCHDOG_INTERVAL in syscfg.yml");
+#endif
+
+am_hal_wdt_config_t g_wdt_cfg;
 
 int
 hal_watchdog_init(uint32_t expire_msecs)
 {
-    /* XXX: Unimplemented. */
+    uint32_t reload;
+
+    reload = (expire_msecs * MYNEWT_VAL(AM_WATCHDOG_CLOCK)) / 1000;
+
+    if (reload > 255) {
+        return -1;
+    }
+
+    uint32_t wdt_clk;
+
+#if MYNEWT_VAL(AM_WATCHDOG_CLOCK) == 1
+    wdt_clk = AM_HAL_WDT_LFRC_CLK_1HZ;
+#elif MYNEWT_VAL(AM_WATCHDOG_CLOCK) == 16
+    wdt_clk = AM_HAL_WDT_LFRC_CLK_16HZ;
+#elif MYNEWT_VAL(AM_WATCHDOG_CLOCK) == 128
+    wdt_clk = AM_HAL_WDT_LFRC_CLK_128HZ;
+#else
+#error "Unsupported WDT clock frequency, set AM_WATCHDOG_CLOCK to 1, 16 or 128"
+#endif
+
+    g_wdt_cfg.ui32Config = wdt_clk | AM_HAL_WDT_ENABLE_RESET;
+    g_wdt_cfg.ui16ResetCount = reload;
+    g_wdt_cfg.ui16InterruptCount = 0;
+
+    am_hal_wdt_init(&g_wdt_cfg);
+
     return 0;
 }
 
 void
 hal_watchdog_enable(void)
 {
-    /* XXX: Unimplemented. */
+    am_hal_wdt_start();
 }
 
 void
 hal_watchdog_tickle(void)
 {
-    /* XXX: Unimplemented. */
+    am_hal_wdt_restart();
 }


### PR DESCRIPTION
This commit adds watchdog timer support for Apollo2-based boards. Apollo2 microcontrollers allow selecting different WDT clock frequencies. To enable this feature, a new configuration variable is introduced: `AM_WATCHDOG_CLOCK`.

You can set `AM_WATCHDOG_CLOCK` to one of the supported values:
- 1 (default)
- 16
- 128

The clock affects how long the watchdog timeout can be, since the hardware register for reset timeout is 8 bit.
This means:
- for 128Hz, max timeout ~ 2 seconds
- for 16Hz, max timeout ~ 16 seconds
- for 1Hz, max timeout 255 seconds

If you choose a higher clock, you must decrease the interval values accordingly. Two other config variables should be adjusted based on the selected clock:
- SANITY_INTERVAL
- WATCHDOG_INTERVAL

Example for syscfg.yml in an app or target:
```
syscfg.vals:
    AM_WATCHDOG_CLOCK: 16
    SANITY_INTERVAL: 1000
    WATCHDOG_INTERVAL: 5000
```