### PR TITLE
hw/mcu: add missing includes for __BKPT() and integer types

### DIFF
--- a/hw/mcu/atmel/samd21xx/include/mcu/mcu.h
+++ b/hw/mcu/atmel/samd21xx/include/mcu/mcu.h
@@ -19,6 +19,8 @@
 
 #ifndef __MCU_MCU_H_
 #define __MCU_MCU_H_
+#include <stdint.h>
+#include <cmsis_gcc.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This fixes build issues with `__BKPT()` and standard types.