### PR TITLE
compiler/cortex-m7: Change optimization for debug

### DIFF
--- a/compiler/arm-none-eabi-m7/compiler.yml
+++ b/compiler/arm-none-eabi-m7/compiler.yml
@@ -29,7 +29,7 @@ compiler.flags.base: [-mcpu=cortex-m7, -mthumb-interwork, -mthumb, -Wall, -Werro
 compiler.flags.default: [compiler.flags.base, -O1, -ggdb]
 compiler.flags.optimized: [compiler.flags.base, -Os, -ggdb]
 compiler.flags.speed: [compiler.flags.base, -O3, -ggdb]
-compiler.flags.debug: [compiler.flags.base, -O0, -ggdb]
+compiler.flags.debug: [compiler.flags.base, -Og, -ggdb]
 
 compiler.as.flags: [-x, assembler-with-cpp]
 


### PR DESCRIPTION
Compiler settings had -O0 while all other compilers use -Og for debug.

Now cortex-m7 is sync with other cortex linex