### PR TITLE
mbedtls/hash: Update hardware acceleration code

### DIFF
--- a/apps/hash_test/src/main.c
+++ b/apps/hash_test/src/main.c
@@ -452,20 +452,19 @@ static void
 mbed_sha256_start(void *data, void *arg)
 {
     (void)arg;
-    (void)mbedtls_sha256_starts_ret((mbedtls_sha256_context *)data, 0);
+    (void)mbedtls_sha256_starts((mbedtls_sha256_context *)data, 0);
 }
 
 static void
 mbed_sha256_update(void *data, const uint8_t *input, uint32_t inlen)
 {
-    (void)mbedtls_sha256_update_ret((mbedtls_sha256_context *)data, input,
-            (uint16_t)inlen);
+    (void)mbedtls_sha256_update((mbedtls_sha256_context *)data, input, (uint16_t)inlen);
 }
 
 static void
 mbed_sha256_finish(void *data, uint8_t *output)
 {
-    (void)mbedtls_sha256_finish_ret((mbedtls_sha256_context *)data, output);
+    (void)mbedtls_sha256_finish((mbedtls_sha256_context *)data, output);
 }
 
 static void
@@ -513,7 +512,7 @@ run_sha256_benchmark(char *name, hash_start_func_t start_fn,
         printf("fail\n");
         return;
     }
-    printf("done in %lu ticks\n", os_time_get() - t);
+    printf("done in %lu ms\n", os_time_ticks_to_ms32(os_time_get() - t));
 }
 
 static void
@@ -620,6 +619,8 @@ mynewt_main(int argc, char **argv)
                 tc_sha256_finish, &tc_sha256, NULL);
         os_time_delay(OS_TICKS_PER_SEC);
     }
+
+    mbedtls_sha256_free(&mbed_sha256);
 
     run_concurrency_test(hash);
 

--- a/hw/drivers/hash/hash_stm32/src/hash_stm32.c
+++ b/hw/drivers/hash/hash_stm32/src/hash_stm32.c
@@ -140,7 +140,8 @@ stm32_hash_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
 
     __HAL_HASH_START_DIGEST();
 
-    while (HASH->SR & HASH_FLAG_BUSY) ;
+    while ((HASH->SR & HASH_FLAG_DCIS) == 0) {
+    }
 
     u32p = (uint32_t *)outbuf;
     for (i = 0; i < digestsz; i++) {

--- a/hw/drivers/hash/hash_stm32/src/hash_stm32.c
+++ b/hw/drivers/hash/hash_stm32/src/hash_stm32.c
@@ -45,8 +45,6 @@ stm32_hash_start(struct hash_dev *hash, void *ctx, uint16_t algo)
         return -1;
     }
 
-    os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
-
     switch (algo) {
     case HASH_ALGO_SHA224:
         algomask = HASH_ALGOSELECTION_SHA224;
@@ -58,6 +56,10 @@ stm32_hash_start(struct hash_dev *hash, void *ctx, uint16_t algo)
         assert(0);
         return -1;
     }
+
+    os_mutex_pend(&gmtx, OS_TIMEOUT_NEVER);
+
+    __HAL_RCC_HASH_CLK_ENABLE();
 
     ((struct hash_sha2_context *)ctx)->remain = 0;
     HASH->CR = algomask | HASH_CR_INIT | HASH_DATATYPE_8B;
@@ -150,6 +152,8 @@ stm32_hash_finish(struct hash_dev *hash, void *ctx, uint16_t algo,
         u32p[i] = os_bswap_32(HASH_DIGEST->HR[i]);
     }
 
+    __HAL_RCC_HASH_CLK_DISABLE();
+
     os_mutex_release(&gmtx);
     return 0;
 }
@@ -162,12 +166,9 @@ stm32_hash_dev_open(struct os_dev *dev, uint32_t wait, void *arg)
     hash = (struct hash_dev *)dev;
     assert(hash);
 
