### PR TITLE
hw/mcu: add reset cause handling for apollo3 board

### DIFF
--- a/hw/mcu/ambiq/apollo3/src/hal_system.c
+++ b/hw/mcu/ambiq/apollo3/src/hal_system.c
@@ -46,8 +46,31 @@ hal_system_reset(void)
 enum hal_reset_reason
 hal_reset_cause(void)
 {
-    /* @TODO: Populate reset reason */
-    return HAL_RESET_OTHER;
+    static enum hal_reset_reason reason;
+    uint32_t reg;
+
+    if (reason) {
+        return reason;
+    }
+
+    /* Read STAT register */
+    reg = RSTGEN->STAT;
+
+    if (reg & RSTGEN_STAT_PORSTAT_Msk) {
+        reason = HAL_RESET_POR;
+    } else if (reg & RSTGEN_STAT_WDRSTAT_Msk) {
+        reason = HAL_RESET_WATCHDOG;
+    } else if (reg & RSTGEN_STAT_SWRSTAT_Msk) {
+        reason = HAL_RESET_SOFT;
+    } else if (reg & RSTGEN_STAT_EXRSTAT_Msk) {
+        reason = HAL_RESET_PIN;
+    } else if (reg & RSTGEN_STAT_BORSTAT_Msk) {
+        reason = HAL_RESET_BROWNOUT;
+    } else {
+        reason = HAL_RESET_OTHER;
+    }
+
+    return reason;
 }
 
 int


### PR DESCRIPTION
Added support for reading the reset cause using the `RSTGEN->STAT` register. Function checks what kind of reset occurred and returns matching `hal_reset_reason` enum value.

Unlike in apollo2, apollo3 does not provide a register to manually clear the reset status. Is is cleared automatically on startup.