### PR TITLE
kernel/os: Add M_CHECKIF macro

### DIFF
--- a/kernel/os/include/os/check.h
+++ b/kernel/os/include/os/check.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2025 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef OS_CHECK_H_
+#define OS_CHECK_H_
+
+#include <assert.h>
+#include <syscfg/syscfg.h>
+
+#if MYNEWT_VAL(OS_ASSERT_ON_ERRORS)
+#define M_CHECKIF(expr)                                                       \
+    assert(!(expr));                                                          \
+    if (0)
+#elif MYNEWT_VAL(OS_NO_RUNTIME_CHECKS)
+#define M_CHECKIF(expr) if (0 && (expr))
+#else
+#define M_CHECKIF(expr) if (expr)
+#endif
+
+#endif /* OS_CHECK_H_ */

--- a/kernel/os/syscfg.yml
+++ b/kernel/os/syscfg.yml
@@ -201,6 +201,15 @@ syscfg.defs:
             If set, run time is measured in cpu time ticks rather than OS time
             ticks.
         value: 0
+    OS_ASSERT_ON_ERRORS:
+        description: >
+            Assert on errors covered with the M_CHECKIF() macro.
+        value: 0
+    OS_NO_RUNTIME_CHECKS:
+        description: >
+            Do not do any runtime checks or asserts when using the M_CHECKIF()
+            macro.
+        value: 0
 
 syscfg.vals.OS_DEBUG_MODE:
     OS_CRASH_STACKTRACE: 1


### PR DESCRIPTION
This adds M_CHECKIF macro that does runtime checks or, if compiled with OS_ASSERT_ON_ERRORS option runtime asserts.
OS_NO_RUNTIME_CHECKS option disables any runtime checks or asserts. The code has been copied from Zephyr and adjusted for MyNewt.