### PR TITLE
tinyusb/stm32_fsdev: Add dcd_connect/dcd_disconnect

### DIFF
--- a/hw/usb/tinyusb/stm32_fsdev/stm32f3/syscfg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/stm32f3/syscfg.yml
@@ -17,30 +17,3 @@
 # under the License.
 #
 
-syscfg.defs:
-    USB_DP_PULLUP_CONTROL_PIN:
-        description: >
-            Set pin number (other then PA11) that connects 1.5k resistor to D+
-        value: -1
-
-syscfg.defs.(USB_DP_PULLUP_CONTROL_PIN!=-1):
-    USB_DP_PULLUP_CONTROL_PIN_MODE:
-        description: >
-            1.5 kOhm Resistor can be connected directly to one of the output pins,
-            or it can use additional switch to connect resistor.
-        choices:
-            # Following two cases are used when 1.5k is connected when MCU is down
-            # and needs some control pin value to be shorted to ground
-            - enable_input_disable_0
-            - enable_input_disable_1
-            # This is rare case when both disable and enable requires control pin
-            # to be connected and set to certain value
-            - enable_1_disable_0
-            - enable_0_disable_1
-            # Current can be drawn directly from control PIN it there is not additional
-            # switching hardware element.
-            - enable_1_disable_input
-            # Case when resistor is connected from MCU pin via inverting transistor
-            # current is not drawn from MCU pin.
-            - enable_0_disable_input
-        value:

--- a/hw/usb/tinyusb/stm32_fsdev/syscfg.yml
+++ b/hw/usb/tinyusb/stm32_fsdev/syscfg.yml
@@ -25,3 +25,28 @@ syscfg.defs:
             then device is discovered by host.
         value: 1
 
+    USB_DP_PULLUP_CONTROL_PIN:
+        description: >
+            Set pin number (other then PA11) that connects 1.5k resistor to D+
+        value: -1
+
+    USB_DP_PULLUP_CONTROL_PIN_MODE:
+        description: >
+            1.5 kOhm Resistor can be connected directly to one of the output pins,
+            or it can use additional switch to connect resistor.
+        choices:
+            # Following two cases are used when 1.5k is connected when MCU is down
+            # and needs some control pin value to be shorted to ground
+            - enable_input_disable_0
+            - enable_input_disable_1
+            # This is rare case when both disable and enable requires control pin
+            # to be connected and set to certain value
+            - enable_1_disable_0
+            - enable_0_disable_1
+            # Current can be drawn directly from control PIN it there is not additional
+            # switching hardware element.
+            - enable_1_disable_input
+            # Case when resistor is connected from MCU pin via inverting transistor
+            # current is not drawn from MCU pin.
+            - enable_0_disable_input
+        value: enable_1_disable_0


### PR DESCRIPTION
STM32F1/F3 do not have internal pull-up resistor on D+ line that can be automatically attached.
Many board have external pull-up resistor that is
connected all the time.
So far when USB_DP_HAS_EXTERNAL_PULL_UP was 1 (default) code was shorting D+ line to the ground as GPIO output for a wile during startup.

It is possible to have external pull-up resistor that is switchable at runtime (via transistor or resistor is just sourced from one of the GPIO pins).
For this purpose now dcd_connect and dcd_disconnect functions are provided that can enabled pull-up resistor in several ways.

With such setup device that is connected to USB just for power does not have to be detected by host system as broken one.