### PR TITLE
ci: Add option to align macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,7 +65,7 @@ BinPackArguments: true
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: true
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
 
 # Control statements
 AlwaysBreakAfterReturnType: TopLevelDefinitions


### PR DESCRIPTION
Modify macro alignment option for aligning
macros (especially define statements).
Align will be enforced across comments and empty lines.