### PR TITLE
baselibc: Fix memset compilation error on gcc15

### DIFF
--- a/libc/baselibc/src/memset.c
+++ b/libc/baselibc/src/memset.c
@@ -62,8 +62,8 @@ void *memset(void *dst, int c, size_t n)
                   "1: strb %[val], [%[buf], %[len]]         \n"
                   "3: subs %[len], #1                       \n"
                   "   bpl  1b                               \n"
-                  : [buf] "+r" (q), [val] "+r" (c), [len] "+r" (n)
-                  :
+                  : [buf] "+l" (q), [len] "+l" (n)
+                  : [val] "l" (c)
                   : "r3", "r4", "memory"
                  );
 #elif defined(__riscv)


### PR DESCRIPTION
This fixes the memset compilation error seen on gcc 15.

/tmp/cccS6DLj.s:50: Error: cannot honor width suffix -- `adds r3,ip,r2'
/tmp/cccS6DLj.s:57: Error: cannot honor width suffix -- `strb r1,[ip,r2]'
/tmp/cccS6DLj.s:61: Error: cannot honor width suffix -- `str r1,[ip,r2]'
/tmp/cccS6DLj.s:66: Error: cannot honor width suffix -- `strb r1,[ip,r2]'

caused by complier placing parameters (dst in this case) into high registers. Since the memset implementation uses instructions that update the CPSR, the use of high registers will cause errors as above.

This fixes this issue by forcing compiler to use low registers. 'c' aka 'val' operand constraint as not changed by function is changed to "r" meaning it is read-only operand.