### PR TITLE
sys/log/shell: Fix string log shell printf for log entries with a trailer

### DIFF
--- a/sys/log/full/include/log/log.h
+++ b/sys/log/full/include/log/log.h
@@ -611,6 +611,16 @@ log_read_entry_len(struct log *log, const void *dptr);
 uint16_t
 log_read_trailer(struct log *log, const void *dptr, uint8_t *buf);
 
+/**
+ * @brief                Read log trailer length of a specific entry
+ *
+ * @param log            The log to read trailer data from
+ * @param dptr           Data pointer to the log entry
+ *
+ * @return length of the trailer for a specific log entry;
+ */
+uint16_t log_read_trailer_len(struct log *log, const void *dptr);
+
 /**Add commentMore actions
  * @brief Returns trailer data in an mbuf specified by the caller
  *

--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -89,6 +89,9 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
     bool read_data = ueh->ue_etype != LOG_ETYPE_CBOR;
     bool read_hash = ueh->ue_flags & LOG_FLAGS_IMG_HASH;
     bool add_lf = true;
+    uint16_t trailer_len = 0;
+
+    (void)trailer_len;
 
     if (arg) {
         arg->count++;
@@ -98,6 +101,14 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
         }
     }
 
+#if MYNEWT_VAL(LOG_FLAGS_TRAILER)
+    trailer_len = log_read_trailer_len(log, dptr);
+    if (trailer_len) {
+        /* If trailer is present, so is the length of the trailer */
+        trailer_len += LOG_TRAILER_LEN_SIZE;
+    }
+    len -= trailer_len;
+#endif
     dlen = min(len, 128);
 
     if (read_data) {


### PR DESCRIPTION
- For string logs, the trailer would get printed on the shell. This PR fixes it such that we subtract the trailer length and size of trailer length from the log entry being printed