### PR TITLE
at45db: fix leaked settings and corrupted global default baudrate (#3701)

### DIFF
--- a/hw/drivers/flash/at45db/src/at45db.c
+++ b/hw/drivers/flash/at45db/src/at45db.c
@@ -416,7 +416,7 @@ int
 at45db_init(const struct hal_flash *hal_flash_dev)
 {
     int rc;
-    struct hal_spi_settings *settings;
+    struct hal_spi_settings *settings = NULL;
     struct at45db_dev *dev;
 
     dev = (struct at45db_dev *) hal_flash_dev;
@@ -430,18 +430,21 @@ at45db_init(const struct hal_flash *hal_flash_dev)
             return -1;
         }
         memcpy(settings, &at45db_default_settings, sizeof(at45db_default_settings));
-        at45db_default_settings.baudrate = dev->baudrate;
+        settings->baudrate = dev->baudrate;
+        dev->settings = settings;
     }
 
     hal_gpio_init_out(dev->ss_pin, 1);
 
     rc = hal_spi_init(dev->spi_num, dev->spi_cfg, HAL_SPI_TYPE_MASTER);
     if (rc) {
+        free(settings);
         return (rc);
     }
 
     rc = hal_spi_config(dev->spi_num, dev->settings);
     if (rc) {
+        free(settings);
         return (rc);
     }
 


### PR DESCRIPTION
Fixes #3701.

## Problem

`at45db_init()`'s non-default-baudrate path allocated a per-device copy of `hal_spi_settings` but never used it correctly:

```c
settings = malloc(sizeof(at45db_default_settings));
...
memcpy(settings, &at45db_default_settings, sizeof(at45db_default_settings));
at45db_default_settings.baudrate = dev->baudrate;
```

Two problems:

1. `dev->settings` is never assigned in this branch (only the default-baudrate branch does `dev->settings = &at45db_default_settings`), so the later `hal_spi_config(dev->spi_num, dev->settings)` call is passed an unset/stale pointer for every device using a non-default baudrate. The allocated `settings` buffer itself leaks - the only pointer to it (the local variable) goes out of scope at the end of the function.
2. The baudrate is written into the **global** `at45db_default_settings` instead of the per-device copy, corrupting the shared default for every other at45db device initialized afterwards.

## Fix

Store the baudrate on the allocated copy (not the global), assign the copy to `dev->settings`, and free it on the two error paths that follow (`hal_spi_init()`/`hal_spi_config()` failing) so the allocation doesn't leak there either. `settings` is initialized to `NULL` so `free(settings)` is a safe no-op on the default-baudrate path, where no allocation happens.

## Verification

I don't have the physical AT45DB flash hardware or a full Mynewt build environment set up, so I verified the corrected logic with a standalone C reproduction of the exact allocate/copy/assign pattern:

- Two devices initialized with different non-default baudrates (4000, 2000): before the fix, both end up with `settings == NULL` and the shared global default gets stomped to the last device's baudrate (2000). After the fix, each device gets its own non-NULL settings with its own correct baudrate, and the global default stays untouched.
- Simulated a `hal_spi_config()` failure after allocation: before the fix, the allocation leaks (1 malloc, 0 free). After the fix, it's correctly freed (1 malloc, 1 free).

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission. Per the ASF's [generative-tooling policy](https://www.apache.org/legal/generative-tooling.html), this is noted in the commit message (`Generated-by: Claude (Anthropic)`), which the policy recommends as a good practice.
