### PR TITLE
crypto_stm32: Fix build warning

### DIFF
--- a/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c
+++ b/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c
@@ -83,7 +83,7 @@ stm32_crypto_op(struct crypto_dev *crypto, uint8_t op, uint16_t algo,
         const uint8_t *inbuf, uint8_t *outbuf, uint32_t len)
 {
     HAL_StatusTypeDef status;
-    CRYP_ConfigTypeDef conf;
+    CRYP_ConfigTypeDef conf = { 0 };
     uint32_t sz = 0;
     uint8_t i;
 #if MYNEWT_VAL(CRYPTO_HW_AES_CTR)


### PR DESCRIPTION
Warning:
```
Error: repos/apache-mynewt-core/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c: In function 'stm32_crypto_op': repos/apache-mynewt-core/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c:134:13: error: 'conf.pInitVect' may be used uninitialized [-Werror=maybe-uninitialized]
  134 |     if (conf.pInitVect != NULL) {
      |         ~~~~^~~~~~~~~~
repos/apache-mynewt-core/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c:86:24: note: 'conf' declared here
   86 |     CRYP_ConfigTypeDef conf;
      |                        ^~~~
```
is now fixed by initialization `conf` variable