### PR TITLE
DA1469x: Fix crash when LPCLK is set to XTAL32K

### DIFF
--- a/hw/mcu/dialog/da1469x/src/da1469x_clock.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_clock.c
@@ -89,7 +89,8 @@ enum da1469x_rtc_div_denom_sel {
 static uint32_t g_mcu_clock_rcx_freq;
 static uint32_t g_mcu_clock_rc32k_freq;
 static uint32_t g_mcu_clock_rc32m_freq = RC32M_FREQ;
-static uint32_t g_mcu_clock_xtal32k_freq;
+/* 32 kHz xtal freq, with nominal value until calibration */
+static uint32_t g_mcu_clock_xtal32k_freq = XTAL32K_FREQ;
 
 uint32_t SystemCoreClock = RC32M_FREQ;
 

--- a/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
+++ b/hw/mcu/dialog/da1469x/src/da1469x_lpclk.c
@@ -39,6 +39,7 @@ static void
 da1469x_lpclk_settle_tmr_cb(void *arg)
 {
     da1469x_clock_lp_xtal32k_switch();
+    da1469x_clock_lp_xtal32k_calibrate();
     da1469x_lpclk_enabled();
 }
 #endif
@@ -87,12 +88,14 @@ da1469x_lpclk_rc_init(void)
 {
 #if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RCX)
     da1469x_clock_lp_rc32k_disable();
+    da1469x_clock_lp_xtal32k_disable();
     da1469x_clock_lp_rcx_enable();
     da1469x_clock_lp_rcx_switch();
     da1469x_clock_lp_calibrate();
     da1469x_lpclk_enabled();
 #elif MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, RC32K)
     da1469x_clock_lp_rcx_disable();
+    da1469x_clock_lp_xtal32k_disable();
     da1469x_clock_lp_rc32k_enable();
     da1469x_clock_lp_rc32k_switch();
     da1469x_clock_lp_calibrate();
@@ -102,8 +105,12 @@ da1469x_lpclk_rc_init(void)
      * We cannot switch lp_clk to XTAL32K here since it needs some time to
      * settle, so we just disable RCX (we don't need it) and then we'll handle
      * switch to XTAL32K from sysinit since we need os_cputime for this.
+     *
+     * Note: RC32K is still needed for the Watchdog timer.
      */
     da1469x_clock_lp_rcx_disable();
+    da1469x_clock_lp_rc32k_enable();
+    da1469x_clock_lp_xtal32k_enable();
 #endif
 }
 
@@ -112,7 +119,6 @@ da1469x_lpclk_init(void)
 {
 #if MYNEWT_VAL_CHOICE(MCU_LPCLK_SOURCE, XTAL32K)
     static struct hal_timer lpclk_settle_tmr;
-    da1469x_clock_lp_xtal32k_enable();
     os_cputime_timer_init(&lpclk_settle_tmr, da1469x_lpclk_settle_tmr_cb, NULL);
     os_cputime_timer_relative(&lpclk_settle_tmr,
                               MYNEWT_VAL(MCU_CLOCK_XTAL32K_SETTLE_TIME_MS) * 1000);


### PR DESCRIPTION
Fix the root-cause of `g_mcu_clock_xtal32k_freq` not getting updated with a proper frequency value.