### PR TITLE
ci: Force clang-format to check empty function brace split

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ BraceWrapping:
   BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
-  SplitEmptyFunction: false
+  SplitEmptyFunction: true
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
 


### PR DESCRIPTION
Previously function braces were forced to be in one-line
We prefer to keep the braces separated by newline