### PR TITLE
ci: Add mcuboot unit tests to main branch test

### DIFF
--- a/.github/workflows/build_bootloader_main.yml
+++ b/.github/workflows/build_bootloader_main.yml
@@ -68,3 +68,4 @@ jobs:
              git checkout main
              cd ../..
              bash ../.github/test_build_bootloader_main.sh
+             newt test @mcuboot/boot/boot_serial


### PR DESCRIPTION
This will help to catch any issues with unit test on mcuboot main branch (ie. prior to release).