### PR TITLE
fcb: Fix checks for empty fcb

### DIFF
--- a/fs/fcb/src/fcb.c
+++ b/fs/fcb/src/fcb.c
@@ -23,6 +23,12 @@
 #include "fcb_priv.h"
 #include "string.h"
 
+static int
+fcb_start_offset(struct fcb *fcb)
+{
+    return fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
+}
+
 int
 fcb_init(struct fcb *fcb)
 {
@@ -80,7 +86,7 @@ fcb_init(struct fcb *fcb)
     fcb->f_align = max_align;
     fcb->f_oldest = oldest_fap;
     fcb->f_active.fe_area = newest_fap;
-    fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
+    fcb->f_active.fe_elem_off = fcb_start_offset(fcb);
     fcb->f_active_id = newest;
     fcb->f_active.fe_elem_ix = 0;
 
@@ -133,10 +139,11 @@ fcb_free_sector_cnt(struct fcb *fcb)
 int
 fcb_is_empty_nolock(struct fcb *fcb)
 {
-    bool ret = false;
+    bool ret;
+    uint32_t first_entry_offset = fcb_start_offset(fcb);
 
-    ret = (fcb->f_active.fe_area == fcb->f_oldest &&
-           fcb->f_active.fe_elem_off == sizeof(struct fcb_disk_area));
+    ret = fcb->f_active.fe_area == fcb->f_oldest &&
+          fcb->f_active.fe_elem_off == first_entry_offset;
 
     return ret;
 }
@@ -144,16 +151,17 @@ fcb_is_empty_nolock(struct fcb *fcb)
 int
 fcb_is_empty(struct fcb *fcb)
 {
-    int rc = 0;
-    bool ret = false;
+    int rc;
+    bool ret;
+    uint32_t first_entry_offset = fcb_start_offset(fcb);
 
     rc = os_mutex_pend(&fcb->f_mtx, OS_WAIT_FOREVER);
     if (rc && rc != OS_NOT_STARTED) {
         return FCB_ERR_ARGS;
     }
 
-    ret = (fcb->f_active.fe_area == fcb->f_oldest &&
-      fcb->f_active.fe_elem_off == sizeof(struct fcb_disk_area));
+    ret = fcb->f_active.fe_area == fcb->f_oldest &&
+          fcb->f_active.fe_elem_off == first_entry_offset;
 
     os_mutex_release(&fcb->f_mtx);
 


### PR DESCRIPTION
Functions fcb_is_empty_nolock and fcb_is_empty
incorrectly reported that fcb sector was not empty for devices that have write alignment > 8.

On devices with higher alignment that leads to
infinite loop during fcb rotation where code
could not detect that sector was already empty.

Now code takes into account flash alignment when
checks if oldest sector write offset.