### PR TITLE
hw/mcu/stm32f4: Fix mcu info command

### DIFF
--- a/hw/mcu/stm/stm32f4xx/mcu_cli/src/mcu_cli.c
+++ b/hw/mcu/stm/stm32f4xx/mcu_cli/src/mcu_cli.c
@@ -205,7 +205,7 @@ static void
 print_apb1_peripherals(struct streamer *streamer, bool all)
 {
     uint32_t pckl1 = HAL_RCC_GetPCLK1Freq();
-    uint32_t timmul = RCC->CFGR & RCC_CFGR_PPRE2_2 ? 2 : 1;
+    uint32_t timmul = RCC->CFGR & RCC_CFGR_PPRE1_2 ? 2 : 1;
     char freq_buf[20];
 
     streamer_printf(streamer, "  APB1 PCLK1: %s\n", freq_str(pckl1, freq_buf));


### PR DESCRIPTION
When TIM frequencies were calculated for APB1
timers prescaler from APB2 was taken.
This resulted in wrong frequency being printed
in /mcu info command for timers

Now correct filed is taken for prescaler