### PR TITLE
hw/mcu: Fix header guards in Apollo2 and Apollo3 HALs

### DIFF
--- a/hw/mcu/ambiq/apollo2/include/mcu/hal_apollo2.h
+++ b/hw/mcu/ambiq/apollo2/include/mcu/hal_apollo2.h
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#ifndef __HAL_APOLLO2_H_
+#ifndef __HAL_APOLLO2_H__
 #define __HAL_APOLLO2_H__
 
 #include "os/mynewt.h"

--- a/hw/mcu/ambiq/apollo3/include/mcu/hal_apollo3.h
+++ b/hw/mcu/ambiq/apollo3/include/mcu/hal_apollo3.h
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#ifndef __HAL_APOLLO3_H_
+#ifndef __HAL_APOLLO3_H__
 #define __HAL_APOLLO3_H__
 
 #include "os/mynewt.h"


### PR DESCRIPTION
There was a typo which resulted in header guards not working at all.