### PR TITLE
compiler/xc32: Add speed profile

### DIFF
--- a/compiler/xc32/compiler.yml
+++ b/compiler/xc32/compiler.yml
@@ -28,6 +28,7 @@ compiler.path.objcopy: "xc32-objcopy"
 compiler.flags.base: [-std=gnu11, -fno-common, -mnewlib-libc, -ffunction-sections, -fdata-sections]
 compiler.flags.default: [compiler.flags.base, -O2, -g3]
 compiler.flags.optimized: [compiler.flags.base, -O2, -g3]
+compiler.flags.speed: [compiler.flags.base, -O2, -g3]
 compiler.flags.debug: [compiler.flags.base, -Og, -g3]
 
 compiler.as.flags: [-x, assembler-with-cpp]


### PR DESCRIPTION
Other compiler.yml file do have speed profile
and this profile is selected by coremark
```
2026/06/26 09:56:33.444 [WARNING] Unsupported build profile for package, using default build profile (pkg="@apache-mynewt-core/util/coremark/repo" build_profile="speed" OS="windows")
```

This adds speed profile that is same as optimized
as **-Ofast** or **-O3** does not work in free xc32 compiler