### PR TITLE
Fix string handling in json code

### DIFF
--- a/encoding/json/hosttest/src/test_json_priv.h
+++ b/encoding/json/hosttest/src/test_json_priv.h
@@ -42,8 +42,8 @@ extern int buf_index;
 struct test_jbuf {
     /* json_buffer must be first element in the structure */
     struct json_buffer json_buf;
-    char * start_buf;
-    char * end_buf;
+    const char *start_buf;
+    const char *end_buf;
     int current_position;
 };
 
@@ -51,7 +51,7 @@ char test_jbuf_read_next(struct json_buffer *jb);
 char test_jbuf_read_prev(struct json_buffer *jb);
 int test_jbuf_readn(struct json_buffer *jb, char *buf, int size);
 int test_write(void *buf, char* data, int len);
-void test_buf_init(struct test_jbuf *ptjb, char *string);
+void test_buf_init(struct test_jbuf *ptjb, const char *string);
 
 #ifdef __cplusplus
 }

--- a/encoding/json/hosttest/src/test_json_utils.c
+++ b/encoding/json/hosttest/src/test_json_utils.c
@@ -93,7 +93,7 @@ test_jbuf_readn(struct json_buffer *jb, char *buf, int size)
 }
 
 void
-test_buf_init(struct test_jbuf *ptjb, char *string)
+test_buf_init(struct test_jbuf *ptjb, const char *string)
 {
     /* initialize the decode */
     ptjb->json_buf.jb_read_next = test_jbuf_read_next;

--- a/encoding/json/include/json/json.h
+++ b/encoding/json/include/json/json.h
@@ -46,7 +46,7 @@ struct json_value {
     union {
         uint64_t u;
         float fl;
-        char *str;
+        const char *str;
         struct {
             char **keys;
             struct json_value **values;
@@ -117,7 +117,7 @@ typedef enum {
 } json_type;
 
 struct json_enum_t {
-    char *name;
+    const char *name;
     long long int value;
 };
 

--- a/encoding/json/selftest/src/test_json.c
+++ b/encoding/json/selftest/src/test_json.c
@@ -23,6 +23,7 @@
 
 TEST_CASE_DECL(test_json_simple_encode);
 TEST_CASE_DECL(test_json_simple_decode);
+TEST_CASE_DECL(test_json_decode_errors);
 
 TEST_SUITE(test_json_suite)
 {
@@ -31,6 +32,7 @@ TEST_SUITE(test_json_suite)
 
     test_json_simple_encode();
     test_json_simple_decode();
+    test_json_decode_errors();
 
     free(bigbuf);
 }

--- a/encoding/json/selftest/src/test_json_priv.h
+++ b/encoding/json/selftest/src/test_json_priv.h
@@ -42,8 +42,8 @@ extern int buf_index;
 struct test_jbuf {
     /* json_buffer must be first element in the structure */
     struct json_buffer json_buf;
-    char * start_buf;
-    char * end_buf;
+    const char *start_buf;
+    const char *end_buf;
     int current_position;
 };
 
@@ -51,7 +51,7 @@ char test_jbuf_read_next(struct json_buffer *jb);
 char test_jbuf_read_prev(struct json_buffer *jb);
 int test_jbuf_readn(struct json_buffer *jb, char *buf, int size);
 int test_write(void *buf, char* data, int len);
-void test_buf_init(struct test_jbuf *ptjb, char *string);
+void test_buf_init(struct test_jbuf *ptjb, const char *string);
 
 #ifdef __cplusplus
 }

--- a/encoding/json/selftest/src/test_json_utils.c
+++ b/encoding/json/selftest/src/test_json_utils.c
@@ -94,7 +94,7 @@ test_jbuf_readn(struct json_buffer *jb, char *buf, int size)
 }
 
 void
-test_buf_init(struct test_jbuf *ptjb, char *string)
+test_buf_init(struct test_jbuf *ptjb, const char *string)
 {
     /* initialize the decode */
     ptjb->json_buf.jb_read_next = test_jbuf_read_next;

--- a/encoding/json/selftest/src/testcases/json_decode_errors.c
+++ b/encoding/json/selftest/src/testcases/json_decode_errors.c
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "json/json.h"
+#include "test_json_priv.h"
+
+static long long unsigned int uint_val;
+static long long int int_val;
+static bool bool_val;
+static char string1[16];
+static char string2[16];
+static long long int intarr[8];
+static int array_count;
+
+static struct json_attr_t test_attr[7] = {
+    [0] = {
+        .attribute = "KeyBool",
+        .type = t_boolean,
+        .addr.boolean = &bool_val,
+        .nodefault = true
+    },
+    [1] = {
+        .attribute = "KeyInt",
+        .type = t_integer,
+        .addr.integer = &int_val,
+        .nodefault = true
+        },
+    [2] = {
+        .attribute = "KeyUint",
+        .type = t_uinteger,
+        .addr.uinteger = &uint_val,
+        .nodefault = true
+        },
+    [3] = {
+        .attribute = "KeyString",
+        .type = t_string,
+        .addr.string = string1,
+        .nodefault = true,
+        .len = sizeof(string1)
+        },
+    [4] = {
+        .attribute = "KeyStringN",
+        .type = t_string,
+        .addr.string = string2,
+        .nodefault = true,
+        .len = sizeof(string2)
+    },
+    [5] = {
+        .attribute = "KeyIntArr",
+        .type = t_array,
+        .addr.array = {
+            .element_type = t_integer,
+            .arr.integers.store = intarr,
+            .maxlen = sizeof intarr / sizeof intarr[0],
+            .count = &array_count,
+        },
+        .nodefault = true,
+        .len = sizeof(intarr)
+    },
+    [6] = {
+        .attribute = NULL
+    }
+};
+
+int
+json_test_decode(const char *json_str)
+{
+    struct test_jbuf tjb;
+
+    test_buf_init(&tjb, json_str);
+
+    return json_read_object(&tjb.json_buf, test_attr);
+}
+
+static const char json_ok1[] =
+    "{\"KeyBool\": true,\"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_ok2[] =
+    "{\"KeyBool\": false,\"KeyInt\": 9223372036854775807,\"KeyUint\": 18446744073709551615,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_ok3[] =
+    "{\"KeyBool\": false,\"KeyInt\": -9223372036854775808,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_int_out_of_range1[] =
+    "{\"KeyBool\": false,\"KeyInt\": -9223372036854775809,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_int_out_of_range2[] =
+    "{\"KeyBool\": false,\"KeyInt\": 9223372036854775807,\"KeyUint\": 18446744073709551616,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_bool_fail[] =
+    "{\"KeyBool\": truea,\"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_missing_val[] =
+    "{\"KeyBool\":,\"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_str_to_long1[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"12345678901234567\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_str_to_long2[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"1234567890123456\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_str_no_quotes[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_extra_coma0[] =
+    "{\"KeyBool\":false, , \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_extra_coma1[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322],}";
+static const char json_extra_coma2[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322,]}";
+static const char json_missing_quote[] =
+    "{\"KeyBool\": false, \"KeyInt\": -1234,\"KeyUint: 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322],}";
+static const char json_attr_to_long[] =
+    "{\"A2345678901234567890123456789012\": false, \"KeyInt\": -1234,\"KeyUint: 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_bad_attr[] =
+    "{\"A234567890123456789012345678901\": false, \"KeyInt\": -1234,\"KeyUint: 1353214,\"KeyString\": 123456789012345,\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+static const char json_no_brak[] =
+    "{\"KeyBool\": true,\"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322}";
+static const char json_no_start[] =
+    "\"KeyBool\": true,\"KeyInt\": -1234,\"KeyUint\": 1353214,\"KeyString\": \"foobar\",\"KeyStringN\": \"foobarlong\",\"KeyIntArr\": [153,2532,-322]}";
+
+/* now test the decode on a string */
+TEST_CASE_SELF(test_json_decode_errors)
+{
+    int rc;
+
+    rc = json_test_decode(json_ok1);
+    TEST_ASSERT(rc == 0);
+    rc = json_test_decode(json_ok2);
+    TEST_ASSERT(rc == 0);
+    rc = json_test_decode(json_ok3);
+    TEST_ASSERT(rc == 0);
+    rc = json_test_decode(json_int_out_of_range1);
+    TEST_ASSERT(rc == 0);
+    rc = json_test_decode(json_int_out_of_range2);
+    TEST_ASSERT(rc == 0);
+    /* Invalid bool value, not "true" or "false", makes false */
+    rc = json_test_decode(json_bool_fail);
+    TEST_ASSERT(rc == 0 && bool_val == false);
+    rc = json_test_decode(json_missing_val);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_missing_quote);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_str_to_long1);
+    TEST_ASSERT(rc == JSON_ERR_STRLONG);
+    rc = json_test_decode(json_str_to_long2);
+    TEST_ASSERT(rc == JSON_ERR_STRLONG);
+    rc = json_test_decode(json_str_no_quotes);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_extra_coma0);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_extra_coma1);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_extra_coma2);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_attr_to_long);
+    TEST_ASSERT(rc == JSON_ERR_ATTRLEN);
+    rc = json_test_decode(json_bad_attr);
+    TEST_ASSERT(rc == JSON_ERR_BADATTR);
+    rc = json_test_decode(json_no_brak);
+    TEST_ASSERT(rc != 0);
+    rc = json_test_decode(json_no_start);
+    TEST_ASSERT(rc != 0);
+}

