### PR TITLE
Fix PWM compilation errors for STM32G0 MCUs.

### DIFF
--- a/hw/bsp/nucleo-g0b1re/src/hal_bsp.c
+++ b/hw/bsp/nucleo-g0b1re/src/hal_bsp.c
@@ -43,14 +43,14 @@
 
 #if MYNEWT_VAL(PWM_0)
 struct stm32_pwm_conf os_bsp_pwm0_cfg = {
-    .tim = TIM3,
-    .irq = TIM3_IRQn,
+    .tim = TIM2,
+    .irq = TIM2_IRQn,
 };
 #endif
 #if MYNEWT_VAL(PWM_1)
 struct stm32_pwm_conf os_bsp_pwm1_cfg = {
     .tim = TIM4,
-    .irq = TIM4_IRQn,
+    .irq = TIM3_TIM4_IRQn,
 };
 #endif
 #if MYNEWT_VAL(PWM_2)

--- a/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
+++ b/hw/drivers/pwm/pwm_stm32/src/pwm_stm32.c
@@ -541,7 +541,11 @@ stm32_pwm_dev_init(struct os_dev *odev, void *arg)
 #endif
 #ifdef TIM14
     case (uintptr_t)TIM14:
+#if defined(LL_APB2_GRP1_PERIPH_TIM14)
+        LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM14);
+#elif defined(LL_APB1_GRP1_PERIPH_TIM14)
         LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM14);
+#endif
         dev->pwm_chan_count = 1;
         break;
 #endif


### PR DESCRIPTION
- Updated PWM driver to support TIM14 on APB2 bus
- PWM_0 mapped to TIM2  and fixed IRQ settings 