### PR TITLE
drivers/crypto_stm32: Fix build for some devices

### DIFF
--- a/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c
+++ b/hw/drivers/crypto/crypto_stm32/src/crypto_stm32.c
@@ -239,6 +239,9 @@ stm32_crypto_dev_open(struct os_dev *dev, uint32_t wait, void *arg)
 #ifdef CRYP
         __HAL_RCC_CRYP_CLK_ENABLE();
         g_hcryp.Instance = CRYP;
+#elif defined(AES)
+        __HAL_RCC_AES_CLK_ENABLE();
+        g_hcryp.Instance = AES;
 #else
         __HAL_RCC_AES1_CLK_ENABLE();
         g_hcryp.Instance = AES1;


### PR DESCRIPTION
AES1 is valid peripheral for STM32WB
AES is valid for some F4/F7/H7/H5/U5/L4/L1
CRYP is valid for some F4/F7/H7

For hardware that do have AES accelerator code would not build becuase it assumed that either CRYP instance is availble or AES1 which is true only for STM32WB devices.

Now additionally code checks if AES instance is present and used it when neede.