### PR TITLE
mcu/nrf5340: Disable UART before pin configuration

### DIFF
--- a/hw/mcu/nordic/nrf5340/src/hal_uart.c
+++ b/hw/mcu/nordic/nrf5340/src/hal_uart.c
@@ -354,6 +354,8 @@ hal_uart_init(int port, void *arg)
         assert(false);
     }
 
+    /* Disable UART for pin configuration */
+    u->nrf_uart->ENABLE = 0;
     u->nrf_uart->PSEL.TXD = cfg->suc_pin_tx;
     u->nrf_uart->PSEL.RXD = cfg->suc_pin_rx;
     u->nrf_uart->PSEL.RTS = cfg->suc_pin_rts;


### PR DESCRIPTION
Code was modifying UART PSEL configuration even
when peripheal was alreay enabled.

In normal case this is not a problem since during
hal_uart_init is called peripheral is not enabled. However when booloader already enabled UART and
application tried to used peripheral with different pin configuration change would not be apply

With this change peripheral is disabled before
modification it will be enabled later when needed.