### PR TITLE
hw/bsp/dialog_da1469x-dk-pro: select linker script by MCU_TARGET

### DIFF
--- a/hw/bsp/dialog_da1469x-dk-pro/boot-da14691.ld
+++ b/hw/bsp/dialog_da1469x-dk-pro/boot-da14691.ld
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+MEMORY
+{
+    /*
+     * Flash is remapped at 0x0 by 1st stage bootloader, but this is done with
+     * an offset derived from image header thus it is safer to use remapped
+     * address space at 0x0 instead of QSPI_M address space at 0x16000000.
+     * Bootloader partition is 32K, but 9K is currently reserved for product
+     * header (8K) and image header (1K).
+     * First 512 bytes of SYSRAM are remapped at 0x0 and used as ISR vector
+     * (there's no need to reallocate ISR vector) and thus cannot be used by
+     * application.
+     */
+
+    FLASH (rx)  : ORIGIN = (0x00000000), LENGTH = (23 * 1024)
+    RAM (rw)    : ORIGIN = (0x20000000), LENGTH = (384 * 1024)
+}
+
+/* The bootloader does not contain an image header */
+_imghdr_size = 0x0;

--- a/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
+++ b/hw/bsp/dialog_da1469x-dk-pro/bsp.yml
@@ -30,12 +30,24 @@ bsp.linkerscript:
     - "hw/bsp/dialog_da1469x-dk-pro/da1469x.ld"
     - "hw/mcu/dialog/da1469x/da1469x.ld"
 
+bsp.linkerscript.'MCU_TARGET == "DA14691"'.OVERWRITE:
+    - "hw/bsp/dialog_da1469x-dk-pro/da14691.ld"
+    - "hw/mcu/dialog/da1469x/da1469x.ld"
+
 bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - "hw/bsp/dialog_da1469x-dk-pro/boot-da1469x.ld"
     - "hw/mcu/dialog/da1469x/da1469x.ld"
 
+bsp.linkerscript.BOOT_LOADER.'MCU_TARGET == "DA14691"'.OVERWRITE:
+    - "hw/bsp/dialog_da1469x-dk-pro/boot-da14691.ld"
+    - "hw/mcu/dialog/da1469x/da1469x.ld"
+
 bsp.linkerscript.RAM_RESIDENT.OVERWRITE:
     - "hw/bsp/dialog_da1469x-dk-pro/boot-da1469x.ld"
+    - "hw/mcu/dialog/da1469x/da1469x_ram_resident.ld"
+
+bsp.linkerscript.RAM_RESIDENT.'MCU_TARGET == "DA14691"'.OVERWRITE:
+    - "hw/bsp/dialog_da1469x-dk-pro/boot-da14691.ld"
     - "hw/mcu/dialog/da1469x/da1469x_ram_resident.ld"
 
 bsp.flash_map:

--- a/hw/bsp/dialog_da1469x-dk-pro/da14691.ld
+++ b/hw/bsp/dialog_da1469x-dk-pro/da14691.ld
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = (0x16008000), LENGTH = (384 * 1024)
+    RAM (rw)    : ORIGIN = (0x20000000), LENGTH = (384 * 1024)
+}
+
+/* This linker script is used for images and thus contains an image header */
+_imghdr_size = 0x20;

--- a/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
+++ b/hw/bsp/dialog_da1469x-dk-pro/include/bsp/bsp.h
@@ -36,7 +36,12 @@ extern "C" {
 #define bssnz_t         sec_bss_nz_core
 
 extern uint8_t _ram_start;
-#define RAM_SIZE        0x80000
+
+#if MYNEWT_VAL_CHOICE(MCU_TARGET, DA14691)
+#define RAM_SIZE 0x60000
+#else
+#define RAM_SIZE 0x80000
+#endif
 
 /* LED pins */
 #define LED_1           (33)    /* P1_1 */


### PR DESCRIPTION
Pick the linker script dynamically based on the syscfg MCU_TARGET value. This makes flashing DA14691 easier since it has a different RAM size than other DA1469x chips.