### PR TITLE
mcu/picm32: Fix build warnings in hal

### DIFF
--- a/hw/mcu/microchip/pic32mz/src/hal_gpio.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_gpio.c
@@ -213,7 +213,7 @@ hal_gpio_handle_isr(uint32_t port)
         }
 
         mask = GPIO_MASK(hal_gpio_irqs[index].pin);
-        if (CNFx(port) & mask != mask) {
+        if ((CNFx(port) & mask) != mask) {
             continue;
         }
 
@@ -360,6 +360,8 @@ hal_gpio_deinit(int pin)
 
     /* Configure pin direction as input */
     TRISxSET(port) = mask;
+
+    return 0;
 }
 
 void
@@ -405,8 +407,6 @@ int
 hal_gpio_irq_init(int pin, hal_gpio_irq_handler_t handler, void *arg,
                   hal_gpio_irq_trig_t trig, hal_gpio_pull_t pull)
 {
-    uint32_t port = GPIO_PORT(pin);
-    uint32_t mask = GPIO_MASK(pin);
     uint32_t ctx;
     int ret;
     uint8_t index;

--- a/hw/mcu/microchip/pic32mz/src/hal_spi.c
+++ b/hw/mcu/microchip/pic32mz/src/hal_spi.c
@@ -374,7 +374,7 @@ hal_spi_disable_int(int spi_num)
     }
 }
 
-static void
+static void __attribute__((unused))
 hal_spi_handle_isr(int spi_num)
 {
     uint32_t rxdata;
@@ -594,8 +594,6 @@ hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int cnt)
 int
 hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt)
 {
-    uint32_t ctx;
-
     /* Slave mode not supported */
     if (spis[spi_num].slave) {
         return -1;


### PR DESCRIPTION
In several places local variables were initialized but unused.
One int function did not return anything.
There were missing in () in one condition.

Warning about hal_spi_handle_isr being unused suppressed by function attribute.

Errors were not detected before because there is no -Wall -Werror in xc32 compiler.yml