### PR TITLE
hw/mpu: Add link table configuration of MPU

### DIFF
--- a/hw/cmsis-core/include/arm_mpu.h
+++ b/hw/cmsis-core/include/arm_mpu.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef ARM_MPU_H
+#define ARM_MPU_H
+
+#include <os/mynewt.h>
+#include <os/link_tables.h>
+
+#if __MPU_PRESENT
+#if (__CORTEX_M == 0) || (__CORTEX_M == 3) || (__CORTEX_M == 4) || (__CORTEX_M == 7)
+
+LINK_TABLE(ARM_MPU_Region_t, mpu_regions);
+
+#define MPU_ARM_V7_REGION(name, address, rasr)                                \
+    LINK_TABLE_ELEMENT(mpu_regions, name) = {                                 \
+        .RBAR = address | MPU_RBAR_VALID_Msk,                                 \
+        .RASR = rasr,                                                         \
+    };
+
+#elif (__CORTEX_M == 23) || (__CORTEX_M == 33) || (__CORTEX_M == 34) ||       \
+    (__CORTEX_M == 35)
+/* TODO: Add support for MPU ARMV8 */
+#endif
+
+void arm_mpu_init(void);
+
+#endif
+#endif

--- a/hw/cmsis-core/src/arm_mpu.c
+++ b/hw/cmsis-core/src/arm_mpu.c
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <os/os.h>
+#include <os/link_tables.h>
+#include <arm_mpu.h>
+
+#ifndef __CORTEX_M
+#error "Macro __CORTEX_M not defined; must define cortex-m type!"
+#endif
+
+#if __MPU_PRESENT
+#if (__CORTEX_M == 0) || (__CORTEX_M == 3) || (__CORTEX_M == 4) || (__CORTEX_M == 7)
+
+void
+arm_mpu_init(void)
+{
+    ARM_MPU_Region_t regions[8] = { 0 };
+    size_t size = min(ARRAY_SIZE(regions), mpu_regions_size());
+
+    ARM_MPU_Disable();
+
+    for (size_t i = 0; i < size; ++i) {
+        regions[i].RBAR = (mpu_regions[i].RBAR & ~MPU_RBAR_REGION_Msk) | i;
+        regions[i].RASR = mpu_regions[i].RASR;
+    }
+
+    ARM_MPU_Load(regions, size);
+
+    ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
+}
+#elif (__CORTEX_M == 23) || (__CORTEX_M == 33) || (__CORTEX_M == 34) ||       \
+    (__CORTEX_M == 35)
+/* TODO: Add support for MPU ARMV8 */
+#endif
+
+#endif

--- a/hw/cmsis-core/syscfg.yml
+++ b/hw/cmsis-core/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,26 +16,8 @@
 # under the License.
 #
 
-pkg.name: hw/cmsis-core
-pkg.description: CMSIS-CORE abstraction layer for Cortex-M processors.
-pkg.author: "Keil"
-pkg.homepage: "http://www.keil.com/pack/doc/CMSIS/Core/html/index.html"
-pkg.keywords:
-    - cmsis
-    - core
+syscfg.defs:
+    ARM_MPU:
+        description: ARM MPU is present
+        value:
 
-pkg.type: sdk
-
-pkg.include_dirs:
-    - "@arm-CMSIS_5/CMSIS/Core/Include"
-    - "@arm-CMSIS_5/CMSIS/DSP/Include"
-
-pkg.link_tables:
-    - mpu_regions
-
-repository.arm-CMSIS_5:
-    type: github
-    vers: 5.9.0-commit
-    branch: master
-    user: ARM-software
-    repo: CMSIS_5


### PR DESCRIPTION
This adds way to configure MPU (v7) using link
tables.

User code will just have to declare MPU etrny in
any place to add region to MPU.