### PR TITLE
hw/mcu/nrf54lxx: enable GRTC SYSCOUNTER auto_mode with WAKETIME/TIMEOUT

### DIFF
--- a/hw/mcu/nordic/nrf54lxx/src/hal_os_tick.c
+++ b/hw/mcu/nordic/nrf54lxx/src/hal_os_tick.c
@@ -195,6 +195,9 @@ os_tick_init(uint32_t os_ticks_per_sec, int prio)
     nrf_grtc_sys_counter_compare_event_enable(NRF_GRTC, OS_IDLE_CMPREG);
 
     nrf_grtc_sys_counter_interval_set(NRF_GRTC, g_hal_os_tick.ticks_per_ostick);
+    nrf_grtc_sys_counter_auto_mode_set(NRF_GRTC, true);
+    nrf_grtc_waketime_set(NRF_GRTC, 4);
+    nrf_grtc_timeout_set(NRF_GRTC, 5);
     nrf_grtc_sys_counter_set(NRF_GRTC, true);
     nrf_grtc_task_trigger(NRF_GRTC, NRF_GRTC_TASK_START);
 


### PR DESCRIPTION
Enable auto_mode on the GRTC SYSCOUNTER domain so it sleeps during WFI
(tickless idle) and wakes when the CPU is active, reducing power
consumption during idle periods.

Without these settings, os_tick_idle() can freeze the CPU. The per-CPU SYSCOUNTER[].ACTIVE register is at its reset value (NotActive, "Allow SYSCOUNTER to go to sleep" per the MDK), so the SYSCOUNTER subdomain is permitted to sleep during idle. nrf54l_os_tick_counter() is called from os_tick_idle() inside a critical section (PRIMASK=1) and contains a spin loop on SYSCOUNTERH.BUSY. When the subdomain is asleep on entry, the clock-domain handshake required to clear BUSY cannot complete, the loop spins indefinitely with interrupts globally disabled, and the device becomes unresponsive. Captured frozen-state PCs resolved to the spin in nrf_grtc_sys_counter_high_get and the while-condition in nrf54l_os_tick_counter; recovery required external bus activity to wake the power domain.

Setting MODE.AUTOEN = CpuActive replaces the implicit-sleep default with "any local CPU that is not sleeping keeps the SYSCOUNTER active" (MDK). This guarantees the subdomain is awake whenever the CPU is executing, including during the spin loop itself, so BUSY can clear.

WAKETIME = 4 (4 LFCLK cycles, ~122 us) tells the hardware to begin waking the subdomain that many cycles before any programmed compare event. The GRTC compare-event ISR therefore runs with the subdomain already awake and the spin loop exits immediately.

TIMEOUT = 5 (5 LFCLK cycles, ~152 us) is the delay after all CPUs enter WFI before the subdomain actually goes to sleep, providing hysteresis against short WFI windows.

Sleep registers are configured before enabling SYSCOUNTEREN: the hardware requires TIMEOUT and WAKETIME to be set while the SYSCOUNTER is disabled.

Assisted-by: Claude:claude-4.7-opus