### PR TITLE
bsp/nucleo-h7xxx: correct RTC APB clock in hal_bsp_deinit()

### DIFF
--- a/hw/bsp/nucleo-h723zg/src/hal_bsp.c
+++ b/hw/bsp/nucleo-h723zg/src/hal_bsp.c
@@ -229,7 +229,7 @@ hal_bsp_deinit(void)
     RCC->APB1HENR = 0;
     RCC->APB2ENR = 0;
     RCC->APB3ENR = 0;
-    RCC->APB4ENR = 0x0001000;
+    RCC->APB4ENR = 0x00010000;
 
     RCC->AHB1RSTR = 0x06038203;
     RCC->AHB2RSTR = 0x60030271;

--- a/hw/bsp/nucleo-h753zi/src/hal_bsp.c
+++ b/hw/bsp/nucleo-h753zi/src/hal_bsp.c
@@ -221,7 +221,7 @@ hal_bsp_deinit(void)
     RCC->APB1HENR = 0;
     RCC->APB2ENR = 0;
     RCC->APB3ENR = 0;
-    RCC->APB4ENR = 0x0001000;
+    RCC->APB4ENR = 0x00010000;
 
     RCC->AHB1RSTR = 0x06038203;
     RCC->AHB2RSTR = 0x60030271;


### PR DESCRIPTION
Correct RTC APB clock to match hardware defaults