### PR TITLE
mgmt/imgmgr: Add option to enable frugal list in mcumgr

### DIFF
--- a/mgmt/imgmgr/syscfg.yml
+++ b/mgmt/imgmgr/syscfg.yml
@@ -48,3 +48,7 @@ syscfg.defs:
                       useful when there are no images present, Eg: unit
                       tests'
         value: 0
+    IMGMGR_FRUGAL_LIST:
+        description: >
+            Include only true/non-zero attributes in image status list.
+        value: 0


### PR DESCRIPTION
This option is then used by mcumgr to set default value for its syscfg, as for other options.