### PR TITLE
hw/bsp: Add alternate flashmap for nordic_pca10056 with 48k bootloader

### DIFF
--- a/hw/bsp/nordic_pca10056/bsp.yml
+++ b/hw/bsp/nordic_pca10056/bsp.yml
@@ -58,3 +58,35 @@ bsp.flash_map:
             device: 0
             offset: 0x000fc000
             size: 16kB
+
+bsp.flash_map.BSP_BOOTLOADER_48K:
+    areas:
+        # System areas.
+        FLASH_AREA_BOOTLOADER:
+            device: 0
+            offset: 0x00000000
+            size: 48kB
+        FLASH_AREA_IMAGE_0:
+            device: 0
+            offset: 0x0000c000
+            size: 464kB
+        FLASH_AREA_IMAGE_1:
+            device: 0
+            offset: 0x00080000
+            size: 464kB
+        FLASH_AREA_IMAGE_SCRATCH:
+            device: 0
+            offset: 0x000f8000
+            size: 16kB
+
+        # User areas.
+        FLASH_AREA_REBOOT_LOG:
+            user_id: 0
+            device: 0
+            offset: 0x000f4000
+            size: 16kB
+        FLASH_AREA_NFFS:
+            user_id: 1
+            device: 0
+            offset: 0x000fc000
+            size: 16kB

--- a/hw/bsp/pkg.yml
+++ b/hw/bsp/pkg.yml
@@ -17,30 +17,7 @@
 # under the License.
 #
 
-pkg.name: hw/bsp/nordic_pca10056
-pkg.type: bsp
-pkg.description: BSP definition for the Nordic PCA10056 (nRF52840 DK)
+pkg.name: hw/bsp
+pkg.description: Common BSP definitions.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-    - nrf52840
-    - nrf52840dk
-    - nordic
-    - pca10056
-
-pkg.cflags:
-    - '-DNRF52840_XXAA'
-
-pkg.cflags.HARDFLOAT:
-    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/bsp"
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc"
-    - "@apache-mynewt-core/hw/scripts"
-    - "@apache-mynewt-core/sys/flash_map"
-    - "@apache-mynewt-core/boot/startup"
-
-pkg.deps.SOFT_PWM:
-    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"

--- a/hw/bsp/syscfg.yml
+++ b/hw/bsp/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,30 +16,9 @@
 # under the License.
 #
 
-pkg.name: hw/bsp/nordic_pca10056
-pkg.type: bsp
-pkg.description: BSP definition for the Nordic PCA10056 (nRF52840 DK)
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-    - nrf52840
-    - nrf52840dk
-    - nordic
-    - pca10056
-
-pkg.cflags:
-    - '-DNRF52840_XXAA'
-
-pkg.cflags.HARDFLOAT:
-    - -mfloat-abi=hard -mfpu=fpv4-sp-d16
-
-pkg.deps:
-    - "@apache-mynewt-core/hw/bsp"
-    - "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
-    - "@apache-mynewt-core/libc"
-    - "@apache-mynewt-core/hw/scripts"
-    - "@apache-mynewt-core/sys/flash_map"
-    - "@apache-mynewt-core/boot/startup"
-
-pkg.deps.SOFT_PWM:
-    - "@apache-mynewt-core/hw/drivers/pwm/soft_pwm"
+syscfg.defs:
+    BSP_BOOTLOADER_48K:
+        description: >
+            Specifies that FLASH_AREA_BOOTLOADER should be at
+            least 48k.
+        value: 0


### PR DESCRIPTION
This allows to use larger bootloader. Bootloader area is now 48k while slot0 and 1 were reduced to 464kb. Reboot area is now moved past slot1.

Also added basic common hw/bsp package that can be used to share global configs among BSPs.