### PR TITLE
    hw/scripts/nrfutil: make traits optional and improve device selection

### DIFF
--- a/hw/bsp/nordic_pca10059/syscfg.yml
+++ b/hw/bsp/nordic_pca10059/syscfg.yml
@@ -30,16 +30,16 @@ syscfg.defs:
             tool without debugger.
         value: 0
 
-syscfg.BSP_NRF_SDK_FLASH_LAYOUT:
+syscfg.vals.BSP_NRF_SDK_FLASH_LAYOUT:
     # Change to use Nordic DFU bootloader which is likely to be used
     # when device still has original bootloader
-    NRFUTIL_TRAITS: nordicDfu
+    NRFUTIL_DFU_MODE: 1
+    BOOTUTIL_SINGLE_APPLICATION_SLOT: 1
 
 syscfg.vals:
     MYNEWT_DOWNLOADER: nrfutil
     JLINK_TARGET: nRF52840_xxAA
     PYOCD_TARGET: nrf52840
-    NRFUTIL_TRAITS: jlink
 
 # Enable nRF52840 MCU and common startup code
     MCU_TARGET: nRF52840

--- a/hw/scripts/syscfg.yml
+++ b/hw/scripts/syscfg.yml
@@ -89,11 +89,20 @@ syscfg.defs:
             Some NRF have more then one core. This can specify non-default core
             (i.e. CP_NETWORK for NRF5340).
         value:
+    NRFUTIL_DFU_MODE:
+        description: >
+            Enables firmware upload through nrfutil dfu usb-serial.
+        value:
     NRFUTIL_TRAITS:
         description: >
-            Traits passed to nrfutil command. If not set `jlink` is the default.
-            It can be 'nordicDfu' to upload binary using Nordic SDK DFU
-            bootloader protocol.
+              Optional device traits used by nrfutil to select boards for flashing.
+              When set (e.g. 'jlink'), all connected devices matching this trait
+              will be programmed.
+        value:
+    NRFUTIL_DFU_SN:
+        description: >
+            DFU serial number passed to the nrfutil script.
+            Used to select the target device for firmware upload.
         value:
     MYNEWT_DEBUGGER_SN:
         description: >


### PR DESCRIPTION
Traits are no longer by default. They are now optional and only used when the user explicitly wants to flash multiple boards at once. DFU mode is controlled through NRFUTIL_DFU_MODE, and NRFUTIL_DFU_SN can be used to select a specific DFU device when several are connected.