### PR TITLE
hw/mcu: STM32H7 Add dcache support

### DIFF
--- a/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
+++ b/hw/mcu/stm/stm32h7xx/src/clock_stm32h7xx.c
@@ -50,11 +50,6 @@ SystemClock_Config(void)
     RCC_PeriphCLKInitTypeDef per_clk_init = {0};
     HAL_StatusTypeDef status;
 
-    /* Enable the MCU instruction cache */
-#if MYNEWT_VAL(STM32_ENABLE_ICACHE)
-    SCB_EnableICache();
-#endif
-
     /*
      *  Supply configuration update enable
      */

--- a/hw/mcu/stm/stm32h7xx/src/hal_system_init.c
+++ b/hw/mcu/stm/stm32h7xx/src/hal_system_init.c
@@ -33,7 +33,16 @@ hal_system_init(void)
     /* Update SystemCoreClock global variable */
     SystemCoreClockUpdate();
 
+    /* Enable the instruction cache */
+#if MYNEWT_VAL(STM32_ENABLE_ICACHE)
+    SCB_EnableICache();
+#endif
+
+    /* Enable the data cache */
+#if MYNEWT_VAL(STM32_ENABLE_DCACHE)
+    SCB_EnableDCache();
+#endif
+
     /* Relocate the vector table */
     NVIC_Relocate();
 }
-

--- a/hw/mcu/stm/stm32h7xx/syscfg.yml
+++ b/hw/mcu/stm/stm32h7xx/syscfg.yml
@@ -34,6 +34,10 @@ syscfg.defs:
         description: Enable instruction caching
         value: 1
 
+    STM32_ENABLE_DCACHE:
+        description: Enable data caching
+        value: 1
+
     STM32_CLOCK_VOLTAGESCALING_CONFIG:
         description: Voltage scale
         value: 0


### PR DESCRIPTION
Device supports DCache now it's enabled by default.

Enabling DCACHE may increase performance quite a lot

Coremark run without cache (before patch applied)
```sh
Coremark running on weact_h743vi at 480 MHz

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 2164
Total time (secs): 16
Iterations/Sec   : 687
Iterations       : 11000
Compiler version : GCC13.3.0
Compiler flags   :
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x33ff
Correct operation validated. See readme.txt for run and reporting rules.
```

With cache enabled iteration per second increased from **687** to **2000**
```sh
Coremark running on weact_h743vi at 480 MHz

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 1960
Total time (secs): 15
Iterations/Sec   : 2000
Iterations       : 30000
Compiler version : GCC13.3.0
Compiler flags   :
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x5275
Correct operation validated. See readme.txt for run and reporting rules.
```