### PR TITLE
nvic: Add NVIC_ConfigVector

### DIFF
--- a/hw/cmsis-core/include/mynewt_nvic.h
+++ b/hw/cmsis-core/include/mynewt_nvic.h
@@ -20,12 +20,16 @@
 #ifndef MYNEWT_NVIC_H
 #define MYNEWT_NVIC_H
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <mcu/cmsis_nvic.h>
 #include <os/util.h>
 
 void NVIC_Relocate(void);
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
 uint32_t NVIC_GetVector(IRQn_Type IRQn);
+void NVIC_ConfigVector(IRQn_Type IRQn, void (*vector)(void), uint8_t priority,
+                       bool enable);
 
 static inline void
 NVIC_DisableAll(void)

--- a/hw/cmsis-core/src/cmsis_nvic.c
+++ b/hw/cmsis-core/src/cmsis_nvic.c
@@ -3,7 +3,8 @@
  *
  * CMSIS-style functionality to support dynamic vectors
  */
-#include "mcu/cmsis_nvic.h"
+
+#include <mynewt_nvic.h>
 
 #ifndef __CORTEX_M
     #error "Macro __CORTEX_M not defined; must define cortex-m type!"
@@ -18,6 +19,16 @@
 
 extern char __isr_vector[];
 extern char __vector_tbl_reloc__[];
+
+void
+NVIC_ConfigVector(IRQn_Type IRQn, void (*vector)(void), uint8_t priority, bool enable)
+{
+    NVIC_SetPriority(IRQn, priority);
+    NVIC_SetVector(IRQn, (uint32_t)vector);
+    if (enable) {
+        NVIC_EnableIRQ(IRQn);
+    }
+}
 
 void
 NVIC_Relocate(void)


### PR DESCRIPTION
Almost all NVIC vector configurations follow
pattern:

```c
NVIC_SetPriority(irq, 2)
NVIC_SetVector(irq, (uint32_t)isr);
NVIC_EnableIRQ(irq);
```
Now there is one function that does those things

```c
NVIC_ConfigVector(irq, isr, 2, true);
```

Cast to uint32_t is done inside.