### PR TITLE
tinyusb/msc_fat_view: Fix build for non baselibc

### DIFF
--- a/hw/usb/tinyusb/msc_fat_view/src/entry_huge_file.c
+++ b/hw/usb/tinyusb/msc_fat_view/src/entry_huge_file.c
@@ -18,6 +18,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <sysflash/sysflash.h>
 #include <msc_fat_view/msc_fat_view.h>
 #include <bootutil/image.h>


### PR DESCRIPTION
Code was using memset without including <string.h> That does not work on non baselibc build.