### PR TITLE
hw/bus: Update sanity check for locking

### DIFF
--- a/hw/bus/src/bus.c
+++ b/hw/bus/src/bus.c
@@ -531,11 +531,13 @@ bus_node_lock(struct os_dev *node, os_time_t timeout)
 #endif
 
     /*
-     * Configuration is done on 1st lock so in case we need to configure device
-     * on nested lock it means that most likely bus device was locked for one
-     * node and then access is done on another node which is not correct.
+     * Configuration is done on 1st lock. For nested lock make sure that
+     * bnode did not change.
      */
     if (MYNEWT_VAL(OS_SCHEDULING) && os_mutex_get_level(&bdev->lock) != 1) {
+        if (bdev->configured_for == bnode) {
+            return 0;
+        }
         (void)bus_node_unlock(node);
         return SYS_EACCES;
     }


### PR DESCRIPTION
Code assume that node can be locked only once and
second lock is probably for another node.
Lock are internally use on each transaction.
Write, read, write then read transactions can be
used with just one lock.
spiflash driver locks node when it wants to write, however writing consist of two transactions fist
command is sent (4 bytes) then another write is
done with separate buffer. CS must be low during
those two writes. While write could be performed
successfully current implementation would require
SPI controller to be unlocked between writes.
This could potentially lead to SPI controller
being locked for another device while CS is still
down for spi flash.
In fact due to sanity check spi flash driver
did not work at all with any bus driver since
code tried to lock device before writes and
then both writes would fail due to nested lock
sanity check.

Now sanit check verifies that nested lock is
for same device.