### PR TITLE
hal_uart: Fix loop_slave file descriptor leak

### DIFF
--- a/hw/mcu/native/src/hal_uart.c
+++ b/hw/mcu/native/src/hal_uart.c
@@ -288,6 +288,7 @@ uart_pty(int port)
         goto err;
     }
 
+    close(loop_slave);
     snprintf(msg, sizeof(msg), "uart%d at %s\n", port, pty_name);
     write(1, msg, strlen(msg));
     return fd;


### PR DESCRIPTION
The loop_slave file descriptor opened by openpty() in uart_pty() was never closed, leading to a resource leak.