### PR TITLE
ci: Use mcuboot from main branch for unittests

### DIFF
--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -59,6 +59,13 @@ jobs:
              sed -i "s/0.0.0/$GITHUB_SHA-commit/g" project.yml
              newt upgrade --shallow=1
              cd ..
+      - name: Switch to main mcuboot
+        # This is temporary until next mcuboot release is available
+        shell: bash
+        run: |
+             cd build/repos/mcuboot
+             git fetch origin main:main
+             git checkout main
       - name: newt test all
         run: |
              cd build


### PR DESCRIPTION
This is temporary solution until next mcuboot release which will contain required fix.