### PR TITLE
ci: Add workflow for building mtest apps

### DIFF
--- a/.github/project_build_mtest_apps.yml
+++ b/.github/project_build_mtest_apps.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project.name: "build_mtest_apps"
+
+project.repositories:
+  - apache-mynewt-core
+
+# Use github's distribution mechanism for core ASF libraries.
+# This provides mirroring automatically for us.
+#
+repository.apache-mynewt-core:
+  type: github
+  vers: 0.0.0
+  user: apache
+  repo: mynewt-core
+
+
+project.repositories.allowed:
+  - apache-mynewt-core
+  - apache-mynewt-nimble
+  - apache-mynewt-mcumgr
+  - mcuboot
+  - tinyusb
+  - arm-CMSIS_5
+  - stm-cmsis_device_h7
+  - stm-stm32h7xx_hal_driver
+  - nordic-nrfx
+  - mbedtls

--- a/.github/test_build_mtest_apps.sh
+++ b/.github/test_build_mtest_apps.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -x
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+EXIT_CODE=0
+
+APPS=$(basename -a `ls -d repos/apache-mynewt-core/test/mtest/*/`)
+IGNORED_APPS="mtest"
+
+BOARDS="nordic_pca10056 nucleo-h723zg"
+
+for app in ${APPS}; do
+    # NOTE: do not remove the spaces around IGNORED_APPS; it's required to
+    #       match against the first and last entries
+    if [[ " ${IGNORED_APPS} " =~ [[:blank:]]${app}[[:blank:]] ]]; then
+        continue
+    fi
+    echo "Testing $app:"
+    for board in ${BOARDS}; do
+        echo " - building on $board"
+
+        target="mtest-test-$app"
+        newt target delete -s -f $target &> /dev/null
+        newt target create -s $target
+        newt target set -s $target bsp="@apache-mynewt-core/hw/bsp/$board"
+        newt target set -s $target app="@apache-mynewt-core/test/mtest/$app"
+        newt build -q $target
+
+        rc=$?
+        [[ $rc -ne 0 ]] && EXIT_CODE=$rc
+
+        newt clean $target
+        newt target delete -s -f $target
+    done
+
+done
+
+exit $EXIT_CODE

--- a/.github/workflows/build_mtest_apps.yml
+++ b/.github/workflows/build_mtest_apps.yml
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build mtest apps
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  targets:
+    name: Build all apps
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: '${{ matrix.os }}'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: stable
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1.12.3
+        with:
+          release: 15.2.Rel1
+      - name: Install Dependencies
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+      - name: Install newt
+        shell: bash
+        run: |
+          go version
+          go install mynewt.apache.org/newt/newt@latest
+      - name: Setup project
+        shell: bash
+        run: |
+          newt new build_mtest
+          cp -f .github/project_build_mtest_apps.yml build_mtest/project.yml
+          cd build_mtest
+          newt upgrade --shallow=1
+          git -C repos/apache-mynewt-core fetch origin $GITHUB_SHA
+          sed -i "s/0.0.0/$GITHUB_SHA-commit/g" project.yml
+          newt upgrade --shallow=1
+          rm -rf targets
+          cd ..
+      - name: Build mtest apps
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd build_mtest
+          bash ../.github/test_build_mtest_apps.sh
+          cd ..


### PR DESCRIPTION
This workflow builds all apps contained in the test/mtest folder on boards defined in the test script. This helps to catch any changes in APIs early.