### PR TITLE
ci: Trigger CI label workflow on synchronize action

### DIFF
--- a/.github/workflows/add_ci_label.yml
+++ b/.github/workflows/add_ci_label.yml
@@ -21,7 +21,7 @@ name: Informative CI status
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Previously this workflow would trigger only on opened PR. 
Force pushes for PR would not re-enable the label. 
Now this workflow will add label in all those situations.