### PR TITLE
kernel/os: Check if CONTAINER_OF is already defined

### DIFF
--- a/kernel/os/include/os/util.h
+++ b/kernel/os/include/os/util.h
@@ -27,8 +27,10 @@
 #define INT_TO_POINTER(u) ((void *) ((intptr_t) (u)))
 
 /* Helper to retrieve pointer to "parent" object in structure */
+#ifndef CONTAINER_OF
 #define CONTAINER_OF(ptr, type, field) \
         ((type *)(((char *)(ptr)) - offsetof(type, field)))
+#endif
 
 /* Helper to calculate number of elements in array */
 #ifndef ARRAY_SIZE


### PR DESCRIPTION
Check if CONTAINER_OF is already defined before defining in the OS. This is quite common macro name and may cause macro redefine error otherwise.