### PR TITLE
ci: Disable macos builds

### DIFF
--- a/.github/workflows/build_blinky.yml
+++ b/.github/workflows/build_blinky.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This needs to be disable until GHA arm-none-eabi-gcc-action is fixed. See https://github.com/carlosperate/arm-none-eabi-gcc-action/issues/74


note that this likely also affects ubuntu and windows runner however there we are lucky to have valid cache and thus don't hit (for now...) issue mentioned above!