--- a/encoding/json/src/json_decode.c
+++ b/encoding/json/src/json_decode.c
@@ -265,7 +265,7 @@ json_internal_read_object(struct json_buffer *jb,
                     maxlen = 5; /* false */
                 }
                 pval = valbuf;
-            } else if (pattr >= attrbuf + JSON_ATTR_MAX - 1) {
+            } else if ((pattr - attrbuf) >= JSON_ATTR_MAX) {
                 /* don't update end here, leave at attribute start */
                 return JSON_ERR_ATTRLEN;
             } else {
@@ -308,8 +308,7 @@ json_internal_read_object(struct json_buffer *jb,
             } else if (c == '"') {
                 *pval++ = '\0';
                 state = post_val;
-            } else if (pval > valbuf + JSON_VAL_MAX - 1
-                       || pval > valbuf + maxlen) {
+            } else if ((pval - valbuf) >= JSON_VAL_MAX || (pval - valbuf) >= maxlen) {
                 /* don't update end here, leave at value start */
                 return JSON_ERR_STRLONG;        /*  */
             } else {
@@ -459,7 +458,6 @@ json_internal_read_object(struct json_buffer *jb,
                         return JSON_ERR_NOPARSTR;
                     }
                     (void)strncpy(lptr, valbuf, cursor->len);
-                    valbuf[sizeof(valbuf)-1] = '\0';
                     break;
                 case t_boolean: {
                         bool tmp = (strcmp(valbuf, "true") == 0);


### PR DESCRIPTION
There was error where string value could be left unterminated in during decoding.
Code would not write beyond buffer intended for value but it could leave buffer with string that is not 0 terminated.

Now in such case decoded reports error as was intended.
Additionally handling of long names for attributes is also fixed. Code would allowed attributes name to be shorter by one character than it suggested.

Unit test for failing data is also added.

Some structure fields that were `char *` are not change to `const char *` to allow builds when attribute descriptors are from string literals that are const.

Fixes #3596