### PR TITLE
ci: Add body to PR commit message

### DIFF
--- a/.github/workflows/update_hw_ci_badges.yml
+++ b/.github/workflows/update_hw_ci_badges.yml
@@ -48,6 +48,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
             Update HW CI badges in README
+
+            Automated update of hardware CI status badges.
+            This commit fetches the latest test results from the Codecoup lab.
           branch: update-hw-ci-badges
           title: "Update HW CI status badges"
           body: |


### PR DESCRIPTION
Expand the commit message in the HW CI badges update workflow to comply with Apache commit style