### PR TITLE
bsp/stm32f3discovery: Disable UART_0 in bootloader

### DIFF
--- a/hw/bsp/stm32f3discovery/syscfg.yml
+++ b/hw/bsp/stm32f3discovery/syscfg.yml
@@ -72,5 +72,8 @@ syscfg.vals:
     MYNEWT_DOWNLOADER_MFG_IMAGE_FLASH_OFFSET: 0x08000000
     JLINK_TARGET: STM32F303VC
 
+syscfg.vals.BOOT_LOADER:
+    UART_0: 0
+
 syscfg.restrictions:
     - "!LSM303DLHC_ONB || I2C_0"


### PR DESCRIPTION
After upgrade to mcuboot 2.3 bootloader no longer
fits in 16kB.

This disables UART for bootloader builds, that is not used anyway, to make boot code smaller.