### PR TITLE
stm32u5: Fix flash write with cache

### DIFF
--- a/hw/mcu/stm/stm32_common/src/hal_flash.c
+++ b/hw/mcu/stm/stm32_common/src/hal_flash.c
@@ -94,7 +94,7 @@ stm32_flash_write_linear(const struct hal_flash *dev, uint32_t address,
     int rc = 0;
     uint8_t align;
     uint32_t num_words;
-#if defined(STM32H5)
+#if defined(STM32H5) || defined(STM32U5)
     bool icache_enabled = LL_ICACHE_IsEnabled();
 #endif
     align = dev->hf_align;
@@ -153,7 +153,7 @@ stm32_flash_write_linear(const struct hal_flash *dev, uint32_t address,
         }
     }
 
-#ifdef STM32H5
+#if defined(STM32H5) || defined(STM32U5)
     if (icache_enabled) {
         LL_ICACHE_Invalidate();
     }

--- a/hw/mcu/stm/stm32u5xx/include/mcu/stm32_hal.h
+++ b/hw/mcu/stm/stm32u5xx/include/mcu/stm32_hal.h
@@ -41,6 +41,7 @@ extern "C" {
 #include "stm32u5xx_hal_tim.h"
 #include "stm32u5xx_ll_bus.h"
 #include "stm32u5xx_ll_tim.h"
+#include "stm32u5xx_ll_icache.h"
 #include "stm32u5xx_hal_def.h"
 #include "stm32u5xx_hal_flash.h"
 #include "stm32u5xx_hal_flash_ex.h"


### PR DESCRIPTION
It turned out that same problem that was seen on
stm32h5 devices applies to stm32u5.
After writeing correctly to flash, cache was not
invalidated and subsequent read from place where
data was just written returned incorrect data
from cache.
It was detected when FCB was used on flash and
during CRC calculation written data was not
seed as expected and CRC was never written.