### PR TITLE
mgmt/imgmgr: Remove obsolete variable

### DIFF
--- a/boot/stub/src/bootutil.c
+++ b/boot/stub/src/bootutil.c
@@ -20,8 +20,6 @@
 #include <defs/error.h>
 #include "bootutil/bootutil.h"
 
-int boot_current_slot;
-
 int boot_swap_type(void)
 {
     return BOOT_SWAP_TYPE_NONE;

--- a/mgmt/imgmgr/include/imgmgr/imgmgr.h
+++ b/mgmt/imgmgr/include/imgmgr/imgmgr.h
@@ -44,8 +44,6 @@ extern "C" {
 #define IMGMGR_STATE_F_ACTIVE           0x04
 #define IMGMGR_STATE_F_PERMANENT        0x08
 
-extern int boot_current_slot;
-
 void imgmgr_module_init(void);
 
 struct image_version;

--- a/mgmt/imgmgr/src/imgmgr.c
+++ b/mgmt/imgmgr/src/imgmgr.c
@@ -154,7 +154,7 @@ imgr_get_current_hash(uint8_t *hash, uint16_t hashlen)
 int
 imgr_my_version(struct image_version *ver)
 {
-    return img_mgmt_read_info(boot_current_slot, ver, NULL, NULL);
+    return img_mgmt_read_info(0, ver, NULL, NULL);
 }
 
 /*

--- a/sys/coredump/src/coredump.c
+++ b/sys/coredump/src/coredump.c
@@ -96,7 +96,7 @@ coredump_dump(void *regs, int regs_sz)
     off = sizeof(hdr);
     dump_core_tlv(fa, &off, &tlv, regs);
 
-    if (img_mgmt_read_info(boot_current_slot, &ver, hash, NULL) == 0) {
+    if (img_mgmt_read_info(0, &ver, hash, NULL) == 0) {
         tlv.ct_type = COREDUMP_TLV_IMAGE;
         tlv.ct_len = IMGMGR_HASH_LEN;
 

--- a/sys/reboot/src/log_reboot.c
+++ b/sys/reboot/src/log_reboot.c
@@ -192,7 +192,7 @@ log_reboot_write(const struct log_reboot_info *info)
     }
 #endif
 
-    rc = img_mgmt_read_info(boot_current_slot, &ver, hash, &flags);
+    rc = img_mgmt_read_info(0, &ver, hash, &flags);
     if (rc != 0) {
         return rc;
     }
@@ -245,7 +245,7 @@ log_reboot_write(const struct log_reboot_info *info)
         cbor_encode_int(&map, info->pc);
     }
 
-    state_flags = img_mgmt_state_flags(boot_current_slot);
+    state_flags = img_mgmt_state_flags(0);
     cbor_encode_text_stringz(&map, "flags");
     off = 0;
     buf[0] = '\0';


### PR DESCRIPTION
Variable was never set and was always 0.