### PR TITLE
hw/usb: tinyusb update from tag 0.15.0 to 0.18.0

### DIFF
--- a/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
+++ b/hw/usb/tinyusb/tinyusb_sdk/pkg.yml
@@ -41,6 +41,6 @@ pkg.source_dirs:
 repository.tinyusb:
     type: github
     branch: master
-    vers: 0.15.0-commit
+    vers: 0.18.0-commit
     user: hathach
     repo: tinyusb


### PR DESCRIPTION
The nucleo-h723zg board could not build with TinyUSB 0.15.0. With 0.18.0 the build works again, and the TinyUSB is up to date with the latest changes from upstream.