### PR TITLE
hw/mcu/samd21xx: use commit with fix for macro redefinition

### DIFF
--- a/hw/mcu/atmel/samd21xx/ext/pkg.yml
+++ b/hw/mcu/atmel/samd21xx/ext/pkg.yml
@@ -23,7 +23,7 @@ pkg.type: sdk
 
 repository.atmel-samd21xx:
     type: github
-    vers: 1.13.0
+    vers: c24381e11d1b494684b84f80536afe95aeec376a-commit
     branch: master
     user: runtimeco
     repo: mynewt_arduino_zero


### PR DESCRIPTION
This update `repository.atmel-samd21xx` to commit c24381e1... which includes fixes for macro redefinitions.
Avoids conflicts present in release 1.13.0.

Related PR: https://github.com/runtimeco/mynewt_arduino_zero/pull/25
