### PR TITLE
testutil: Remove duplicated os_start call

### DIFF
--- a/test/testutil/src/testutil.c
+++ b/test/testutil/src/testutil.c
@@ -144,8 +144,6 @@ tu_create_test_task(const char *task_name, os_task_func_t task_handler)
     os_task_init(&task, task_name, tu_test_task_handler, (void *)task_handler,
                  TU_TEST_TASK_PRIO, OS_WAIT_FOREVER, stack,
                  OS_STACK_ALIGN(TU_TEST_STACK_SIZE));
-
-    os_start();
 }
 
 /**


### PR DESCRIPTION
This removes duplicated os_start() call from tu_create_test_task function, as it is called from tu_start_os() function.