### PR TITLE
Revert "shell: Fix LINK_TABLE start pointer alignment in shell module…

### DIFF
--- a/sys/shell/src/shell.c
+++ b/sys/shell/src/shell.c
@@ -31,30 +31,19 @@
 
 #define SHELL_PROMPT "shell"
 
-static const struct shell_cmd *
-shell_mod_std_commands(const struct shell_mod_std *std_mod)
-{
-    uintptr_t addr = (uintptr_t)std_mod->commands;
-    uintptr_t aligned = (addr + sizeof(struct shell_cmd) - 1) &
-                        ~(uintptr_t)(sizeof(struct shell_cmd) - 1);
-
-    return (const struct shell_cmd *)aligned;
-}
-
 static size_t
 shell_mod_std_count(shell_mod_t mod)
 {
     const struct shell_mod_std *std_mod = (const struct shell_mod_std *)mod;
-    return std_mod->commands_end - shell_mod_std_commands(std_mod);
+    return std_mod->commands_end - std_mod->commands;
 }
 
 static shell_cmd_t
 shell_mod_std_get(shell_mod_t mod, size_t ix)
 {
     const struct shell_mod_std *std_mod = (const struct shell_mod_std *)mod;
-    const struct shell_cmd *commands = shell_mod_std_commands(std_mod);
-    size_t limit = std_mod->commands_end - commands;
-    return ix < limit ? &commands[ix] : NULL;
+    size_t limit = std_mod->commands_end - std_mod->commands;
+    return ix < limit ? &std_mod->commands[ix] : NULL;
 }
 
 const struct shell_mod_ops shell_mod_std_ops = {


### PR DESCRIPTION
#3711 turned out to be not correct solution.

While it works for native Linux 64-bit build, is breaks normal target builds.

It's true that affected table element is 32 bytes long. But size of this structure is not the reason why elements are aligned to 32 bytes so manual alignment to structure size is unfortunately wrong solution.
For 32 bit ARM builds this alignment does not happen.

Working on other solution for this...

This reverts commit 1431593f7a2c46c71edd9d3b4e4d11db7ee037bb.