### PR TITLE
ci: Auto label PR's with needs-ci-approval

### DIFF
--- a/.github/workflows/add_ci_label.yml
+++ b/.github/workflows/add_ci_label.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Informative CI status
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-label:
+    if: ${{ !contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+           && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'needs-ci-approval';
+            try {
+              try {
+                await github.request('POST /repos/{owner}/{repo}/labels', {
+                  ...context.repo,
+                  name: label,
+                  color: 'E3650b'
+                });
+              } catch (e) {
+                if (e.status !== 422) throw e; // already exists
+              }
+
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.issue.number,
+                labels: [label],
+              });
+              core.info(`Added '${label}' to PR #${context.issue.number}`);
+            } catch (e) {
+              core.setFailed(`Failed to label PR: ${e.status || ''} ${e.message}`);
+            }


### PR DESCRIPTION
Add a pull_request_target workflow that labels PRs. 
Skips OWNER/MEMBER/COLLABORATOR and dependabot.
Ensures the label exists, adds it via the Issues API.