### PR TITLE
Bump NRFX to 4.5

### DIFF
--- a/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
+++ b/hw/drivers/adc/adc_nrf52/src/adc_nrf52.c
@@ -513,7 +513,7 @@ nrf52_adc_read_channel(struct adc_dev *dev, uint8_t cnum, int *result)
 {
     int rc;
     int unlock = 0;
-    uint16_t adc_value;
+    nrf_saadc_value_t adc_value;
 
     if (nrf_saadc_busy_check(NRF_SAADC)) {
         return OS_EBUSY;

--- a/hw/drivers/i2s/i2s_nrf52/src/i2s_nrf52.c
+++ b/hw/drivers/i2s/i2s_nrf52/src/i2s_nrf52.c
@@ -24,6 +24,12 @@
 #include <i2s_nrf52/i2s_nrf52.h>
 #include <drivers/include/nrfx_i2s.h>
 
+#if defined(NRF_I2S0)
+#define I2S_NRF52_DEV NRF_I2S0
+#elif defined(NRF_I2S)
+#define I2S_NRF52_DEV NRF_I2S
+#endif
+
 struct nrf52_i2s {
     nrfx_i2s_t inst;
     nrfx_i2s_config_t nrfx_i2s_cfg;
@@ -34,7 +40,7 @@ struct nrf52_i2s {
 };
 
 static struct nrf52_i2s nrf52_i2s = {
-    NRFX_I2S_INSTANCE(0),
+    NRFX_I2S_INSTANCE(I2S_NRF52_DEV),
 };
 
 static void
@@ -59,6 +65,8 @@ nrfx_add_buffer(struct i2s *i2s, struct i2s_sample_buffer *buffer)
         nrfx_buffers.p_rx_buffer = buffer->sample_data;
     }
 
+    nrfx_buffers.buffer_size = buffer_size;
+
     assert(nrf52_i2s.nrfx_queued_count < 2);
     assert(nrf52_i2s.nrfx_buffers[nrf52_i2s.nrfx_queued_count] == NULL);
 
@@ -66,7 +74,7 @@ nrfx_add_buffer(struct i2s *i2s, struct i2s_sample_buffer *buffer)
     nrf52_i2s.nrfx_queued_count++;
     if (nrf52_i2s.nrfx_queued_count == 1) {
         i2s_driver_state_changed (i2s, I2S_STATE_RUNNING);
-        err = nrfx_i2s_start(&nrf52_i2s.inst, &nrfx_buffers, buffer_size, 0);
+        err = nrfx_i2s_start(&nrf52_i2s.inst, &nrfx_buffers, 0);
     } else {
         err = nrfx_i2s_next_buffers_set(&nrf52_i2s.inst, &nrfx_buffers);
     }
@@ -108,6 +116,12 @@ nrf52_i2s_data_handler(const nrfx_i2s_buffers_t *p_released, uint32_t status)
     }
 }
 
