### PR TITLE
mcu/stm32u5: Update repositories

### DIFF
--- a/hw/mcu/stm/stm32u5xx/pkg.yml
+++ b/hw/mcu/stm/stm32u5xx/pkg.yml
@@ -27,6 +27,9 @@ pkg.keywords:
 
 pkg.type: sdk
 
+pkg.cflags:
+    - -Wno-maybe-uninitialized
+
 pkg.ign_files:
     - ".*template.*"
 
@@ -52,14 +55,14 @@ pkg.deps.'(SPI_0_MASTER || SPI_1_MASTER || SPI_2_MASTER) && BUS_DRIVER_PRESENT':
 
 repository.stm-cmsis_device_u5:
     type: github
-    vers: v1.2.0-commit
+    vers: v1.4.3-commit
     branch: main
     user: STMicroelectronics
     repo: cmsis_device_u5
 
 repository.stm-stm32u5xx_hal_driver:
     type: github
-    vers: v1.2.0-commit
+    vers: v1.6.3-commit
     branch: main
     user: STMicroelectronics
     repo: stm32u5xx_hal_driver


### PR DESCRIPTION
This updates STM32U5 repositories to newest.

Warning about uninitialized variables has to
be tunred on (regardless of repository update)
for gcc 14.3.