### PR TITLE
hw/mcu/nrf5340: Conditionally enable watchdog stopping

### DIFF
--- a/hw/bsp/nordic_pca10095_net/syscfg.yml
+++ b/hw/bsp/nordic_pca10095_net/syscfg.yml
@@ -23,6 +23,10 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF5340 NET'
         value: 1
 
+    BSP_NRF5340_WDT_STOP:
+        description: 'Enable WDT STOP/STOPEN mode on nRF5340'
+        value: 0
+
     COREDUMP_SKIP_UNUSED_HEAP:
         description: >
             Store whole RAM in crash dump.


### PR DESCRIPTION
When NRF5340_WDT_STOP is enabled, the watchdog is now able to be stopped when the CPU enters stop mode.

If the syscfg option is not set, the watchdog remains configured to run in sleep mode only.