### PR TITLE
spiflash: Add dependency to stats when needed

### DIFF
--- a/hw/drivers/flash/spiflash/pkg.yml
+++ b/hw/drivers/flash/spiflash/pkg.yml
@@ -26,3 +26,6 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/hw/drivers/flash/spiflash/chips"
+
+pkg.deps.SPIFLASH_STAT:
+    - "@apache-mynewt-core/sys/stats"


### PR DESCRIPTION
When SPIFLASH_STAT was set to 1 code tries to
include stats/stats.h but direct dependency was
not there.
It worked if other packages included stats.

Now code compiles when SPIFLASH_STAT is 1 and
nothing else wanted stats.