### PR TITLE
Fix typo in README details summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 ![](https://static.codecoup.pl/mynewt/run/latest/watchdog.svg)
 
 <details>
-<summary>Toggle for more informations</summary>
+<summary>Toggle for more information</summary>
 
 ## blinky
 ![](https://static.codecoup.pl/mynewt/run/latest/blinky/apollo3_evb.svg)


### PR DESCRIPTION
## Summary
- Fix a typo in `README.md`:
  - `informations` -> `information`

## Why
Small docs-only cleanup from a codespell pass.