### PR TITLE
shell: Fix LINK_TABLE start pointer alignment in shell module tables

### DIFF
--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -31,19 +31,30 @@
 
 #define SHELL_PROMPT "shell"
 
+static const struct shell_cmd *
+shell_mod_std_commands(const struct shell_mod_std *std_mod)
+{
+    uintptr_t addr = (uintptr_t)std_mod->commands;
+    uintptr_t aligned = (addr + sizeof(struct shell_cmd) - 1) &
+                        ~(uintptr_t)(sizeof(struct shell_cmd) - 1);
+
+    return (const struct shell_cmd *)aligned;
+}
+
 static size_t
 shell_mod_std_count(shell_mod_t mod)
 {
     const struct shell_mod_std *std_mod = (const struct shell_mod_std *)mod;
-    return std_mod->commands_end - std_mod->commands;
+    return std_mod->commands_end - shell_mod_std_commands(std_mod);
 }
 
 static shell_cmd_t
 shell_mod_std_get(shell_mod_t mod, size_t ix)
 {
     const struct shell_mod_std *std_mod = (const struct shell_mod_std *)mod;
-    size_t limit = std_mod->commands_end - std_mod->commands;
-    return ix < limit ? &std_mod->commands[ix] : NULL;
+    const struct shell_cmd *commands = shell_mod_std_commands(std_mod);
+    size_t limit = std_mod->commands_end - commands;
+    return ix < limit ? &commands[ix] : NULL;
 }
 
 const struct shell_mod_ops shell_mod_std_ops = {


### PR DESCRIPTION
In Mynewt, linker tables are used to group structs together. However, if the linker doesn't perfectly align the start of the section to the struct's size boundary, C pointer arithmetic miscalculates the array bounds. This manually aligns the pointer.