### PR TITLE
stm32/gpio: Remove duplicate prototypes

### DIFF
--- a/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
+++ b/hw/drivers/lwip/stm32_eth/src/stm32_eth.c
@@ -23,6 +23,7 @@
 #include <hal/hal_timer.h>
 #include <mcu/cmsis_nvic.h>
 #include <stm32_common/stm32_hal.h>
+#include <mcu/mcu.h>
 
 #if MYNEWT_VAL(MCU_STM32F4)
 #include <bsp/stm32f4xx_hal_conf.h>

--- a/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
 #include <hal/hal_gpio.h>
 /*
  * Note that not all processors have support for all ports.
@@ -73,6 +74,8 @@ extern "C" {
  */
 #define MCU_GPIO_PIN_NONE       (0xFFFF)
 
+#define MCU_AFIO_GPIO_PP(pin, af, pu, od)                                     \
+    (((0x0F & af) << 12) | (0x00FF & pin) | ((3 & pu) << 8) | (1 & od) << 10)
 
 /*
  * Mapping of a GPIO pin to an alternate function.
@@ -120,6 +123,14 @@ void stm32_start_bootloader(void);
  * @return 0 on success -1 on failure
  */
 int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
+
+/**
+ * Init alternate function on specified pin
+ * @param pin pin config created by MCU_AFIO_PORTx(pin, af) macro or
+ *            MCU_AFIO_GPIO_PP(pin, af, pull, od)
+ * @return 0 on success -1 on failure
+ */
+int hal_gpio_init_fun(uint32_t pin);
 
 #if MYNEWT_VAL_STM32_WFI_FROM_RAM
 extern void stm32_wfi_from_ram(void);

