### PR TITLE
ci: Add workflow for testing against mcuboot main branch

### DIFF
--- a/.github/test_build_bootloader_main.sh
+++ b/.github/test_build_bootloader_main.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+EXIT_CODE=0
+
+TARGETS=$(ls repos/mcuboot/ci/mynewt_targets/)
+
+for target in ${TARGETS}; do
+    newt build @mcuboot/targets/$target
+
+    rc=$?
+    [[ $rc -ne 0 ]] && EXIT_CODE=$rc
+
+done
+
+exit $EXIT_CODE

--- a/.github/workflows/build_bootloader_main.yml
+++ b/.github/workflows/build_bootloader_main.yml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build check
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: 42 0 * * *
+
+jobs:
+  bootloader:
+    name: Build bootloader (main)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.12.3
+        with:
+          release: '15.2.Rel1'
+      - name: Install Dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+             sudo apt-get update
+             sudo apt-get install -y gcc-multilib
+      - name: Install newt
+        run: |
+             go version
+             go install mynewt.apache.org/newt/newt@latest
+      - name: Setup project
+        shell: bash
+        run: |
+             newt new build
+             cp -f .github/project.yml build/project.yml
+             cd build
+             newt upgrade --shallow=1
+             cd ..
+      - name: Build bootloader (main branch)
+        shell: bash
+        run: |
+             cd build
+             cd repos/mcuboot
+             git fetch origin main:main
+             git checkout main
+             cd ../..
+             bash ../.github/test_build_bootloader_main.sh


### PR DESCRIPTION
This will not run on PRs but only on push and cron daily and test againt main branch of mcuboot (not release). This is to early catch any issues related to yet ot be released mcubbot.