### PR TITLE
drivers/adp5061: Remove reference to NRF52

### DIFF
--- a/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
+++ b/hw/drivers/chg_ctrl/adp5061/src/adp5061.c
@@ -23,7 +23,6 @@
 
 #include <os/mynewt.h>
 #include <console/console.h>
-#include <mcu/nrf52_hal.h>
 #include <hal/hal_gpio.h>
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
 #include "bus/drivers/i2c_common.h"


### PR DESCRIPTION
Code was including unrelated header from some MCU.