### PR TITLE
kernel/os/mbuf: Remove unneeded assignment in os_mbuf_dup

### DIFF
--- a/kernel/os/src/os_mbuf.c
+++ b/kernel/os/src/os_mbuf.c
@@ -371,8 +371,6 @@ os_mbuf_dup(struct os_mbuf *om)
     struct os_mbuf *head;
     struct os_mbuf *copy;
 
-    omp = om->om_omp;
-
     head = NULL;
     copy = NULL;
 


### PR DESCRIPTION
omp is assigned in each loop iteration so no need to assign value before loop.