### PR TITLE
hw/bsp/arduino-zero: route default UART to debugger, add UART1

### DIFF
--- a/hw/bsp/arduino_zero/pkg.yml
+++ b/hw/bsp/arduino_zero/pkg.yml
@@ -29,5 +29,9 @@ pkg.deps.UART_0:
     - "@apache-mynewt-core/hw/drivers/uart"
     - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
 
+pkg.deps.UART_1:
+    - "@apache-mynewt-core/hw/drivers/uart"
+    - "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+
 pkg.cflags:
     - -D__SAMD21G18A__

--- a/hw/bsp/arduino_zero/syscfg.yml
+++ b/hw/bsp/arduino_zero/syscfg.yml
@@ -25,6 +25,9 @@ syscfg.defs:
     UART_0:
         description: 'Whether to enable UART0'
         value: 1
+    UART_1:
+        description: 'Whether to enable UART1'
+        value: 0
 
     TIMER_0:
         description: 'Arduino zero Timer 0.'


### PR DESCRIPTION
The default UART used for logging (console_printf) is now routed through the debugger interface instead of external TX/RX pins, making serial output easier to access via USB cable.
Additionally, UART1 has been configured and exposed on external pins for user applications.