### PR TITLE
baselibc: Prevent optimization memset loop

### DIFF
--- a/libc/baselibc/src/memset.c
+++ b/libc/baselibc/src/memset.c
@@ -77,9 +77,15 @@ void *memset(void *dst, int c, size_t n)
                   :
                   :);
 #else
-	while (n--) {
-		*q++ = c;
-	}
+    while (n--) {
+        *q++ = c;
+        /*
+         * Blocks pattern matching, so this loop is not recognized
+         * as something that can be replaced by memset call
+         * that would result in recursion.
+         */
+        __asm__ volatile("" : : : "memory");
+    }
 #endif
 
 	return dst;


### PR DESCRIPTION
Modern compilers can detect that loop in this
function looks like something that can be replaced by memset call.
It would lead to recursive call to itself.

With empty asm inline loop does not match pattern
that can be replace by memset call.