### PR TITLE
ci: Include "n/a" board status in test results

### DIFF
--- a/.github/scripts/update_badges.py
+++ b/.github/scripts/update_badges.py
@@ -48,7 +48,7 @@ def _generate_markdown(results):
 
     for test_name in sorted(results.keys()):
         boards = results[test_name]
-        valid_boards = sorted([b for b, status in boards.items() if status in ("passing", "failing")])
+        valid_boards = sorted([b for b, status in boards.items() if status in ("passing", "failing", "n/a")])
 
         if valid_boards:
             md.append(f"## {test_name}")


### PR DESCRIPTION
Fetch and process "n/a" test status results alongside "passing" and "failing". This improves visual comparison and badge alignment.