### PR TITLE
Enforce compliance check at pr_target

### DIFF
--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -20,8 +20,8 @@
 name: Compliance check
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened, synchronize, labeled, unlabeled]
 
 
 jobs:


### PR DESCRIPTION
Behavior with approving and unlabeling was not preferable. Now this will run on pr_target - meaning as soon as PR is introduced for the repository.

This might also help with review process, as contributor will know right away about any style issues.