### PR TITLE
sensors/lis2dw12: Fix memory corruption in SPI bus configuration

### DIFF
--- a/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
+++ b/hw/drivers/sensors/lis2dw12/include/lis2dw12/lis2dw12.h
@@ -276,7 +276,10 @@ struct lis2dw12_pdd {
 
 struct lis2dw12 {
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
-    struct bus_i2c_node i2c_node;
+    union {
+        struct bus_i2c_node i2c_node;
+        struct bus_spi_node spi_node;
+    };
 #else
     struct os_dev dev;
 #endif

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -2158,11 +2158,11 @@ sensor_dev_create(void)
 #if MYNEWT_VAL(LIS2DW12_OFB)
 #if MYNEWT_VAL(BUS_DRIVER_PRESENT)
 #if MYNEWT_VAL(LIS2DW12_OFB_I2C_NUM) >= 0
-    rc = lis2dw12_create_i2c_sensor_dev((struct bus_i2c_node *)&lis2dw12, "lis2dw12_0",
+    rc = lis2dw12_create_i2c_sensor_dev(&lis2dw12.i2c_node, "lis2dw12_0",
                                         &lis2dw12_node_cfg, &lis2dw12_itf);
     assert(rc == 0);
 #elif MYNEWT_VAL(LIS2DW12_OFB_SPI_NUM) >= 0
-    rc = lis2dw12_create_spi_sensor_dev((struct bus_spi_node *)&lis2dw12, "lis2dw12_0",
+    rc = lis2dw12_create_spi_sensor_dev(&lis2dw12.spi_node, "lis2dw12_0",
                                         &lis2dw12_node_cfg, &lis2dw12_itf);
     assert(rc == 0);
 #endif


### PR DESCRIPTION
This adds a union containing both i2c_node and spi_node. This prevents memory corruption during sensor initialization caused by wrong casting.