### PR TITLE
bsp/fanstel_ev_bt40e: Add support for power amplifier

### DIFF
--- a/hw/bsp/fanstel_ev_bt40e/net/pkg.yml
+++ b/hw/bsp/fanstel_ev_bt40e/net/pkg.yml
@@ -36,3 +36,6 @@ pkg.deps:
     - "@apache-mynewt-core/libc"
     - "@apache-mynewt-core/sys/flash_map"
     - "@apache-mynewt-core/hw/drivers/flash/ipc_nrf5340_flash"
+
+pkg.deps.'BLE_FEM_PA || BLE_FEM_LNA':
+    - "@apache-mynewt-nimble/nimble/drivers/fem/nrf21540"

--- a/hw/bsp/fanstel_ev_bt40e/net/syscfg.yml
+++ b/hw/bsp/fanstel_ev_bt40e/net/syscfg.yml
@@ -23,6 +23,18 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF5340 NET'
         value: 1
 
+    FANSTEL_NRF5340_MODULE:
+        description: >
+            Selects specific module
+        choices:
+            - BT40
+            - BT40F
+            - BT40E
+            - BT40N
+            - BT40NE
+        value:
+            BT40E
+
     COREDUMP_SKIP_UNUSED_HEAP:
         description: >
             Store whole RAM in crash dump.
@@ -82,3 +94,20 @@ syscfg.vals.BLE_CONTROLLER:
 
 syscfg.vals.BLE_TRANSPORT:
     BLE_TRANSPORT_HS: nrf5340
+
+syscfg.vals.'FANSTEL_NRF5340_MODULE=="BT40NE" || FANSTEL_NRF5340_MODULE=="BT40N"':
+    BLE_FEM_PA: 1
+    BLE_FEM_PA_GPIO: 21
+    # Max time PD->PG->TX
+    BLE_FEM_PA_TURN_ON_US: 28
+    BLE_FEM_LNA: 1
+    BLE_FEM_LNA_GPIO: 27
+    # Max time PD->PG->RX
+    BLE_FEM_LNA_TURN_ON_US: 28
+    NRF21540_PIN_PDN: 26
+    NRF21540_PIN_ANT_SEL: 37
+    NRF21540_PIN_MODE: 36
+    # Default value +10 dBm
+    NRF21540_TX_GAIN_PRESET: POUTB
+    # PCB Antenna
+    NRF21540_ANTENNA_PORT: 1

--- a/hw/bsp/fanstel_ev_bt40e/syscfg.yml
+++ b/hw/bsp/fanstel_ev_bt40e/syscfg.yml
@@ -42,6 +42,17 @@ syscfg.defs:
             When 1 only part of heap that was used will be dumped, that
             can reduce size of crash dump.
         value: 0
+    FANSTEL_NRF5340_MODULE:
+        description: >
+            Selects specific module
+        choices:
+            - BT40
+            - BT40F
+            - BT40E
+            - BT40N
+            - BT40NE
+        value:
+            BT40E
 
 syscfg.vals:
     MCU_DEFAULT_STARTUP: 0
@@ -122,6 +133,10 @@ syscfg.vals.BSP_NRF5340_NET_FLASH_ENABLE:
 
 syscfg.vals.IPC_NRF5340_FLASH_CLIENT:
     HAL_FLASH_MAX_DEVICE_COUNT: 3
+
+syscfg.vals.'FANSTEL_NRF5340_MODULE=="BT40NE" || FANSTEL_NRF5340_MODULE=="BT40N"':
+    # NRF21540 pins managed by Network core
+    IPC_NRF5340_NET_GPIO: 21, 26, 27, 36, 37
 
 syscfg.restrictions.BSP_NRF5340_NET_FLASH_ENABLE:
     - 'IPC_NRF5340_CHANNELS >= 4'


### PR DESCRIPTION
BSP was configured to work with BT40E module.
It would work with other modules that did not have power amplifier NRF21540.

Now it's possible to use BT40N and BT40NE that
are manged by GPIO pins.

Pins are configured for netowrk core.