### PR TITLE
ci: Use latest GHA for ARM GCC setup

### DIFF
--- a/.github/workflows/build_all_apps.yml
+++ b/.github/workflows/build_all_apps.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
-      - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.11.0
         with:
           release: '12.2.Rel1'
       - name: Install Dependencies

--- a/.github/workflows/build_blinky.yml
+++ b/.github/workflows/build_blinky.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
-      - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.11.0
         with:
           release: '12.2.Rel1'
       - name: Install Dependencies

--- a/.github/workflows/build_bootloader.yml
+++ b/.github/workflows/build_bootloader.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
-      - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.11.0
         with:
           release: '12.2.Rel1'
       - name: Install Dependencies

--- a/.github/workflows/build_cc_target.yml
+++ b/.github/workflows/build_cc_target.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
-      - uses: carlosperate/arm-none-eabi-gcc-action@v1.10.1
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.11.0
         with:
           release: ${{ matrix.gcc }}
       - name: Install newt

--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 'stable'
-      - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.11.0
         with:
           release: '12.2.Rel1'
       - name: Install GNU sed


### PR DESCRIPTION
This version has updated cache actions.