### PR TITLE
Force linear history

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,3 +21,9 @@ notifications:
   commits: commits@mynewt.apache.org
   issues: notifications@mynewt.apache.org
   pullrequests: notifications@mynewt.apache.org
+
+github:
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true


### PR DESCRIPTION
This disables merge commits and allows only rebase or squash commits. This is to keep repo history linear.