### PR TITLE
hw/mcu/atmel: add CPU_CLOCK_FREQ_MHZ definition for SAMD21

### DIFF
--- a/hw/mcu/atmel/samd21xx/ext/pkg.yml
+++ b/hw/mcu/atmel/samd21xx/ext/pkg.yml
@@ -23,7 +23,7 @@ pkg.type: sdk
 
 repository.atmel-samd21xx:
     type: github
-    vers: c24381e11d1b494684b84f80536afe95aeec376a-commit
+    vers: 08b4c2fdadfaac4b40811b9561a1cfd6b99c1c34-commit
     branch: master
     user: runtimeco
     repo: mynewt_arduino_zero

--- a/hw/mcu/atmel/samd21xx/syscfg.yml
+++ b/hw/mcu/atmel/samd21xx/syscfg.yml
@@ -23,6 +23,11 @@ syscfg.defs:
             Used internally by the newt tool.
         value: 1
 
+    CPU_CLOCK_FREQ_MHZ:
+        description: "CPU clock frequency in MHz"
+        value: 48
+        range: 1, 3, 6, 8, 12, 24, 48
+
     SPI_0:
         description: 'Whether to enable SPI0'
         value:  0


### PR DESCRIPTION
Adds a new syscfg definition that allows users to
select the CPU clock frequency (in MHz) for SAMD21-based targets.