### PR TITLE
crypto/mbedtls: Upgrade to v3.6.6

### DIFF
--- a/crypto/mbedtls/pkg.yml
+++ b/crypto/mbedtls/pkg.yml
@@ -47,7 +47,7 @@ pkg.src_dirs:
 
 repository.mbedtls:
     type: github
-    vers: v3.6.5-commit
+    vers: v3.6.6-commit
     branch: master
     user: Mbed-TLS
     repo: mbedtls


### PR DESCRIPTION
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.6