### PR TITLE
ci: Disable newt tests on macos

### DIFF
--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
              sudo apt-get update
              sudo apt-get install -y gcc-multilib
       - name: Install GNU sed
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         run: |
              brew install gnu-sed
              echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH


### PR DESCRIPTION
Those are not yet supported on arm, while failing on Intel MacOS 15. MacOS 13 runner is not longer supported.