--- a/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
+++ b/hw/mcu/stm/stm32_common/include/stm32_common/mcu.h
@@ -24,6 +24,7 @@
 extern "C" {
 #endif
 
+#include <hal/hal_gpio.h>
 /*
  * Note that not all processors have support for all ports.
  *
@@ -107,6 +108,18 @@ extern "C" {
 #define MCU_AFIO_PIN_NONE       (0xFFFF)
 
 void stm32_start_bootloader(void);
+
+/**
+ * Init alternate function on specified pin
+ *
+ * @param pin pin specified by MCU_GPIO_PORTx(pin) macro
+ * @param af_type - alternate function number 0-15
+ * @param pull - whether to add pull-up or pull-down resistor
+ * @param od - if 1 - enable open drain
+ *
+ * @return 0 on success -1 on failure
+ */
+int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
 
 #if MYNEWT_VAL_STM32_WFI_FROM_RAM
 extern void stm32_wfi_from_ram(void);

--- a/hw/mcu/stm/stm32_common/src/hal_gpio.c
+++ b/hw/mcu/stm/stm32_common/src/hal_gpio.c
@@ -776,6 +776,18 @@ hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od)
 }
 
 /**
+ * gpio init af
+ *
+ * Configure the specified pin for AF.
+ */
+int
+hal_gpio_init_fun(uint32_t pin)
+{
+    return hal_gpio_init_af(pin & 0xFF, (pin >> 12) & 0xF, (pin >> 8) & 3,
+                            (pin >> 10) & 1);
+}
+
+/**
  * Deinitialize the specified pin to revert to default configuration
  *
  * @param pin Pin number to unset

--- a/hw/mcu/stm/stm32_common/src/hal_i2c.c
+++ b/hw/mcu/stm/stm32_common/src/hal_i2c.c
@@ -27,6 +27,7 @@
 #include <hal/hal_gpio.h>
 
 #include <mcu/stm32_hal.h>
+#include <stm32_common/mcu.h>
 
 #if MYNEWT_VAL(I2C_3)
 #define HAL_I2C_MAX_DEVS    4

--- a/hw/mcu/stm/stm32f0xx/include/mcu/stm32f0_bsp.h
+++ b/hw/mcu/stm/stm32f0xx/include/mcu/stm32f0_bsp.h
@@ -42,11 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f0xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
-
 struct hal_flash;
 extern const struct hal_flash stm32f0_flash_dev;
 

--- a/hw/mcu/stm/stm32f1xx/include/mcu/stm32f1_bsp.h
+++ b/hw/mcu/stm/stm32f1xx/include/mcu/stm32f1_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f1xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull,
-                     uint8_t od);
-
 struct hal_flash;
 extern struct hal_flash stm32f1_flash_dev;
 

--- a/hw/mcu/stm/stm32f3xx/include/mcu/stm32f3_bsp.h
+++ b/hw/mcu/stm/stm32f3xx/include/mcu/stm32f3_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f3xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 struct hal_flash* stm32f3_flash_dev(void);
 

--- a/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
+++ b/hw/mcu/stm/stm32f4xx/include/mcu/stm32f4_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;				/* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f4xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 extern const struct hal_flash stm32f4_flash_dev;
 

--- a/hw/mcu/stm/stm32f7xx/include/mcu/stm32f7_bsp.h
+++ b/hw/mcu/stm/stm32f7xx/include/mcu/stm32f7_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f7xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 extern struct hal_flash stm32f7_flash_dev;
 

--- a/hw/mcu/stm/stm32g0xx/include/mcu/stm32g0_bsp.h
+++ b/hw/mcu/stm/stm32g0xx/include/mcu/stm32g0_bsp.h
@@ -42,11 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32g0xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
-
 struct hal_flash;
 extern struct hal_flash stm32g0_flash_dev;
 

--- a/hw/mcu/stm/stm32g4xx/include/mcu/stm32g4_bsp.h
+++ b/hw/mcu/stm/stm32g4xx/include/mcu/stm32g4_bsp.h
@@ -42,11 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32u5xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
-
 struct hal_flash;
 extern struct hal_flash stm32g4_flash_dev;
 

--- a/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7_bsp.h
+++ b/hw/mcu/stm/stm32h7xx/include/mcu/stm32h7_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32f7xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-                     od);
-
 struct hal_flash;
 extern struct hal_flash stm32f7_flash_dev;
 

--- a/hw/mcu/stm/stm32l0xx/include/mcu/stm32l0_bsp.h
+++ b/hw/mcu/stm/stm32l0xx/include/mcu/stm32l0_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32l0xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 extern struct hal_flash stm32l0_flash_dev;
 

--- a/hw/mcu/stm/stm32l1xx/include/mcu/stm32l1_bsp.h
+++ b/hw/mcu/stm/stm32l1xx/include/mcu/stm32l1_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32l1xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 extern struct hal_flash stm32l1_flash_dev;
 

--- a/hw/mcu/stm/stm32l4xx/include/mcu/stm32l4_bsp.h
+++ b/hw/mcu/stm/stm32l4xx/include/mcu/stm32l4_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32l4xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t
-od);
-
 struct hal_flash;
 extern struct hal_flash stm32l4_flash_dev;
 

--- a/hw/mcu/stm/stm32u5xx/include/mcu/stm32u5_bsp.h
+++ b/hw/mcu/stm/stm32u5xx/include/mcu/stm32u5_bsp.h
@@ -42,11 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32u5xx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
-
 struct hal_flash;
 extern struct hal_flash stm32u5_flash_dev;
 

--- a/hw/mcu/stm/stm32wbxx/include/mcu/stm32wb_bsp.h
+++ b/hw/mcu/stm/stm32wbxx/include/mcu/stm32wb_bsp.h
@@ -42,12 +42,6 @@ struct stm32_uart_cfg {
     IRQn_Type suc_irqn;                 /* NVIC IRQn */
 };
 
-/*
- * Internal API for stm32wbxx mcu specific code.
- */
-int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull,
-        uint8_t od);
-
 struct hal_flash;
 extern struct hal_flash stm32wb_flash_dev;
 


### PR DESCRIPTION
One function:
```c
int hal_gpio_init_af(int pin, uint8_t af_type, enum hal_gpio_pull pull, uint8_t od);
``` 
has many instances of prototype now only one stays

Convenience function `int hal_gpio_init_fun(uint32_t pin)` added.

Function will allow easy configuration pin with function with single value from syscfg.

i.e.
```yml
   STM32_QSPI_FLASH_CS_PIN: MCU_AFIO_GPIO_PP(MCU_GPIO_PORTC(2), 10, 0, 0)
```

could be used and later pin can be configured like this

```c
    hal_gpio_init_fun(MYNEWT_VAL_STM32_QSPI_FLASH_CS_PIN);
```

Before function AF number has to be configured in separate syscfg value of hardcoded (which was OK for some functions but may not be OK for many others)