### PR TITLE
test/mtest_nvreg: Add NVREG read/write test application

### DIFF
--- a/test/mtest/mtest_nvreg/include/mtest_nvreg/mtest_nvreg.h
+++ b/test/mtest/mtest_nvreg/include/mtest_nvreg/mtest_nvreg.h
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef MTEST_NVMREG_H
+#define MTEST_NVMREG_H
+#include "mtest/mtest.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MTEST_CASE_DECL(nvreg_test_case_1);
+MTEST_CASE_DECL(nvreg_test_case_2);
+MTEST_CASE_DECL(nvreg_test_case_3);
+
+struct nvreg_err_dump {
+    int reg;
+    uint32_t val;
+    uint32_t exp_val;
+};
+
+void nvregs_reset(void);
+void nvregs_set_zero(void);
+int nvregs_compare_zero(struct nvreg_err_dump *err);
+void nvreg_set_pattern(void);
+int nvregs_compare_pattern(struct nvreg_err_dump *err);
+
+#ifdef __cplusplus
+extern "C"
+}
+#endif
+
+#endif

--- a/test/mtest/mtest_nvreg/pkg.yml
+++ b/test/mtest/mtest_nvreg/pkg.yml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: test/mtest/mtest_nvreg
+pkg.type: app
+pkg.description: "Testing read and write operations on NVREG."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+  - "@apache-mynewt-core/kernel/os"
+  - "@apache-mynewt-core/hw/hal"
+  - "@apache-mynewt-core/sys/console"
+  - "@apache-mynewt-core/sys/log"
+  - "@apache-mynewt-core/test/mtest/mtest"

--- a/test/mtest/mtest_nvreg/src/main.c
+++ b/test/mtest/mtest_nvreg/src/main.c
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sysinit/sysinit.h"
+#include "os/os.h"
+#include "mtest/mtest.h"
+#include "mtest_nvreg/mtest_nvreg.h"
+
+#define FIRST_BOOT_DONE 0xC001B007
+int reset_count __attribute__((section(".noinit")));
+int boot_status __attribute__((section(".noinit")));
+
+MTEST_INIT(nvreg_test)
+{
+    if (boot_status != FIRST_BOOT_DONE) {
+        reset_count = 0;
+        boot_status = FIRST_BOOT_DONE;
+    }
+}
+
+MTEST_SUITE(nvreg_test)
+{
+    MTEST_RUN_INIT(nvreg_test);
+
+    switch (reset_count) {
+    case 0:
+        nvreg_test_case_1();
+        nvregs_reset();
+        break;
+
+    case 1:
+        nvreg_test_case_2();
+        nvregs_reset();
+        break;
+
+    case 2:
+        nvreg_test_case_3();
+        nvregs_reset();
+        break;
+
+    default:
+        boot_status = 0;
+        reset_count = 0;
+        break;
+    }
+}
+
+int
+mynewt_main(int argc, char **argv)
+{
+    sysinit();
+
+    nvreg_test();
+
+    while (1) {
+        os_time_delay(OS_TICKS_PER_SEC);
+    }
+}

--- a/test/mtest/mtest_nvreg/src/nvreg_test_cases.c
+++ b/test/mtest/mtest_nvreg/src/nvreg_test_cases.c
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "mtest/mtest.h"
+#include "mtest_nvreg/mtest_nvreg.h"
+
+MTEST_CASE(nvreg_test_case_1)
+{
+    struct nvreg_err_dump err_dump;
+    int rc;
+
+    rc = nvregs_compare_zero(&err_dump);
+    MTEST_CASE_ASSERT(rc == 0, "reg[%d]=0x%lx, expected reg[%d]=0",
+                      err_dump.reg, err_dump.val, err_dump.reg);
+
+    nvreg_set_pattern();
+}
+
+MTEST_CASE(nvreg_test_case_2)
+{
+    struct nvreg_err_dump err_dump;
+    int rc;
+
+    rc = nvregs_compare_pattern(&err_dump);
+    MTEST_CASE_ASSERT(rc == 0, "pattern mismatch reg[%d]=0x%lx, expected reg[%d]=0x%lx",
+                      err_dump.reg, err_dump.val, err_dump.reg, err_dump.exp_val);
+
+    nvregs_set_zero();
+}
+
+MTEST_CASE(nvreg_test_case_3)
+{
+    struct nvreg_err_dump err_dump;
+    int rc;
+
+    rc = nvregs_compare_zero(&err_dump);
+    MTEST_CASE_ASSERT(rc == 0, "reg[%d]=0x%lx, expected reg[%d]=0",
+                      err_dump.reg, err_dump.val, err_dump.reg);
+}

--- a/test/mtest/mtest_nvreg/src/nvreg_test_helpers.c
+++ b/test/mtest/mtest_nvreg/src/nvreg_test_helpers.c
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "hal/hal_nvreg.h"
+#include "mtest_nvreg/mtest_nvreg.h"
+
+extern int reset_count;
+
+void
+nvregs_reset(void)
+{
+    reset_count++;
+    /* Ensure logs are flushed before reset */
+    os_time_delay(OS_TICKS_PER_SEC / 30);
+    hal_system_reset();
+}
+
+void
+nvregs_set_zero(void)
+{
+    int i;
+
+    for (i = 0; i < hal_nvreg_get_num_regs(); i++) {
+        hal_nvreg_write(i, 0);
+    }
+}
+
+int
+nvregs_compare_zero(struct nvreg_err_dump *ed)
+{
+    uint32_t nvreg_val;
+    int i;
+
+    for (i = 0; i < hal_nvreg_get_num_regs(); i++) {
+        nvreg_val = hal_nvreg_read(i);
+        if (nvreg_val != 0) {
+            *ed = (struct nvreg_err_dump){ .reg = i, .val = nvreg_val, .exp_val = 0 };
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void
+nvreg_set_pattern(void)
+{
+    uint32_t set_val;
+    uint32_t max_bits;
+    int i;
+
+    max_bits = hal_nvreg_get_reg_width() * 8;
+    for (i = 0; i < hal_nvreg_get_num_regs(); i++) {
+        set_val = 1 << (i % max_bits);
+        hal_nvreg_write(i, set_val);
+    }
+}
+
+int
+nvregs_compare_pattern(struct nvreg_err_dump *ed)
+{
+    uint32_t max_bits;
+    uint32_t nvreg_val;
+    uint32_t exp_val;
+    int i;
+
+    max_bits = hal_nvreg_get_reg_width() * 8;
+    for (i = 0; i < hal_nvreg_get_num_regs(); i++) {
+        exp_val = 1 << (i % max_bits);
+        nvreg_val = hal_nvreg_read(i);
+        if (nvreg_val != exp_val) {
+            *ed = (struct nvreg_err_dump){ .reg = i, .val = nvreg_val, .exp_val = exp_val };
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/test/mtest/mtest_nvreg/syscfg.yml
+++ b/test/mtest/mtest_nvreg/syscfg.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:


### PR DESCRIPTION
This test verifies NVREG functionality by writing zeros and bit patterns to the registers and checking their state after a system reboot.