### PR TITLE
Add explicit least-privilege permissions to CI workflows

### DIFF
--- a/.github/workflows/build_all_apps.yml
+++ b/.github/workflows/build_all_apps.yml
@@ -21,6 +21,9 @@ name: Apps
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   targets:
     name: Build all apps

--- a/.github/workflows/build_blinky.yml
+++ b/.github/workflows/build_blinky.yml
@@ -21,6 +21,9 @@ name: Blinky
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   blinky:
     name: Build blinky

--- a/.github/workflows/build_bootloader.yml
+++ b/.github/workflows/build_bootloader.yml
@@ -21,6 +21,9 @@ name: Bootloader
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   bootloader:
     name: Build bootloader

--- a/.github/workflows/build_bootloader_main.yml
+++ b/.github/workflows/build_bootloader_main.yml
@@ -26,6 +26,9 @@ on:
   schedule:
     - cron: 42 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   bootloader:
     name: Build bootloader (main)

--- a/.github/workflows/build_cc_target.yml
+++ b/.github/workflows/build_cc_target.yml
@@ -21,6 +21,9 @@ name: GCC target
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   targets:
     name: Build GCC test target

--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -21,6 +21,9 @@ name: Targets
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   targets:
     name: Build all test targets

--- a/.github/workflows/check_compliance.yml
+++ b/.github/workflows/check_compliance.yml
@@ -23,6 +23,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 
 jobs:
   style_check:

--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -21,6 +21,9 @@ name: Unit tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   newt_test:
     name: Run newt test all

--- a/.github/workflows/update_hw_ci_badges.yml
+++ b/.github/workflows/update_hw_ci_badges.yml
@@ -23,6 +23,10 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-badges:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit workflow token permissions to CI workflows currently relying on implicit defaults.
- Set `contents: read` for build/test/check workflows.
- For the badge-update automation workflow that creates pull requests, grant only required write scopes:
  - `contents: write`
  - `pull-requests: write`

## Why
Explicitly declaring least-privilege `GITHUB_TOKEN` permissions improves Actions security posture and documents required access for each workflow without changing CI behavior.