### PR TITLE
sys/log: add format attribute to modlog_printf prototype

### DIFF
--- a/net/oic/src/port/mynewt/ip_adaptor.c
+++ b/net/oic/src/port/mynewt/ip_adaptor.c
@@ -165,8 +165,9 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
             to.msin6_scope_id = itf2.mif_idx;
             rc = mn_sendto(oc_ucast6, n, (struct mn_sockaddr *) &to);
             if (rc != 0) {
-                OC_LOG_ERROR("Failed to send buffer %u on itf %d\n",
-                             OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
+                OC_LOG_ERROR("Failed to send buffer %u on itf %u\n",
+                             OS_MBUF_PKTHDR(m)->omp_len,
+                             (unsigned int)to.msin6_scope_id);
                 STATS_INC(oc_ip_stats, oerr);
                 os_mbuf_free_chain(n);
             }
@@ -176,8 +177,9 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
             to.msin6_scope_id = itf2.mif_idx;
             rc = mn_sendto(oc_ucast6, m, (struct mn_sockaddr *) &to);
             if (rc != 0) {
-                OC_LOG_ERROR("Failed sending buffer %u on itf %d\n",
-                             OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
+                OC_LOG_ERROR("Failed sending buffer %u on itf %u\n",
+                             OS_MBUF_PKTHDR(m)->omp_len,
+                             (unsigned int)to.msin6_scope_id);
                 STATS_INC(oc_ip_stats, oerr);
                 os_mbuf_free_chain(m);
             }
@@ -187,8 +189,8 @@ oc_send_buffer_ip6_int(struct os_mbuf *m, int is_mcast)
     } else {
         rc = mn_sendto(oc_ucast6, m, (struct mn_sockaddr *) &to);
         if (rc != 0) {
-            OC_LOG_ERROR("Failed to send buffer %u on itf %d\n",
-                         OS_MBUF_PKTHDR(m)->omp_len, to.msin6_scope_id);
+            OC_LOG_ERROR("Failed to send buffer %u on itf %u\n",
+                         OS_MBUF_PKTHDR(m)->omp_len, (unsigned int)to.msin6_scope_id);
             STATS_INC(oc_ip_stats, oerr);
             os_mbuf_free_chain(m);
         }

--- a/net/osdp/src/osdp_phy.c
+++ b/net/osdp/src/osdp_phy.c
@@ -282,7 +282,7 @@ osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 
     if (!ISSET_FLAG(pd, PD_FLAG_PD_MODE) &&
         !(pkt->pd_address & 0x80)) {
-        OSDP_LOG_ERROR("Reply without address MSB set!\n", pkt->pd_address);
+        OSDP_LOG_ERROR("Reply without address MSB set 0x%02x!\n", pkt->pd_address);
         return OSDP_ERR_PKT_FMT;
     }
 

--- a/sys/log/modlog/include/modlog/modlog.h
+++ b/sys/log/modlog/include/modlog/modlog.h
@@ -190,7 +190,12 @@ int modlog_foreach(modlog_foreach_fn *fn, void *arg);
  * @param level                 The severity of the log entry to write.
  * @param msg                   The "printf" formatted string to write.
  */
-void modlog_printf(uint8_t module, uint8_t level, const char *msg, ...);
+
+void modlog_printf(uint8_t module, uint8_t level, const char *msg, ...)
+#if MYNEWT_VAL(MODLOG_USE_PRINTF_ATTRIBUTE)
+    __attribute__((format(printf, 3, 4)))
+#endif
+    ;
 
 /**
  * @brief Writes a specified number of bytes as a text entry to the specified log module.

--- a/sys/log/modlog/syscfg.yml
+++ b/sys/log/modlog/syscfg.yml
@@ -45,3 +45,9 @@ syscfg.defs:
         description: >
             Sysinit stage for modular logging functionality.
         value: 100
+    MODLOG_USE_PRINTF_ATTRIBUTE:
+        description: >
+            Use the `format(printf, ...)` attribute on the modlog_printf
+            prototype. Enables compile-time checking of modlog_printf arguments
+            against the format string.
+        value: 0


### PR DESCRIPTION
Add format(printf) attribute to modlog_printf to enable compile-time checking that format strings match arguments.

Note that this will cause incorrect modlog_printf usage which previously compiled successfully, to no longer compile.