### PR TITLE
hw/bsp: Add PWM support for Nucleo-F411RE

### DIFF
--- a/hw/bsp/nucleo-f411re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-f411re/src/hal_bsp.c
@@ -33,6 +33,18 @@
 #include <pwm_stm32/pwm_stm32.h>
 #endif
 
+#if MYNEWT_VAL(PWM_0)
+struct stm32_pwm_conf os_bsp_pwm0_cfg = { .tim = TIM3, .irq = TIM3_IRQn };
+#endif
+
+#if MYNEWT_VAL(PWM_1)
+struct stm32_pwm_conf os_bsp_pwm1_cfg = { .tim = TIM2, .irq = TIM2_IRQn };
+#endif
+
+#if MYNEWT_VAL(PWM_2)
+struct stm32_pwm_conf os_bsp_pwm2_cfg = { .tim = TIM1, .irq = TIM1_CC_IRQn };
+#endif
+
 const uint32_t stm32_flash_sectors[] = {
     0x08000000,     /* 16kB */
     0x08004000,     /* 16kB */


### PR DESCRIPTION
This adds PWM device configurations to the Nucleo-F411RE BSP. It defines configuration structures for PWM_0, PWM_1, and PWM_2 mapping them to hardware timers.