### PR TITLE
fs/littlefs: Bump to v2.11.2 and update glue layer

### DIFF
--- a/fs/littlefs/include/littlefs/littlefs.h
+++ b/fs/littlefs/include/littlefs/littlefs.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _LITTLEFS_LITTLEFS_H
+#define _LITTLEFS_LITTLEFS_H
+
+/**
+ * Formats littlefs filesystem
+ *
+ * @return FS_EOK on success
+ *         FS_* on error (translated from lfs error)
+ */
+int littlefs_format(void);
+
+/**
+ * Mounts littlefs filesystem
+ *
+ * This shall be called from application if auto-mount is disabled before
+ * file system can be accessed.
+ *
+ * @return FS_EOK on success
+ *         FS_* on error (translated from lfs error)
+ */
+int littlefs_mount(void);
+
+#endif /* _LITTLEFS_LITTLEFS_H */

--- a/fs/littlefs/pkg.yml
+++ b/fs/littlefs/pkg.yml
@@ -18,7 +18,7 @@
 #
 
 pkg.name: fs/littlefs
-pkg.description: LittleFS file system.
+pkg.description: littlefs file system glue
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
@@ -30,7 +30,7 @@ pkg.type: sdk
 
 repository.littlefs:
     type: github
-    vers: v2.5.0-commit
+    vers: v2.11.2-commit
     branch: master
     user: littlefs-project
     repo: littlefs
@@ -44,15 +44,21 @@ pkg.deps:
 pkg.source_dirs:
     - "@littlefs/."
     - "src"
-
 pkg.include_dirs:
     - "@littlefs/."
-
-pkg.cflags.LITTLEFS_MIGRATE_V1:
-    - -DLFS_MIGRATE
+pkg.ignore_dirs:
+    - "bd"
+    - "benches"
+    - "runners"
+    - "scripts"
+    - "tests"
 
 pkg.cflags.LITTLEFS_READONLY:
     - -DLFS_READONLY
+pkg.cflags.LITTLEFS_THREAD_SAFE:
+    - -DLFS_THREADSAFE
+pkg.cflags.LITTLEFS_ENABLE_TRACE:
+    - -DLFS_YES_TRACE
 
 pkg.init:
-    littlefs_pkg_init: 'MYNEWT_VAL(LITTLEFS_SYSINIT_STAGE)'
+    littlefs_sysinit: 'MYNEWT_VAL(LITTLEFS_SYSINIT_STAGE)'

--- a/fs/littlefs/syscfg.yml
+++ b/fs/littlefs/syscfg.yml
@@ -24,36 +24,55 @@ syscfg.defs:
         restrictions:
             - $notnull
 
-    LITTLEFS_DETECT_FAIL_FORMAT:
+    LITTLEFS_BLOCK_COUNT:
         description: >
-            Behavior when mounting an FS fails. If set, re-format it (default).
-            If unset just ignore the error and continue without mouting the FS.
-        value: 1
+            Number of blocks (sectors) use by this partition.
+            If 0, all sectors of littlefs flash ares are used.
+        value: 0
 
     LITTLEFS_BLOCK_SIZE:
         description: >
-            Size of the sectors used to store a littlefs partition. All sectors
-            must have the same size.
+            Size of the blocks (sectors) on littlefs flash area.
+            All blocks shall have the same size.
+            If 0, sector size of littlefs flash area is used.
         value: 0
 
-    LITTLEFS_MIGRATE_V1:
+    LITTLEFS_BLOCK_CYCLES:
         description: >
-            Enable support for migrating LFSv1 filesystems to v2.
+            Number of erase cycles before metadata is moved to another sector
+            to reduce wear.
+            Equivalent to block_cycles value in littlefs configuration.
+        value: 500
+
+    LITTLEFS_AUTO_MOUNT:
+        description: >
+            Enables mounting of filesystem on init.
         value: 0
+
+    LITTLEFS_AUTO_FORMAT:
+        description: >
+            Enables (re)formatting of filesystem on mount error.
+        value: 0
+
+    LITTLEFS_THREAD_SAFE:
+        description: >
+            Enables littlefs calls locking to endure thread-safety.
+        value: 1
 
     LITTLEFS_READONLY:
         description: >
-            Build LittleFS without write support.
+            Build littlefs without write support.
         value: 0
 
-    LITTLEFS_BLOCK_COUNT:
-        description: >
-            Number of blocks/sectors use by this partition.
-        value: 0
+    LITTLEFS_DISABLE_INLINED_FILES:
+         description: >
+             Disables inlined files.
+         value: 0
 
-    LITTLEFS_DISABLE_SYSINIT:
+    LITTLEFS_ENABLE_TRACE:
         description: >
-            Skip sysinit based initialization when enabled.
+            Enabled littlefs internal trace.
+            This is only for debugging pruposes and it may create a lot of printouts.
         value: 0
 
     LITTLEFS_SYSINIT_STAGE:
@@ -61,6 +80,16 @@ syscfg.defs:
             Sysinit stage for littlefs functionality.
         value: 200
 
+    LITTLEFS_DETECT_FAIL_FORMAT:
+        description: Use LITTLEFS_AUTO_FORMAT
+        value: 0
+        defunct: 1
+
+    LITTLEFS_DISABLE_SYSINIT:
+        description: Use LITTLEFS_AUTO_MOUNT instead
+        value: 0
+        defunct: 1
+
 syscfg.restrictions:
-    - LITTLEFS_BLOCK_SIZE > 0
-    - LITTLEFS_BLOCK_COUNT > 0
+    # block size and block count must be both either default or set; block size must be >=128 (littlefs requirement)
+    - (LITTLEFS_BLOCK_COUNT == 0 && LITTLEFS_BLOCK_SIZE == 0) || (LITTLEFS_BLOCK_COUNT > 0 && LITTLEFS_BLOCK_SIZE >= 128)


### PR DESCRIPTION
This bumps littlefs repository to the latest v2.11.2 and improves and cleans up glue layer.

New featues:
- add automatic detection of block size and block count from flash area
- add option to disable thread-safety
- add option to disable inlined files
- add option to enabled littlefs traces