### PR TITLE
sim: Fix -Werror compilation issues on 64-bit Linux

### DIFF
--- a/sys/log/full/src/log_shell.c
+++ b/sys/log/full/src/log_shell.c
@@ -128,7 +128,7 @@ shell_log_dump_entry(struct log *log, struct log_offset *log_offset,
             console_printf("[ih=0x%02x%02x%02x%02x]", ueh->ue_imghash[0], ueh->ue_imghash[1],
                            ueh->ue_imghash[2], ueh->ue_imghash[3]);
         }
-        console_printf(" [%llu] ", ueh->ue_ts);
+        console_printf(" [%llu] ", (unsigned long long)ueh->ue_ts);
     }
 
 #if MYNEWT_VAL(LOG_SHELL_SHOW_INDEX)

--- a/sys/shell/src/shell_nlip.c
+++ b/sys/shell/src/shell_nlip.c
@@ -103,7 +103,7 @@ shell_nlip_process(char *data, int len)
                 crc = crc16_ccitt(crc, m->om_data, m->om_len);
             }
             if (crc == 0 && g_nlip_expected_len >= sizeof(crc)) {
-                os_mbuf_adj(g_nlip_mbuf, -sizeof(crc));
+                os_mbuf_adj(g_nlip_mbuf, -(int)sizeof(crc));
                 g_shell_nlip_in_func(g_nlip_mbuf, g_shell_nlip_in_arg);
             } else {
                 os_mbuf_free_chain(g_nlip_mbuf);


### PR DESCRIPTION
This fixes two warnings that break compilation when -Werror is enabled for the simulator on 64-bit Linux:

1. Fixes an int64_t format warning in log_shell.c.
2. Fixes an overflow warning in shell_nlip.c where an unsigned size_t was negated.