### PR TITLE
tinyusb: Add missing syscfg definition

### DIFF
--- a/hw/usb/tinyusb/std_descriptors/syscfg.yml
+++ b/hw/usb/tinyusb/std_descriptors/syscfg.yml
@@ -134,6 +134,16 @@ syscfg.defs:
         description: CDC endpoint IN FIFO size
         value:
 
+    USBD_CDC_CONSOLE_DATA_OUT_EP:
+        description: CDC CONSOLE data out endpoint number
+        value:
+    USBD_CDC_CONSOLE_DATA_IN_EP:
+        description: CDC CONSOLE data out endpoint number
+        value:
+    USBD_CDC_CONSOLE_NOTIFY_EP:
+        description: CDC CONSOLE notify endpoint number
+        value:
+
     USBD_CDC_DESCRIPTOR_STRING:
         description: String for CDC interface
         value:


### PR DESCRIPTION
Values:
USBD_CDC_CONSOLE_DATA_OUT_EP,
USBD_CDC_CONSOLE_DATA_IN_EP,
USBD_CDC_CONSOLE_NOTIFY_EP,
were referenced in code but definition was missing, makeing it impossible to have console on usb
and anothere CDC function enumerated.
When CONSOLE_USB was selected and additional
CDC was enabled (cdc_uart) configuration descriptor had duplicated enpoint numbers.

With definition provided is is possible to
have USB device with multiply CDC functions
enabled.