### PR TITLE
sensor: free listener in sensor_trigger_init() if registration fails (#3703)

### DIFF
--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -2160,6 +2160,7 @@ sensor_trigger_init(struct sensor *sensor, sensor_type_t type,
 
     rc = sensor_register_listener(sensor, sensor_trig_lner);
     if (rc) {
+        free(sensor_trig_lner);
         return;
     }
 }


### PR DESCRIPTION
Fixes #3703.

## Problem

`sensor_trigger_init()` allocates a `struct sensor_listener` locally and passes ownership to `sensor_register_listener()`, but only after that function successfully inserts it into `sensor->s_listener_list`:

```c
rc = sensor_lock(sensor);
if (rc != 0) {
    goto err;
}
SLIST_INSERT_HEAD(&sensor->s_listener_list, listener, sl_next);
sensor_unlock(sensor);
return (0);
err:
    return (rc);
```

If `sensor_register_listener()` returns an error before the insert (e.g. `sensor_lock()` fails), the listener was never attached to the sensor and there is no later owner that could release it. The caller's `if (rc) { return; }` then drops the only pointer, leaking the allocation.

This is a narrow window in practice - `sensor_lock()` uses `OS_TIMEOUT_NEVER`, so ordinary mutex contention won't fail this path by timeout - but the allocated buffer should still be freed on this error path since it was never handed off.

## Fix

`free(sensor_trig_lner)` before returning on the error path.

## Verification

This is a minimal, single-line fix to an already-local, not-yet-shared allocation on an early-return error path - the ownership boundary is unambiguous from reading `sensor_register_listener()`'s own success/error contract (insert-then-succeed vs never-inserted-on-error), so no separate reproduction harness was needed beyond reading the two functions side by side. I don't have the sensor hardware/build environment set up to exercise a `sensor_lock()` failure at runtime.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission. Per the ASF's [generative-tooling policy](https://www.apache.org/legal/generative-tooling.html), this is noted in the commit message (`Generated-by: Claude (Anthropic)`), which the policy recommends as a good practice.