### PR TITLE
shell: Fix static command registration

### DIFF
--- a/sys/shell/include/shell/shell.h
+++ b/sys/shell/include/shell/shell.h
@@ -210,13 +210,14 @@ LINK_TABLE(shell_mod_t, shell_modules)
  * @param func_ - function to execute
  * @param help_ - help structure for function
  */
-#define SHELL_MODULE_CMD_WITH_NAME(mod_, cmd_, name_, ext_, func_, help_)            \
-    const struct shell_cmd shell_cmd_##cmd_ SHELL_MODULE_CMD_SECTION(mod_, cmd_) = { \
-        .sc_ext = ext_,                                                              \
-        .sc_cmd_ext_func = (shell_cmd_ext_func_t)(func_),                            \
-        .sc_cmd = name_,                                                             \
-        .help = SHELL_HELP_(help_),                                                  \
-    };
+#define SHELL_MODULE_CMD_WITH_NAME(mod_, cmd_, name_, ext_, func_, help_)     \
+    const struct shell_cmd SHELL_MODULE_CMD_SECTION(mod_, cmd_)               \
+        shell_cmd_##mod_##_##cmd_ = {                                         \
+            .sc_ext = ext_,                                                   \
+            .sc_cmd_ext_func = (shell_cmd_ext_func_t)(func_),                 \
+            .sc_cmd = name_,                                                  \
+            .help = SHELL_HELP_(help_),                                       \
+        };
 
 /**
  * Create command for module

--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -448,11 +448,11 @@ shell_find_cmd(int argc, char *argv[], struct streamer *streamer)
     }
 
     if (!strcmp(first_string, "help")) {
-        return &shell_cmd_help;
+        return &shell_cmd_compat_help;
     }
 
     if (!strcmp(first_string, "select")) {
-        return &shell_cmd_select;
+        return &shell_cmd_compat_select;
     }
 
     if ((argc == 1) && (def_module == NULL)) {
@@ -501,7 +501,8 @@ shell_exec(int argc, char **argv, struct streamer *streamer)
     /* Allow invoking a cmd with module name as a prefix; a command should
      * not know how it was invoked (with or without prefix)
      */
-    if (def_module == NULL && cmd != &shell_cmd_select && cmd != &shell_cmd_help) {
+    if (def_module == NULL && cmd != &shell_cmd_compat_select &&
+        cmd != &shell_cmd_compat_help) {
         argc_offset = 1;
     }
 


### PR DESCRIPTION
Command registered to module via link table created variable that did not include module
name. This resulted in name collision if second module tried to make command with same
name.
Collision would happen in following case:
```c
SHELL_MODULE_CMD(module1, test, cmd1, NULL);
SHELL_MODULE_CMD(module2, test, cmd2, NULL);
```
While two modules do have different name, same command name would not build.

Now internal variable that is created has module embedded to prevent collision.

Adjustment in **shell.c** for compat command is applied.