### PR TITLE
baselibc: Add option to disable memset and memcpy

### DIFF
--- a/libc/baselibc/pkg.yml
+++ b/libc/baselibc/pkg.yml
@@ -37,5 +37,11 @@ pkg.cflags:
 pkg.cflags.BASELIBC_DEBUG_MALLOC:
     - -DDEBUG_MALLOC
 
+pkg.ign_files.BASELIBC_NO_MEMCPY:
+    - memcpy.c
+
+pkg.ign_files.BASELIBC_NO_MEMSET:
+    - memset.c
+
 pkg.lflags.!MCU_NATIVE:
     - -umain

--- a/libc/baselibc/src/memcpy.c
+++ b/libc/baselibc/src/memcpy.c
@@ -23,27 +23,38 @@ void *memcpy(void *dst, const void *src, size_t n)
         (void)p;
         (void)q;
 
-#if defined(__ARM_FEATURE_UNALIGNED)
-        /*
-         * We can speed up a bit by moving 32-bit words if unaligned access is
-         * supported (e.g. Cortex-M3/4/7/33).
-         */
         asm (".syntax unified           \n"
-             "       b    test1         \n"
-             "loop1: ldr  r3, [r1, r2]  \n"
-             "       str  r3, [r0, r2]  \n"
-             "test1: subs r2, #4        \n"
-             "       bpl  loop1         \n"
-             "       add  r2, #4        \n"
-            );
+             "       push {r0, r4}      \n"
+#if !defined(__ARM_FEATURE_UNALIGNED)
+             /*
+              * For Cortex-M0 check if copy by 32-bit is possible, if not
+              * copy everything by byte.
+              */
+             "       movs r3, r0        \n"
+             "       orrs r3, r1        \n"
+             "       lsls r3, #30       \n"
+             "       bne  2f            \n"
 #endif
-
-        asm (".syntax unified           \n"
-             "       b    test2         \n"
-             "loop2: ldrb r3, [r1, r2]  \n"
+             "       lsrs r3, r2, #2    \n"
+             "       beq  2f            \n"
+             "       lsls r4, r3, #2    \n"
+             "       subs r2, r2, r4    \n"
+             "       rsbs r4, #0        \n"
+             "       subs r0, r4        \n"
+             "       subs r1, r4        \n"
+             "1:     ldr  r3, [r1, r4]  \n"
+             "       str  r3, [r0, r4]  \n"
+             "       adds r4, #4        \n"
+             "       bmi  1b            \n"
+             "2:     rsbs r2, #0        \n"
+             "       beq  4f            \n"
+             "       subs r0, r2        \n"
+             "       subs r1, r2        \n"
+             "3:     ldrb r3, [r1, r2]  \n"
              "       strb r3, [r0, r2]  \n"
-             "test2: subs r2, #1        \n"
-             "       bpl  loop2         \n"
+             "       adds r2, #1        \n"
+             "       bmi  3b            \n"
+             "4:     pop  {r0, r4}      \n"
             );
 #else
 	while (n--) {

--- a/libc/baselibc/syscfg.yml
+++ b/libc/baselibc/syscfg.yml
@@ -42,3 +42,17 @@ syscfg.defs:
             Set to 1 to enable extra debugging for malloc/free calls.
             This will e.g. assert on double-free.
         value: 0
+
+    BASELIBC_NO_MEMCPY:
+        description: >
+            Set to 1 to disable baselibc version of memcpy and let compiler
+            provide it's own which may be more efficient or user code
+            can have custom one.
+        value: 0
+
+    BASELIBC_NO_MEMSET:
+        description: >
+            Set to 1 to disable baselibc version of memset and let compiler
+            provide it's own which may be more efficient or user code
+            can have custom one.
+        value: 0


### PR DESCRIPTION
baselibc version of memcpy and memset are optimized for speed if compared to pure C code.
However compiler provided version are more efficient. Additionally baselibc version for ARM copies data
in revers direction which is allowed but may degrade performance when buffers are aligned but number of bytes to copy is not multiply of 4.

Second case where this approach shows it's drawbacks is when memcpy is used to copy data from memory mapped QSPI flash when reading from the last byte is very inefficient.

This just add option to drop baselibc version in favor of other (compiler provided or user provided).

baselibc version now copies 8-bit/32-bit words from the beginning. It is slightly slower that previous version when 8-bit copy kicks in. It is much faster for Cortex-M0 when buffers are aligned. It is faster when buffers are aligned but length is not multiply of 4.