### PR TITLE
hw/scripts: Add adapter selection via syscfg.yml

### DIFF
--- a/hw/scripts/jlink.sh
+++ b/hw/scripts/jlink.sh
@@ -37,6 +37,8 @@ jlink_target_cmd () {
 jlink_sn () {
     if [ -n "$JLINK_SN" ]; then
         EXTRA_JTAG_CMD="-select usb=$JLINK_SN " $EXTRA_JTAG_CMD
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        EXTRA_JTAG_CMD="-select usb=$MYNEWT_VAL_MYNEWT_DEBUGGER_SN " $EXTRA_JTAG_CMD
     fi
 }
 

--- a/hw/scripts/nrfjprog.sh
+++ b/hw/scripts/nrfjprog.sh
@@ -17,6 +17,16 @@
 #
 . $CORE_PATH/hw/scripts/common.sh
 
+jlink_sn () {
+    if [ -n "$JLINK_SN" ]; then
+        SRN_ARG="--snr $JLINK_SN"
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        SRN_ARG="--snr $MYNEWT_VAL_MYNEWT_DEBUGGER_SN"
+    else
+        SRN_ARG=""
+    fi
+}
+
 #
 # FILE_NAME must contain the name of the file to load
 # FLASH_OFFSET must contain the offset in flash where to place it
@@ -42,14 +52,16 @@ nrfjprog_load () {
     fi
     arm-none-eabi-objcopy -O ihex -I binary --adjust-vma ${FLASH_OFFSET} ${FILE_NAME} ${BIN_BASENAME}.hex
 
+    jlink_sn
+
     echo "Downloading" $FILE_NAME "to" $FLASH_OFFSET
 
-    nrfjprog ${NRFJPROG_ARG} --program ${BIN_BASENAME}.hex --sectorerase --verify ${JLINK_SN:+--snr $JLINK_SN}
+    nrfjprog ${NRFJPROG_ARG} --program ${BIN_BASENAME}.hex --sectorerase --verify $SRN_ARG
 
     if [ $? -ne 0 ]; then
         exit 1
     fi
-    nrfjprog --reset ${JLINK_SN:+--snr $JLINK_SN}
+    nrfjprog --reset $SRN_ARG
 
     return 0
 }

--- a/hw/scripts/nrfutil.sh
+++ b/hw/scripts/nrfutil.sh
@@ -17,6 +17,16 @@
 #
 . $CORE_PATH/hw/scripts/common.sh
 
+jlink_sn () {
+    if [ -n "$JLINK_SN" ]; then
+        SRN_ARG="--serial-number $JLINK_SN"
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        SRN_ARG="--serial-number $MYNEWT_VAL_MYNEWT_DEBUGGER_SN"
+    else
+        SRN_ARG=""
+    fi
+}
+
 #
 # FILE_NAME must contain the name of the file to load
 # FLASH_OFFSET must contain the offset in flash where to place it
@@ -75,14 +85,16 @@ nrfutil_load () {
     fi
 
     if [ -z ${ZIP_FILE} ] ; then
+        jlink_sn
+
         echo "Downloading" ${HEX_FILE}
 
-        nrfutil device program --firmware ${HEX_FILE} ${JLINK_SN:+--serial-number $JLINK_SN} ${NRFUTIL_ARG} ${NRFUTIL_TRAITS} --options chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE
+        nrfutil device program --firmware ${HEX_FILE} $SRN_ARG ${NRFUTIL_ARG} ${NRFUTIL_TRAITS} --options chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE
 
         if [ $? -ne 0 ]; then
             ret=1
         else
-            nrfutil device reset ${JLINK_SN:+--serial-number $JLINK_SN}
+            nrfutil device reset $SRN_ARG
         fi
     fi
 

--- a/hw/scripts/openocd.sh
+++ b/hw/scripts/openocd.sh
@@ -30,6 +30,8 @@ openocd_sn() {
         echo "adapter serial $STLINK_SN" > $OCD_SERIAL_FILE
     elif [ -n "$JLINK_SN" ]; then
         echo "adapter serial $JLINK_SN" > $OCD_SERIAL_FILE
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        echo "adapter serial $MYNEWT_VAL_MYNEWT_DEBUGGER_SN" > $OCD_SERIAL_FILE
     else
         return
     fi

--- a/hw/scripts/pyocd.sh
+++ b/hw/scripts/pyocd.sh
@@ -33,6 +33,8 @@ pyocd_sn() {
         UID_ARG="-u $STLINK_SN"
     elif [ -n "$CMSIS_DAP_SN" ]; then
         UID_ARG="-u $CMSIS_DAP_SN"
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        UID_ARG="-u $MYNEWT_VAL_MYNEWT_DEBUGGER_SN"
     else
         UID_ARG=""
     fi

--- a/hw/scripts/stlink.sh
+++ b/hw/scripts/stlink.sh
@@ -28,6 +28,12 @@ stlink_sn () {
         else
             EXTRA_JTAG_CMD="--serial $STLINK_SN " $EXTRA_JTAG_CMD
         fi
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        if [ "$STLINK_USE_STM32_PROGRAMMER_CLI" == 1 ] ; then
+            EXTRA_JTAG_CMD="sn=$MYNEWT_VAL_MYNEWT_DEBUGGER_SN " $EXTRA_JTAG_CMD
+        else
+            EXTRA_JTAG_CMD="--serial $MYNEWT_VAL_MYNEWT_DEBUGGER_SN " $EXTRA_JTAG_CMD
+        fi
     fi
 }
 

--- a/hw/scripts/stm32_programmer.sh
+++ b/hw/scripts/stm32_programmer.sh
@@ -24,6 +24,8 @@
 stlink_sn () {
     if [ -n "$STLINK_SN" ]; then
         EXTRA_JTAG_CMD="sn=$STLINK_SN " $EXTRA_JTAG_CMD
+    elif [ -n "$MYNEWT_VAL_MYNEWT_DEBUGGER_SN" ]; then
+        EXTRA_JTAG_CMD="sn=$MYNEWT_VAL_MYNEWT_DEBUGGER_SN " $EXTRA_JTAG_CMD
     fi
 }
 

--- a/hw/scripts/syscfg.yml
+++ b/hw/scripts/syscfg.yml
@@ -90,3 +90,7 @@ syscfg.defs:
             It can be 'nordicDfu' to upload binary using Nordic SDK DFU
             bootloader protocol.
         value:
+    MYNEWT_DEBUGGER_SN:
+        description: >
+            Debugger serial number to use for flash
+        value:


### PR DESCRIPTION
Added option for selecting USB serial of a debug probe via syscfg.vals in targets syscfg.yml file.

This was achieved by addition of following definitions to hw/scripts/syscfg.yml file:
- STLINK_SN
- JLINK_SN
- CMSIS_DAP_SN and their usage in scripts.

This removes the need of manual choosing target device everytime load is called, by having serial number value in targets syscfg.yml file.
This value will be used, when environment variable is missing.