### PR TITLE
lwip/apps: Add iperf2 application

### DIFF
--- a/net/ip/lwip/apps/pkg.yml
+++ b/net/ip/lwip/apps/pkg.yml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: net/ip/lwip/apps
+pkg.description: LwIP apps
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://savannah.nongnu.org/git/?group=lwip"
+pkg.keywords:
+    - lwip
+    - ip
+    - ipv6
+    - tcp
+    - udp
+
+pkg.source_dirs:
+    - src
+
+pkg.source_dirs.LWIP_APPS_HTTPD:
+    - "@lwip/src/apps/httpd"
+
+pkg.source_dirs.LWIP_APPS_IPERF:
+    - "@lwip/src/apps/lwiperf"
+
+pkg.source_dirs.LWIP_APPS_MDNS:
+    - "@lwip/src/apps/mdns"
+
+pkg.source_dirs.LWIP_APPS_MQTT:
+    - "@lwip/src/apps/mqtt"
+
+pkg.source_dirs.LWIP_APPS_NETBIOSNS:
+    - "@lwip/src/apps/netbiosns"
+
+pkg.source_dirs.LWIP_APPS_SNMP:
+    - "@lwip/src/apps/snmp"
+
+pkg.source_dirs.LWIP_APPS_SNTP:
+    - "@lwip/src/apps/sntp"
+
+pkg.source_dirs.LWIP_APPS_TFTP:
+    - "@lwip/src/apps/tftp"
+
+pkg.deps:
+    - "@apache-mynewt-core/net/ip/lwip"
+
+pkg.init.LWIP_APPS_IPERF_START:
+    iperf_init: 1000

--- a/net/ip/lwip/apps/src/iperf.c
+++ b/net/ip/lwip/apps/src/iperf.c
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/mynewt.h>
+#include <stdio.h>
+#include <lwip/apps/lwiperf.h>
+
+void
+iperf_cb(void *arg, enum lwiperf_report_type report_type, const ip_addr_t *local_addr,
+         u16_t local_port, const ip_addr_t *remote_addr, u16_t remote_port,
+         u32_t bytes_transferred, u32_t ms_duration, u32_t bandwidth_kbitpsec)
+{
+    int MB10 = 10 * bytes_transferred / (1024 * 1024);
+    int Mb10 = 10 * bandwidth_kbitpsec / 1000;
+
+    printf("[ ID] Interval       Transfer    Bandwidth\n");
+    printf("[  1] 0.00-%d.%02d sec %d.%d MBytes %d.%d Mbits/sec\n",
+           (int)ms_duration / 1000, (int)ms_duration / 10 % 100, MB10 / 10,
+           MB10 % 10, Mb10 / 10, Mb10 % 10);
+}
+
+void
+iperf_start(void)
+{
+    printf("\n------------------------------------------------------------\n"
+           "Server listening on TCP port %d\n"
+           "TCP window size: 64.0 KByte (default)\n"
+           "------------------------------------------------------------\n",
+           LWIPERF_TCP_PORT_DEFAULT);
+    lwiperf_start_tcp_server_default(iperf_cb, NULL);
+}
+
+void
+iperf_init(void)
+{
+    iperf_start();
+}

--- a/net/ip/lwip/apps/syscfg.yml
+++ b/net/ip/lwip/apps/syscfg.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    LWIP_APPS_HTTPD:
+        description: 'Enable HTTPD'
+        value: 0
+    LWIP_APPS_IPERF:
+        description: 'Enable iperf2 server'
+        value: 0
+    LWIP_APPS_IPERF_START:
+        description: 'Start iperf2 server in sysinit'
+        value: 0
+    LWIP_APPS_MDNS:
+        description: 'Enable MDNS'
+        value: 0
+    LWIP_APPS_MQTT:
+        description: 'Enable MQTT'
+        value: 0
+    LWIP_APPS_NETBIONS:
+        description: 'Enable NETBIOSNS'
+        value: 0
+    LWIP_APPS_SNMP:
+        description: 'Enable SNMP'
+        value: 0
+    LWIP_APPS_SNTP:
+        description: 'Enable SNTP'
+        value: 0
+    LWIP_APPS_TFTP:
+        description: 'Enable TFTP'
+        value: 0


### PR DESCRIPTION
This adds package that allow to include various
applications present in lwip.

It also adds code for server side of iperf2
so lwip performance can be tested.