### PR TITLE
tinyusb: Fix power requirement description

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -41,8 +41,9 @@ syscfg.defs:
     USBD_CONFIGURATION_MAX_POWER:
         description: >
             Maximum power consumption of the USB device from the bus in this specific
-            configuration when the device is fully operational. Expressed in 2 mA units
-            (i.e., 50 = 100 mA).
+            configuration when the device is fully operational. Expressed in 1 mA units.
+            Value will be rounded down to next even number, specifying 101 is equivalent
+            to setting it to 100.
         value: 100
     USBD_CONFIGURATION_SELF_POWERED:
         description: >


### PR DESCRIPTION
**USBD_CONFIGURATION_MAX_POWER** description stated that it used 2 ma units just as is stored in device
descriptor. But it really is in 1 mA and is converted in code before it land up in descriptor.

This fixes description so it's not misleading.