+static void
+nrf52_i2s_irq_handler(void)
+{
+    nrfx_i2s_irq_handler(&nrf52_i2s.inst);
+}
+
 static int
 nrf52_i2s_init(struct i2s *i2s, const struct i2s_cfg *cfg)
 {
@@ -115,7 +129,7 @@ nrf52_i2s_init(struct i2s *i2s, const struct i2s_cfg *cfg)
 
     nrf52_i2s.i2s = i2s;
 
-    NVIC_SetVector(nrfx_get_irq_number(NRF_I2S), (uint32_t)nrfx_i2s_0_irq_handler);
+    NVIC_SetVector(nrfx_get_irq_number(I2S_NRF52_DEV), (uint32_t)nrf52_i2s_irq_handler);
 
     nrf52_i2s.nrfx_i2s_cfg = cfg->nrfx_i2s_cfg;
     switch (cfg->nrfx_i2s_cfg.sample_width) {
@@ -207,7 +221,7 @@ nrf52_select_i2s_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
 {
     int i;
 
-    if (cfg->ratio != 0 || cfg->mck_setup != 0) {
+    if (cfg->prescalers.ratio != 0 || cfg->prescalers.mck_setup != 0) {
         /* User provided custom clock setup, no need to use stock values */
         return;
     }
@@ -215,11 +229,11 @@ nrf52_select_i2s_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
         if (sample_rates[i] == sample_rate) {
             if (cfg->sample_width == NRF_I2S_SWIDTH_8BIT ||
                 cfg->sample_width == NRF_I2S_SWIDTH_16BIT) {
-                cfg->ratio = mck_for_8_16_bit_samples[i].ratio;
-                cfg->mck_setup = mck_for_8_16_bit_samples[i].mck_setup;
+                cfg->prescalers.ratio = mck_for_8_16_bit_samples[i].ratio;
+                cfg->prescalers.mck_setup = mck_for_8_16_bit_samples[i].mck_setup;
             } else if (cfg->sample_width == NRF_I2S_SWIDTH_24BIT) {
-                cfg->ratio = mck_for_24_bit_samples[i].ratio;
-                cfg->mck_setup = mck_for_24_bit_samples[i].mck_setup;
+                cfg->prescalers.ratio = mck_for_24_bit_samples[i].ratio;
+                cfg->prescalers.mck_setup = mck_for_24_bit_samples[i].mck_setup;
             } else {
                 /* Invalid value of sample_width */
                 assert(0);
@@ -227,7 +241,7 @@ nrf52_select_i2s_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
             break;
         }
     }
-    assert(cfg->mck_setup);
+    assert(cfg->prescalers.mck_setup);
 }
 
 int

--- a/hw/drivers/i2s/i2s_nrf52/syscfg.yml
+++ b/hw/drivers/i2s/i2s_nrf52/syscfg.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,4 +17,5 @@
 # under the License.
 #
 
-syscfg.defs:
+syscfg.vals:
+    NRFX_I2S_ENABLED: 1

--- a/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
+++ b/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
@@ -226,10 +226,10 @@ static const struct i2s_clock_cfg mck_for_24_bit_samples[] = {
     { NRF_I2S_MCK_32MDIV15, NRF_I2S_RATIO_48X}   /* 48000: 44444.444 LRCK error -7.4% */
 };
 
+#if NRF_I2S_HAS_CLKCONFIG
 static void
 set_mck_setup_for_bypass(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
 {
-#if NRF_I2S_HAS_CLKCONFIG
     static const struct {
         uint16_t ratio_val;
         nrf_i2s_ratio_t ratio_enum;
@@ -265,8 +265,8 @@ set_mck_setup_for_bypass(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
         /* Anything, needed by NRFX */
         cfg->mck_setup = NRF_I2S_MCK_32MDIV8;
     }
-#endif
 }
+#endif
 
 static void
 i2s_nrfx_select_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)

--- a/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
+++ b/hw/drivers/i2s/i2s_nrfx/src/i2s_nrfx.c
@@ -25,6 +25,12 @@
 #include <drivers/include/nrfx_i2s.h>
 #include <nrfx_clock.h>
 
+#if defined(NRF_I2S0)
+#define I2S_NRFX_DEV NRF_I2S0
+#elif defined(NRF_I2S)
+#define I2S_NRFX_DEV NRF_I2S
+#endif
+
 struct i2s_nrfx {
     nrfx_i2s_t inst;
     nrfx_i2s_config_t nrfx_i2s_cfg;
@@ -35,7 +41,7 @@ struct i2s_nrfx {
 };
 
 static struct i2s_nrfx i2s_nrfx = {
-    NRFX_I2S_INSTANCE(0),
+    NRFX_I2S_INSTANCE(I2S_NRFX_DEV),
 };
 
 static void
@@ -80,7 +86,7 @@ nrfx_add_buffer(struct i2s *i2s, struct i2s_sample_buffer *buffer)
         err = nrfx_i2s_next_buffers_set(&i2s_nrfx.inst, &nrfx_buffers);
     }
 
-    assert(err == NRFX_SUCCESS);
+    assert(err == 0);
 }
 
 static void
@@ -117,6 +123,12 @@ i2s_nrfx_data_handler(const nrfx_i2s_buffers_t *p_released, uint32_t status)
     }
 }
 
+static void
+i2s_nrfx_irq_handler(void)
+{
+    nrfx_i2s_irq_handler(&i2s_nrfx.inst);
+}
+
 static int
 i2s_nrfx_init(struct i2s *i2s, const struct i2s_cfg *cfg)
 {
@@ -124,7 +136,7 @@ i2s_nrfx_init(struct i2s *i2s, const struct i2s_cfg *cfg)
 
     i2s_nrfx.i2s = i2s;
 
-    NVIC_SetVector(nrfx_get_irq_number(NRF_I2S0), (uint32_t)nrfx_i2s_0_irq_handler);
+    NVIC_SetVector(nrfx_get_irq_number(I2S_NRFX_DEV), (uint32_t)i2s_nrfx_irq_handler);
 
     i2s_nrfx.nrfx_i2s_cfg = cfg->nrfx_i2s_cfg;
     switch (cfg->nrfx_i2s_cfg.sample_width) {
@@ -248,14 +260,14 @@ set_mck_setup_for_bypass(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
     uint16_t mclk_div;
     size_t i;
 
-    if (cfg->enable_bypass) {
+    if (cfg->prescalers.enable_bypass) {
         mclk = cfg->clksrc == NRF_I2S_CLKSRC_PCLK32M ? 32000000UL : 12288000UL;
         mclk_div = mclk / sample_rate;
 
         for (i = 0; i < ARRAY_SIZE(ratios); i++) {
             if (mclk_div == ratios[i].ratio_val) {
                 /* Ratio for bit clock */
-                cfg->ratio = ratios[i].ratio_enum;
+                cfg->prescalers.ratio = ratios[i].ratio_enum;
                 break;
             }
         }
@@ -263,7 +275,7 @@ set_mck_setup_for_bypass(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
         assert(i < ARRAY_SIZE(ratios));
 
         /* Anything, needed by NRFX */
-        cfg->mck_setup = NRF_I2S_MCK_32MDIV8;
+        cfg->prescalers.mck_setup = NRF_I2S_MCK_32MDIV8;
     }
 }
 #endif
@@ -288,27 +300,27 @@ i2s_nrfx_select_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
             nrfx_clock_hfclkaudio_config_set(39854);
         }
         NRF_CLOCK->TASKS_HFCLKAUDIOSTART = 1;
-        if (cfg->mck_setup != 0) {
+        if (cfg->prescalers.mck_setup != 0) {
             /* User provided custom clock setup, no need to compute values */
             return;
         }
 
         src_frq = (32000000 * (4 + nrfx_clock_hfclkaudio_config_get() * 0.000015259f) / 12);
         if (cfg->sample_width == NRF_I2S_SWIDTH_24BIT) {
-            cfg->ratio = NRF_I2S_RATIO_48X;
+            cfg->prescalers.ratio = NRF_I2S_RATIO_48X;
             ratio = 48;
         } else if (cfg->sample_width == NRF_I2S_SWIDTH_32BIT || cfg->sample_width == NRF_I2S_SWIDTH_16BIT_IN32BIT ||
             cfg->sample_width == NRF_I2S_SWIDTH_24BIT_IN32BIT || cfg->sample_width == NRF_I2S_SWIDTH_8BIT_IN32BIT) {
-            cfg->ratio = NRF_I2S_RATIO_64X;
+            cfg->prescalers.ratio = NRF_I2S_RATIO_64X;
             ratio = 64;
         } else {
-            cfg->ratio = NRF_I2S_RATIO_32X;
+            cfg->prescalers.ratio = NRF_I2S_RATIO_32X;
             ratio = 32;
         }
         mck = sample_rate * ratio;
-        cfg->mck_setup = 4096 * (mck * 1048576ull / (src_frq + mck / 2));
+        cfg->prescalers.mck_setup = 4096 * (mck * 1048576ull / (src_frq + mck / 2));
         return;
-    } else if (cfg->mck_setup != 0) {
+    } else if (cfg->prescalers.mck_setup != 0) {
         /* User provided custom clock setup, no need to use stock values */
         return;
     }
@@ -316,16 +328,16 @@ i2s_nrfx_select_clock_cfg(nrfx_i2s_config_t *cfg, uint32_t sample_rate)
     for (i = 0; i < ARRAY_SIZE(sample_rates); ++i) {
         if (sample_rates[i] == sample_rate) {
             if (cfg->sample_width == NRF_I2S_SWIDTH_24BIT) {
-                cfg->ratio = mck_for_24_bit_samples[i].ratio;
-                cfg->mck_setup = mck_for_24_bit_samples[i].mck_setup;
+                cfg->prescalers.ratio = mck_for_24_bit_samples[i].ratio;
+                cfg->prescalers.mck_setup = mck_for_24_bit_samples[i].mck_setup;
             } else {
-                cfg->ratio = mck_for_8_16_bit_samples[i].ratio;
-                cfg->mck_setup = mck_for_8_16_bit_samples[i].mck_setup;
+                cfg->prescalers.ratio = mck_for_8_16_bit_samples[i].ratio;
+                cfg->prescalers.mck_setup = mck_for_8_16_bit_samples[i].mck_setup;
             }
             break;
         }
     }
-    assert(cfg->mck_setup);
+    assert(cfg->prescalers.mck_setup);
 }
 
 int

--- a/hw/drivers/i2s/i2s_nrfx/syscfg.yml
+++ b/hw/drivers/i2s/i2s_nrfx/syscfg.yml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    NRFX_I2S_ENABLED: 1

--- a/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
+++ b/hw/drivers/pwm/pwm_nrf52/src/pwm_nrf52.c
@@ -37,6 +37,8 @@
 /* Max number on PWM instances on existing nRF52xxx MCUs */
 #define NRF52_PWM_MAX_INSTANCES     4
 
+#define NRF52_PWM_INST(_id)         NRFX_PWM_INSTANCE(NRF_PWM##_id)
+
 struct nrf52_pwm_dev_global {
     bool in_use;
     bool playing;
@@ -45,7 +47,7 @@ struct nrf52_pwm_dev_global {
     nrf_pwm_values_individual_t duty_cycles;
     uint32_t n_cycles;
     nrfx_pwm_flag_t flags;
-    nrfx_pwm_handler_t internal_handler;
+    nrfx_pwm_event_handler_t internal_handler;
     user_handler_t cycle_handler;
     user_handler_t seq_end_handler;
     void* cycle_data;
@@ -57,7 +59,7 @@ static struct nrf52_pwm_dev_global instances[] =
 #if MYNEWT_VAL(PWM_0)
     [0].in_use = false,
     [0].playing = false,
-    [0].drv_instance = NRFX_PWM_INSTANCE(0),
+    [0].drv_instance = NRF52_PWM_INST(0),
     [0].config = NRFX_PWM_DEFAULT_CONFIG(NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
@@ -74,7 +76,7 @@ static struct nrf52_pwm_dev_global instances[] =
 #if MYNEWT_VAL(PWM_1)
     [1].in_use = false,
     [1].playing = false,
-    [1].drv_instance = NRFX_PWM_INSTANCE(1),
+    [1].drv_instance = NRF52_PWM_INST(1),
     [1].config = NRFX_PWM_DEFAULT_CONFIG(NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
@@ -91,7 +93,7 @@ static struct nrf52_pwm_dev_global instances[] =
 #if MYNEWT_VAL(PWM_2)
     [2].in_use = false,
     [2].playing = false,
-    [2].drv_instance = NRFX_PWM_INSTANCE(2),
+    [2].drv_instance = NRF52_PWM_INST(2),
     [2].config = NRFX_PWM_DEFAULT_CONFIG(NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
@@ -108,7 +110,7 @@ static struct nrf52_pwm_dev_global instances[] =
 #if MYNEWT_VAL(PWM_3)
     [3].in_use = false,
     [3].playing = false,
-    [3].drv_instance = NRFX_PWM_INSTANCE(3),
+    [3].drv_instance = NRF52_PWM_INST(3),
     [3].config = NRFX_PWM_DEFAULT_CONFIG(NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
                                          NRF_PWM_PIN_NOT_CONNECTED,
@@ -126,19 +128,19 @@ static struct nrf52_pwm_dev_global instances[] =
 
 #if MYNEWT_VAL(PWM_0)
 static void
-handler_0(nrfx_pwm_evt_type_t event_type, void *unused)
+handler_0(nrfx_pwm_event_type_t event_type, void *unused)
 {
     switch (event_type) {
-    case NRFX_PWM_EVT_END_SEQ0:
-    case NRFX_PWM_EVT_END_SEQ1:
+    case NRFX_PWM_EVENT_END_SEQ0:
+    case NRFX_PWM_EVENT_END_SEQ1:
         instances[0].cycle_handler(instances[0].cycle_data);
         break;
 
-    case NRFX_PWM_EVT_FINISHED:
+    case NRFX_PWM_EVENT_FINISHED:
         instances[0].seq_end_handler(instances[0].seq_end_data);
         break;
 
-    case NRFX_PWM_EVT_STOPPED:
+    case NRFX_PWM_EVENT_STOPPED:
         break;
 
     default:
@@ -149,19 +151,19 @@ handler_0(nrfx_pwm_evt_type_t event_type, void *unused)
 
 #if MYNEWT_VAL(PWM_1)
 static void
-handler_1(nrfx_pwm_evt_type_t event_type, void *unused)
+handler_1(nrfx_pwm_event_type_t event_type, void *unused)
 {
     switch (event_type) {
-    case NRFX_PWM_EVT_END_SEQ0:
-    case NRFX_PWM_EVT_END_SEQ1:
+    case NRFX_PWM_EVENT_END_SEQ0:
+    case NRFX_PWM_EVENT_END_SEQ1:
         instances[1].cycle_handler(instances[1].cycle_data);
         break;
 
-    case NRFX_PWM_EVT_FINISHED:
+    case NRFX_PWM_EVENT_FINISHED:
         instances[1].seq_end_handler(instances[1].seq_end_data);
         break;
 
-    case NRFX_PWM_EVT_STOPPED:
+    case NRFX_PWM_EVENT_STOPPED:
         break;
 
     default:
@@ -172,19 +174,19 @@ handler_1(nrfx_pwm_evt_type_t event_type, void *unused)
 
 #if MYNEWT_VAL(PWM_2)
 static void
-handler_2(nrfx_pwm_evt_type_t event_type, void *unused)
+handler_2(nrfx_pwm_event_type_t event_type, void *unused)
 {
     switch (event_type) {
-    case NRFX_PWM_EVT_END_SEQ0:
-    case NRFX_PWM_EVT_END_SEQ1:
+    case NRFX_PWM_EVENT_END_SEQ0:
+    case NRFX_PWM_EVENT_END_SEQ1:
         instances[2].cycle_handler(instances[2].cycle_data);
         break;
 
-    case NRFX_PWM_EVT_FINISHED:
+    case NRFX_PWM_EVENT_FINISHED:
         instances[2].seq_end_handler(instances[2].seq_end_data);
         break;
 
-    case NRFX_PWM_EVT_STOPPED:
+    case NRFX_PWM_EVENT_STOPPED:
         break;
 
     default:
@@ -196,19 +198,19 @@ handler_2(nrfx_pwm_evt_type_t event_type, void *unused)
 
 #if MYNEWT_VAL(PWM_3)
 static void
-handler_3(nrfx_pwm_evt_type_t event_type, void *unused)
+handler_3(nrfx_pwm_event_type_t event_type, void *unused)
 {
     switch (event_type) {
-    case NRFX_PWM_EVT_END_SEQ0:
-    case NRFX_PWM_EVT_END_SEQ1:
+    case NRFX_PWM_EVENT_END_SEQ0:
+    case NRFX_PWM_EVENT_END_SEQ1:
         instances[3].cycle_handler(instances[3].cycle_data);
         break;
 
-    case NRFX_PWM_EVT_FINISHED:
+    case NRFX_PWM_EVENT_FINISHED:
         instances[3].seq_end_handler(instances[3].seq_end_data);
         break;
 
-    case NRFX_PWM_EVT_STOPPED:
+    case NRFX_PWM_EVENT_STOPPED:
         break;
 
     default:
@@ -217,7 +219,7 @@ handler_3(nrfx_pwm_evt_type_t event_type, void *unused)
 }
 #endif
 
-static nrfx_pwm_handler_t internal_handlers[] = {
+static nrfx_pwm_event_handler_t internal_handlers[] = {
 #if MYNEWT_VAL(PWM_0)
 handler_0,
 #else
@@ -754,14 +756,17 @@ nrf52_pwm_get_resolution_bits(struct pwm_dev *dev)
     return (-EINVAL);
 }
 
-#if MYNEWT_VAL(OS_SYSVIEW)
 #if MYNEWT_VAL(PWM_0)
 static void
 pwm_0_irq_handler(void)
 {
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_enter();
-    nrfx_pwm_0_irq_handler();
+#endif
+    nrfx_pwm_irq_handler(&instances[0].drv_instance);
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_exit();
+#endif
 }
 #endif
 
@@ -769,9 +774,13 @@ pwm_0_irq_handler(void)
 static void
 pwm_1_irq_handler(void)
 {
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_enter();
-    nrfx_pwm_1_irq_handler();
+#endif
+    nrfx_pwm_irq_handler(&instances[1].drv_instance);
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_exit();
+#endif
 }
 #endif
 
@@ -779,9 +788,13 @@ pwm_1_irq_handler(void)
 static void
 pwm_2_irq_handler(void)
 {
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_enter();
-    nrfx_pwm_2_irq_handler();
+#endif
+    nrfx_pwm_irq_handler(&instances[2].drv_instance);
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_exit();
+#endif
 }
 #endif
 
@@ -789,18 +802,18 @@ pwm_2_irq_handler(void)
 static void
 pwm_3_irq_handler(void)
 {
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_enter();
-    nrfx_pwm_3_irq_handler();
+#endif
+    nrfx_pwm_irq_handler(&instances[3].drv_instance);
+#if MYNEWT_VAL(OS_SYSVIEW)
     os_trace_isr_exit();
+#endif
 }
 #endif
 
 #define PWM_IRQ_HANDLER(_pwm_no) \
                             (uint32_t) pwm_ ## _pwm_no ## _irq_handler
-#else
-#define PWM_IRQ_HANDLER(_pwm_no) \
-                            (uint32_t) nrfx_pwm_ ## _pwm_no ## _irq_handler
-#endif
 
 /**
  * Callback to initialize an adc_dev structure from the os device

--- a/hw/drivers/pwm/pwm_nrf52/syscfg.yml
+++ b/hw/drivers/pwm/pwm_nrf52/syscfg.yml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    NRFX_PWM_ENABLED: 1

--- a/hw/mcu/nordic/include/nrfx_config_common.h
+++ b/hw/mcu/nordic/include/nrfx_config_common.h
@@ -40,12 +40,12 @@
 
 /** @brief Symbol specifying major version of the nrfx API to be used. */
 #ifndef NRFX_CONFIG_API_VER_MAJOR
-#define NRFX_CONFIG_API_VER_MAJOR 3
+#define NRFX_CONFIG_API_VER_MAJOR 4
 #endif
 
 /** @brief Symbol specifying minor version of the nrfx API to be used. */
 #ifndef NRFX_CONFIG_API_VER_MINOR
-#define NRFX_CONFIG_API_VER_MINOR 14
+#define NRFX_CONFIG_API_VER_MINOR 5
 #endif
 
 /** @brief Symbol specifying micro version of the nrfx API to be used. */

--- a/hw/mcu/nordic/include/nrfx_glue.h
+++ b/hw/mcu/nordic/include/nrfx_glue.h
@@ -36,7 +36,19 @@
 
 #include <assert.h>
 #include <stdatomic.h>
+#include <drivers/nrfx_utils.h>
+#include <drivers/nrfx_errors.h>
 #include "os/mynewt.h"
+
+#ifndef NRF_STATIC_INLINE
+#define NRF_STATIC_INLINE __STATIC_INLINE
+#endif
+#ifndef NRFX_STATIC_INLINE
+#define NRFX_STATIC_INLINE __STATIC_INLINE
+#endif
+#ifndef NRFY_STATIC_INLINE
+#define NRFY_STATIC_INLINE __STATIC_INLINE
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -326,6 +338,15 @@ extern "C" {
 
 /** @brief Bitmask that defines TIMER instances that are reserved for use outside of the nrfx library. */
 #define NRFX_TIMERS_USED          0
+
+#ifndef nrf_clock_hf_is_running
+#define nrf_clock_hf_is_running(p_reg, clk_src)                               \
+    ({                                                                        \
+        uint32_t _src = 0;                                                    \
+        nrf_clock_is_running((p_reg), NRF_CLOCK_DOMAIN_HFCLK, &_src) &&       \
+            (_src == (uint32_t)(clk_src));                                    \
+    })
+#endif
 
 /** @} */
 

--- a/hw/mcu/nordic/nrf51xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf51xxx/syscfg.yml
@@ -113,3 +113,4 @@ syscfg.vals:
     # clocked at 32768Hz. The tick frequency is chosen such that it divides
     # cleanly into 32768 to avoid a systemic bias in the actual tick frequency.
     OS_TICKS_PER_SEC: 128
+    NRFX_NVMC_ENABLED: 1

--- a/hw/mcu/nordic/nrf52xxx/pkg.yml
+++ b/hw/mcu/nordic/nrf52xxx/pkg.yml
@@ -29,6 +29,15 @@ pkg.deps:
     - "@apache-mynewt-core/hw/mcu/nordic"
     - "@apache-mynewt-core/hw/mcu/nordic/nrf_common"
 
+pkg.include_dirs:
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52840"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52833"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52820"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52811"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52810"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52805"
+
 pkg.ign_files.'!MCU_COMMON_STARTUP || SPLIT_LOADER':
     - gcc_startup_cm4.s
 pkg.ign_files.'!MCU_COMMON_STARTUP || !SPLIT_LOADER':

--- a/hw/mcu/nordic/nrf52xxx/syscfg.yml
+++ b/hw/mcu/nordic/nrf52xxx/syscfg.yml
@@ -444,6 +444,7 @@ syscfg.defs:
 
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
+    NRFX_NVMC_ENABLED: 1
 
 syscfg.vals.'(MCU_TARGET == "nRF52832" || MCU_TARGET == "nRF52840")':
     MCU_ICACHE_ENABLED: 1

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -594,6 +594,9 @@ syscfg.defs:
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
 
+syscfg.vals.QSPI_ENABLE:
+    NRFX_QSPI_ENABLED: 1
+
 syscfg.vals.CORTEX_DEFAULT_STARTUP:
     MCU_RAM_START: 0x20000400
     MCU_RAM_SIZE: 0x7FC00

--- a/hw/mcu/nordic/nrf5340/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340/syscfg.yml
@@ -593,6 +593,7 @@ syscfg.defs:
 
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
+    NRFX_NVMC_ENABLED: 1
 
 syscfg.vals.QSPI_ENABLE:
     NRFX_QSPI_ENABLED: 1

--- a/hw/mcu/nordic/nrf5340_net/syscfg.yml
+++ b/hw/mcu/nordic/nrf5340_net/syscfg.yml
@@ -169,6 +169,7 @@ syscfg.defs:
 
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
+    NRFX_NVMC_ENABLED: 1
 
 syscfg.vals.CORTEX_DEFAULT_STARTUP:
     MCU_RAM_START: 0x21000000

--- a/hw/mcu/nordic/nrf91xx/syscfg.yml
+++ b/hw/mcu/nordic/nrf91xx/syscfg.yml
@@ -450,6 +450,7 @@ syscfg.defs:
 
 syscfg.vals:
     OS_TICKS_PER_SEC: 128
+    NRFX_NVMC_ENABLED: 1
 
 syscfg.vals.MCU_NRF9160:
     MCU_TARGET: nRF9160

--- a/hw/mcu/nordic/pkg.yml
+++ b/hw/mcu/nordic/pkg.yml
@@ -31,22 +31,273 @@ pkg.keywords:
 pkg.type: sdk
 
 pkg.ign_dirs:
-    - "soc"
+    - "bsp"
     - "templates"
-    - "mdk"
+    - "lib"
+    - "doc"
 
 pkg.include_dirs:
     - "@nordic-nrfx/drivers/include"
     - "@nordic-nrfx/drivers"
     - "@nordic-nrfx/drivers/src"
     - "@nordic-nrfx/hal"
+    - "@nordic-nrfx/haly"
     - "@nordic-nrfx/helpers"
-    - "@nordic-nrfx/mdk"
+    - "@nordic-nrfx/bsp/stable"
+    - "@nordic-nrfx/bsp/stable/mdk"
+    - "@nordic-nrfx/bsp/stable/mdk/common"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf51"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52840"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52833"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52832"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52820"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52811"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52810"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf52/nrf52805"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf53"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf53/nrf5340"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf54h"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf54h/nrf54h20"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf54l"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf54l/nrf54l15"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf91"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf91/nrf9160"
+    - "@nordic-nrfx/bsp/stable/mdk/nrf91/nrf9120"
+    - "@nordic-nrfx/bsp/stable/soc"
     - "@nordic-nrfx/."
     - "include"
 
-pkg.src_dirs:
-    - "@nordic-nrfx/drivers/src"
+pkg.source_files.NRFX_ADC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_adc.c"
+app.cflags.NRFX_ADC_ENABLED:
+    - -DNRFX_ADC_ENABLED=1
+
+pkg.source_files.NRFX_BELLBOARD_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_bellboard.c"
+app.cflags.NRFX_BELLBOARD_ENABLED:
+    - -DNRFX_BELLBOARD_ENABLED=1
+
+pkg.source_files.NRFX_CLOCK_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_clock.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_hfclk.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_hfclk192m.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_hfclkaudio.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_lfclk.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_xo.c"
+    - "@nordic-nrfx/drivers/src/nrfx_clock_xo24m.c"
+app.cflags.NRFX_CLOCK_ENABLED:
+    - -DNRFX_CLOCK_ENABLED=1
+
+pkg.source_files.NRFX_COMP_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_comp.c"
+app.cflags.NRFX_COMP_ENABLED:
+    - -DNRFX_COMP_ENABLED=1
+
+pkg.source_files.NRFX_CRACEN_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_cracen.c"
+app.cflags.NRFX_CRACEN_ENABLED:
+    - -DNRFX_CRACEN_ENABLED=1
+
+pkg.source_files.NRFX_DPPI_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_dppi.c"
+app.cflags.NRFX_DPPI_ENABLED:
+    - -DNRFX_DPPI_ENABLED=1
+
+pkg.source_files.NRFX_EGU_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_egu.c"
+app.cflags.NRFX_EGU_ENABLED:
+    - -DNRFX_EGU_ENABLED=1
+
+pkg.source_files.NRFX_GPIOTE_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_gpiote.c"
+app.cflags.NRFX_GPIOTE_ENABLED:
+    - -DNRFX_GPIOTE_ENABLED=1
+
+pkg.source_files.NRFX_GRTC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_grtc.c"
+app.cflags.NRFX_GRTC_ENABLED:
+    - -DNRFX_GRTC_ENABLED=1
+
+pkg.source_files.NRFX_I2S_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_i2s.c"
+app.cflags.NRFX_I2S_ENABLED:
+    - -DNRFX_I2S_ENABLED=1
+
+pkg.source_files.NRFX_IPC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_ipc.c"
+app.cflags.NRFX_IPC_ENABLED:
+    - -DNRFX_IPC_ENABLED=1
+
+pkg.source_files.NRFX_KMU_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_kmu.c"
+app.cflags.NRFX_KMU_ENABLED:
+    - -DNRFX_KMU_ENABLED=1
+
+pkg.source_files.NRFX_LPCOMP_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_lpcomp.c"
+app.cflags.NRFX_LPCOMP_ENABLED:
+    - -DNRFX_LPCOMP_ENABLED=1
+
+pkg.source_files.NRFX_MRAMC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_mramc.c"
+app.cflags.NRFX_MRAMC_ENABLED:
+    - -DNRFX_MRAMC_ENABLED=1
+
+pkg.source_files.NRFX_NFCT_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_nfct.c"
+app.cflags.NRFX_NFCT_ENABLED:
+    - -DNRFX_NFCT_ENABLED=1
+
+pkg.source_files.NRFX_NVMC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_nvmc.c"
+app.cflags.NRFX_NVMC_ENABLED:
+    - -DNRFX_NVMC_ENABLED=1
+
+pkg.source_files.NRFX_PDM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_pdm.c"
+app.cflags.NRFX_PDM_ENABLED:
+    - -DNRFX_PDM_ENABLED=1
+
+pkg.source_files.NRFX_POWER_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_power.c"
+app.cflags.NRFX_POWER_ENABLED:
+    - -DNRFX_POWER_ENABLED=1
+
+pkg.source_files.NRFX_PPI_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_ppi.c"
+app.cflags.NRFX_PPI_ENABLED:
+    - -DNRFX_PPI_ENABLED=1
+
+pkg.source_files.NRFX_PPIB_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_ppib.c"
+app.cflags.NRFX_PPIB_ENABLED:
+    - -DNRFX_PPIB_ENABLED=1
+
+pkg.source_files.NRFX_PRS_ENABLED:
+    - "@nordic-nrfx/drivers/src/prs/nrfx_prs.c"
+app.cflags.NRFX_PRS_ENABLED:
+    - -DNRFX_PRS_ENABLED=1
+
+pkg.source_files.NRFX_PWM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_pwm.c"
+app.cflags.NRFX_PWM_ENABLED:
+    - -DNRFX_PWM_ENABLED=1
+
+pkg.source_files.NRFX_QDEC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_qdec.c"
+app.cflags.NRFX_QDEC_ENABLED:
+    - -DNRFX_QDEC_ENABLED=1
+
+pkg.source_files.NRFX_QSPI_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_qspi.c"
+app.cflags.NRFX_QSPI_ENABLED:
+    - -DNRFX_QSPI_ENABLED=1
+
+pkg.source_files.NRFX_RNG_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_rng.c"
+app.cflags.NRFX_RNG_ENABLED:
+    - -DNRFX_RNG_ENABLED=1
+
+pkg.source_files.NRFX_RRAMC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_rramc.c"
+app.cflags.NRFX_RRAMC_ENABLED:
+    - -DNRFX_RRAMC_ENABLED=1
+
+pkg.source_files.NRFX_RTC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_rtc.c"
+app.cflags.NRFX_RTC_ENABLED:
+    - -DNRFX_RTC_ENABLED=1
+
+pkg.source_files.NRFX_SAADC_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_saadc.c"
+app.cflags.NRFX_SAADC_ENABLED:
+    - -DNRFX_SAADC_ENABLED=1
+
+pkg.source_files.NRFX_SPI_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_spi.c"
+app.cflags.NRFX_SPI_ENABLED:
+    - -DNRFX_SPI_ENABLED=1
+
+pkg.source_files.NRFX_SPIM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_spim.c"
+app.cflags.NRFX_SPIM_ENABLED:
+    - -DNRFX_SPIM_ENABLED=1
+
+pkg.source_files.NRFX_SPIS_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_spis.c"
+app.cflags.NRFX_SPIS_ENABLED:
+    - -DNRFX_SPIS_ENABLED=1
+
+pkg.source_files.NRFX_SYSTICK_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_systick.c"
+app.cflags.NRFX_SYSTICK_ENABLED:
+    - -DNRFX_SYSTICK_ENABLED=1
+
+pkg.source_files.NRFX_TBM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_tbm.c"
+app.cflags.NRFX_TBM_ENABLED:
+    - -DNRFX_TBM_ENABLED=1
+
+pkg.source_files.NRFX_TDM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_tdm.c"
+app.cflags.NRFX_TDM_ENABLED:
+    - -DNRFX_TDM_ENABLED=1
+
+pkg.source_files.NRFX_TEMP_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_temp.c"
+app.cflags.NRFX_TEMP_ENABLED:
+    - -DNRFX_TEMP_ENABLED=1
+
+pkg.source_files.NRFX_TIMER_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_timer.c"
+app.cflags.NRFX_TIMER_ENABLED:
+    - -DNRFX_TIMER_ENABLED=1
+
+pkg.source_files.NRFX_TWI_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_twi.c"
+app.cflags.NRFX_TWI_ENABLED:
+    - -DNRFX_TWI_ENABLED=1
+
+pkg.source_files.NRFX_TWIM_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_twim.c"
+app.cflags.NRFX_TWIM_ENABLED:
+    - -DNRFX_TWIM_ENABLED=1
+
+pkg.source_files.NRFX_TWIS_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_twis.c"
+app.cflags.NRFX_TWIS_ENABLED:
+    - -DNRFX_TWIS_ENABLED=1
+
+pkg.source_files.NRFX_UART_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_uart.c"
+app.cflags.NRFX_UART_ENABLED:
+    - -DNRFX_UART_ENABLED=1
+
+pkg.source_files.NRFX_UARTE_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_uarte.c"
+app.cflags.NRFX_UARTE_ENABLED:
+    - -DNRFX_UARTE_ENABLED=1
+
+pkg.source_files.NRFX_USBD_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_usbd.c"
+app.cflags.NRFX_USBD_ENABLED:
+    - -DNRFX_USBD_ENABLED=1
+
+pkg.source_files.NRFX_USBREG_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_usbreg.c"
+app.cflags.NRFX_USBREG_ENABLED:
+    - -DNRFX_USBREG_ENABLED=1
+
+pkg.source_files.NRFX_VEVIF_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_vevif.c"
+app.cflags.NRFX_VEVIF_ENABLED:
+    - -DNRFX_VEVIF_ENABLED=1
+
+pkg.source_files.NRFX_WDT_ENABLED:
+    - "@nordic-nrfx/drivers/src/nrfx_wdt.c"
+app.cflags.NRFX_WDT_ENABLED:
+    - -DNRFX_WDT_ENABLED=1
 
 pkg.cflags:
     - -std=gnu99
@@ -58,7 +309,7 @@ pkg.deps:
 
 repository.nordic-nrfx:
     type: github
-    vers: v3.14.0-commit
+    vers: v4.5.0-commit
     branch: master
     user: NordicSemiconductor
     repo: nrfx

--- a/hw/mcu/nordic/syscfg.yml
+++ b/hw/mcu/nordic/syscfg.yml
@@ -1,0 +1,199 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    NRFX_ADC_ENABLED:
+        description: Enable NRFX ADC driver
+        value: 0
+
+    NRFX_BELLBOARD_ENABLED:
+        description: Enable NRFX BELLBOARD driver
+        value: 0
+
+    NRFX_CLOCK_ENABLED:
+        description: Enable NRFX CLOCK driver
+        value: 0
+
+    NRFX_COMP_ENABLED:
+        description: Enable NRFX COMP driver
+        value: 0
+
+    NRFX_CRACEN_ENABLED:
+        description: Enable NRFX CRACEN driver
+        value: 0
+
+    NRFX_DPPI_ENABLED:
+        description: Enable NRFX DPPI driver
+        value: 0
+
+    NRFX_EGU_ENABLED:
+        description: Enable NRFX EGU driver
+        value: 0
+
+    NRFX_GPIOTE_ENABLED:
+        description: Enable NRFX GPIOTE driver
+        value: 0
+
+    NRFX_GRTC_ENABLED:
+        description: Enable NRFX GRTC driver
+        value: 0
+
+    NRFX_I2S_ENABLED:
+        description: Enable NRFX I2S driver
+        value: 0
+
+    NRFX_IPC_ENABLED:
+        description: Enable NRFX IPC driver
+        value: 0
+
+    NRFX_KMU_ENABLED:
+        description: Enable NRFX KMU driver
+        value: 0
+
+    NRFX_LPCOMP_ENABLED:
+        description: Enable NRFX LPCOMP driver
+        value: 0
+
+    NRFX_MRAMC_ENABLED:
+        description: Enable NRFX MRAMC driver
+        value: 0
+
+    NRFX_NFCT_ENABLED:
+        description: Enable NRFX NFCT driver
+        value: 0
+
+    NRFX_NVMC_ENABLED:
+        description: Enable NRFX NVMC driver
+        value: 0
+
+    NRFX_PDM_ENABLED:
+        description: Enable NRFX PDM driver
+        value: 0
+
+    NRFX_POWER_ENABLED:
+        description: Enable NRFX POWER driver
+        value: 0
+
+    NRFX_PPI_ENABLED:
+        description: Enable NRFX PPI driver
+        value: 0
+
+    NRFX_PPIB_ENABLED:
+        description: Enable NRFX PPIB driver
+        value: 0
+
+    NRFX_PRS_ENABLED:
+        description: Enable NRFX Peripheral Resource Sharing (PRS)
+        value: 0
+
+    NRFX_PWM_ENABLED:
+        description: Enable NRFX PWM driver
+        value: 0
+
+    NRFX_QDEC_ENABLED:
+        description: Enable NRFX QDEC driver
+        value: 0
+
+    NRFX_QSPI_ENABLED:
+        description: Enable NRFX QSPI driver
+        value: 0
+
+    NRFX_RNG_ENABLED:
+        description: Enable NRFX RNG driver
+        value: 0
+
+    NRFX_RRAMC_ENABLED:
+        description: Enable NRFX RRAMC driver
+        value: 0
+
+    NRFX_RTC_ENABLED:
+        description: Enable NRFX RTC driver
+        value: 0
+
+    NRFX_SAADC_ENABLED:
+        description: Enable NRFX SAADC driver
+        value: 0
+
+    NRFX_SPI_ENABLED:
+        description: Enable NRFX SPI driver
+        value: 0
+
+    NRFX_SPIM_ENABLED:
+        description: Enable NRFX SPIM driver
+        value: 0
+
+    NRFX_SPIS_ENABLED:
+        description: Enable NRFX SPIS driver
+        value: 0
+
+    NRFX_SYSTICK_ENABLED:
+        description: Enable NRFX SYSTICK driver
+        value: 0
+
+    NRFX_TBM_ENABLED:
+        description: Enable NRFX TBM driver
+        value: 0
+
+    NRFX_TDM_ENABLED:
+        description: Enable NRFX TDM driver
+        value: 0
+
+    NRFX_TEMP_ENABLED:
+        description: Enable NRFX TEMP driver
+        value: 0
+
+    NRFX_TIMER_ENABLED:
+        description: Enable NRFX TIMER driver
+        value: 0
+
+    NRFX_TWI_ENABLED:
+        description: Enable NRFX TWI driver
+        value: 0
+
+    NRFX_TWIM_ENABLED:
+        description: Enable NRFX TWIM driver
+        value: 0
+
+    NRFX_TWIS_ENABLED:
+        description: Enable NRFX TWIS driver
+        value: 0
+
+    NRFX_UART_ENABLED:
+        description: Enable NRFX UART driver
+        value: 0
+
+    NRFX_UARTE_ENABLED:
+        description: Enable NRFX UARTE driver
+        value: 0
+
+    NRFX_USBD_ENABLED:
+        description: Enable NRFX USBD driver
+        value: 0
+
+    NRFX_USBREG_ENABLED:
+        description: Enable NRFX USBREG driver
+        value: 0
+
+    NRFX_VEVIF_ENABLED:
+        description: Enable NRFX VEVIF driver
+        value: 0
+
+    NRFX_WDT_ENABLED:
+        description: Enable NRFX WDT driver
+        value: 0


### PR DESCRIPTION
Changes to build mynewt code with nrfx 4.5

NRFX does not have now files that remove all content
depending on NRFX_XXXX_ENABLED flags.

Mynewt SDK package for NRFX selects now only relevant
files during build instead of building everything.

Some minor changes to adjust name changes in structures.