### PR TITLE
da1469x/flash: Fix non baselibc builds

### DIFF
--- a/hw/mcu/dialog/da1469x/src/hal_flash.c
+++ b/hw/mcu/dialog/da1469x/src/hal_flash.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <syscfg/syscfg.h>
 #include <assert.h>
 #include <string.h>
 #include "mcu/mcu.h"


### PR DESCRIPTION
hal_flash.c relied on syscfg.h being included by assert.h

Now inclusion is implicit to work with newlib

Fixes #3658