### PR TITLE
sys/log: Fix storage info for log_cbmem

### DIFF
--- a/sys/log/full/src/log_cbmem.c
+++ b/sys/log/full/src/log_cbmem.c
@@ -242,14 +242,16 @@ log_cbmem_storage_info(struct log *log, struct log_storage_info *info)
 {
     struct cbmem *cbmem;
     uint32_t size;
-    uint32_t used;
+    uint32_t used = 0;
 
     cbmem = (struct cbmem *)log->l_arg;
 
     size = cbmem->c_buf_end - cbmem->c_buf;
 
-    used = (uintptr_t)cbmem->c_entry_end + cbmem->c_entry_end->ceh_len -
-           (uintptr_t)cbmem->c_entry_start;
+    if (cbmem->c_buf_cur_end) {
+        used = (uintptr_t)cbmem->c_entry_end + cbmem->c_entry_end->ceh_len -
+               (uintptr_t)cbmem->c_entry_start;
+    }
     if ((int32_t)used < 0) {
         used += size;
     }


### PR DESCRIPTION
When log_cbmem is empty, (nothing was logged yet)
storage_info would crash due to NULL pointer
dereference object used in arithemtic.

Now code checks for NULL and reports whole size
of the buffer during storage_info call.