### PR TITLE
drivers/mmc: Read crc for data commands

### DIFF
--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -250,7 +250,7 @@ send_mmc_cmd(mmc_disk_t *mmc, sd_cmd_t cmd, uint32_t payload)
     uint16_t status;
     uint8_t crc;
     uint8_t buf[6];
-    char strbuf[30];
+    char strbuf[90];
 
     mmc_led_on();
 

--- a/hw/drivers/mmc/src/mmc.c
+++ b/hw/drivers/mmc/src/mmc.c
@@ -360,6 +360,7 @@ mmc_cmd_receive_data(mmc_disk_t *mmc, uint8_t cmd, uint32_t payload,
 {
     int status;
     uint8_t res;
+    uint8_t crc[2];
 
     mmc_spi_set_cs(mmc, 0);
 
@@ -371,6 +372,8 @@ mmc_cmd_receive_data(mmc_disk_t *mmc, uint8_t cmd, uint32_t payload,
             mmc_spi_rx(mmc, buffer, count);
         }
     }
+
+    mmc_spi_rx(mmc, crc, 2);
 
     mmc_spi_set_cs(mmc, 1);
 


### PR DESCRIPTION
Code was not reading CRC for commands with
data other then CMD17/CMD18.

It could result in strange behavior for some
cards that send CRC on subsequent clocks
that belong to other requests and synchronization
was lost.

Now CRC is read after data block is received.