### PR TITLE
encoding/json: Add float support

### DIFF
--- a/encoding/json/include/json/json.h
+++ b/encoding/json/include/json/json.h
@@ -25,7 +25,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <sys/types.h>
-
+#include <syscfg/syscfg.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +37,18 @@ extern "C" {
 #define JSON_VALUE_TYPE_STRING (3)
 #define JSON_VALUE_TYPE_ARRAY  (4)
 #define JSON_VALUE_TYPE_OBJECT (5)
+
+#if MYNEWT_VAL_JSON_FLOAT_SUPPORT
+#define FLOAT_SUPPORT 1
+#endif
+
+#if MYNEWT_VAL_JSON_REAL_IS_FLOAT
+typedef float json_real_t;
+#define strtoreal strtof
+#else
+typedef double json_real_t;
+#define strtoreal strtod
+#endif
 
 struct json_value {
     uint8_t jv_pad1;
@@ -141,7 +153,7 @@ struct json_array_t {
             long long unsigned int *store;
         } uintegers;
         struct {
-            double *store;
+            json_real_t *store;
         } reals;
         struct {
             bool *store;
@@ -157,7 +169,7 @@ struct json_attr_t {
     union {
         long long int *integer;
         long long unsigned int *uinteger;
-        double *real;
+        json_real_t *real;
         char *string;
         bool *boolean;
         char *character;
@@ -167,7 +179,7 @@ struct json_attr_t {
     union {
         long long int integer;
         long long unsigned int uinteger;
-        double real;
+        json_real_t real;
         bool boolean;
         char character;
         char *check;

--- a/encoding/json/src/json_decode.c
+++ b/encoding/json/src/json_decode.c
@@ -185,7 +185,7 @@ json_internal_read_object(struct json_buffer *jb,
                            sizeof(long long unsigned int));
                     break;
                 case t_real:
-                    memcpy(lptr, &cursor->dflt.real, sizeof(double));
+                    memcpy(lptr, &cursor->dflt.real, sizeof(json_real_t));
                     break;
                 case t_string:
                     if (parent != NULL
@@ -444,8 +444,8 @@ json_internal_read_object(struct json_buffer *jb,
                     break;
                 case t_real: {
 #ifdef FLOAT_SUPPORT
-                        double tmp = atof(valbuf);
-                        memcpy(lptr, &tmp, sizeof(double));
+                        json_real_t tmp = strtoreal(valbuf, NULL);
+                        memcpy(lptr, &tmp, sizeof(json_real_t));
 #else
                         return JSON_ERR_MISC;
 #endif
@@ -597,7 +597,7 @@ json_read_array(struct json_buffer *jb, const struct json_array_t *arr)
             n = jb->jb_readn(jb, valbuf, sizeof(valbuf)-1);
             valbuf[n] = '\0';
 
-            arr->arr.reals.store[offset] = strtod(valbuf, &ep);
+            arr->arr.reals.store[offset] = strtoreal(valbuf, &ep);
             if (ep == valbuf) {
                 return JSON_ERR_BADNUM;
             } else {

--- a/encoding/json/syscfg.yml
+++ b/encoding/json/syscfg.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,8 +16,15 @@
 # under the License.
 #
 
-pkg.name: encoding/json
-pkg.description: JSON encoding / decoding library.
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
+syscfg.defs:
+    JSON_FLOAT_SUPPORT:
+        description: "Enable floating point numbers in json code"
+        value: 0
+    JSON_REAL_IS_FLOAT:
+        description: "If set to 1 real numbers are of type float not double"
+        value: 0
+
+syscfg.vals.FLOAT_USER:
+    # Enable by default when FLOAT_USER is enabled
+    # Can be separately disabled in target/application
+    JSON_FLOAT_SUPPORT: 1


### PR DESCRIPTION
When syscfg value `FLOAT_USER` was defined, json code enabled float point support with `double` as storage.

Now `FLOAT_USER` also enables floating point support by default but it can be overridden in syscfg.
This way floating point numbers can be used somewhere else and json code size can be reduced if needed
by not supporting floats.

Additionally **syscfg** `JSON_REAL_IS_FLOAT` is introduced to allow use `float` type instead of `double`
to further reduce code size and conversion overhead
on platforms that don't have hardware double
precision floating point support.