### PR TITLE
boot/startup: Fix alignment for relocate vectors

### DIFF
--- a/boot/startup/mynewt_cortex_m3.ld
+++ b/boot/startup/mynewt_cortex_m3.ld
@@ -84,7 +84,7 @@ SECTIONS
     /* Keep first in RAM, no need to clear it */
     .vector_relocation :
     {
-        . = ALIGN(4);
+        . = ALIGN(128);
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);

--- a/boot/startup/mynewt_cortex_m33.ld
+++ b/boot/startup/mynewt_cortex_m33.ld
@@ -84,7 +84,7 @@ SECTIONS
     /* Keep first in RAM, no need to clear it */
     .vector_relocation :
     {
-        . = ALIGN(4);
+        . = ALIGN(128);
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);

--- a/boot/startup/mynewt_cortex_m4.ld
+++ b/boot/startup/mynewt_cortex_m4.ld
@@ -84,7 +84,7 @@ SECTIONS
     /* Keep first in RAM, no need to clear it */
     .vector_relocation :
     {
-        . = ALIGN(4);
+        . = ALIGN(128);
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);

--- a/boot/startup/mynewt_cortex_m7.ld
+++ b/boot/startup/mynewt_cortex_m7.ld
@@ -84,7 +84,7 @@ SECTIONS
     /* Keep first in RAM, no need to clear it */
     .vector_relocation :
     {
-        . = ALIGN(4);
+        . = ALIGN(128);
         __vector_tbl_reloc__ = .;
         . = . + (__isr_vector_end - __isr_vector_start);
         . = ALIGN(4);


### PR DESCRIPTION
Relocated vectors had 4 byte alignment while VTOR
is 128 byte aligned.

Code only worked because relocation vector was
at the beginning of RAM.
If something was put there interrupt vectors would not match and strange things would happen.