### PR TITLE
mcu/stmxxx: Enable LSI by default

### DIFF
--- a/hw/mcu/stm/stm32g0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32g0xx/syscfg.yml
@@ -37,7 +37,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)

--- a/hw/mcu/stm/stm32g4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32g4xx/syscfg.yml
@@ -37,7 +37,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)

--- a/hw/mcu/stm/stm32l0xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l0xx/syscfg.yml
@@ -33,7 +33,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)

--- a/hw/mcu/stm/stm32l1xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l1xx/syscfg.yml
@@ -33,7 +33,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)

--- a/hw/mcu/stm/stm32l4xx/syscfg.yml
+++ b/hw/mcu/stm/stm32l4xx/syscfg.yml
@@ -33,7 +33,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)

--- a/hw/mcu/stm/stm32u5xx/syscfg.yml
+++ b/hw/mcu/stm/stm32u5xx/syscfg.yml
@@ -33,7 +33,7 @@ syscfg.defs:
 
     STM32_CLOCK_LSI:
         description: Enable low-speed internal clock source
-        value: 0
+        value: 1
 
     STM32_CLOCK_LSE:
         description: Enable low-speed external clock source (aka RTC xtal)


### PR DESCRIPTION
LSI was not enable by default is several MCUs.
LSI is required for Watchdog which is enable by default in mynewt.

Now LSI is enabled. It can be disabled if user
really knows why this could be needed.