-    /* XXX Not reentrant? */
-    if (dev->od_flags & OS_DEV_F_STATUS_OPEN) {
-        return OS_EBUSY;
+    if ((dev->od_flags & OS_DEV_F_STATUS_READY) == 0) {
+        return OS_ERROR;
     }
-
-    __HAL_RCC_HASH_CLK_ENABLE();
 
     return 0;
 }

--- a/hw/drivers/hash/include/hash/sha256_alt.h
+++ b/hw/drivers/hash/include/hash/sha256_alt.h
@@ -39,22 +39,12 @@ void mbedtls_sha256_init(mbedtls_sha256_context *ctx);
 void mbedtls_sha256_free(mbedtls_sha256_context *ctx);
 void mbedtls_sha256_clone(mbedtls_sha256_context *dst,
                           const mbedtls_sha256_context *src);
-int mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224);
-int mbedtls_sha256_update_ret(mbedtls_sha256_context *ctx,
-                              const unsigned char *input, size_t ilen);
-int mbedtls_sha256_finish_ret(mbedtls_sha256_context *ctx,
-                              unsigned char output[32]);
+int mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224);
+int mbedtls_sha256_update(mbedtls_sha256_context *ctx,
+                          const unsigned char *input, size_t ilen);
+int mbedtls_sha256_finish(mbedtls_sha256_context *ctx, unsigned char *output);
 int mbedtls_internal_sha256_process(mbedtls_sha256_context *ctx,
                                     const unsigned char data[64]);
-
-/*
- * XXX deprecated functions
- */
-void mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224);
-void mbedtls_sha256_update(mbedtls_sha256_context *ctx,
-        const unsigned char *input, size_t ilen);
-void mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
-        unsigned char output[32]);
 
 #ifdef __cplusplus
 }

--- a/hw/drivers/hash/src/mbedtls_sha256_alt.c
+++ b/hw/drivers/hash/src/mbedtls_sha256_alt.c
@@ -48,7 +48,7 @@ mbedtls_sha256_clone(mbedtls_sha256_context *dst,
 }
 
 int
-mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224)
+mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224)
 {
     /* SHA-224 not supported */
     if (is224) {
@@ -58,45 +58,16 @@ mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224)
 }
 
 int
-mbedtls_sha256_update_ret(mbedtls_sha256_context *ctx,
-                          const unsigned char *input, size_t ilen)
+mbedtls_sha256_update(mbedtls_sha256_context *ctx, const unsigned char *input,
+                      size_t ilen)
 {
     return hash_sha256_update(&ctx->sha256ctx, input, ilen);
 }
 
 int
-mbedtls_sha256_finish_ret(mbedtls_sha256_context *ctx,
-                          unsigned char output[32])
+mbedtls_sha256_finish(mbedtls_sha256_context *ctx, unsigned char *output)
 {
     return hash_sha256_finish(&ctx->sha256ctx, output);
-}
-
-/*
- * XXX deprecated mbedTLS functions
- */
-
-void
-mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224)
-{
-    /* SHA-224 not supported */
-    if (is224) {
-        return;
-    }
-    (void)hash_sha256_start(&ctx->sha256ctx, ctx->hash);
-}
-
-void
-mbedtls_sha256_update(mbedtls_sha256_context *ctx,
-                      const unsigned char *input, size_t ilen)
-{
-    (void)hash_sha256_update(&ctx->sha256ctx, input, ilen);
-}
-
-void
-mbedtls_sha256_finish(mbedtls_sha256_context *ctx,
-                      unsigned char output[32])
-{
-    (void)hash_sha256_finish(&ctx->sha256ctx, output);
 }
 
 int


### PR DESCRIPTION
mbedtls project once deprecated void functions:
mbedtls_sha256_starts
mbedtls_sha256_update
mbedtls_sha256_finish

replacing them with function with sufix _ret

Now old functions name are in use again and variants
with _ret are deprecated.
mbedtls provides macros so _ret versions can be
still used.

This removes _ret versions completly leaving
new styl names that return int values.

STM32 hash was change to allow multiply device open

hash_test application is update to changes in mbedtls