### PR TITLE
ci: Change CI workflow conditions

### DIFF
--- a/.github/workflows/add_ci_label.yml
+++ b/.github/workflows/add_ci_label.yml
@@ -30,25 +30,27 @@ permissions:
 
 jobs:
   add-label:
-    if: ${{ github.event.pull_request.author_association != 'CONTRIBUTOR' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
-           const pr = context.payload.pull_request;
+            const pr = context.payload.pull_request;
 
-            // Fetch author's repository permission level: admin|maintain|write|triage|read|none
+            // Get author's effective repo permission: admin|maintain|write|triage|read|none
             let permission = 'unknown';
             try {
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                 ...context.repo,
                 username: pr.user.login,
               });
-              permission = data.permission;
+              permission = data.permission || 'unknown';
             } catch (e) {
+              permission = 'none';
               core.warning(`Could not fetch collaborator permission: ${e.status || ''} ${e.message}`);
             }
+
+            const trusted = ['admin','maintain','write'].includes(permission);
 
             const info = {
               number: pr.number,
@@ -56,29 +58,37 @@ jobs:
               author: pr.user.login,
               author_association: pr.author_association,
               author_permission: permission,
+              trusted_by_permission: trusted,
               base_repo: pr.base.repo.full_name,
               head_repo: pr.head.repo.full_name,
               is_fork: !!pr.head.repo.fork,
             };
             core.info('PR author info:\n' + JSON.stringify(info, null, 2));
-            const label = 'needs-ci-approval';
-            try {
-              try {
-                await github.request('POST /repos/{owner}/{repo}/labels', {
-                  ...context.repo,
-                  name: label,
-                  color: 'E3650b'
-                });
-              } catch (e) {
-                if (e.status !== 422) throw e; // already exists
-              }
 
-              await github.rest.issues.addLabels({
-                ...context.repo,
-                issue_number: context.issue.number,
-                labels: [label],
-              });
-              core.info(`Added '${label}' to PR #${context.issue.number}`);
-            } catch (e) {
-              core.setFailed(`Failed to label PR: ${e.status || ''} ${e.message}`);
+            // Only add the label if the author does NOT have write-level permission
+            if (!trusted) {
+              const label = 'needs-ci-approval';
+              try {
+                // Ensure the label exists (422 = already exists)
+                try {
+                  await github.request('POST /repos/{owner}/{repo}/labels', {
+                    ...context.repo,
+                    name: label,
+                    color: 'E3650b',
+                  });
+                } catch (e) {
+                  if (e.status !== 422) throw e;
+                }
+
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  labels: [label],
+                });
+                core.info(`Added '${label}' to PR #${context.issue.number}`);
+              } catch (e) {
+                core.setFailed(`Failed to label PR: ${e.status || ''} ${e.message}`);
+              }
+            } else {
+              core.info('Author has write-level permission; not adding label.');
             }


### PR DESCRIPTION
Change condition from checking the role
to checking the permissions of the user.
Printout information before check, that
way we don't skip the workflow on wrong
conditions.