### PR TITLE
tinyusb/da146xx/usb_monitor: Add usb monitor for da146xx

### DIFF
--- a/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/include/da146xx_usb_monitor/da146xx_usb_monitor.h
+++ b/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/include/da146xx_usb_monitor/da146xx_usb_monitor.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_DA146XX_USB_MONITOR_
+#define H_DA146XX_USB_MONITOR_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <os/os.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * USB monitor state detection callback type
+ *
+ * @param connected true when USB is connected, false when disconnected
+ */
+typedef void (*da146xx_usb_monitor_cb_t)(bool connected);
+
+/**
+ * Initialize USB monitor state
+ *
+ * @return 0 on success, error code on failure
+ */
+int da146xx_usb_monitor_init(void);
+
+/**
+ * Register callback for USB connection status changes
+ *
+ * @param cb Callback function
+ */
+void da146xx_usb_monitor_register_cb(da146xx_usb_monitor_cb_t cb);
+
+/**
+ * Check if USB is connected (received setup packet)
+ *
+ * @return true if USB is connected, false otherwise
+ */
+bool da146xx_usb_monitor_is_connected(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_DA146XX_USB_MONITOR_ */

--- a/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/pkg.yml
+++ b/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/pkg.yml
@@ -17,20 +17,18 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb/da146xx
-pkg.description: Hardware initialization for Tinyusb
+pkg.name: hw/usb/tinyusb/da146xx/da146xx_usb_monitor
+pkg.description: USB state monitor for TinyUSB, DA146xx implementation
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - usb
+    - monitor
     - tinyusb
-
-pkg.apis:
-    - TINYUSB_HW_INIT
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/hw/usb/tinyusb"
+    - "@apache-mynewt-core/hw/hal"
 
-pkg.deps.DA146XX_USB_MONITOR:
-    - "@apache-mynewt-core/hw/usb/tinyusb/da146xx/da146xx_usb_monitor"
+pkg.apis:
+    - da146xx_usb_monitor

--- a/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/src/usb_monitor.c
+++ b/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/src/usb_monitor.c
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <string.h>
+#include "syscfg/syscfg.h"
+#include <tusb.h>
+
+#if MYNEWT_VAL(DA146XX_USB_MONITOR)
+#include "da146xx_usb_monitor/da146xx_usb_monitor.h"
+
+/* Keep-alive detection state structure */
+struct da146xx_usb_monitor_state {
+    struct os_callout monitor_callout;
+    bool last_connected_state;
+    da146xx_usb_monitor_cb_t callback;
+};
+
+/* USB monitor state */
+static struct da146xx_usb_monitor_state g_ums;
+
+/*
+ * Monitor callout callback for periodic connection checking
+ */
+static void
+da146xx_usb_monitor_cb(struct os_event *ev)
+{
+    bool is_connected;
+    bool state_changed = false;
+
+    /* Check if CDC is connected and mounted */
+    is_connected = tud_connected();
+    /* Check for state change */
+    if (is_connected != g_ums.last_connected_state) {
+        g_ums.last_connected_state = is_connected;
+        state_changed = true;
+    }
+
+    /* Notify callback if state changed */
+    if (state_changed && g_ums.callback) {
+        g_ums.callback(is_connected);
+    }
+
+    /* Reset callout */
+    os_callout_reset(&g_ums.monitor_callout,
+                     os_time_ms_to_ticks32(MYNEWT_VAL(DA146XX_USB_MONITOR_RATE_MS)));
+}
+
+static void
+da146xx_usb_monitor_evq_set(struct os_eventq *evq)
+{
+    os_callout_init(&g_ums.monitor_callout, evq, da146xx_usb_monitor_cb, NULL);
+}
+
+int
+da146xx_usb_monitor_init(void)
+{
+    /* Initialize state */
+    memset(&g_ums, 0, sizeof(g_ums));
+
+#if MYNEWT_VAL_DA146XX_USB_MONITOR_EVQ
+    /* Set event queue if specified */
+    da146xx_usb_monitor_evq_set(MYNEWT_VAL(DA146XX_USB_MONITOR_EVQ));
+#else
+    /* Use default event queue */
+    da146xx_usb_monitor_evq_set(os_eventq_dflt_get());
+#endif
+
+    /* Start monitoring */
+    os_callout_reset(&g_ums.monitor_callout,
+                     os_time_ms_to_ticks32(MYNEWT_VAL(DA146XX_USB_MONITOR_RATE_MS)));
+
+    return 0;
+}
+
+void
+da146xx_usb_monitor_register_cb(da146xx_usb_monitor_cb_t cb)
+{
+    g_ums.callback = cb;
+}
+
+bool
+da146xx_usb_monitor_is_connected(void)
+{
+    return g_ums.last_connected_state;
+}
+#endif /* MYNEWT_VAL(DA146XX_USB_MONITOR) */

--- a/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/syscfg.yml
+++ b/hw/usb/tinyusb/da146xx/da146xx_usb_monitor/syscfg.yml
@@ -17,20 +17,11 @@
 # under the License.
 #
 
-pkg.name: hw/usb/tinyusb/da146xx
-pkg.description: Hardware initialization for Tinyusb
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-    - usb
-    - tinyusb
+syscfg.defs:
+    DA146XX_USB_MONITOR_RATE_MS:
+        description: 'USB monitor check rate in milliseconds'
+        value: 500
 
-pkg.apis:
-    - TINYUSB_HW_INIT
-
-pkg.deps:
-    - "@apache-mynewt-core/kernel/os"
-    - "@apache-mynewt-core/hw/usb/tinyusb"
-
-pkg.deps.DA146XX_USB_MONITOR:
-    - "@apache-mynewt-core/hw/usb/tinyusb/da146xx/da146xx_usb_monitor"
+    DA146XX_USB_MONITOR_EVQ:
+        description: 'Event queue for USB state monitoring (NULL for default)'
+        value: ""

--- a/hw/usb/tinyusb/da146xx/include/tusb_hw.h
+++ b/hw/usb/tinyusb/da146xx/include/tusb_hw.h
@@ -22,8 +22,27 @@
 
 #define CFG_TUSB_MCU OPT_MCU_DA1469X
 
+#include <os/mynewt.h>
 #include <syscfg/syscfg.h>
 #include <stdbool.h>
+
+#if MYNEWT_VAL(DA146XX_USB_MONITOR)
+/**
+ * Set event queue for USB monitoring
+ */
+void tinyusb_da146xx_usb_monitor_evq_set(struct os_eventq *evq);
+
+/**
+ *
+ * Register callback for USB state monitor changes
+ */
+void tinyusb_da146xx_usb_monitor_register_cb(void (*cb)(bool connected));
+#endif
+
+/**
+ * Check if USB is connected (based on keep-alive and VBUS if used)
+ */
+bool tinyusb_da146xx_is_connected(void);
 
 /* Function should be exported from TinyUSB */
 void tusb_vbus_changed(bool present);

--- a/hw/usb/tinyusb/da146xx/syscfg.yml
+++ b/hw/usb/tinyusb/da146xx/syscfg.yml
@@ -39,6 +39,11 @@ syscfg.defs:
             - ignore
             - custom
 
+    DA146XX_USB_MONITOR:
+        description: >
+          'Enable USB monitoring to track USB connect/disconnect events on DA1469x'
+        value: 0
+
 syscfg.restrictions:
     - USBD_EP0_SIZE == 8
     - MCU_PLL_ENABLE


### PR DESCRIPTION
- Add USB monitor to check if USB is connected to DA146xx
- A callback can be registered to detect USB connection state
- tud_connected() is based on the USB SETUP packet which monitors the connectivity with the host instead of just monitoring VBUS.